### PR TITLE
Add preview settings in frigg config

### DIFF
--- a/.frigg.yml
+++ b/.frigg.yml
@@ -3,6 +3,15 @@ tasks:
  - npm test
  - npm run lint
 
+deploy_tasks:
+ - npm install
+ - npm install forever
+ - npm run bundle
+ - PORT=8000 ./node_modules/.bin/forever start node_modules/.bin/6to5-node server.js
+
 coverage:
   path: coverage/cobertura-coverage.xml
   parser: cobertura
+
+deployment:
+  image: frigg/frigg-test-base

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "webkom",
   "license": "MIT",
   "scripts": {
+    "bundle-js": "browserify src/index.js -d -o public/app.js -v",
+    "bundle-css": "stylus --use nib assets/stylesheets/style.styl -o public/app.css",
+    "bundle": "npm run bundle-js && npm run bundle-css",
     "watch-js": "watchify src/index.js -d -o public/app.js -v",
     "watch-css": "stylus --use nib -w assets/stylesheets/style.styl -o public/app.css",
     "watch": "npm run watch-js & npm run watch-css & npm run start",


### PR DESCRIPTION
This will make each PR be deployed to `<random-number>.pr.frigg.io`, thus reviewing will hopefully be easier. It will stay deployed for one hour. In order to redeploy just restart the test with a comment: `retest now please` and it will be deployed after the tests succeeds.
