### PR TITLE
Enable react production mode and fix uglify settings

### DIFF
--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -6,9 +6,17 @@ var baseConfig = require('./base.config');
 module.exports = objectAssign(baseConfig, {
   entry: './src/index.js',
   plugins: [
-    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        screw_ie8: true,
+        warnings: false
+      }
+    }),
     new webpack.DefinePlugin({
       __DEV__: false
+    }),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production')
     })
   ]
 });


### PR DESCRIPTION
Forgot to fix https://github.com/webkom/lego-webapp/pull/26#discussion_r41568216 before it was merged, this fixes it. Also enables screw IE6 - IE8 mode, since we don't really support that anyway.
