### PR TITLE
[Depsy] Upgrade dependency react-redux to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "0.14.0",
     "react-hot-loader": "2.0.0-alpha-2",
     "react-overlays": "0.5.0",
-    "react-redux": "2.1.2",
+    "react-redux": "4.0.0",
     "react-router": "1.0.0-rc1",
     "redux": "3.0.0",
     "redux-form": "^1.5.3",


### PR DESCRIPTION
Hi!

A new version was just released of `react-redux`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-redux to 4.0.0
#### Changelog:
#### Version 4.0.0
## Breaking Changes
### React 0.14 is now required and a peer dependency

If you need 0.13 support, keep using 3.x. In addition, React has now been promoted to be a peer dependency because you’ll use the same `react` package for web and native.
### `react-redux/native` entry point has been removed

Track [this React Native issue](https://github.com/facebook/react-native/issues/2985) and wait until RN works _on top of_ React 0.14. Then React Redux 4.x should “just work” in React Native. Until then, you need to keep using 3.x with React Native.
### `<Provider>` no longer accepts a function child

This resolves a ton of router-related issues and also helps beginners understand what's going on.
#### Before

``` js
React.render(
  <Provider>
    {() => <App />}
  </Provider>,
  rootEl
);
```
#### After

``` js
ReactDOM.render(
  <Provider>
    <App />
  </Provider>,
  rootEl
);
```
### Refs are now opt-in

`connect()` no longer provides a ref to the wrapped component by default. You need to specify `withRef: true` in the `options` as the fourth argument to `connect()` to get the old behavior. `getWrappedInstance()` will throw unless you do that.

This fixes https://github.com/rackt/react-redux/issues/141.
#### Before

``` js
class MyComponent extends Component { ... }
MyComponent = connect(mapStateToProps)(MyComponent);

// later
let instance = React.render(<MyComponent />, targetEl);
console.log(instance.getWrappedInstance());
```
#### After

``` js
class MyComponent extends Component { ... }
MyComponent = connect(mapStateToProps, null, null, { withRef: true })(MyComponent);

// later
let instance = ReactDOM.render(<MyComponent />, targetEl);
console.log(instance.getWrappedInstance());
```
#### Version 3.1.0
- Static methods are now hoisted and available on the connected component. The exact semantics are provided by [hoist-non-react-statics](https://github.com/mridgway/hoist-non-react-statics). (https://github.com/rackt/react-redux/issues/53, https://github.com/rackt/react-redux/issues/127)
- We removed usage of `Object.defineProperty` for IE8 support in the CommonJS build. We won't pledge to support IE8 forever but this was a low-hanging fruit. Note that UMD build still may have problems with IE8 because it uses `screw_ie8` option—if you really care, use CommonJS build and choose Uglify options yourself. (https://github.com/rackt/react-redux/pull/135, https://github.com/rackt/react-redux/issues/133)
#### Version 3.0.1
- Fixes a regression introduced in 3.0.0 that caused component with `{ pure: false }` to not get updated (#118, #122)
#### Version 3.0.0
## Breaking Changes Since 3.0.0-alpha

This release is identical to [3.0.0-alpha](https://github.com/rackt/react-redux/releases/tag/v3.0.0-alpha).
If you’re already using it, you don’t need to change anything.
## Breaking Changes Since 2.x

Now the map functions (`mapStateToProps`, `mapDispatchToProps` and `mergeProps`) are not called until React starts to render the `connect()`ed components. Previously the map functions where called immediately when store changed which could cause weird edge case bugs when the `ownProps` parameter was a derivative of the state. The state from which it was derivative of was a different version than what was passed as the `state`parameter. In some cases the states can be incompatible with each other and cause very confusing bugs in user code.

Unfortunately the state stays consistent only when store dispatches are called in batches ie. from DOM handlers or manually from `ReactDOM.unstable_batchedUpdates(fn)`. Luckily [`redux-batched-updates`](https://github.com/acdlite/redux-batched-updates) middleware can be used to force batching for all dispatches.

If you're interested in the details, feel free to check out:
- [A new test that was failing in 2.x, but is fixed in 3.0 beta](https://github.com/epeli/react-redux/commit/661e643b60b4eab4ec41296fe41d50c389ded3c1)
- [The original issue](https://github.com/rackt/react-redux/issues/86)
- [The pull request attempting to fix it](https://github.com/rackt/react-redux/pull/99)
#### Version 3.0.0-alpha
## Breaking Change

Now the map functions (`mapStateToProps`, `mapDispatchToProps` and `mergeProps`) are not called until React starts to render the `connect()`ed components. Previously the map functions where called immediately when store changed which could cause weird edge case bugs when the `ownProps` parameter was a derivative of the state. The state from which it was derivative of was a different version than what was passed as the `state`parameter. In some cases the states can be incompatible with each other and cause very confusing bugs in user code.

Unfortunately the states stay consistent only when store dispatches are called in batches ie. from DOM handlers or manually from `ReactDOM.unstable_batchedUpdates(fn)`. Luckily [`redux-batched-updates`](https://github.com/acdlite/redux-batched-updates) middleware can be used to force batching for all dispatches.

If you're interested in the details, feel free to check out:
- [A new test that was failing in 2.x, but is fixed in 3.0 beta](https://github.com/epeli/react-redux/commit/661e643b60b4eab4ec41296fe41d50c389ded3c1)
- [The original issue](https://github.com/rackt/react-redux/issues/86)
- [The pull request attempting to fix it](https://github.com/rackt/react-redux/pull/99)
