### PR TITLE
[Depsy] Upgrade dependency redux-form to ^2.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-redux": "2.1.2",
     "react-router": "1.0.0-rc1",
     "redux": "3.0.0",
-    "redux-form": "^1.5.3",
+    "redux-form": "^2.2.8",
     "redux-logger": "1.0.6",
     "redux-react-router": "1.0.0-beta3",
     "redux-thunk": "0.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `redux-form`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded redux-form to ^2.2.8
#### Changelog:
#### Version 2.2.7

:ballot_box_with_check: Fixed error on server-side render with `initialValues` prop. #97. Thanks, @SpainTrain!
#### Version 2.2.6

:ballot_box_with_check: Added passed in props as a parameter to synchronous validation function to address #122.
#### Version 2.2.5

:ballot_box_with_check: Obscured lazily cached values to avoid collisions with props. #130.
#### Version 2.2.4

:ballot_box_with_check: Fixed bug with `handleChange()`, #108. Thanks, @Nicktho.
:ballot_box_with_check: Upgraded `react-lazy-cache` to `v3.0.0` to fix bug caused by production uglification.
:ballot_box_with_check: Allowed async errors to be returned via a rejected promise as suggested on #119.
#### Version 2.2.1

:ballot_box_with_check: Fixed sync validation bug introduced in v2.2.0. #127.
#### Version 2.2.0

:ballot_box_with_check: Reworked redux-form HOC to cache event handlers, hoping to address #123.
#### Version 2.1.0

:ballot_box_with_check: Enabled text dragging from one input to another, as requested in #114.
#### Version 2.0.1

:ballot_box_with_check: Fixed probably insignificant inconsistency with how the react-native bits were being imported. Fixes #115.
#### Version 2.0.0

:ballot_box_with_check: Removed default export. Should not be a huge issue since the docs have been discouraging the direct use of `reduxForm` since `v0.4.0`.
:ballot_box_with_check: Improved support for React Native. Fixed #99. React Native users **_must_** import from `redux-form/native` now, just like from the `react-redux` package.
## Migration Guide

| ` ` | `v1.x.x` | `v2.0.0` | ` ` |
| --- | --- | --- | --- |
| _React DOM_ | `import reduxForm from 'redux-form';` | `import {reduxForm} from 'redux-form';` | ` ` |
| _React Native_ | `import reduxForm from 'redux-form';` | `import {reduxForm} from 'redux-form/native';` | :warning: |
| _React Native_ | `import {connectReduxForm} from 'redux-form';` | `import {connectReduxForm} from 'redux-form/native';` | :warning: |

Note that using `reduxForm` rather than `connectReduxForm` is still discouraged unless you really know what you are doing.
