### PR TITLE
[Depsy] Upgrade dependency eslint to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-core": "5.8.25",
     "babel-eslint": "4.1.3",
     "babel-loader": "5.3.2",
-    "eslint": "1.6.0",
+    "eslint": "1.7.1",
     "eslint-config-airbnb": "0.1.0",
     "eslint-config-webkom": "*",
     "eslint-plugin-react": "3.5.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint to 1.7.1
#### Changelog:
#### Version 1.7.0
- Fix: array-bracket-spacing for empty array (fixes #4141) (alberto)
- Fix: `indent` arrow function check fix (fixes #4142) (Gyandeep Singh)
- Update: Support .js files for config (fixes #3102) (Gyandeep Singh)
- Fix: Make eslint-config-eslint work (fixes #4145) (Nicholas C. Zakas)
- Fix: `prefer-arrow-callback` had been wrong at arguments (fixes #4095) (Toru Nagashima)
- Docs: Update various rules docs (Nicholas C. Zakas)
- New: Create eslint-config-eslint (fixes #3525) (Nicholas C. Zakas)
- Update: RuleTester allows string errors in invalid cases (fixes #4117) (Kevin Partington)
- Docs: Reference no-unexpected-multiline in semi (fixes #4114) (alberto)
- Update: added exceptions to `lines-around-comment` rule. (fixes #2965) (Mathieu M-Gosselin)
- Update: Add `matchDescription` option to `valid-jsdoc` (fixes #2449) (Gyandeep Singh)
- Fix: check for objects or arrays in array-bracket-spacing (fixes #4083) (alberto)
- Docs: Alphabetize Rules lists (Kenneth Chung)
- Fix: message templates fail when no parameters are passed (fixes #4080) (Ilya Volodin)
- Fix: `indent` multi-line function call (fixes #4073, fixes #4075) (Gyandeep Singh)
- Docs: Improve comma-dangle documentation (Gilad Peleg)
- Fix: no-mixed-tabs-and-spaces fails with some comments (fixes #4086) (alberto)
- Fix: `semi` to check for do-while loops (fixes #4090) (Gyandeep Singh)
- Build: Fix path related failures on Windows in tests (fixes #4061) (Burak Yigit Kaya)
- Fix: `no-unused-vars` had been missing some parameters (fixes #4047) (Toru Nagashima)
- Fix: no-mixed-spaces-and-tabs with comments and templates (fixes #4077) (alberto)
- Update: Add `allow` option for `no-underscore-dangle` rule (fixes #2135) (Gyandeep Singh)
- Update: `allowArrowFunctions` option for `func-style` rule (fixes #1897) (Gyandeep Singh)
- Fix: Ignore template literals in no-mixed-tabs-and-spaces (fixes #4054) (Nicholas C. Zakas)
- Build: Enable CodeClimate (fixes #4068) (Nicholas C. Zakas)
- Fix: `no-cond-assign` had needed double parens in `for` (fixes #4023) (Toru Nagashima)
- Update: Ignore end of function in newline-after-var (fixes #3682) (alberto)
- Build: Performance perf to not ignore jshint file (refs #3765) (Gyandeep Singh)
- Fix: id-match bug incorrectly errors on `NewExpression` (fixes #4042) (Burak Yigit Kaya)
- Fix: `no-trailing-spaces` autofix to handle linebreaks (fixes #4050) (Gyandeep Singh)
- Fix: renamed no-magic-number to no-magic-numbers (fixes #4053) (Vincent Lemeunier)
- New: add "consistent" option to the "curly" rule (fixes #2390) (Benoît Zugmeyer)
- Update: Option to ignore for loops in init-declarations (fixes #3641) (alberto)
- Update: Add webextensions environment (fixes #4051) (Blake Winton)
- Fix: no-cond-assign should report assignment location (fixes #4040) (alberto)
- New: no-empty-pattern rule (fixes #3668) (alberto)
- Upgrade: Upgrade globals to 8.11.0 (fixes #3599) (Burak Yigit Kaya)
- Docs: Re-tag JSX code fences (fixes #4020) (Brandon Mills)
- New: no-magic-number rule (fixes #4027) (Vincent Lemeunier)
- Docs: Remove list of users from README (fixes #3881) (Brandon Mills)
- Fix: `no-redeclare` and `no-sahadow` for builtin globals (fixes #3971) (Toru Nagashima)
- Build: Add `.eslintignore` file for the project (fixes #3765) (Gyandeep Singh)
