### PR TITLE
[Depsy] Upgrade dependency css-loader to 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "animate.css": "3.4.0",
     "camelize": "1.0.0",
     "classnames": "2.2.0",
-    "css-loader": "0.19.0",
+    "css-loader": "0.21.0",
     "cssnext-loader": "1.0.1",
     "file-loader": "0.8.4",
     "history": "1.12.5",


### PR DESCRIPTION
Hi!

A new version was just released of `css-loader`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded css-loader to 0.21.0
