### PR TITLE
[Depsy] Upgrade dependency eslint to 1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-core": "5.8.25",
     "babel-eslint": "4.1.3",
     "babel-loader": "5.3.2",
-    "eslint": "1.7.1",
+    "eslint": "1.7.3",
     "eslint-config-airbnb": "0.1.0",
     "eslint-config-webkom": "*",
     "eslint-plugin-react": "3.5.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint to 1.7.3
#### Changelog:
#### Version 1.7.2
- Fix: comma-dangle confused by parens (fixes `#4195`) (Nicholas C. Zakas)
- Fix: no-mixed-spaces-and-tabs (fixes `#4189`, fixes `#4190`) (alberto)
- Fix: no-extend-native disallow using Object.properties (fixes `#4180`) (Nathan Woltman)
- Fix: no-magic-numbers should ignore Number.parseInt (fixes `#4167`) (Henry Zhu)
