### PR TITLE
[Depsy] Upgrade dependency redux to 3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-overlays": "0.5.0",
     "react-redux": "4.0.0",
     "react-router": "1.0.0-rc3",
-    "redux": "3.0.2",
+    "redux": "3.0.4",
     "redux-form": "~2.4.5",
     "redux-logger": "2.0.4",
     "redux-react-router": "1.0.0-beta3",


### PR DESCRIPTION
Hi!

A new version was just released of `redux`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded redux to 3.0.4
#### Changelog:
#### Version 3.0.4
- Unsubscribing a store listener is now a no-op when called twice instead of a bug (`#938`, `#939`, b7031ce3acb23b6ecadbd977b1cfa32486447904)
#### Version 3.0.3
- `combineReducers()` now returns the same object if none of the child states have changed. (`#853`, `#856`)
