### PR TITLE
[Depsy] Upgrade dependency history to 1.12.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "css-loader": "0.19.0",
     "cssnext-loader": "1.0.1",
     "file-loader": "0.8.4",
-    "history": "1.12.5",
+    "history": "1.12.6",
     "jwt-decode": "1.4.0",
     "lodash": "3.10.1",
     "moment": "2.10.6",


### PR DESCRIPTION
Hi!

A new version was just released of `history`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded history to 1.12.6
