### PR TITLE
[Depsy] Upgrade dependency babel to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "url-loader": "0.5.6"
   },
   "devDependencies": {
-    "babel": "5.8.29",
+    "babel": "6.0.0",
     "babel-core": "5.8.30",
     "babel-loader": "5.3.2",
     "babel-eslint": "^4.1.3",


### PR DESCRIPTION
Hi!

A new version was just released of `babel`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel to 6.0.0
