### PR TITLE
[Depsy] Upgrade dependency babel-core to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "babel": "5.8.29",
-    "babel-core": "5.8.30",
+    "babel-core": "6.0.2",
     "babel-loader": "5.3.2",
     "babel-eslint": "^4.1.3",
     "eslint": "^1.7.3",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-core`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-core to 6.0.2
