### PR TITLE
[Depsy] Upgrade dependency react-overlays to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-addons-css-transition-group": "0.14.0",
     "react-dom": "0.14.1",
     "react-hot-loader": "2.0.0-alpha-4",
-    "react-overlays": "0.5.0",
+    "react-overlays": "0.5.1",
     "react-redux": "4.0.0",
     "react-router": "1.0.0-rc3",
     "redux": "3.0.4",


### PR DESCRIPTION
Hi!

A new version was just released of `react-overlays`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-overlays to 0.5.1
