### PR TITLE
[Depsy] Upgrade dependency babel-core to 6.3.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-loader": "5.3.2",
     "babel-eslint": "^4.1.3",
     "eslint": "^1.7.3",
-    "babel-core": "6.3.15",
+    "babel-core": "6.3.17",
     "eslint-config-webkom": "^1.0.0",
     "eslint-plugin-react": "^3.5.1",
     "object-assign": "4.0.1",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-core`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-core to 6.1.2
