### PR TITLE
[Depsy] Upgrade dependency postcss-import to 7.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "nib": "1.1.0",
     "normalize.css": "3.0.3",
     "postcss-cssnext": "2.2.0",
-    "postcss-import": "7.1.2",
+    "postcss-import": "7.1.3",
     "postcss-loader": "0.7.0",
     "postcss-nested": "1.0.0",
     "react": "0.14.2",


### PR DESCRIPTION
Hi!

A new version was just released of `postcss-import`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded postcss-import to 7.1.3
#### Changelog:
#### Version 7.1.3
- Fixed: ensure node 0.12 compatibility, round 2
  (`#93` (`https://github.com/postcss/postcss-import/pull/93`))
