### PR TITLE
[Depsy] Upgrade dependency babel-loader to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "babel": "5.8.29",
     "babel-core": "5.8.30",
-    "babel-loader": "6.1.0",
+    "babel-loader": "6.2.0",
     "babel-eslint": "^4.1.3",
     "eslint": "^1.7.3",
     "eslint-config-airbnb": "^0.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-loader`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-loader to 6.1.0
