### PR TITLE
[Depsy] Upgrade dependency babel to 6.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "url-loader": "0.5.6"
   },
   "devDependencies": {
-    "babel": "6.1.18",
+    "babel": "6.3.13",
     "babel-core": "5.8.30",
     "babel-loader": "5.3.2",
     "babel-eslint": "^4.1.3",


### PR DESCRIPTION
Hi!

A new version was just released of `babel`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel to 5.8.34
