### PR TITLE
[Depsy] Upgrade dependency history to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "css-loader": "0.22.0",
     "expect": "1.12.2",
     "file-loader": "0.8.4",
-    "history": "1.15.0",
+    "history": "1.16.0",
     "jsdom": "7.0.2",
     "jwt-decode": "1.4.0",
     "lodash": "3.10.1",


### PR DESCRIPTION
Hi!

A new version was just released of `history`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded history to 1.13.1
