### PR TITLE
[Depsy] Upgrade dependency mocha to 2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jsdom": "7.0.2",
     "jwt-decode": "1.4.0",
     "lodash": "3.10.1",
-    "mocha": "2.3.3",
+    "mocha": "2.3.4",
     "moment": "2.10.6",
     "nib": "1.1.0",
     "normalize.css": "3.0.3",


### PR DESCRIPTION
Hi!

A new version was just released of `mocha`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded mocha to 2.3.4
