### PR TITLE
[Depsy] Upgrade dependency react-overlays to 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-addons-test-utils": "0.14.2",
     "react-dom": "0.14.2",
     "react-hot-loader": "2.0.0-alpha-4",
-    "react-overlays": "0.5.3",
+    "react-overlays": "0.5.4",
     "react-redux": "4.0.0",
     "react-router": "1.0.0-rc4",
     "redux": "3.0.4",


### PR DESCRIPTION
Hi!

A new version was just released of `react-overlays`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-overlays to 0.5.3
