### PR TITLE
[Depsy] Upgrade dependency url-loader to 0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "redux-thunk": "1.0.0",
     "style-loader": "0.13.0",
     "superagent": "1.4.0",
-    "url-loader": "0.5.6"
+    "url-loader": "0.5.7"
   },
   "devDependencies": {
     "babel": "5.8.29",


### PR DESCRIPTION
Hi!

A new version was just released of `url-loader`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded url-loader to 0.5.7
