### PR TITLE
[Depsy] Upgrade dependency classnames to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "animate.css": "3.4.0",
     "camelize": "1.0.0",
-    "classnames": "2.2.0",
+    "classnames": "2.2.1",
     "css-loader": "0.22.0",
     "expect": "1.12.2",
     "file-loader": "0.8.4",


### PR DESCRIPTION
Hi!

A new version was just released of `classnames`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded classnames to 2.2.1
