### PR TITLE
[Depsy] Upgrade dependency babel-eslint to ^4.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel": "5.8.29",
     "babel-core": "5.8.30",
     "babel-loader": "5.3.2",
-    "babel-eslint": "^4.1.3",
+    "babel-eslint": "^4.1.6",
     "eslint": "^1.7.3",
     "eslint-config-airbnb": "^0.1.0",
     "eslint-config-webkom": "^1.0.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-eslint`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-eslint to ^4.1.6
#### Changelog:
#### Version 5.0.0-beta1

Initial support for babel 6.
- use specific babel packages
- remove references to comprehensions
- update acorn-to-esprima (update AST to babylon format)
- update babylon options

There's probably a lot more issues so report any issues you have when updating.
