### PR TITLE
[Depsy] Upgrade dependency superagent to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "redux-react-router": "1.0.0-beta3",
     "redux-thunk": "1.0.0",
     "style-loader": "0.13.0",
-    "superagent": "1.6.0",
+    "superagent": "1.6.1",
     "url-loader": "0.5.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `superagent`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded superagent to 1.5.0
