### PR TITLE
[Depsy] Upgrade dependency expect to 1.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "camelize": "1.0.0",
     "classnames": "2.2.0",
     "css-loader": "0.22.0",
-    "expect": "1.13.3",
+    "expect": "1.13.4",
     "file-loader": "0.8.4",
     "history": "1.13.0",
     "jsdom": "7.0.2",


### PR DESCRIPTION
Hi!

A new version was just released of `expect`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded expect to 1.13.1
