### PR TITLE
[Depsy] Upgrade dependency redux to 3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-overlays": "0.5.1",
     "react-redux": "4.0.0",
     "react-router": "1.0.0-rc4",
-    "redux": "3.0.4",
+    "redux": "3.0.5",
     "redux-form": "~3.0.0-beta-2",
     "redux-logger": "2.0.4",
     "redux-react-router": "1.0.0-beta3",


### PR DESCRIPTION
Hi!

A new version was just released of `redux`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded redux to 3.0.5
#### Changelog:
#### Version 3.0.5
- Removes `.babelrc` in the compiled package because it is irrelevant (we ship ES5 code) and breaks React Native 0.16 and some consumers who use Babel 6 forgetting to exclude `node_modules` from transformations. (`https://github.com/rackt/redux/issues/1033,` `https://github.com/rackt/redux/issues/1039,` `https://github.com/rackt/redux/issues/1127`)
