### PR TITLE
[Depsy] Upgrade dependency react-redux to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": "0.14.2",
     "react-hot-loader": "2.0.0-alpha-4",
     "react-overlays": "0.5.1",
-    "react-redux": "3.1.2",
+    "react-redux": "4.0.1",
     "react-router": "1.0.0-rc4",
     "redux": "3.0.4",
     "redux-form": "~3.0.0-beta-2",


### PR DESCRIPTION
Hi!

A new version was just released of `react-redux`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-redux to 4.0.1
#### Changelog:
#### Version 4.0.1
- Removes `.babelrc` in the compiled package because it is irrelevant (we ship ES5 code) and breaks React Native 0.16 and some consumers who use Babel 6 forgetting to exclude `node_modules` from transformations. (`https://github.com/rackt/react-redux/pull/213,` `https://github.com/rackt/redux/issues/1033,` `https://github.com/rackt/redux/issues/1039,` `https://github.com/rackt/redux/issues/1127`)
