### PR TITLE
[Depsy] Upgrade dependency redux-thunk to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "redux-form": "~3.0.0-beta-2",
     "redux-logger": "2.0.4",
     "redux-react-router": "1.0.0-beta3",
-    "redux-thunk": "1.0.1",
+    "redux-thunk": "1.0.2",
     "style-loader": "0.13.0",
     "superagent": "1.4.0",
     "url-loader": "0.5.6"


### PR DESCRIPTION
Hi!

A new version was just released of `redux-thunk`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded redux-thunk to 1.0.1
#### Changelog:
#### Version 1.0.1
- Removes `.babelrc` from the NPM package because it confuses React Native 0.16 (`https://github.com/gaearon/redux-thunk/pull/40`)
