### PR TITLE
[Depsy] Upgrade dependency postcss-cssnext to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "moment": "2.10.6",
     "nib": "1.1.0",
     "normalize.css": "3.0.3",
-    "postcss-cssnext": "2.2.0",
+    "postcss-cssnext": "2.3.0",
     "postcss-import": "7.1.3",
     "postcss-loader": "0.7.0",
     "postcss-nested": "1.0.0",


### PR DESCRIPTION
Hi!

A new version was just released of `postcss-cssnext`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded postcss-cssnext to 2.3.0
#### Changelog:
#### Version 2.3.0
- Added: we use latest version of pixrem(@^3)
  (19 (`https://github.com/cssnext/postcss-cssnext/pull/19`))  
  So now `rem` have
  [2 new parameters](https://github.com/robwierzbowski/node-pixrem#options):
  - `rootValue` to define the root element font-size manually
  - `unitPrecision` for rounded values
