### PR TITLE
[Doppins] Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-config-airbnb": "^5.0.0",
     "eslint-config-webkom": "^1.1.1",
     "eslint-plugin-react": "^3.5.1",
-    "expect-jsx": "2.2.2",
+    "expect-jsx": "2.3.0",
     "object-assign": "4.0.1",
     "webpack": "1.12.13",
     "webpack-dev-server": "1.14.1"


### PR DESCRIPTION
Hi, and thank you for trying out [Doppins](https://doppins.com).

This initial pull request upgrades all your dependency ranges to the latest
available version. From now on any new dependency releases will result in a pull
request to your repository, submitted in real-time.

Make sure that it doesn't break anything, and happy merging! :shipit:

**The upgraded dependencies are:**

---
- **animate.css** from `3.4.0` to `3.5.1`
- **redux-logger** from `2.3.2` to `2.5.2`
- **expect** from `1.13.4` to `1.14.0`
- **lodash** from `4.0.0` to `4.3.0`
- **moment** from `2.11.1` to `2.11.2`
- **react** from `0.14.6` to `0.14.7`
- **jsdom** from `7.2.2` to `8.0.2`
- **react-dom** from `0.14.6` to `0.14.7`
- **history** from `1.17.0` to `2.0.0`
- **react-router** from `1.0.3` to `2.0.0`
- **react-addons-test-utils** from `0.14.6` to `0.14.7`
- **mocha** from `2.3.4` to `2.4.5`
- **react-redux** from `4.0.6` to `4.4.0`
- **react-treeview** from `0.4.2` to `0.4.3`
- **postcss-import** from `7.1.3` to `8.0.2`
- **redux** from `3.0.5` to `3.3.1`
- **superagent** from `1.7.0` to `1.7.2`
- **react-addons-css-transition-group** from `0.14.6` to `0.14.7`
- **babel-preset-stage-0** from `6.3.13` to `6.5.0`
- **babel-core** from `6.4.0` to `6.5.1`
- **babel-polyfill** from `6.3.14` to `6.5.0`
- **babel-loader** from `6.2.1` to `6.2.2`
- **babel-eslint** from `^5.0.0-beta6` to `^5.0.0-beta10`
- **babel-preset-es2015** from `6.3.13` to `6.5.0`
- **eslint-config-airbnb** from `^3.1.0` to `^5.0.0`
- **babel-preset-react** from `6.3.13` to `6.5.0`
- **webpack** from `1.12.11` to `1.12.13`
- **enzyme** from `1.3.1` to `2.0.0`
- **expect-jsx** from `2.2.2` to `2.3.0`
