### PR TITLE
[Doppins] Upgrade dependency postcss-loader to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "normalize.css": "3.0.3",
     "postcss-cssnext": "2.4.0",
     "postcss-import": "7.1.3",
-    "postcss-loader": "0.8.0",
+    "postcss-loader": "0.8.1",
     "postcss-nested": "1.0.0",
     "react": "0.14.6",
     "react-addons-css-transition-group": "0.14.6",


### PR DESCRIPTION
Hi!

A new version was just released of `postcss-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded postcss-loader from `0.8.0` to `0.8.1`
