### PR TITLE
[Doppins] Upgrade dependency eslint-config-airbnb to ^5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-preset-stage-0": "6.3.13",
     "enzyme": "1.5.0",
     "eslint": "^1.7.3",
-    "eslint-config-airbnb": "^3.1.0",
+    "eslint-config-airbnb": "^5.0.1",
     "eslint-config-webkom": "^1.1.1",
     "eslint-plugin-react": "^3.5.1",
     "expect-jsx": "2.2.2",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-config-airbnb`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-config-airbnb from `^3.1.0` to `^5.0.1`
