### PR TITLE
[Doppins] Upgrade dependency jsdom to 8.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "expect": "1.13.4",
     "file-loader": "0.8.5",
     "history": "1.17.0",
-    "jsdom": "8.0.3",
+    "jsdom": "8.0.4",
     "jwt-decode": "1.5.1",
     "lodash": "4.0.0",
     "mocha": "2.3.4",


### PR DESCRIPTION
Hi!

A new version was just released of `jsdom`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded jsdom from `7.2.2` to `8.0.3`
