### PR TITLE
[Doppins] Upgrade dependency babel-loader to 6.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "babel-core": "6.4.0",
     "babel-eslint": "^5.0.0-beta6",
-    "babel-loader": "6.2.1",
+    "babel-loader": "6.2.3",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-polyfill": "6.3.14",
     "babel-preset-es2015": "6.3.13",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-loader from `6.2.1` to `6.2.3`
