### PR TITLE
Added pagination support for new api version

### DIFF
--- a/app/reducers/entities.js
+++ b/app/reducers/entities.js
@@ -77,7 +77,8 @@ export function fetchSuccess(state, action) {
     ...state,
     isFetching: false,
     items: forceArray(action.payload.result),
-    error: null
+    error: null,
+    pagination: action.pagination
   };
 }
 

--- a/app/utils/http.js
+++ b/app/utils/http.js
@@ -101,7 +101,12 @@ export function callAPI({
       promise: fetchJSON(urlFor(endpoint), options)
         .then(({ json, response }) => ({
           response,
-          json: _normalize(json)
+          json: _normalize(json.results || json),
+          pagination: json.count ? {
+            count: json.count,
+            next: json.next,
+            previous: json.previous
+          } : null
         }))
     });
   };

--- a/app/utils/promiseMiddleware.js
+++ b/app/utils/promiseMiddleware.js
@@ -24,10 +24,11 @@ export default function promiseMiddleware() {
 
     return new Promise((resolve, reject) => {
       promise.then(
-        ({ json, response }) => resolve(next({
+        ({ json, response, pagination }) => resolve(next({
           type: SUCCESS,
           payload: json,
-          meta
+          meta,
+          pagination
         })),
         (error) => reject(next({
           type: FAILURE,


### PR DESCRIPTION
Added pagination support for new api version. Currently just storing pagination with the entity meta information. Should be displayed and used in future.
