### PR TITLE
Upgrade react-hot-loader

### DIFF
--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -101,6 +101,7 @@ export function refreshToken(token) {
   return callAPI({
     types: [User.LOGIN_BEGIN, User.LOGIN_SUCCESS, User.LOGIN_FAILURE],
     endpoint: '//authorization/token-auth/refresh/',
+    method: 'post',
     body: { token }
   });
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "express": "4.13.4",
     "json-loader": "0.5.4",
     "object-assign": "4.0.1",
-    "react-hot-loader": "3.0.0-beta.1",
+    "react-hot-loader": "3.0.0-beta.3",
     "redux-mock-store": "1.0.2",
     "sinon": "1.17.3",
     "sinon-chai": "2.8.0",


### PR DESCRIPTION
It swallowed some errors in the previous version, so you couldn't see
that you were trying to send a GET request with a body, which is not
allowed in the fetch API spec.

I think refreshToken() is broken, so if you have an old token in the localStorage the app won't work. By deleting it, the app should render again.
