### PR TITLE
Print proper listen address on console output

### DIFF
--- a/webpack/server.js
+++ b/webpack/server.js
@@ -22,7 +22,7 @@ function printMessage(message) {
   |_______||_______||_______||_______|
 
 
-  The app is running at ${chalk.blue(`http://localhost:${app.get('port')}`)}!
+  The app is running at ${chalk.blue(`http://${app.get('host')}:${app.get('port')}`)}!
   NODE_ENV=${chalk.green(process.env.NODE_ENV)}
 
   ${message}


### PR DESCRIPTION
Was always printing localhost, instead of current listen address.
