### PR TITLE
Info Bubble

### DIFF
--- a/app/components/InfoBubble/index.js
+++ b/app/components/InfoBubble/index.js
@@ -12,10 +12,7 @@ type Props = {
 function InfoBubble({ icon, data, meta, style }: Props) {
   return (
     <div className={styles.infoBubble} style={style}>
-      <div className={styles.bubble}>
-        <span className={styles.circle}><Icon name={'circle'} className={styles.abaRed}/></span>
-        <span className={styles.icon}>{icon ? (<i className={`fa fa-${icon}`}></i>) : '-'}</span>
-      </div>
+      <div className={styles.bubble}><Icon name={icon} className={styles.icon} /></div>
       <span className={styles.data}>{data || '-'}</span>
       <span className={styles.meta}>{meta || '-'}</span>
     </div>

--- a/app/components/InfoBubble/infoBubble.css
+++ b/app/components/InfoBubble/infoBubble.css
@@ -6,15 +6,15 @@
 }
 
 .bubble {
-  margin: -30px auto 10px auto;
+  margin: 0 auto 10px auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   order: 0;
   width: 70px;
-  position: relative;
-}
-
-.circle {
-  font-size: 80px;
-  position: absolute;
+  height: 70px;
+  background-color: #d13c32;
+  border-radius: 35px;
 }
 
 .data, .meta {
@@ -25,28 +25,16 @@
 .icon {
   font-size: 35px;
   color: white;
-  position: absolute;
-  width: 70px;
-  top: 52px;
-  display: flex;
-}
-
-.icon i {
   margin: 0 auto;
 }
 
 .data {
   order: 1;
   font-size: 25px;
-  margin-top: 100px;
 }
 
 .meta {
   order: 2;
   font-size: 18px;
   font-weight: 200;
-}
-
-.abaRed {
-  color: #d13c32;
 }


### PR DESCRIPTION
This pull request adds a graphical component that I've named _InfoBubble_. 
InfoBubble aims to be a pretty way to display small bits of information. They look a little bit like this:

<img width="700" alt="skjermbilde 2016-10-11 kl 20 25 09" src="https://cloud.githubusercontent.com/assets/14221386/19283065/dc56b0ae-8ff0-11e6-8d8a-eb5edb7f3a9c.png">

The background circle and the icons are both [fontawesome icons](http://fontawesome.io/icons/), which makes the component both light and easy to use. 
You use it by simply passing the text, description and icon you want. As such:

`
<InfoBubble
     icon={'phone'}
     data={props.phone}
     meta={'Telefon'}
     style={{ order: 0 }}
/>
`

Note that you don't need to pass the entire `fa fa-phone`, but just `phone` for ease of use. 
The `style` property is optional, and will apply any given style object to the div containing the InfoBubbles, which means the component style is fully customizable.
