### PR TITLE
InfoBubble improvement

### DIFF
--- a/app/components/InfoBubble/index.js
+++ b/app/components/InfoBubble/index.js
@@ -1,17 +1,20 @@
 import React from 'react';
 import styles from './InfoBubble.css';
 import Icon from 'app/components/Icon';
+import cx from 'classnames';
 
 type Props = {
   icon: string,
   data: string,
-  meta: string,
-  style?: Object
+  meta: string
 };
 
-function InfoBubble({ icon, data, meta, style }: Props) {
+function InfoBubble({ icon, data, meta, className, ...props }: Props) {
   return (
-    <div className={styles.infoBubble} style={style}>
+    <div
+      className={cx(styles.infoBubble, className)}
+      {...props}
+    >
       <div className={styles.bubble}><Icon name={icon} className={styles.icon} /></div>
       <span className={styles.data}>{data || '-'}</span>
       <span className={styles.meta}>{meta || '-'}</span>


### PR DESCRIPTION
The InfoBubble was not able to use classNames properly before. This PR adds a cx() to include any custom classNames properly, and also uses {...props} to catch any other props the user might want to send.