### PR TITLE
Remove all other moment locales

### DIFF
--- a/webpack/webpack.config.babel.js
+++ b/webpack/webpack.config.babel.js
@@ -41,6 +41,9 @@ module.exports = {
     !isProduction && new webpack.HotModuleReplacementPlugin(),
     !isProduction && new webpack.NoErrorsPlugin(),
 
+    // Only include the Norwegian moment locale:
+    new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /nb-NO/),
+
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false


### PR DESCRIPTION
Kind of hacky, but this removes all other moment locales than Norwegian. Found it here: https://github.com/moment/moment/issues/2517

Reduces the size of moment from 430kb to 120kb pre-uglify.