### PR TITLE
Fix default props on Editor

### DIFF
--- a/app/components/Editor/index.js
+++ b/app/components/Editor/index.js
@@ -30,13 +30,19 @@ export type Props = {
   content: string,
   autoFocus: boolean,
   placeholder?: string,
-  onChange: () => void,
-  onFocus: () => void,
-  onBlur: () => void
+  onChange?: func,
+  onFocus?: func,
+  onBlur?: func
 };
 
 class EditorComponent extends Component {
   props: Props;
+
+  static defaultProps = {
+    onChange: () => {},
+    onFocus: () => {},
+    onBlur: () => {}
+  }
 
   constructor(props) {
     super(props);


### PR DESCRIPTION
#266 breaks Editor as `onChange`, `onFocus` and `onBlur` defaults to `undefined`, instead of an "empty" function.