### PR TITLE
Radio button css fix

### DIFF
--- a/app/components/Form/RadioButton.css
+++ b/app/components/Form/RadioButton.css
@@ -43,7 +43,7 @@
   content: '\2022';
   position: absolute;
   top: -7px;
-  left: 3.8px;
+  left: 3px;
   font-size: 35px;
   line-height: 0.8;
   color: #c0392b;


### PR DESCRIPTION
Simple css fix that centralizes the `checked` graphic for our custom radio buttons.