### PR TITLE
Add actionGrant field to state

### DIFF
--- a/app/actions/callAPI.js
+++ b/app/actions/callAPI.js
@@ -50,9 +50,12 @@ export default function callAPI({
     }
 
     function normalizeJsonResponse(jsonResponse = {}) {
-      const { results } = jsonResponse;
+      const { results, actionGrant } = jsonResponse;
       const payload = Array.isArray(results) ? results : jsonResponse;
-      return schema ? normalize(payload, schema) : payload;
+      return schema ? {
+        ...normalize(payload, schema),
+        actionGrant
+      } : payload;
     }
 
     // @todo: better id gen (cuid or something)

--- a/app/utils/createEntityReducer.js
+++ b/app/utils/createEntityReducer.js
@@ -55,7 +55,8 @@ export function entities(key: string) {
     return {
       ...state,
       byId: merge(state.byId, result),
-      items: union(state.items, arrayOf(action.payload.result))
+      items: union(state.items, arrayOf(action.payload.result)),
+      actionGrant: action.payload.actionGrant
     };
   };
 }


### PR DESCRIPTION
Appends the actionGrant field from the API to the payload and redux state.

- actionGrants on list endpoints is set in the object with byId and Items for the respective entity.

- actionGrants on detailed are already set within the object itself.