### PR TITLE
Remove Quote Likes

### DIFF
--- a/app/routes/quotes/components/Quote.js
+++ b/app/routes/quotes/components/Quote.js
@@ -19,7 +19,7 @@ export default class Quote extends Component {
       <li className={styles.singleQuote}>
         <div className={styles.leftQuote}>
           <i
-            className='fa fa-quote-right'
+            className="fa fa-quote-right"
             style={{
               fontSize: '100px',
               color: '#dbdbdb',
@@ -34,21 +34,6 @@ export default class Quote extends Component {
 
         </div>
 
-        <div className={styles.rightQuote}>
-          <a
-            className={`${quote.hasLiked ? 'quote-unlikes' : 'quote-likes'}`}
-            onClick={() => (quote.hasLiked ? unlike(quote.id) : like(quote.id))}
-          >
-            <i
-              className={`fa fa-thumbs-up ${quote.hasLiked ? styles.quoteLiked :
-                styles.quoteDefault}`}
-              style={{ paddingTop: '5px', fontSize: '35px', order: '0' }}
-            />
-          </a>
-          <br />
-
-          <span className={styles.likeCount}> {quote.likes}</span>
-        </div>
         <div className={styles.quoteBottom}>
 
           <span className={styles.quoteSource}>
@@ -59,19 +44,23 @@ export default class Quote extends Component {
             {<Time time={quote.createdAt} wordsAgo />}
           </div>
 
-          {quote.permissions && quote.permissions.indexOf('can_approve') !== -1 && (
-          <div className={styles.quoteAdmin}>
-            <a
-              className='approveQuote'
-              onClick={() => (quote.approved ? unapprove(quote.id) :
-                approve(quote.id))}
-            > {(quote.approved ? 'Fjern Godkjenning' : 'Godkjenn')}</a>
-            <a
-              className={styles.deleteQuote}
-              onClick={() => deleteQuote(quote.id)}
-            >Slett</a>
-          </div>
-          )}
+          {quote.permissions &&
+            quote.permissions.indexOf('can_approve') !== -1 &&
+            <div className={styles.quoteAdmin}>
+              <a
+                className="approveQuote"
+                onClick={() =>
+                  quote.approved ? unapprove(quote.id) : approve(quote.id)}
+              >
+                {' '}{quote.approved ? 'Fjern Godkjenning' : 'Godkjenn'}
+              </a>
+              <a
+                className={styles.deleteQuote}
+                onClick={() => deleteQuote(quote.id)}
+              >
+                Slett
+              </a>
+            </div>}
         </div>
       </li>
     );

--- a/app/routes/quotes/components/Quotes.css
+++ b/app/routes/quotes/components/Quotes.css
@@ -105,7 +105,7 @@
 }
 
 .singleQuote .theQuote {
-  width: 93%;
+  padding-left: 5px;
 }
 
 .singleQuote .theQuote a {
@@ -119,7 +119,7 @@
 
 .singleQuote .leftQuote {
   display: flex;
-  width: calc(100% - 100px);
+  width: 100%;
   order: 1;
 }
 

--- a/app/routes/quotes/components/__tests__/SingleQuote.spec.js
+++ b/app/routes/quotes/components/__tests__/SingleQuote.spec.js
@@ -14,32 +14,14 @@ const emptyProps = () => ({
 
 describe('components', () => {
   describe('SingleQuote', () => {
-    it('should notice that like is clicked and recieve correct quoteId', () => {
-      const like = jest.fn();
-      const wrapper = shallow(
-        <Quote {...emptyProps()} like={like} quote={singleQuote()} />
-      );
-      const likeButton = wrapper.find('.quote-likes');
-
-      expect(likeButton.exists()).toBe(true);
-      likeButton.simulate('click');
-      // Will fail if the id of the first fixture quote is changed
-      expect(like).toBeCalledWith(quotes[0].id);
-    });
-
-    it('should notice that unlike is clicked and recieve correct quoteId', () => {
-      const unlike = jest.fn();
-      const wrapper = shallow(
-        <Quote {...emptyProps()} unlike={unlike} quote={singleQuote(true)} />
-      );
-      wrapper.find('.quote-unlikes').simulate('click');
-      expect(unlike).toBeCalledWith(quotes[0].id);
-    });
-
     it('should notice that approve is clicked and recieve correct quoteId', () => {
       const approve = jest.fn();
       const wrapper = shallow(
-        <Quote {...emptyProps()} approve={approve} quote={singleQuote(false, false)} />
+        <Quote
+          {...emptyProps()}
+          approve={approve}
+          quote={singleQuote(false, false)}
+        />
       );
       const approveButton = wrapper.find('.quoteAdmin').children().at(0);
       approveButton.simulate('click');
@@ -49,7 +31,11 @@ describe('components', () => {
     it('should notice that unapprove is clicked and recieve correct quoteId', () => {
       const unapprove = jest.fn();
       const wrapper = shallow(
-        <Quote {...emptyProps()} unapprove={unapprove} quote={singleQuote(false, true, 1)} />
+        <Quote
+          {...emptyProps()}
+          unapprove={unapprove}
+          quote={singleQuote(false, true, 1)}
+        />
       );
       const approveButton = wrapper.find('.quoteAdmin').children().at(0);
       approveButton.simulate('click');
@@ -59,7 +45,11 @@ describe('components', () => {
     it('should notice that delete is clicked and recieve correct quoteId', () => {
       const deleteQuote = jest.fn();
       const wrapper = shallow(
-        <Quote {...emptyProps()} deleteQuote={deleteQuote} quote={singleQuote()} />
+        <Quote
+          {...emptyProps()}
+          deleteQuote={deleteQuote}
+          quote={singleQuote()}
+        />
       );
       const deleteButton = wrapper.find('.quoteAdmin').children().at(1);
       deleteButton.simulate('click');


### PR DESCRIPTION
Since we removed the "Like" model back-end in favor of Reactions, then benched Reactions, I simply removed the entire reaction/like part of quotes for now:

**Old**
<img width="748" alt="skjermbilde 2017-03-11 kl 00 29 52" src="https://cloud.githubusercontent.com/assets/14221386/23817244/e8b8a1b4-05f1-11e7-8f79-500cf17e2e6c.png">


**New**
<img width="750" alt="skjermbilde 2017-03-11 kl 00 26 56" src="https://cloud.githubusercontent.com/assets/14221386/23817228/c3ff9ecc-05f1-11e7-8e99-61a8ff71074d.png">
