### PR TITLE
Update styleguidist

### DIFF
--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -3,3 +3,5 @@ If you want to completely hide something on mobile, add the `hiddenOnMobile` cla
 full version.
 
 Make sure to double check that your feature is responsive; this is 2017.
+
+__PROTIP__: If you have an Android device, Google Chrome DevTools allows you to debug and forward ports to your device easily. This is called  [remote-debugging](https://developers.google.com/web/tools/chrome-devtools/remote-debugging/), and gives you the exact same developer tools you have in Chrome, on you Android device. This works on all chromium based browsers, that means all webviews, all versions of chrome, and also oem versions like Samsung Internet Browser.

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "postcss-nested": "1.0.1",
     "prettier": "^1.5.2",
     "react-hot-loader": "3.0.0-beta.4",
-    "react-styleguidist": "^5.2.1",
+    "react-styleguidist": "^5.5.4",
     "react-test-renderer": "^15.6.0",
     "redux-mock-store": "^1.2.2",
     "start-server-webpack-plugin": "^2.1.2",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -27,18 +27,6 @@ module.exports = {
           content: 'docs/layout.md'
         },
         {
-          name: 'Styling',
-          sections: [
-            {
-              content: 'app/styles/README.md'
-            },
-            {
-              name: 'CSS Files',
-              content: '.css.tmp.md'
-            }
-          ]
-        },
-        {
           name: 'Headers',
           content: 'docs/headers.md'
         },
@@ -61,7 +49,19 @@ module.exports = {
         {
           name: 'List items',
           content: 'docs/list-items.md'
-        }
+        },
+        {
+          name: 'Styling',
+          sections: [
+            {
+              content: 'app/styles/README.md'
+            },
+            {
+              name: 'CSS Files',
+              content: '.css.tmp.md'
+            }
+          ]
+        },
       ]
     }
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,9 +1036,9 @@ babylon@^6.13.0, babylon@^6.17.0, babylon@^6.17.2:
   version "6.17.3"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.3.tgz#1327d709950b558f204e5352587fd0290f8d8e48"
 
-babylon@~5.8.3:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-5.8.38.tgz#ec9b120b11bf6ccd4173a18bf217e60b79859ffd"
+babylon@v7.0.0-beta.8:
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
 
 backoff@^2.4.1:
   version "2.5.0"
@@ -1439,6 +1439,10 @@ cli-truncate@^0.2.1:
 cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
+
+clipboard-copy@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-1.2.0.tgz#f6a3de65a8a252fa993fcb2a4e0cfe3aa4b8769e"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -3095,6 +3099,12 @@ globjoin@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
 
+glogg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/glogg/-/glogg-1.0.0.tgz#7fe0f199f57ac906cf512feead8f90ee4a284fc5"
+  dependencies:
+    sparkles "^1.0.0"
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -3575,9 +3585,9 @@ is-hexadecimal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.0.tgz#5c459771d2af9a2e3952781fd54fcb1bcfe4113c"
 
-is-in-browser@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.0.2.tgz#f688bea8f1e5aadc3244ebc870d188cfb9b613cf"
+is-in-browser@^1.0.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
 is-my-json-valid@^2.10.0:
   version "2.16.0"
@@ -4130,40 +4140,40 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jss-camel-case@^4.0.0:
+jss-camel-case@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-5.0.0.tgz#886c1fe56a8a11577454d6a8b4133caa6c1f53a0"
+
+jss-compose@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-4.0.0.tgz#39ef2a137aaa1e2f160ab826845305f8efabcfd5"
-
-jss-compose@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-3.0.1.tgz#0ac07f20baf1d523c211016d383dab08dcfe4186"
+  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-4.0.0.tgz#f0109e8e8301a2678279301c24523dbc76115b9b"
   dependencies:
     warning "^3.0.0"
 
-jss-default-unit@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-6.1.2.tgz#6c460154129b7be304a4a4dcd2b283584954aec5"
+jss-default-unit@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-7.0.0.tgz#176c1db91da870e3ad16301f6f4b4cfc6fe1e90a"
 
-jss-global@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-1.0.1.tgz#36731778f6d8649110611f7c178dbcd60fd92b24"
+jss-global@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-2.0.0.tgz#a162f822f17e5d760151d908bdb41d7f2824c28f"
 
-jss-isolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jss-isolate/-/jss-isolate-3.0.0.tgz#69f715a67a58db0ce0b99f55b330fe81d7a105d1"
+jss-isolate@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jss-isolate/-/jss-isolate-4.0.0.tgz#b33eb4f60f6e66fb8fd85f02dc25515c7b271302"
 
-jss-nested@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-4.0.1.tgz#f50cc206430c8a920ccd54e3b756f7fc72455130"
+jss-nested@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-5.0.0.tgz#c0752f31f2d465110d7de6ac83583dbed669faa0"
   dependencies:
     warning "^3.0.0"
 
-jss@^7.1.5:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-7.1.7.tgz#f2ace208247f1a68166dd20ccd69c866105fa404"
+jss@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-8.0.0.tgz#7b6e3153a5045d396245adc3fad5817d00c59457"
   dependencies:
-    is-in-browser "1.0.2"
-    warning "3.0.0"
+    is-in-browser "^1.0.2"
+    warning "^3.0.0"
 
 jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4:
   version "1.4.1"
@@ -6223,13 +6233,13 @@ react-docgen-displayname-handler@^1.0.0:
   dependencies:
     recast "0.11.12"
 
-react-docgen@^2.15.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.16.0.tgz#03c9eba935de8031d791ab62657b7b6606ec5da6"
+react-docgen@^3.0.0-beta5:
+  version "3.0.0-beta5"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-3.0.0-beta5.tgz#1ae8e506f3608ef00ef1521e29ba61298605b4b1"
   dependencies:
     async "^2.1.4"
     babel-runtime "^6.9.2"
-    babylon "~5.8.3"
+    babylon v7.0.0-beta.8
     commander "^2.9.0"
     doctrine "^2.0.0"
     node-dir "^0.1.10"
@@ -6389,15 +6399,16 @@ react-stripe-checkout@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-stripe-checkout/-/react-stripe-checkout-2.4.0.tgz#1b9cdcc79ef131199cc39e944b34e1e81a00cd10"
 
-react-styleguidist@^5.2.1:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/react-styleguidist/-/react-styleguidist-5.4.4.tgz#e00fa9dbeb7b37fe9effe6ad66a75dfda6903268"
+react-styleguidist@^5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/react-styleguidist/-/react-styleguidist-5.5.4.tgz#6baa622b309c27bc71fa2309caf8ca220c5305c5"
   dependencies:
     ast-types "^0.9.11"
     buble "^0.15.2"
     chalk "^1.1.3"
     classnames "^2.2.5"
     clean-webpack-plugin "^0.1.16"
+    clipboard-copy "^1.2.0"
     codemirror "^5.26.0"
     common-dir "^1.0.1"
     css-loader "^0.28.4"
@@ -6408,17 +6419,18 @@ react-styleguidist@^5.2.1:
     function.name-polyfill "^1.0.5"
     github-slugger "^1.1.3"
     glob "^7.1.2"
+    glogg "^1.0.0"
     highlight.js "^9.11.0"
     html-webpack-plugin "^2.28.0"
     is-directory "^0.3.1"
     json-loader "^0.5.4"
-    jss "^7.1.5"
-    jss-camel-case "^4.0.0"
-    jss-compose "^3.0.1"
-    jss-default-unit "^6.1.2"
-    jss-global "^1.0.1"
-    jss-isolate "^3.0.0"
-    jss-nested "^4.0.1"
+    jss "^8.0.0"
+    jss-camel-case "^5.0.0"
+    jss-compose "^4.0.0"
+    jss-default-unit "^7.0.0"
+    jss-global "^2.0.0"
+    jss-isolate "^4.0.0"
+    jss-nested "^5.0.0"
     leven "^2.1.0"
     listify "^1.0.0"
     loader-utils "^1.1.0"
@@ -6429,7 +6441,7 @@ react-styleguidist@^5.2.1:
     prop-types "^15.5.10"
     react-codemirror "^1.0.0"
     react-dev-utils "^0.5.2"
-    react-docgen "^2.15.0"
+    react-docgen "^3.0.0-beta5"
     react-docgen-displayname-handler "^1.0.0"
     react-group "^1.0.4"
     react-icons "^2.2.5"
@@ -7157,6 +7169,10 @@ sourcemapped-stacktrace@^1.1.6:
   dependencies:
     source-map "0.5.6"
 
+sparkles@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.0.tgz#1acbbfb592436d10bbe8f785b7cc6f82815012c3"
+
 spawn-command@^0.0.2-1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2.tgz#9544e1a43ca045f8531aac1a48cb29bdae62338e"
@@ -7882,7 +7898,7 @@ warning@2.x:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@3.0.0, warning@^3.0.0:
+warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   dependencies:


### PR DESCRIPTION
"Major" changes
- `NODE_ENV` is no longer overridden - `yarn run styleguide` server now works
- Added support for newest `react-docgen` - Support for all the new flow annotations 

Also added a small chapter about remote debugging in Chrome.