### PR TITLE
Update retry logic in fetchJSON

### DIFF
--- a/app/utils/fetchJSON.js
+++ b/app/utils/fetchJSON.js
@@ -98,7 +98,11 @@ export default function fetchJSON(path, requestOptions = { headers: [] }) {
           .then(rejectOnHttpErrors)
           .then(resolve)
       ]).catch(error => {
-        if (!retryDelays || requestsAttempted > retryDelays.length) {
+        if (
+          (error.response && error.response.status < 500) ||
+          !retryDelays ||
+          requestsAttempted > retryDelays.length
+        ) {
           return reject(error);
         }
 


### PR DESCRIPTION
When the client gets a status code < 500, it should not retry. There is no need to repeat a request that is invalid. We should create a list in the documentation with all the http-codes we use in the backend. The `fetchJSON` function should know about all of them, and what to "do" with them. 

This only applies to http status codes outside the interval `[200-299]` (ref. [this](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok))