### PR TITLE
Add variable check before checking status code

### DIFF
--- a/app/actions/callAPI.js
+++ b/app/actions/callAPI.js
@@ -17,7 +17,7 @@ function urlFor(resource) {
 
 function handleError(error) {
   return dispatch => {
-    if (error.response.status === 401) {
+    if (error.response && error.response.status === 401) {
       dispatch(logout());
     }
     throw error;


### PR DESCRIPTION
Check that the client got a response before trying to compare
the status code. Related to the logic introduced in #401.

This problem occurs when the request times out.