### PR TITLE
Make header and other essential components responsive

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -59,8 +59,9 @@
   height: 60px;
   line-height: 60px;
   flex: 2;
+  white-space: nowrap;
 
-  @media (--small-viewport) {
+  @media (--mobile-device) {
     display: none;
   }
 }

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -102,9 +102,6 @@ class Header extends Component {
             <Link to="/joblistings" activeClassName={styles.activeItem}>
               Karriere
             </Link>
-            <Link to="/bdb" activeClassName={styles.activeItem}>
-              BDB
-            </Link>
             <Link
               to="/readme"
               activeClassName={styles.activeItem}
@@ -112,8 +109,8 @@ class Header extends Component {
             >
               readme
             </Link>
-            <Link to="/quotes" activeClassName={styles.activeItem}>
-              Sitater
+            <Link to="/about" activeClassName={styles.activeItem}>
+              Om Abakus
             </Link>
           </div>
 

--- a/app/components/HeaderNotifications/HeaderNotifications.css
+++ b/app/components/HeaderNotifications/HeaderNotifications.css
@@ -1,9 +1,18 @@
+@import 'app/styles/variables.css';
+
 .notifications {
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 400px;
-  padding: 0;
+  @media (--small-viewport) {
+    width: 100%;
+
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
 }
 
 .seeAllWrapper {
@@ -18,7 +27,6 @@
 
 .notification {
   border-bottom: 1px solid lightgray;
-  width: 100%;
   padding: 15px;
   display: flex;
   flex-direction: row;

--- a/app/components/HeaderNotifications/index.js
+++ b/app/components/HeaderNotifications/index.js
@@ -82,7 +82,7 @@ export default class NotificationsDropdown extends Component {
 
   renderNotifications = notifications => {
     return (
-      <div className={styles.notifications}>
+      <div>
         {notifications.map((notification, i) =>
           <NotificationElement
             key={i}
@@ -113,8 +113,9 @@ export default class NotificationsDropdown extends Component {
         }
         contentClassName={styles.notifications}
       >
+      {/* TODO FIXME - do same as the menu element*/}
         {notifications.length
-          ? <div>
+          ? <div style={{ width: '100%'}}>
               <div style={{ maxHeight: '300px', overflowY: 'overlay' }}>
                 {this.renderNotifications(notifications)}
               </div>

--- a/app/components/Modal/Modal.css
+++ b/app/components/Modal/Modal.css
@@ -35,5 +35,5 @@
   position: absolute;
   top: 10px;
   right: 10px;
-  font-size: 20px;
+  font-size: 30px;
 }

--- a/app/components/Search/Search.css
+++ b/app/components/Search/Search.css
@@ -12,13 +12,8 @@
   display: flex;
   justify-content: space-between;
   height: 120px;
-  padding-top: 40px;
   border-bottom: 1px solid #ccc;
-
-  @media (--small-viewport) {
-    padding: 0 20px;
-    height: 96px;
-  }
+  padding: 0 20px;
 }
 
 .inputContainer input {
@@ -26,7 +21,7 @@
   outline: none;
   border: 0;
   padding: 0 1rem;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   font-weight: 400;
   color: #333;
   background: transparent;
@@ -51,20 +46,20 @@
 }
 
 .closeButton {
-  width: 60px;
+  width: 40px;
   outline: none;
   border: 0;
   background: transparent;
   color: #333;
   cursor: pointer;
-  font-size: 50px;
+  font-size: 40px;
 }
 
 .resultsContainer {
   display: flex;
   background: rgba(255, 255, 255, 0.8);
 
-  @media (--small-viewport) {
+  @media (--mobile-device) {
     flex-direction: column;
   }
 }

--- a/app/components/Search/index.js
+++ b/app/components/Search/index.js
@@ -104,11 +104,11 @@ class Search extends Component {
             <div className={styles.searchIcon}>
               <Icon name="search" />
             </div>
-
             <input
               onChange={e => this.onQueryChanged(e.target.value)}
               value={this.state.query}
               type="search"
+              size="1"
               placeholder="Hva leter du etter?"
               autoFocus
             />
@@ -118,7 +118,7 @@ class Search extends Component {
               className={styles.closeButton}
               onClick={onCloseSearch}
             >
-              <Icon name={searching ? 'spinner fa-spin' : 'close'} />
+              <Icon name={searching ? 'refresh' : 'close'} />
             </button>
           </div>
 

--- a/app/components/UserAttendance/AttendanceModal.css
+++ b/app/components/UserAttendance/AttendanceModal.css
@@ -1,6 +1,7 @@
 .list {
   width: 100%;
-  height: 400px;
+  min-height: 200px;
+  max-height: 400px;
   padding: 0 30px;
   margin-bottom: 5px;
   overflow-y: scroll;

--- a/app/routes/meetings/components/MeetingList.js
+++ b/app/routes/meetings/components/MeetingList.js
@@ -124,7 +124,7 @@ export default class MeetingList extends Component {
 
   render() {
     const { meetings, userMe } = this.props;
-    if (meetings === undefined) {
+    if (!meetings) {
       return <LoadingIndicator loading />;
     }
     const pools = this.sortMeetings(meetings);

--- a/app/routes/overview/components/CompactEvents.css
+++ b/app/routes/overview/components/CompactEvents.css
@@ -1,7 +1,7 @@
 .compactEvents {
   display: flex;
   justify-content: space-between;
-  padding: 10px 10px 0;
+  white-space: nowrap;
   width: 100%;
   text-align: left;
 }
@@ -21,21 +21,13 @@
 
 .compactLeft,
 .compactRight {
-  width: 50%;
-  padding: 10px;
+  flex: 1;
+  padding: 5px 20px;
 }
 
 .compactEvents li {
   display: flex;
   justify-content: space-between;
-}
-
-.compactLeft .innerList {
-  padding-right: 30px;
-}
-
-.compactRight {
-  padding-left: 20px;
 }
 
 .showMoreLink {

--- a/app/routes/overview/components/CompactEvents.js
+++ b/app/routes/overview/components/CompactEvents.js
@@ -69,14 +69,11 @@ export default class CompactEvents extends Component {
       return null;
     }
     return (
-      <Flex column>
-        <Flex className={styles.compactEvents}>
+      <Flex wrap column>
+        <Flex wrap className={styles.compactEvents}>
           <Flex column className={styles.compactLeft}>
             <h3 className="u-ui-heading">Bedriftspresentasjoner</h3>
-            <ul
-              className={styles.innerList}
-              style={{ borderRight: '1px solid #aaa' }}
-            >
+            <ul className={styles.innerList}>
               {leftEvents}
             </ul>
           </Flex>

--- a/app/routes/overview/components/Feed.css
+++ b/app/routes/overview/components/Feed.css
@@ -1,6 +1,8 @@
 .root {
   padding: 10px;
-  flex: 0.95;
+  flex: 1;
+  min-width: 20em;
+  whitespace: no-wrap;
 }
 
 .content {

--- a/app/routes/overview/components/LatestReadme.js
+++ b/app/routes/overview/components/LatestReadme.js
@@ -40,7 +40,7 @@ class LatestReadme extends Component {
                 className={styles.thumb}
               >
                 <Image
-                  src={`http://readme.abakus.no/bilder/16/2016-0${issue}.jpg`}
+                  src={`http://readme.abakus.no/bilder/2016/2016-0${issue}.jpg`}
                 />
               </a>
             )}

--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -1,3 +1,5 @@
+@import 'app/styles/variables.css';
+
 .item {
   text-align: justify;
   flex: 1 0 100%;
@@ -9,6 +11,10 @@
 .inner {
   composes: withShadow from 'app/styles/utilities.css';
   flex: 1;
+
+  @media (--mobile-device) {
+    flex-wrap: wrap;
+  }
 }
 
 .innerRight {
@@ -35,7 +41,7 @@
 
 .pinnedHeading {
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
   justify-content: space-between;
   background: rgba(242, 241, 237, 0.2);
   padding: 20px;
@@ -52,6 +58,17 @@
 .image {
   border-radius: 3px 3px 0 0;
   object-fit: cover;
+}
+
+.imageContainer {
+  display: 'block';
+  width: 350px;
+  height: 192px;
+
+  @media (--mobile-device) {
+    width: auto;
+    max-height: 192px;
+  }
 }
 
 .itemTitle {

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -13,7 +13,7 @@ import { EVENT_TYPE_TO_STRING, colorForEvent } from 'app/routes/events/utils';
 import Button from 'app/components/Button';
 
 const TITLE_MAX_LENGTH = 50;
-const DESCRIPTION_MAX_LENGTH = 150;
+const DESCRIPTION_MAX_LENGTH = 140;
 const IMAGE_HEIGHT = 192;
 const IMAGE_WIDTH = 350;
 
@@ -64,14 +64,7 @@ const OverviewItem = ({ event, showImage }) =>
     <Flex className={styles.inner}>
       <Flex column>
         {showImage &&
-          <Link
-            to={`/events/${event.id}`}
-            style={{
-              width: IMAGE_WIDTH,
-              height: IMAGE_HEIGHT,
-              display: 'block'
-            }}
-          >
+          <Link to={`/events/${event.id}`} className={styles.imageContainer}>
             <Image className={styles.image} src={event.cover} />
           </Link>}
       </Flex>
@@ -134,12 +127,12 @@ export default class Overview extends Component {
     return (
       <Content>
         <Helmet title="Hjem" />
-        <Flex style={{ justifyContent: 'space-between' }}>
-          <Flex column style={{ width: '65%' }}>
+        <Flex wrap style={{ justifyContent: 'space-between' }}>
+          <Flex column style={{ flex: 2 }}>
             <CompactEvents events={events} />
             <PrimaryItem event={events[0]} />
           </Flex>
-          <Feed />
+          <Feed style={{ flex: 2 }} />
         </Flex>
         <Flex />
         <Flex padding={10}>

--- a/app/routes/quotes/components/Quotes.css
+++ b/app/routes/quotes/components/Quotes.css
@@ -1,3 +1,5 @@
+@import 'app/styles/variables.css';
+
 .root {
   composes: contentContainer from 'app/styles/utilities.css';
 }
@@ -229,7 +231,7 @@
   border-bottom: none;
 }
 
-@media (max-width: 480px) {
+@media (--small-viewport) {
   .quoteContainer {
     margin: 0 15px;
     width: 100%;

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -1,4 +1,5 @@
-@custom-media --small-viewport (max-width: 30em);
+@custom-media --small-viewport (max-width: 35em);
+@custom-media --mobile-device (max-width: 992px);
 
 :root {
   --lego-background-color: linear-gradient(0deg, #f4f4f4, #eae9e8);


### PR DESCRIPTION
Do not merge. This is work in progress... Will rebase/fix commits later.

**TL;DR:** `--small-viewport` is now for singe column devices (phones in portrait), and `--mobile-device` is for phones & tablets.


- [X] Make top bar / header responsive
- [X] Make front page (the non public one) responsive
- [X] Make search work properly on mobile devices
- [x] Update docs (Will be done in another PR)

We need some more media queries than just `--small-viewport`, it only works for small phones. We should also start using them more often, ie. to change `flex-flow` to column instead of row when necessary. I have added the `--mobile-device` media query, that represents all mobile devices (phones & tablets).

It would also be nice if everyone could make new things (everything that isn't admin/abakom stuff) responsive, instead of having to do it later. :+1: 

This PR is mostly to fix broken things, making it possible to test responsive things on phones/tablets.

![localhost-3000- nexus 5x](https://user-images.githubusercontent.com/1467188/29631696-c5bf79a4-8840-11e7-98fd-62bcf858fd5a.png)
![localhost-3000- ipad](https://user-images.githubusercontent.com/1467188/29631703-c835b81a-8840-11e7-83fd-e8734e82816e.png)
![localhost-3000- nexus 5x 1](https://user-images.githubusercontent.com/1467188/29631676-b2dea0c6-8840-11e7-8963-8e7c2af2ad71.png)
![localhost-3000-meetings- ipad](https://user-images.githubusercontent.com/1467188/29632451-55d2c6e8-8843-11e7-8af7-84f7a417aa17.png)

