### PR TITLE
Only show searching icon on active fields

### DIFF
--- a/app/components/Form/Field.js
+++ b/app/components/Form/Field.js
@@ -39,6 +39,7 @@ export function createField(Component: any) {
         <Component
           {...input}
           {...props}
+          meta={meta}
           className={cx(props.className, hasError && styles.inputWithError)}
         />
         {hasError && renderErrorMessage(meta.error)}

--- a/app/components/Form/SelectInput.js
+++ b/app/components/Form/SelectInput.js
@@ -8,6 +8,7 @@ import 'react-select/dist/react-select.css';
 type Props = {
   placeholder?: string,
   multiple?: boolean,
+  meta?: any,
   tags?: boolean,
   fetching: boolean,
   className?: string,
@@ -19,6 +20,7 @@ type Props = {
 
 function SelectInput({
   fetching,
+  meta,
   selectStyle,
   onBlur,
   value,
@@ -45,7 +47,7 @@ function SelectInput({
       value={value}
       onBlurResetsInput={false}
       onBlur={() => onBlur(value)}
-      isLoading={fetching}
+      isLoading={meta && meta.active && fetching}
       onInputChange={value => {
         if (props.onSearch) {
           props.onSearch(value);

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -171,6 +171,7 @@ function EventEditor({
                   fieldClassName={cx(styles.metaField, styles.fieldShadow)}
                   simpleValue
                   component={SelectInput.Field}
+                  fetching={searching}
                   options={Object.keys(eventTypes).map(type => ({
                     label: eventTypes[type],
                     value: type
@@ -246,6 +247,7 @@ function EventEditor({
                   <FieldArray
                     name="pools"
                     component={renderPools}
+                    searching={searching}
                     autocompleteResult={autocompleteResult}
                     groupQueryChanged={groupQueryChanged}
                   />


### PR DESCRIPTION
This solves one of the problems with the `SelectInput` autocomplete componet, where all autocomplete fields shows the searching icon when search is active.