### PR TITLE
[Doppins] Upgrade dependency react-router to ^4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-portal": "^3.0.0",
     "react-prepare": "^0.3.6",
     "react-redux": "^5.0.1",
-    "react-router": "^3.0.5",
+    "react-router": "^4.2.0",
     "react-router-redux": "^4.0.8",
     "react-select": "^1.0.0-rc.3",
     "react-stripe-checkout": "^2.4.0",


### PR DESCRIPTION
Hi!

A new version was just released of `react-router`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-router from `^3.0.5` to `^4.2.0`

#### Changelog:

#### Version 4.1.1
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.1.0...v4.1.1`)
> Apr 12, 2017

- Fixes for the various PropTypes related issues. 

Note: This work is still ongoing, as the React team still has some outstanding issues to figure out themselves. Keep an eye on this issue (`https://github.com/facebook/react/issues/9398`) and [the `prop-types` repo](https://github.com/reactjs/prop-types) for updates as we all work through this craziness. 

#### Version 4.1.0
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0...v4.1.0`)
> Apr 11, 2017

- Add `wrappedComponent` to the component returned by `withRouter`
- Add `wrappedComponentRef` prop to the component returned by `withRouter`
- Add non-react static methods and properties of the wrapped component to the component returned by `withRouter`

#### Version 4.0.0
## Changes (`https://github.com/ReactTraining/react-router/compare/dc2149ec0c63bfc95b71e40c81431e34cfbfeda9...v4.0.0?w=1`)
> Mar 10, 2017

- Released! No code changes from 4.0.0-beta.8

#### Version 4.0.0
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-beta.7...v4.0.0-beta.8`)
> Mar 8, 2017

- Updated website
- Revert to using `context.router` for everything since Relay uses `context.route`
- Add `staticContext` route prop when rendering `<Route>`s inside a `<StaticRouter>`
- Pass through the parent `match` object to `<Route>`s w/out a `path`. This also
  includes components wrapped using `withRouter`
- Fix unicode `<Route>` paths
- Set `NavLink`'s default `activeClassName` prop to `active`

#### Version 4.0.0
This is a pretty big change from the alpha versions, so the diff isn't super helpful.

This release breaks things into a monorepo (`https://github.com/babel/babel/blob/master/doc/design/monorepo.md`) format, with several sub-packages for different ways of using the router. Think react-dom vs. react-native. 


#### Version 4.0.0
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-beta.1...v4.0.0-beta.2`)
- No end-user changes

#### Version 4.0.0
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-beta.2...v4.0.0-beta.3`)
- Fix missing StaticRouter (`#4389` by `@supasate`)

#### Version 4.0.0
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-beta.3...v4.0.0-beta.4`)
- Fix NavLink location variable (`#4403` by `@inuscript`)
- NavLink tests (`#4421` by `@pshrmn`)
- Preact support (`#4423` by `@kwelch`)
- Allow initialIndex, initialIndex in NativeRouter (`#4415` by `@IljaDaderko`)
- Add `<NavLink strict>` and `<NavLink exact>`
- invariant dependency was missing

#### Version 4.0.0
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-beta.4...v4.0.0-beta.5`)
- Remove basename from `<StaticRouter>` locations
- Add ES build to react-router and react-router-dom (`#4432` by `@billyjanitsch`)
- NavLink exact & strict tests (`#4454` by `@pshrmn`)
- Use boolean strings for cache keys (`#4448` by `@pshrmn`)
- Fix scripts on windows (`#4447` by `@pshrmn`)
- Use peer deps for react-native
- Warn when `<Router>` is given >1 children (`#4450` by `@jackfranklin`)
- Only nullify empty children array (`#4475` by `@pshrmn`)

#### Version 4.0.0
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-beta.6...v4.0.0-beta.7`)
- Added support for `<Redirect>` as a child of a `<Switch>`
- Fixed a bug where `<Switch>` would always remount children
- Removed subscriptions to avoid unneccessary rerendering in every `<Route>`
- Added `<Switch location>` and `<Route location>` props so that "pure" route
  components can know when the location changes
- Removed location persistence across app restarts in `<NativeRouter>`
- Made docs easier to find in individual `packages` directories
- Split `context.router` into two parts: `context.history` and `context.route`
- Changed `matchPath` signature to `matchPath(pathname, options)`


#### Version 4.0.0
## Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-beta.5...v4.0.0-beta.6`)
- Fixed a bug with `<StaticRouter>`'s `createHref` (`#4484` thanks `@pshrmn`)
- Added support for objects in `<Link to>` in `react-router-native` (`#4483` by `@CodogoFreddie`)
- Include `react-router` in `react-router-dom`'s UMD bundle


#### Version 4.0.0
This release fixes problems with the last release for users of npm 2.x and yarn. If you're having trouble with alpha 5, this version should give you less trouble.

Skipping the changelog on this one, as `@ryanflorence` has a heavily refactored version coming in the next day or two. Please wait for that release before upgrading if you're not blocked by the previous release's packaging issues. 


#### Version 4.0.0
### Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-alpha.4...v4.0.0-alpha.5`)
- URL decode all parameters (`@tyrsius` in `#3991`)
- Fix ambiguous Miss component not rendering (`@TimothyKrell` in `#3980`)
- Don't include a trailing slash if the basename is not empty (`@jochenberger` in `#4000`! 😮 )
- Match exactly takes parent into account (`@alisd23` in `#4001`)
- Fix non-exact match of pattern with trailing slash (`@aaugustin` in `#3923`)
- Add <Link replace> and <Redirect push> (`@aaugustin` in `#3912`)
- Limit size of matcher cache (`@alisd23` in `#4004`)
- Re-enable proptypes warnings (`@mjackson` in 5f4b649)
- Fix build scripts on windows (`@alisd23` in `#4088`)
- Fix hashType prop on HashRouter (`@herrkris` in `#4024`)
- Remove react-history dep (`@ryanflorence` in d041434)
- Links apathetic to active state don't subscribe (`@pshrmn` in `#3986`)
- blockTransitions returns teardown function (`@maxdeviant` in `#4058`)


#### Version 4.0.0
### Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-alpha.3...v4.0.0-alpha.4`)
- PropTypes are now exported (`@alisd23` in `#3910`)
- Subscribe to location changes along context. Fixes usage with React Redux (`@ryanflorence` in bb7d8ee and ce59676)
- Strip propTypes in production (`@mjackson` in eb8a4ef)
- Remove the entire website application from the npm package (`@timdorr` in a5e05f7)
- StaticRouter now tracks location in state (`@mjackson` in 5550cc3)
- Rename PropTypes.router to PropTypes.routerContext (`@mjackson` in c8510da)
- Remove direct history dependency (`@mjackson` in a603eaa)


#### Version 4.0.0
### Quick Version Note

I've swapped out the version string to better represent the prerelease nature of the `v4` branch currently. It may not have been obvious before, but according to [semver](http://semver.org/), any version string with a `-anything` on the end is considered a prerelease version. I've seen some references to the versions before as 4.0.1 and 4.0.2. This isn't correct, as we haven't yet pushed a 4.0.0 final version. **This is not production-ready code. We're not done building 4.0!** 

And, most importantly, we need your help to figure out things that are missing, either stuff that should go into the core of React Router or external libraries and code patterns that need to be established. React Router is now a building block as much as React itself is, and this more lean, mean, super-minimal core means that you can build a lot of interesting stuff on top of it. Now's a great time to get into open source and contribute some code. Keep those issues and PRs coming!

~~**Also, for the love of god, _yes_, we know the docs site isn't scrollable.** We'll push a new version soon!~~

Use this link for the docs site from now on: https://react-router.now.sh/ We'll keep it updated.

### Changes (`https://github.com/ReactTraining/react-router/compare/v4.0.0-2...v4.0.0-alpha.3`)


#### Version 4.0.0
- Use the global `React` in the UMD build.


#### Version 4.0.0
- Add missing `path-to-regexp` dependency
- Remove an extraneous `<div>` sometimes added by `<StaticRouter>`


#### Version 4.0.0
## ⚠️  🚀  NEW VERSION ALERT ⚠️

Available on npm: `npm install react-router@next`

This is a ground-up rewrite of React Router that `@ryanflorence` and `@mjackson` have been working on for the last few months (with a tiny bit of help from yours truly). The central thesis for this version is "declarative everything". Almost all imperative code is completely gone in 4.0. 

The API is not only completely different, so is the way of thinking about routing in general. Async behaviors are gone, replaced by always rendering something (even if that's just a "Loading..." screen). There are no top-level route configuration, as you can "route" from anywhere in your component tree (but that doesn't keep you from creating your own route config).

We are working on an migration strategy that will allow you to run both version in tandem and update your routes incrementally.

Many of these familiar concepts are removed because they are best implemented from outside the router. v4 is much smaller in scope and code size, which is intentional. These, now external, features will eventually be implement as addon libraries, either provided officially or from the community. 

As expected, there will be growing pains. And bugs. And Twitter flame wars 💦🔥. But this is a declarative, composable approach to routing that fits the declarative, composable model of React. Please let us know where it is not 100% awesome with issues and pull requests.

### Quick Update:

Yes, there will still be a 3.0 release (soon!). It is simply v2.0 without any deprecation warnings. We intend to keep supporting the 3.x branch indefinitely (published separately on npm to aid in migration), although there will likely not be any future major versions based on that code. 4.0 is the future, but we won't leave you hanging if you want to stick with 2.x/3.x.

#### [Examples and Docs Site](https://react-router-website-uxmsaeusnn.now.sh)


