### PR TITLE
[Doppins] Upgrade dependency postcss-cssnext to ^3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "^20.0.4",
     "lint-staged": "^3.3.1",
-    "postcss-cssnext": "^2.9.0",
+    "postcss-cssnext": "^3.0.2",
     "postcss-import": "^9.0.0",
     "postcss-loader": "^1.2.1",
     "postcss-nested": "1.0.1",


### PR DESCRIPTION
Hi!

A new version was just released of `postcss-cssnext`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded postcss-cssnext from `^2.9.0` to `^3.0.2`

#### Changelog:

#### Version 3.0.2
- Fixed: remove incorrect "postinstall" npm script
  (`#404` (`https://github.com/MoOx/postcss-cssnext/issues/404`) - `@MoOx`)


#### Version 3.0.1

- Fixed: specify the actual require peer dependency for caniuse database (caniuse-lite is used since latest caniuse-api latest major bump)
  (`@MoOx`)
- Fixed: bump dependencies not updated to PostCSS@6
  (`#401` (`https://github.com/MoOx/postcss-cssnext/issues/401`) - `@MoOx`)


#### Version 3.0.0

## Removed: support for node 0.12

Node 4+ is supported.

## Changed: upgrade to PostCSS 6

All postcss plugins dependencies have been updated to latest version to ensure
full PostCSS 6 compatibility.

Some breaking (minor) changes:

- image-set polyfill change 2x from 144dpi to 192dpi
- whitespace changes for image-set polyfill output
- rebeccapurpule is now an hexa number
- custom-selector does not output useless (empty) blocks with a selector with no rules associated

You can expect some other since all postcss plugins used have been updated to
latest versions.
If you have unexpected regression, please check corresponding plugins changelog before opening an issue.

## Added: warning is emitted is you use custom property sets and ``@apply``

This feature won't be included in next the major release of postcss-cssnext.

This most likely won't get any more support from browser vendors as the
spec is yet considered deprecated and alternative solutions are being
discussed.
Read more about the reason here https://github.com/pascalduez/postcss-apply


