### PR TITLE
[Doppins] Upgrade dependency postcss-nested to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "postcss-cssnext": "^2.9.0",
     "postcss-import": "^9.0.0",
     "postcss-loader": "^1.2.1",
-    "postcss-nested": "1.0.1",
+    "postcss-nested": "2.1.2",
     "prettier": "^1.5.3",
     "react-hot-loader": "3.0.0-beta.4",
     "react-styleguidist": "^5.5.4",


### PR DESCRIPTION
Hi!

A new version was just released of `postcss-nested`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded postcss-nested from `1.0.1` to `2.1.2`

