### PR TITLE
[Doppins] Upgrade dependency react-hot-loader to 3.0.0-beta.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "postcss-loader": "^1.2.1",
     "postcss-nested": "1.0.1",
     "prettier": "^1.5.3",
-    "react-hot-loader": "3.0.0-beta.4",
+    "react-hot-loader": "3.0.0-beta.7",
     "react-styleguidist": "^5.5.4",
     "react-test-renderer": "^15.6.0",
     "redux-mock-store": "^1.2.2",


### PR DESCRIPTION
Hi!

A new version was just released of `react-hot-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-hot-loader from `3.0.0-beta.4` to `3.0.0-beta.7`

#### Changelog:

#### Version 3.0.0-beta.7
- Update `redbox-react` dependency to fix prop-types deprecation errors (`https://github.com/gaearon/react-hot-loader/commit/87c9123ceb302fdee0522b5dd7c5a41d5e1dd9b8`)

#### Version 3.0.0-beta.6
- Use production versions of `patch` and `AppContainer` if no `module.hot` available, so it doesn't break people using `NODE_ENV=test` (`#398`)
- Opt out of transforming static class properties (`#381`)


#### Version 3.0.0-beta.5
- Makes the class properties portion of the Babel plugin work with async functions. (`#372`)
- Change the output of the tagger code in the Babel plugin so that it doesn't break the output of `babel-node`. (`#374`)


