### PR TITLE
[Doppins] Upgrade dependency reselect to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "redux-form": "^6.5.0",
     "redux-logger": "^3.0.1",
     "redux-thunk": "^2.2.0",
-    "reselect": "2.5.4",
+    "reselect": "3.0.1",
     "slate": "^0.21.3",
     "slate-auto-replace": "^0.5.0",
     "websocket.js": "^0.1.7"


### PR DESCRIPTION
Hi!

A new version was just released of `reselect`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded reselect from `2.5.4` to `3.0.1`

#### Changelog:

#### Version 3.0.1
Fix selector type for using the right extension, see `https://github.com/reactjs/reselect/pull/240`

#### Version 3.0.0
## New Features

Performance improvements (thanks to `@johnhaley81`)
Updated Typescript typings (thanks to everyone who helped)

## Breaking Changes

For performance reasons, a selector is now not recalculated if its input is equal by reference (`===`).

### Example:

```js
import { createSelector } from 'reselect';

const mySelector = createSelector(
  state => state.values.filter(val => val < 5),
  values => {
    console.log('calling..')
    return values.reduce((acc, val) => acc + val, 0)
  }
)

var createSelector = require('./dist/reselect.js').createSelector;

const mySelector = createSelector(
  state => state.values.filter(val => val < 5),
  values => {
    console.log('calling..')
    return values.reduce((acc, val) => acc + val, 0)
  }
)

var state1 = {values: [1,2,3,4,5,6,7,8,9]};
console.log(mySelector(state1));
state1.values = [3,4,5,6,7,8,9];
console.log(mySelector(state1));
var state2 = {values: [1,2,3,4,5,6,7,8,9]};
console.log(mySelector(state2));
var state3 = {values: [3,4,5,6,7]};
console.log(mySelector(state3));
```

### Output in v2.5.4:

```
calling..
10
calling..
7
calling..
10
calling..
7
```

### Output in v3.0.0:

```
calling..
10
10
calling..
10
calling..
7
```

#### Version 3.0.0
# Please try this release candidate out!

npm install -S reselect@rc

If there are no problems reported, I'll release 3.0.0 proper next week.

## New Features

Performance improvements (thanks to `@johnhaley81`)
Updated Typescript typings (thanks to everyone who helped)

