### PR TITLE
[Doppins] Upgrade dependency react-dropzone to ^4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-cookie": "^1.0.4",
     "react-cropper": "^0.12.0",
     "react-dom": "^15.6.1",
-    "react-dropzone": "^3.10.0",
+    "react-dropzone": "^4.1.0",
     "react-google-recaptcha": "^0.9.6",
     "react-helmet": "^5.1.3",
     "react-notification": "^6.6.0",


### PR DESCRIPTION
Hi!

A new version was just released of `react-dropzone`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-dropzone from `^3.10.0` to `^4.1.0`

#### Changelog:

#### Version 4.1.0
### 4.1.0 (2017-08-20)

#### Features

* Add `disable` prop. [`#473`]


#### Version 4.0.1
<a name"4.0.1"></a>
### 4.0.1 (2017-08-16)


#### Bug Fixes

* Set autocomplete="off" on input to remove SecurityError in Firefox (`#476`) (43e55741](`https://github.com/okonet/react-dropzone/commit/43e55741`), closes [`#475` (`https://github.com/okonet/react-dropzone/issues/475`))



#### Version 4.0.0
<a name"4.0.0"></a>
## 4.0.0 (2017-08-04)


#### Bug Fixes

* Always show an active drag state during the drag (`#467`) (d08eabdb](`https://github.com/okonet/react-dropzone/commit/d08eabdb`), closes [`#440`](`https://github.com/okonet/react-dropzone/issues/440`), [`#461` (`https://github.com/okonet/react-dropzone/issues/461`))


#### Breaking Changes

* isDragAccept acts like isDragActive before. isDragActive is true during the drag.
 (d08eabdb (`https://github.com/okonet/react-dropzone/commit/d08eabdb`))



