### PR TITLE
[Doppins] Upgrade dependency minireset.css to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jwt-decode": "2.2.0",
     "lodash": "^4.17.2",
     "marked": "0.3.6",
-    "minireset.css": "0.0.2",
+    "minireset.css": "0.0.3",
     "moment": "^2.17.1",
     "moment-timezone": "^0.5.10",
     "normalizr": "^3.2.2",


### PR DESCRIPTION
Hi!

A new version was just released of `minireset.css`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded minireset.css from `0.0.2` to `0.0.3`

