### PR TITLE
[Doppins] Upgrade dependency react-cropper to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react": "^15.6.1",
     "react-async-script": "^0.9.1",
     "react-cookie": "^1.0.4",
-    "react-cropper": "^0.12.0",
+    "react-cropper": "^1.0.0",
     "react-dom": "^15.6.1",
     "react-dropzone": "^3.10.0",
     "react-google-recaptcha": "^0.9.6",


### PR DESCRIPTION
Hi!

A new version was just released of `react-cropper`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-cropper from `^0.12.0` to `^1.0.0`

