### PR TITLE
[Doppins] Upgrade dependency flow-bin to ^0.53.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "express": "^4.14.1",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
-    "flow-bin": "^0.51.1",
+    "flow-bin": "^0.53.1",
     "friendly-errors-webpack-plugin": "^1.6.1",
     "identity-obj-proxy": "3.0.0",
     "jest": "^20.0.4",


### PR DESCRIPTION
Hi!

A new version was just released of `flow-bin`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded flow-bin from `^0.51.1` to `^0.53.1`

