### PR TITLE
[Doppins] Upgrade dependency lint-staged to ^4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "friendly-errors-webpack-plugin": "^1.6.1",
     "identity-obj-proxy": "3.0.0",
     "jest": "^20.0.4",
-    "lint-staged": "^3.3.1",
+    "lint-staged": "^4.0.4",
     "postcss-cssnext": "^2.9.0",
     "postcss-import": "^9.0.0",
     "postcss-loader": "^1.2.1",


### PR DESCRIPTION
Hi!

A new version was just released of `lint-staged`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded lint-staged from `^3.3.1` to `^4.0.4`

#### Changelog:

#### Version 4.0.4
<a name"4.0.4"></a>
### 4.0.4 (2017-08-24)


#### Bug Fixes

* Disable concurrent sub task execution by default (`#229`) (48c8c6ff](`https://github.com/okonet/lint-staged/commit/48c8c6ff`), closes [`#225` (`https://github.com/okonet/lint-staged/issues/225`))



#### Version 4.0.3
<a name"4.0.3"></a>
### 4.0.3 (2017-08-06)


#### Bug Fixes

* **package:** update execa to version 0.8.0 (`#222`) (27adf8bb (`https://github.com/okonet/lint-staged/commit/27adf8bb`))



#### Version 4.0.2
<a name"4.0.2"></a>
### 4.0.2 (2017-07-17)


#### Bug Fixes

* Remove unportable postinstall step (`#213`) (a2dcd047](`https://github.com/okonet/lint-staged/commit/a2dcd047`), closes [`#212`](`https://github.com/okonet/lint-staged/issues/212`), [`#192` (`https://github.com/okonet/lint-staged/issues/192`))



#### Version 4.0.1
<a name"4.0.1"></a>
### 4.0.1 (2017-07-06)


#### Bug Fixes

* Bail on fatal errors (`#208`) (ca85d82a (`https://github.com/okonet/lint-staged/commit/ca85d82a`))

#### Version 4.0.0
<a name"4.0.0"></a>
## 4.0.0 (2017-06-18)


#### Bug Fixes

* Skip '--' argument for non-npm commands (`#196`) (ad265664](`https://github.com/okonet/lint-staged/commit/ad265664`), closes [`#195` (`https://github.com/okonet/lint-staged/issues/195`))


#### Breaking Changes

* 

This might affect existing setups which depend on the `--` argument.
 (ad265664 (`https://github.com/okonet/lint-staged/commit/ad265664`))

