### PR TITLE
[Doppins] Upgrade dependency stylelint-config-standard to ^17.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "start-server-webpack-plugin": "^2.1.2",
     "style-loader": "^0.18.2",
     "stylelint": "^7.7.0",
-    "stylelint-config-standard": "^16.0.0",
+    "stylelint-config-standard": "^17.0.0",
     "url-loader": "^0.5.9",
     "webpack": "^3.4.1",
     "webpack-dev-middleware": "^1.11.0",


### PR DESCRIPTION
Hi!

A new version was just released of `stylelint-config-standard`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded stylelint-config-standard from `^16.0.0` to `^17.0.0`

#### Changelog:

#### Version 17.0.0

-   Changed: now extends `stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended), which turns on the `at-rule-no-unknown` rule. Therefore, if you use non-standard at-rules, like those introduced in SCSS and Less (e.g. ``@extends``, ``@includes`` etc), be sure to [extend the config](README.md#extending-the-config) and make use of `at-rule-no-unknown`'s [`ignoreAtRules: []` secondary option (`https://github.com/stylelint/stylelint/tree/master/lib/rules/at-rule-no-unknown#ignoreatrules-regex-string`).


