### PR TITLE
[Doppins] Upgrade dependency eslint-config-prettier to ^2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "css-loader": "^0.28.0",
     "enzyme": "^2.7.0",
     "eslint": "^3.17.1",
-    "eslint-config-prettier": "^1.5.0",
+    "eslint-config-prettier": "^2.3.0",
     "eslint-config-react-app": "^0.6.1",
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-flowtype": "^2.30.3",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-config-prettier`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-config-prettier from `^1.5.0` to `^2.3.0`

