### PR TITLE
[Doppins] Upgrade dependency react-styleguidist to ^6.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "postcss-nested": "1.0.1",
     "prettier": "^1.5.3",
     "react-hot-loader": "3.0.0-beta.4",
-    "react-styleguidist": "^5.5.4",
+    "react-styleguidist": "^6.0.21",
     "react-test-renderer": "^15.6.0",
     "redux-mock-store": "^1.2.2",
     "start-server-webpack-plugin": "^2.1.2",


### PR DESCRIPTION
Hi!

A new version was just released of `react-styleguidist`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-styleguidist from `^5.5.4` to `^6.0.21`

#### Changelog:

#### Version 6.0.21
* **Fixed:** Improve terminal output on style guide server start (`#595`)

#### Version 6.0.20
* **Fixed:** Create custom JSS instance

#### Version 6.0.19
* **Fixed:** Omit component if propsParser returns an empty array (`#588`)

#### Version 6.0.18
* **Fixed:** Prefix generated by JSS class names

#### Version 6.0.17
* **Fixed:** Inherit font-size to make em sizing work properly in components (`#585`)

#### Version 6.0.16
* **Fixed:** Do not lowercase nested keys of example settings object, pass props to Preview component

#### Version 6.0.15
* **Fixed:** Pass example file path to updateExample (`#583`)

#### Version 6.0.14
* **Fixed:** Migrate to react-codemirror2 (`#574`)

#### Version 6.0.13
* **Fixed:** Fix parsing of error about webpack loaders

#### Version 6.0.12
* **Fixed:** Update syntax in an example inside “Add examples to this component”

#### Version 6.0.11
* **Fixed:** Lock jss-isolate version because of a regression in the latest patch release

#### Version 6.0.10
* **Fixed:** Pass devtool webpack option in dev mode (`#569`)

#### Version 6.0.9
* **Fixed:** Support config theme overriding top level theme properties (`#566`) (`#571`)

#### Version 6.0.8
* **Fixed:** Fallback to not formatting defaultProps (`#564`)

#### Version 6.0.7
* **Fixed:** Disable isolation for global CodeMirror styles

#### Version 6.0.6
* **Fixed:** Read showCode option from the right place

#### Version 6.0.5
* **Fixed:** Support to enable HMR for component dependencies (`#557`)

#### Version 6.0.4
* **Fixed:** Only use primary style for top level sections (`#555`)

#### Version 6.0.3
* **Fixed:** Hide empty path line (`#558`)

#### Version 6.0.2
* **Fixed:** Render null and undefined defaultValues as code (`#556`)

#### Version 6.0.1
* **Fixed:** Clean lib directory before compilation

#### Version 6.0.0
## Breaking changes

### Changed fenced code blocks handling in Markdown

Any code block with a language tag of `js`, `jsx` or `javascript` will be rendered as a React component with a interactive playground.

    React component example:

    ```js
    <Button size="large">Push Me</Button>
    ```

    You can disable an editor by passing a 'noeditor' modifier:

    ```jsx noeditor
    <Button>Push Me</Button>
    ```

    You can disable a playground by passing a 'static' modifier:

    ```jsx static
    import React from 'react';
    ```

    Examples with all other languages are rendered only as highlighted source code, not an actual component:

    ```html
    <Button size="large">Push Me</Button>
    ```

Fenced code blocks without a language or indented code blocks are rendered as before: with an interactive playground.

A custom `example` language for fenced code blocks was removed.

You can customize this behavior with the new `updateExample` config option. For example you can use it to load examples from files:

```javascript
module.exports = {
  updateExample: function(props) {
    const { settings, lang } = props;
    if (typeof settings.file === 'string') {
      const filepath = settings.file;
      delete settings.file;
      return {
        content: fs.readFileSync(filepath),
        settings,
        lang,
      }
    }
    return props;
  }
};
```

Use it like this in you Markdown files:

    ```js { "file": "./some/file.js" }
    ```

### Removed webpack 1 support

Webpack 2+ is required now.

## How to migrate

1. Add a `static` modifier to all fenced code block with a language tag of `js`, `jsx` or `javascript`:

    ```` ```js```` → ```` ```js static````

2. (Recommended) Replace any fenced code blocks that have `example` language with fenced code blocks with a language tag of `js`, `jsx` or `javascript`:

    ```` ```example```` → ```` ```js````

3. (Recommended) Replace indented code blocks with fenced code blocks with a language tag of `js`, `jsx` or `javascript`:

        5.x:

            <Button size="large">Push Me</Button>

        6.x:

        ```js
        <Button size="large">Push Me</Button>
        ```


#### Version 6.0.0
**Try it now:**

```bash
npm install react-styleguidist@6.0.0-beta.2
```

See all code changes in this pull request (`https://github.com/styleguidist/react-styleguidist/pull/543`).

Changes since beta.1:

* Fixed an issue on case-sensitive file systems (wrong files were published to npm)
* `updateExample` config option is really working now
* `example` language for fenced code blocks works again but with a warning

#### Version 6.0.0
**Try it now:**

```bash
npm install react-styleguidist@6.0.0-beta.1
```

See all code changes in this pull request (`https://github.com/styleguidist/react-styleguidist/pull/543`).

## Breaking changes

### Changed fenced code blocks handling in Markdown

Any code block with a language tag of `js`, `jsx` or `javascript` will be rendered as a React component with a interactive playground.

    React component example:

    ```js
    <Button size="large">Push Me</Button>
    ```

    You can disable an editor by passing a 'noeditor' modifier:

    ```jsx noeditor
    <Button>Push Me</Button>
    ```

    You can disable a playground by passing a 'static' modifier:

    ```jsx static
    import React from 'react';
    ```

    Examples with all other languages are rendered only as highlighted source code, not an actual component:

    ```html
    <Button size="large">Push Me</Button>
    ```

Fenced code blocks without a language or indented code blocks are rendered as before: with an interactive playground.

A custom `example` language for fenced code blocks was removed.

You can customize this behavior with the new `updateExample` config option. For example you can use it to load examples from files:

```javascript
module.exports = {
  updateExample: function(props) {
    const { settings, lang } = props;
    if (typeof settings.file === 'string') {
      const filepath = settings.file;
      delete settings.file;
      return {
        content: fs.readFileSync(filepath),
        settings,
        lang,
      }
    }
    return props;
  }
};
```

Use it like this in you Markdown files:

    ```js { "file": "./some/file.js" }
    ```

### Remove webpack 1 support

Webpack 2+ is required now.

## How to migrate

1. Add a `static` modifier to all fenced code block with a language tag of `js`, `jsx` or `javascript`:

    ```` ```js```` → ```` ```js static````

2. (Recommended) Replace any fenced code blocks that have `example` language with fenced code blocks with a language tag of `js`, `jsx` or `javascript`:

    ```` ```example```` → ```` ```js````

3. (Recommended) Replace indented code blocks with fenced code blocks with a language tag of `js`, `jsx` or `javascript`:

        5.x:

            <Button size="large">Push Me</Button>

        6.x:

        ```js
        <Button size="large">Push Me</Button>
        ```


