### PR TITLE
Disable serverside rendering in dev

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,9 +16,9 @@ const log = app.get('log');
 
 app.listen(app.get('port'), app.get('host'), err => {
   if (err) {
-    log.error(err, 'could_not_start_server')
+    log.error(err, 'could_not_start_server');
   }
-  log.info({ port: app.get('port'), host: app.get('host')}, 'app_stated')
+  log.info({ port: app.get('port'), host: app.get('host') }, 'app_started');
 });
 
 if (module.hot) {

--- a/server/render.js
+++ b/server/render.js
@@ -24,6 +24,13 @@ require('../app/assets/icon-512x512.png');
 function render(req, res, next) {
   const log = req.app.get('log');
   cookie.plugToRequest(req, res);
+
+  if (process.env.NODE_ENV !== 'production') {
+    return res.send(
+      renderPage({ body: '', state: {}, helmet: Helmet.rewind() })
+    );
+  }
+
   match({ routes, location: req.url }, (err, redirect, renderProps) => {
     if (err) {
       return next(err);
@@ -58,8 +65,8 @@ function render(req, res, next) {
     };
 
     prepare(app).then(respond).catch(error => {
-      const err = error.error ? error.payload : error
-      log.error(err, 'render_error')
+      const err = error.error ? error.payload : error;
+      log.error(err, 'render_error');
       Raven.captureException(err);
       respond();
     });


### PR DESCRIPTION
Server rendering is working quite nicely, and should not be necessary to run it in dev. Requires less restarts and yarn builds when doing client side rendering with hot-module reloading.

A bit quick fix, but I guess this should suffice? It seems to be working ok in my environment.