### PR TITLE
Fix #494

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -196,6 +196,10 @@ export const Feed = {
   FETCH: generateStatuses('Feed.FETCH')
 };
 
+export const FetchHistory = {
+  SET_HISTORY: 'FetchHistory.SET_HISTORY'
+};
+
 /**
  *
  */

--- a/app/reducers/fetchHistory.js
+++ b/app/reducers/fetchHistory.js
@@ -1,10 +1,24 @@
+import { FetchHistory } from 'app/actions/ActionTypes';
+
 export default function fetchHistory(state: State = {}, action: Action) {
   const success = action.meta && action.meta.success;
-  if (success && action.type === success) {
-    return {
-      ...state,
-      [action.meta.endpoint]: Date.now()
-    };
+  switch (action.type) {
+    case success: {
+      if (!success) {
+        return state;
+      }
+      return {
+        ...state,
+        [action.meta.endpoint]: Date.now()
+      };
+    }
+    case FetchHistory.SET_HISTORY: {
+      return {
+        ...state,
+        [action.payload]: Date.now()
+      };
+    }
+    default:
+      return state;
   }
-  return state;
 }

--- a/app/routes/events/EventDetailRoute.js
+++ b/app/routes/events/EventDetailRoute.js
@@ -77,16 +77,16 @@ const mapDispatchToProps = {
   isUserFollowing
 };
 
+const loadData = ({ params: { eventId }, currentUser }, dispatch) => {
+  const userId = currentUser.id;
+  return dispatch(fetchEvent(eventId)).then(() =>
+    dispatch(isUserFollowing(eventId, userId))
+  );
+};
+
 export default compose(
-  dispatched(
-    ({ params: { eventId }, currentUser }, dispatch) => {
-      const userId = currentUser.id;
-      dispatch(fetchEvent(eventId));
-      dispatch(isUserFollowing(eventId, userId));
-    },
-    {
-      componentWillReceiveProps: false
-    }
-  ),
+  dispatched(loadData, {
+    componentWillReceiveProps: false
+  }),
   connect(mapStateToProps, mapDispatchToProps)
 )(EventDetail);

--- a/app/utils/fetchJSON.js
+++ b/app/utils/fetchJSON.js
@@ -101,7 +101,8 @@ export default function fetchJSON(path, requestOptions = { headers: [] }) {
         if (
           (error.response && error.response.status < 500) ||
           !retryDelays ||
-          requestsAttempted > retryDelays.length
+          requestsAttempted > retryDelays.length ||
+          typeof window === 'undefined'
         ) {
           return reject(error);
         }


### PR DESCRIPTION
Closes #494 

SSR does not have window defined, but the client does - therefore we can easily restrict retries by checking typeof window.

The client did initially retry API calls that SSR returns 4xx errors, because the history did not update on failure. This PR fixes this by setting history on 4xx - but not >= 500 since we want to retry those.