### PR TITLE
Add mutate and remove unneded byId operations

### DIFF
--- a/app/reducers/articles.js
+++ b/app/reducers/articles.js
@@ -18,7 +18,8 @@ const mutate = mutateComments('articles');
 export default createEntityReducer({
   key: 'articles',
   types: {
-    fetch: Article.FETCH
+    fetch: Article.FETCH,
+    mutate: Article.CREATE
   },
   mutate
 });

--- a/app/reducers/events.js
+++ b/app/reducers/events.js
@@ -8,7 +8,6 @@ import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
 import { normalize } from 'normalizr';
 import { eventSchema } from 'app/reducers';
-import { omit } from 'lodash';
 
 export type EventEntity = {
   id: number,
@@ -18,17 +17,9 @@ export type EventEntity = {
 
 function mutateEvent(state: any, action: any) {
   switch (action.type) {
-    case Event.CREATE.SUCCESS: {
-      return {
-        ...state,
-        byId: omit(state.byId, action.meta.optimisticId),
-        items: state.items.filter(id => id !== action.meta.optimisticId)
-      };
-    }
     case Event.DELETE.SUCCESS: {
       return {
         ...state,
-        byId: omit(state.byId, action.meta.id),
         items: state.items.filter(id => id !== action.meta.id.toString())
       };
     }
@@ -156,7 +147,8 @@ const mutate = joinReducers(mutateComments('events'), mutateEvent);
 export default createEntityReducer({
   key: 'events',
   types: {
-    fetch: Event.FETCH
+    fetch: Event.FETCH,
+    mutate: Event.CREATE
   },
   mutate
 });

--- a/app/reducers/interestGroups.js
+++ b/app/reducers/interestGroups.js
@@ -3,7 +3,6 @@
 import { createSelector } from 'reselect';
 import { InterestGroup } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
-import { omit } from 'lodash';
 
 export type InterestGroupEntity = {
   id: number,
@@ -23,8 +22,7 @@ export default createEntityReducer({
         const removedId = action.meta.groupId;
         return {
           ...state,
-          items: state.items.filter(g => g !== removedId),
-          byId: omit(state.byId, removedId)
+          items: state.items.filter(g => g !== removedId)
         };
       }
       case InterestGroup.JOIN.SUCCESS: {

--- a/app/reducers/joblistings.js
+++ b/app/reducers/joblistings.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { omit } from 'lodash';
 import { Joblistings } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { createSelector } from 'reselect';
@@ -8,17 +7,15 @@ import { createSelector } from 'reselect';
 export default createEntityReducer({
   key: 'joblistings',
   types: {
-    fetch: Joblistings.FETCH
+    fetch: Joblistings.FETCH,
+    mutate: Joblistings.CREATE
   },
   mutate(state, action) {
     switch (action.type) {
       case Joblistings.DELETE.SUCCESS: {
         return {
           ...state,
-          items: state.items.filter(id => id !== action.meta.id),
-          byId: {
-            ...omit(state.byId, action.meta.id)
-          }
+          items: state.items.filter(id => id !== action.meta.id)
         };
       }
       default:

--- a/app/reducers/meetings.js
+++ b/app/reducers/meetings.js
@@ -7,16 +7,11 @@ import createEntityReducer from 'app/utils/createEntityReducer';
 export default createEntityReducer({
   key: 'meetings',
   types: {
-    fetch: Meeting.FETCH
+    fetch: Meeting.FETCH,
+    mutate: Meeting.CREATE
   },
   mutate(state, action) {
     switch (action.type) {
-      case Meeting.CREATE.SUCCESS:
-        return {
-          ...state,
-          items: state.items.filter(id => action.meta.optimisticId !== id)
-          // Remove the item with the optimisticId
-        };
       case Meeting.DELETE.SUCCESS:
         return {
           ...state,

--- a/app/reducers/notifications.js
+++ b/app/reducers/notifications.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { Notifications } from '../actions/ActionTypes';
+import { union } from 'lodash';
 import type { Action } from 'app/types';
 
 const initialState = {
@@ -17,7 +18,7 @@ export default function notifications(
     case Notifications.NOTIFICATION_ADDED:
       return {
         ...state,
-        items: [...state.items, action.payload]
+        items: union(state.items, [action.payload])
       };
 
     case Notifications.NOTIFICATION_REMOVED:

--- a/app/reducers/pools.js
+++ b/app/reducers/pools.js
@@ -16,7 +16,7 @@ export default createEntityReducer({
         return {
           ...state,
           byId: pools,
-          items: Object.keys(pools).map(Number)
+          items: Object.keys(pools)
         };
       }
       case Event.SOCKET_REGISTRATION.SUCCESS: {

--- a/app/reducers/quotes.js
+++ b/app/reducers/quotes.js
@@ -5,7 +5,6 @@ import createEntityReducer from 'app/utils/createEntityReducer';
 import { createSelector } from 'reselect';
 import { mutateComments } from 'app/reducers/comments';
 import joinReducers from 'app/utils/joinReducers';
-import { omit } from 'lodash';
 
 export type QuoteEntity = {
   id: number,
@@ -22,7 +21,6 @@ function mutateQuote(state: any, action: any) {
       const { quoteId } = action.meta;
       return {
         ...state,
-        byId: omit(state.byId, quoteId),
         items: state.items.filter(id => id != quoteId)
       };
     }
@@ -62,7 +60,8 @@ const mutate = joinReducers(mutateComments('quotes'), mutateQuote);
 export default createEntityReducer({
   key: 'quotes',
   types: {
-    fetch: Quote.FETCH
+    fetch: Quote.FETCH,
+    mutate: Quote.ADD
   },
   mutate
 });

--- a/app/reducers/registrations.js
+++ b/app/reducers/registrations.js
@@ -22,7 +22,7 @@ export default createEntityReducer({
               ...action.payload
             }
           },
-          items: [...state.items, action.payload.id]
+          items: union(state.items, [action.payload.id])
         };
       }
       case Event.UNREGISTER.BEGIN: {


### PR DESCRIPTION
We dont really need to omit items from byId in the reducers, since filtering from items practically removes the items. The mutate flag in createEntityReducer was not used in several apps, so I added it to handle the optimistic ids automatically.