### PR TITLE
Different Loading Indicator

### DIFF
--- a/app/components/LoadingIndicator/LoadingIndicator.css
+++ b/app/components/LoadingIndicator/LoadingIndicator.css
@@ -26,16 +26,17 @@
 }
 
 .bounce2 {
-  animation-delay: -1s;
+  animation-delay: -0.4s;
 }
 
 @keyframes bounce {
   0%,
+  70%,
   100% {
-    transform: scale(0);
+    transform: scale(0.5);
   }
 
-  50% {
+  40% {
     transform: scale(1);
   }
 }


### PR DESCRIPTION
Old:

![original_loading](https://user-images.githubusercontent.com/14221386/30482993-7bc53afe-9a25-11e7-8cc5-d175cfedcff1.gif)

New:

![ny_loading](https://user-images.githubusercontent.com/14221386/30483001-807bf740-9a25-11e7-8090-62aa3dc1ec2d.gif)

Looks more load-y