### PR TITLE
Add a follow button on user detail page

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -181,7 +181,11 @@ export const User = {
   SEND_STUDENT_CONFIRMATION_TOKEN: generateStatuses(
     'User.SEND_STUDENT_CONFIRMATION_TOKEN'
   ),
-  CONFIRM_STUDENT_USER: generateStatuses('User.CONFIRM_STUDENT_USER')
+  CONFIRM_STUDENT_USER: generateStatuses('User.CONFIRM_STUDENT_USER'),
+  FOLLOW_USER: generateStatuses('User.FOLLOW_USER'),
+  UNFOLLOW_USER: generateStatuses('User.UNFOLLOW_USER'),
+  FETCH_USER_FOLLOWINGS: generateStatuses('User.FETCH_USER_FOLLOWINGS'),
+  GET_FOLLOW: generateStatuses('User.GET_FOLLOW')
 };
 
 /**

--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -262,16 +262,12 @@ export function unfollow(followId, eventId) {
 }
 
 export function isUserFollowing(eventId, userId) {
-  return dispatch => {
-    dispatch(
-      callAPI({
-        types: Event.IS_USER_FOLLOWING,
-        endpoint: `/followers-event/?target=${eventId}&follower=${userId}`,
-        method: 'GET',
-        meta: {
-          errorMessage: 'Failed to get event followers'
-        }
-      })
-    );
-  };
+  return callAPI({
+    types: Event.IS_USER_FOLLOWING,
+    endpoint: `/followers-event/?target=${eventId}&follower=${userId}`,
+    method: 'GET',
+    meta: {
+      errorMessage: 'Failed to get event followers'
+    }
+  });
 }

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -293,3 +293,64 @@ export function confirmStudentUser(token) {
     useCache: true
   });
 }
+
+export function followUser(me: object, user: object) {
+  return dispatch =>
+    dispatch(
+      callAPI({
+        types: User.FOLLOW_USER,
+        endpoint: `/followers-user/`,
+        method: 'POST',
+        body: {
+          target: user.id
+        },
+        meta: {
+          follower: me,
+          user,
+          errorMessage: 'Kunne ikke følge brukeren.'
+        }
+      })
+    );
+}
+
+export function unfollowUser(me: object, user: object) {
+  return dispatch =>
+    dispatch(
+      callAPI({
+        types: User.GET_FOLLOW,
+        endpoint: `/followers-user/?following=${me.id}&target=${user.id}`,
+        method: 'GET',
+        meta: {
+          errorMessage: 'Kunne ikke hente følgen.'
+        }
+      })
+    ).then(res => {
+      return dispatch(
+        callAPI({
+          types: User.UNFOLLOW_USER,
+          endpoint: `/followers-user/${res.payload[0].id}/`,
+          method: 'DELETE',
+          meta: {
+            follower: me,
+            user,
+            errorMessage: 'Kunne ikke slutte å følge brukeren.'
+          }
+        })
+      );
+    });
+}
+
+export function fetchUserFollowings(me: object) {
+  return dispatch =>
+    dispatch(
+      callAPI({
+        types: User.FETCH_USER_FOLLOWINGS,
+        endpoint: `/followers-user/?follower=${me.id}`,
+        method: 'GET',
+        meta: {
+          currentUser: me,
+          errorMessage: 'Fant ikke ut hvilke brukere du følger'
+        }
+      })
+    );
+}

--- a/app/reducers/users.js
+++ b/app/reducers/users.js
@@ -24,6 +24,53 @@ export default createEntityReducer({
           }
         };
       }
+      case User.FOLLOW_USER.SUCCESS: {
+        const me = action.meta.follower.username;
+        const user = action.meta.user.id;
+        const following = (state.byId[me].following || [])
+          .filter(id => id !== user)
+          .concat(user);
+        return {
+          ...state,
+          byId: {
+            ...state.byId,
+            [me]: {
+              ...state.byId[me],
+              following
+            }
+          }
+        };
+      }
+      case User.UNFOLLOW_USER.SUCCESS: {
+        const me = action.meta.follower.username;
+        const user = action.meta.user.id;
+        const following = (state.byId[me].following || []).filter(
+          id => id !== user
+        );
+        return {
+          ...state,
+          byId: {
+            ...state.byId,
+            [me]: {
+              ...state.byId[me],
+              following
+            }
+          }
+        };
+      }
+      case User.FETCH_USER_FOLLOWINGS.SUCCESS: {
+        const me = action.meta.currentUser.username;
+        return {
+          ...state,
+          byId: {
+            ...state.byId,
+            [me]: {
+              ...state.byId[me],
+              following: action.payload.map(f => f.target)
+            }
+          }
+        };
+      }
       default:
         return state;
     }

--- a/app/routes/users/UserProfileRoute.js
+++ b/app/routes/users/UserProfileRoute.js
@@ -4,7 +4,12 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { dispatched } from 'react-prepare';
 import UserProfile from './components/UserProfile';
-import { fetchUser } from 'app/actions/UserActions';
+import {
+  fetchUser,
+  followUser,
+  unfollowUser,
+  fetchUserFollowings
+} from 'app/actions/UserActions';
 import { fetchUserFeed } from 'app/actions/FeedActions';
 import {
   selectFeedById,
@@ -14,8 +19,9 @@ import {
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { LoginPage } from 'app/components/LoginForm';
 
-const loadData = ({ params: { username } }, dispatch) => {
+const loadData = ({ params: { username }, currentUser }, dispatch) => {
   return dispatch(fetchUser(username)).then(action => {
+    dispatch(fetchUserFollowings(currentUser));
     /**
      * /users/me has no username property and the application fetches "me"
      * when that happens. Extract the current username from the fetch response
@@ -53,7 +59,12 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-const mapDispatchToProps = { fetchUser, fetchUserFeed };
+const mapDispatchToProps = {
+  fetchUser,
+  fetchUserFeed,
+  followUser,
+  unfollowUser
+};
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -11,6 +11,7 @@ import LoadingIndicator from 'app/components/LoadingIndicator';
 import Feed from 'app/components/Feed';
 import styles from './UserProfile.css';
 import { Flex } from 'app/components/Layout';
+import Button from 'app/components/Button';
 
 const fieldTranslations = {
   username: 'brukernavn',
@@ -22,6 +23,18 @@ type Props = {
   isMe: boolean,
   feedItems: Array<any>,
   feed: Object
+};
+
+const FollowButton = ({ user, isFollowing, followUser, unfollowUser }) => {
+  const label = isFollowing ? 'Slutt å følge ' : 'Følg ';
+  const onClick = isFollowing ? unfollowUser : followUser;
+
+  return (
+    <Button onClick={onClick}>
+      {label}
+      {user.firstName}
+    </Button>
+  );
 };
 
 export default class UserProfile extends Component {
@@ -43,10 +56,19 @@ export default class UserProfile extends Component {
   }
 
   render() {
-    const { user, isMe, feedItems, feed } = this.props;
+    const {
+      user,
+      currentUser,
+      isMe,
+      feedItems,
+      feed,
+      followUser,
+      unfollowUser
+    } = this.props;
     if (!user) {
       return <LoadingIndicator loading />;
     }
+    const isFollowing = (currentUser.following || []).includes(user.id);
 
     return (
       <div className={styles.root}>
@@ -67,7 +89,12 @@ export default class UserProfile extends Component {
               {isMe ? (
                 <Link to="/users/me/settings/profile">Settings</Link>
               ) : (
-                ''
+                <FollowButton
+                  user={user}
+                  isFollowing={isFollowing}
+                  followUser={() => followUser(currentUser, user)}
+                  unfollowUser={() => unfollowUser(currentUser, user)}
+                />
               )}
             </Card>
           </div>


### PR DESCRIPTION
I didn't make a proper reducer and all that, even though we did it with memberships, because I wasn't sure how important that was.

This is the way it works right now: on user page fetch, we get all users that the current logged in user follows, and check if the user we look at is in that list. 

The follow button is butt ugly ¯\\_(ツ)_/¯

Fix #529 