### PR TITLE
Ignore empty values in matchesRegex

### DIFF
--- a/app/utils/validation.js
+++ b/app/utils/validation.js
@@ -7,7 +7,9 @@ export const required = (message = 'Feltet må fylles ut') => value => [
 ];
 
 export const matchesRegex = (regex, message) => value => [
-  regex.test(value),
+  // Ignore empty values here, since we want to validate
+  // that separately with e.g. required:
+  !value || regex.test(value),
   message || `Not matching pattern ${regex.toString()}`
 ];
 


### PR DESCRIPTION
We want to validate those separately with `required()`. Fixes #559.