### PR TITLE
Fix action flow errors

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -118,6 +118,7 @@ export const Comment = {
  */
 export const Company = {
   FETCH: generateStatuses('Company.FETCH'),
+  FETCH_COMPANY_CONTACT: generateStatuses('Company.FETCH_COMPANY_CONTACT'),
   ADD: generateStatuses('Company.ADD'),
   EDIT: generateStatuses('Company.EDIT'),
   DELETE: generateStatuses('Company.DELETE'),
@@ -149,7 +150,8 @@ export const Search = {
   SEARCH: generateStatuses('Search.SEARCH'),
   AUTOCOMPLETE: generateStatuses('Search.AUTOCOMPLETE'),
   RESULTS_RECEIVED: 'Search.RESULTS_RECEIVED',
-  TOGGLE_OPEN: 'Search.TOGGLE_OPEN'
+  TOGGLE_OPEN: 'Search.TOGGLE_OPEN',
+  MENTION: 'Search.MENTION'
 };
 
 export const Notifications = {

--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -18,8 +18,8 @@ export function fetchAll() {
   });
 }
 
-export function fetch(companyId) {
-  return dispatch =>
+export function fetch(companyId: number) {
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: Company.FETCH,
@@ -44,19 +44,8 @@ export function fetch(companyId) {
     );
 }
 
-export function addCompany({
-  name,
-  studentContact,
-  adminComment,
-  active,
-  description,
-  phone,
-  website,
-  companyType,
-  paymentMail,
-  address
-}) {
-  return dispatch => {
+export function addCompany(data: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(
@@ -64,18 +53,7 @@ export function addCompany({
         types: Company.ADD,
         endpoint: '/companies/',
         method: 'post',
-        body: {
-          name,
-          studentContact,
-          adminComment,
-          active,
-          description,
-          phone,
-          website,
-          companyType,
-          paymentMail,
-          address
-        },
+        body: data,
         schema: companySchema,
         meta: {
           errorMessage: 'Adding company failed'
@@ -91,20 +69,8 @@ export function addCompany({
   };
 }
 
-export function editCompany({
-  companyId,
-  name,
-  description,
-  adminComment,
-  website,
-  studentContact,
-  phone,
-  active,
-  companyType,
-  paymentMail,
-  address
-}) {
-  return dispatch => {
+export function editCompany({ companyId, ...data }: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(
@@ -112,18 +78,7 @@ export function editCompany({
         types: Company.EDIT,
         endpoint: `/companies/${companyId}/`,
         method: 'PATCH',
-        body: {
-          name,
-          description,
-          adminComment,
-          website,
-          studentContact,
-          active,
-          phone,
-          companyType,
-          paymentMail,
-          address
-        },
+        body: data,
         schema: companySchema,
         meta: {
           errorMessage: 'Editing company failed'
@@ -136,8 +91,8 @@ export function editCompany({
   };
 }
 
-export function deleteCompany(companyId) {
-  return dispatch => {
+export function deleteCompany(companyId: number) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(
@@ -159,10 +114,12 @@ export function deleteCompany(companyId) {
 }
 
 export function addSemesterStatus(
-  { companyId, year, semester, contactedStatus, contract },
-  detail = false
+  { companyId, ...data }: Object,
+  // TODO: change this to take in an object,
+  // addSemesterStatus(something, false) really doesn't say much
+  detail: boolean = false
 ) {
-  return dispatch => {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(
@@ -170,12 +127,7 @@ export function addSemesterStatus(
         types: Company.ADD_SEMESTER,
         endpoint: `/companies/${companyId}/semester-statuses/`,
         method: 'post',
-        body: {
-          year,
-          semester,
-          contactedStatus,
-          contract
-        },
+        body: data,
         meta: {
           errorMessage: 'Adding semester status failed'
         }
@@ -192,10 +144,12 @@ export function addSemesterStatus(
 }
 
 export function editSemesterStatus(
-  { companyId, semesterId, contactedStatus, contract },
-  detail = false
+  { companyId, semesterId, contactedStatus, contract }: Object,
+  // TODO: change this to take in an object,
+  // editSemesterStatus(something, false) really doesn't say much
+  detail: boolean = false
 ) {
-  return dispatch => {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(
@@ -222,8 +176,8 @@ export function editSemesterStatus(
   };
 }
 
-export function deleteSemesterStatus(companyId, semesterId) {
-  return dispatch => {
+export function deleteSemesterStatus(companyId: number, semesterId: number) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(
@@ -245,7 +199,7 @@ export function deleteSemesterStatus(companyId, semesterId) {
   };
 }
 
-export function fetchCompanyContact({ companyId }) {
+export function fetchCompanyContact({ companyId }: { companyId: number }) {
   return callAPI({
     types: Company.FETCH_COMPANY_CONTACT,
     endpoint: `/companies/${companyId}/company-contacts/`,
@@ -256,8 +210,14 @@ export function fetchCompanyContact({ companyId }) {
   });
 }
 
-export function addCompanyContact({ companyId, name, role, mail, phone }) {
-  return dispatch => {
+export function addCompanyContact({
+  companyId,
+  name,
+  role,
+  mail,
+  phone
+}: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(
@@ -289,8 +249,8 @@ export function editCompanyContact({
   role,
   mail,
   phone
-}) {
-  return dispatch => {
+}: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(
@@ -315,8 +275,11 @@ export function editCompanyContact({
   };
 }
 
-export function deleteCompanyContact(companyId, companyContactId) {
-  return dispatch => {
+export function deleteCompanyContact(
+  companyId: number,
+  companyContactId: number
+) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('company'));
 
     return dispatch(

--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -46,7 +46,7 @@ export function fetchAdministrate(eventId: string) {
 }
 
 export function createEvent(event: Object) {
-  return dispatch =>
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: Event.CREATE,
@@ -63,7 +63,7 @@ export function createEvent(event: Object) {
 }
 
 export function editEvent(event: Object) {
-  return dispatch =>
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: Event.EDIT,
@@ -77,8 +77,8 @@ export function editEvent(event: Object) {
     ).then(() => dispatch(push(`/events/${event.id}`)));
 }
 
-export function deleteEvent(eventId) {
-  return dispatch => {
+export function deleteEvent(eventId: number) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Event.DELETE,
@@ -96,7 +96,7 @@ export function deleteEvent(eventId) {
   };
 }
 
-export function setCoverPhoto(id, token) {
+export function setCoverPhoto(id: number, token: string) {
   return callAPI({
     types: Event.EDIT,
     endpoint: `/events/${id}/`,
@@ -111,7 +111,11 @@ export function setCoverPhoto(id, token) {
   });
 }
 
-export function register(eventId, captchaResponse, feedback) {
+export function register(
+  eventId: number,
+  captchaResponse: string,
+  feedback: string
+) {
   return callAPI({
     types: Event.REGISTER,
     endpoint: `/events/${eventId}/registrations/`,
@@ -127,7 +131,11 @@ export function register(eventId, captchaResponse, feedback) {
   });
 }
 
-export function unregister(eventId, registrationId, admin = false) {
+export function unregister(
+  eventId: number,
+  registrationId: number,
+  admin: boolean = false
+) {
   return callAPI({
     types: Event.UNREGISTER,
     endpoint: `/events/${eventId}/registrations/${registrationId}/`,
@@ -141,14 +149,20 @@ export function unregister(eventId, registrationId, admin = false) {
   });
 }
 
-export function adminRegister(eventId, user, pool, feedback, reason) {
+export function adminRegister(
+  eventId: number,
+  userId: number,
+  poolId: number,
+  feedback: string,
+  reason: string
+) {
   return callAPI({
     types: Event.ADMIN_REGISTER,
     endpoint: `/events/${eventId}/registrations/admin_register/`,
     method: 'post',
     body: {
-      user,
-      pool,
+      user: userId,
+      pool: poolId,
       feedback,
       admin_reason: reason
     },
@@ -158,7 +172,7 @@ export function adminRegister(eventId, user, pool, feedback, reason) {
   });
 }
 
-export function payment(eventId, token) {
+export function payment(eventId: number, token: string) {
   return callAPI({
     types: Event.PAYMENT_QUEUE,
     endpoint: `/events/${eventId}/payment/`,
@@ -172,8 +186,12 @@ export function payment(eventId, token) {
   });
 }
 
-export function updateFeedback(eventId, registrationId, feedback) {
-  return dispatch => {
+export function updateFeedback(
+  eventId: number,
+  registrationId: number,
+  feedback: string
+) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Event.UPDATE_REGISTRATION,
@@ -190,8 +208,12 @@ export function updateFeedback(eventId, registrationId, feedback) {
   };
 }
 
-export function updatePresence(eventId, registrationId, presence) {
-  return dispatch => {
+export function updatePresence(
+  eventId: number,
+  registrationId: number,
+  presence: string
+) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Event.UPDATE_REGISTRATION,
@@ -208,8 +230,12 @@ export function updatePresence(eventId, registrationId, presence) {
   };
 }
 
-export function updatePayment(eventId, registrationId, chargeStatus) {
-  return dispatch => {
+export function updatePayment(
+  eventId: number,
+  registrationId: number,
+  chargeStatus: string
+) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Event.UPDATE_REGISTRATION,
@@ -226,8 +252,8 @@ export function updatePayment(eventId, registrationId, chargeStatus) {
   };
 }
 
-export function follow(userId, eventId) {
-  return dispatch => {
+export function follow(userId: number, eventId: number) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Event.FOLLOW,
@@ -245,8 +271,8 @@ export function follow(userId, eventId) {
   };
 }
 
-export function unfollow(followId, eventId) {
-  return dispatch => {
+export function unfollow(followId: number, eventId: number) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Event.UNFOLLOW,
@@ -261,8 +287,8 @@ export function unfollow(followId, eventId) {
   };
 }
 
-export function isUserFollowing(eventId, userId) {
-  return dispatch => {
+export function isUserFollowing(eventId: number, userId: number) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Event.IS_USER_FOLLOWING,

--- a/app/actions/FileActions.js
+++ b/app/actions/FileActions.js
@@ -1,5 +1,3 @@
-// @flow
-
 import { File } from './ActionTypes';
 import callAPI from './callAPI';
 

--- a/app/actions/GalleryActions.js
+++ b/app/actions/GalleryActions.js
@@ -183,11 +183,13 @@ export function editPicture(galleryId: EntityID, pictureId: EntityID) {
 }
 
 export function addPictures(galleryId: number, files: []) {
-  return dispatch =>
-    Promise.all(files, file =>
-      dispatch(uploadFile({ file })).then(action =>
-        dispatch(
-          addPicture({ galleryId, file: action.meta.fileToken, active: true })
+  return (dispatch: $FlowFixMe) =>
+    Promise.all(
+      files.map(file =>
+        dispatch(uploadFile({ file })).then(action =>
+          dispatch(
+            addPicture({ galleryId, file: action.meta.fileToken, active: true })
+          )
         )
       )
     );

--- a/app/actions/GroupActions.js
+++ b/app/actions/GroupActions.js
@@ -4,7 +4,7 @@ import { groupSchema } from 'app/reducers';
 import callAPI from 'app/actions/callAPI';
 import { Group } from './ActionTypes';
 
-export function fetchGroup(groupId) {
+export function fetchGroup(groupId: number) {
   return callAPI({
     types: Group.FETCH,
     endpoint: `/groups/${groupId}/`,
@@ -28,7 +28,13 @@ export function fetchAll() {
   });
 }
 
-export function updateGroup({ groupId, updates }) {
+export function updateGroup({
+  groupId,
+  updates
+}: {
+  groupId: number,
+  updates: Array<Object>
+}) {
   return callAPI({
     types: Group.UPDATE,
     endpoint: `/groups/${groupId}/`,

--- a/app/actions/InterestGroupActions.js
+++ b/app/actions/InterestGroupActions.js
@@ -31,8 +31,8 @@ export function fetchAll() {
   });
 }
 
-export function createInterestGroup(group: object) {
-  return dispatch => {
+export function createInterestGroup(group: Object) {
+  return (dispatch: $FlowFixMe) => {
     const { name, description, descriptionLong, logo } = group;
     dispatch(
       callAPI({
@@ -69,7 +69,7 @@ export function createInterestGroup(group: object) {
 }
 
 export function removeInterestGroup(id: string) {
-  return dispatch => {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: InterestGroup.REMOVE,
@@ -84,9 +84,9 @@ export function removeInterestGroup(id: string) {
   };
 }
 
-export function editInterestGroup(group: object) {
+export function editInterestGroup(group: Object) {
   const { id } = group;
-  return dispatch => {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: InterestGroup.UPDATE,
@@ -112,8 +112,12 @@ export function editInterestGroup(group: object) {
   };
 }
 
-export function joinInterestGroup(groupId, user, role = 'member') {
-  return dispatch => {
+export function joinInterestGroup(
+  groupId: number,
+  user: Object,
+  role: string = 'member'
+) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Membership.JOIN_GROUP,
@@ -135,8 +139,8 @@ export function joinInterestGroup(groupId, user, role = 'member') {
   };
 }
 
-export function leaveInterestGroup(membership) {
-  return dispatch => {
+export function leaveInterestGroup(membership: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Membership.LEAVE_GROUP,

--- a/app/actions/JoblistingActions.js
+++ b/app/actions/JoblistingActions.js
@@ -19,7 +19,7 @@ export function fetchAll() {
   });
 }
 
-export function fetchJoblisting(id) {
+export function fetchJoblisting(id: number) {
   return callAPI({
     types: Joblistings.FETCH,
     endpoint: `/joblistings/${id}/`,
@@ -31,8 +31,8 @@ export function fetchJoblisting(id) {
   });
 }
 
-export function deleteJoblisting(id) {
-  return dispatch => {
+export function deleteJoblisting(id: number) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(
       callAPI({
         types: Joblistings.DELETE,
@@ -63,8 +63,8 @@ export function createJoblisting({
   fromYear,
   toYear,
   applicationUrl
-}) {
-  return dispatch => {
+}: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('joblistingEditor'));
 
     dispatch(
@@ -120,8 +120,8 @@ export function editJoblisting({
   fromYear,
   toYear,
   applicationUrl
-}) {
-  return dispatch => {
+}: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('joblistingEditor'));
     dispatch(
       callAPI({

--- a/app/actions/MeetingActions.js
+++ b/app/actions/MeetingActions.js
@@ -31,26 +31,30 @@ export function fetchAll() {
   });
 }
 
-export function setInvitationStatus(meetingId, status, user) {
+export function setInvitationStatus(
+  meetingId: number,
+  status: string,
+  userId: number
+) {
   return callAPI({
     types: Meeting.SET_INVITATION_STATUS,
-    endpoint: `/meetings/${meetingId}/invitations/${user}/`,
+    endpoint: `/meetings/${meetingId}/invitations/${userId}/`,
     method: 'put',
     body: {
-      user,
+      user: userId,
       status
     },
     meta: {
       errorMessage: 'Set invitation status failed',
       meetingId,
       status,
-      user
+      user: userId
     }
   });
 }
 
-export function deleteMeeting(id) {
-  return dispatch => {
+export function deleteMeeting(id: number) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('deleteMeeting'));
 
     dispatch(
@@ -84,8 +88,8 @@ export function createMeeting({
   reportAuthor,
   users,
   groups
-}) {
-  return dispatch => {
+}: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('meetingEditor'));
     dispatch(
       callAPI({
@@ -130,7 +134,7 @@ export function createMeeting({
   };
 }
 
-export function inviteUsersAndGroups({ id, users, groups }) {
+export function inviteUsersAndGroups({ id, users, groups }: Object) {
   return callAPI({
     types: Meeting.EDIT,
     endpoint: `/meetings/${id}/bulk_invite/`,
@@ -145,8 +149,12 @@ export function inviteUsersAndGroups({ id, users, groups }) {
   });
 }
 
-export function answerMeetingInvitation(action, token, loggedIn) {
-  return dispatch => {
+export function answerMeetingInvitation(
+  action: string,
+  token: string,
+  loggedIn: boolean
+) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('answerMeetingInvitation'));
 
     return dispatch(
@@ -179,8 +187,8 @@ export function editMeeting({
   id,
   users,
   groups
-}) {
-  return dispatch => {
+}: Object) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('meetingEditor'));
 
     dispatch(

--- a/app/actions/MembershipActions.js
+++ b/app/actions/MembershipActions.js
@@ -1,8 +1,10 @@
+// @flow
+
 import { membershipSchema } from 'app/reducers';
 import callAPI from 'app/actions/callAPI';
 import { Membership } from './ActionTypes';
 
-export function setGroupMembers(groupId, memberships) {
+export function setGroupMembers(groupId: number, memberships: Array<Object>) {
   return callAPI({
     types: Membership.MEMBER_SET,
     endpoint: `/memberships/${groupId}/set-all/`,

--- a/app/actions/NotificationActions.js
+++ b/app/actions/NotificationActions.js
@@ -2,7 +2,7 @@
 
 import { Notifications } from './ActionTypes';
 
-export function removeNotification({ id }) {
+export function removeNotification({ id }: { id: number }) {
   return {
     type: Notifications.NOTIFICATION_REMOVED,
     payload: {
@@ -16,7 +16,7 @@ export function addNotification({
   action = 'Close',
   dismissAfter = 3000,
   ...rest
-}) {
+}: Object) {
   return {
     type: Notifications.NOTIFICATION_ADDED,
     payload: {

--- a/app/actions/NotificationsFeedActions.js
+++ b/app/actions/NotificationsFeedActions.js
@@ -5,7 +5,7 @@ import callAPI from './callAPI';
 import { selectIsLoggedIn } from 'app/reducers/auth';
 
 export function fetchNotificationData() {
-  return (dispatch, getState) => {
+  return (dispatch: $FlowFixMe, getState: $FlowFixMe) => {
     if (selectIsLoggedIn(getState())) {
       return dispatch(
         callAPI({
@@ -29,7 +29,7 @@ export function markAllNotifications() {
   });
 }
 
-export function markNotification(notificationId) {
+export function markNotification(notificationId: number) {
   return callAPI({
     types: NotificationsFeed.MARK,
     endpoint: `/feed-notifications/${notificationId}/mark/`,

--- a/app/actions/QuoteActions.js
+++ b/app/actions/QuoteActions.js
@@ -7,10 +7,10 @@ import callAPI from 'app/actions/callAPI';
 import { Quote } from './ActionTypes';
 import { addNotification } from 'app/actions/NotificationActions';
 
-export function fetchAll({ approved = true }) {
+export function fetchAll({ approved = true }: { approved: boolean }) {
   return callAPI({
     types: Quote.FETCH,
-    endpoint: `/quotes/?approved=${approved}`,
+    endpoint: `/quotes/?approved=${String(approved)}`,
     schema: [quoteSchema],
     meta: {
       errorMessage: `Fetching ${approved ? '' : 'un'}approved quotes failed`
@@ -27,7 +27,7 @@ export function fetchAllUnapproved() {
   return fetchAll({ approved: false });
 }
 
-export function fetchQuote(quoteId) {
+export function fetchQuote(quoteId: number) {
   return callAPI({
     types: Quote.FETCH,
     endpoint: `/quotes/${quoteId}/`,
@@ -53,7 +53,7 @@ export function fetchRandomQuote() {
   });
 }
 
-export function approve(quoteId) {
+export function approve(quoteId: number) {
   return callAPI({
     types: Quote.APPROVE,
     endpoint: `/quotes/${quoteId}/approve/`,
@@ -65,7 +65,7 @@ export function approve(quoteId) {
   });
 }
 
-export function unapprove(quoteId) {
+export function unapprove(quoteId: number) {
   return callAPI({
     types: Quote.UNAPPROVE,
     endpoint: `/quotes/${quoteId}/unapprove/`,
@@ -77,8 +77,8 @@ export function unapprove(quoteId) {
   });
 }
 
-export function addQuotes({ text, source }) {
-  return dispatch => {
+export function addQuotes({ text, source }: { text: string, source: string }) {
+  return (dispatch: $FlowFixMe) => {
     dispatch(startSubmit('addQuote'));
 
     dispatch(
@@ -114,7 +114,7 @@ export function addQuotes({ text, source }) {
   };
 }
 
-export function deleteQuote(quoteId) {
+export function deleteQuote(quoteId: number) {
   return callAPI({
     types: Quote.DELETE,
     endpoint: `/quotes/${quoteId}/`,

--- a/app/actions/RoutingActions.js
+++ b/app/actions/RoutingActions.js
@@ -1,6 +1,8 @@
+// @flow
+
 import { Routing } from './ActionTypes';
 
-export function setStatusCode(statusCode) {
+export function setStatusCode(statusCode: number) {
   return {
     type: Routing.SET_STATUS_CODE,
     payload: statusCode

--- a/app/actions/SearchActions.js
+++ b/app/actions/SearchActions.js
@@ -10,8 +10,8 @@ export function toggleSearch() {
   };
 }
 
-export function autocomplete(query, filter) {
-  return dispatch => {
+export function autocomplete(query: string, filter?: Array<string>) {
+  return (dispatch: $FlowFixMe) => {
     if (!query) {
       return Promise.resolve();
     }
@@ -34,8 +34,8 @@ export function autocomplete(query, filter) {
   };
 }
 
-export function search(query, types) {
-  return dispatch => {
+export function search(query: string, types?: Array<string>) {
+  return (dispatch: $FlowFixMe) => {
     if (!query) {
       return Promise.resolve();
     }
@@ -58,8 +58,8 @@ export function search(query, types) {
   };
 }
 
-export function mention(query) {
-  return dispatch => {
+export function mention(query: string) {
+  return (dispatch: $FlowFixMe) => {
     if (!query) {
       return Promise.resolve();
     }

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -25,8 +25,8 @@ function removeToken() {
   return cookie.remove(USER_STORAGE_KEY, { path: '/' });
 }
 
-export function login(username, password) {
-  return dispatch =>
+export function login(username: string, password: string) {
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: User.LOGIN,
@@ -55,14 +55,17 @@ export function login(username, password) {
 }
 
 export function logout() {
-  return dispatch => {
+  return (dispatch: $FlowFixMe) => {
     removeToken();
     dispatch({ type: User.LOGOUT });
     dispatch(replace('/'));
   };
 }
 
-export function updateUser(user, options = { noRedirect: false }) {
+export function updateUser(
+  user: Object,
+  options: Object = { noRedirect: false }
+) {
   const {
     username,
     firstName,
@@ -72,7 +75,7 @@ export function updateUser(user, options = { noRedirect: false }) {
     allergies,
     profilePicture
   } = user;
-  return dispatch =>
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: User.UPDATE,
@@ -99,8 +102,18 @@ export function updateUser(user, options = { noRedirect: false }) {
     });
 }
 
-export function changePassword({ password, newPassword, retypeNewPassword }) {
-  return dispatch =>
+type PasswordPayload = {
+  password: string,
+  newPassword: string,
+  retypeNewPassword: string
+};
+
+export function changePassword({
+  password,
+  newPassword,
+  retypeNewPassword
+}: PasswordPayload) {
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: User.PASSWORD_CHANGE,
@@ -127,8 +140,8 @@ export function changePassword({ password, newPassword, retypeNewPassword }) {
     });
 }
 
-export function updatePicture({ picture }) {
-  return (dispatch, getState) => {
+export function updatePicture({ picture }: { picture: string }) {
+  return (dispatch: $FlowFixMe, getState: $FlowFixMe) => {
     const username = getState().auth.username;
     return dispatch(uploadFile({ file: picture })).then(action =>
       dispatch(
@@ -160,7 +173,7 @@ function getExpirationDate(token) {
   return moment(decodedToken.exp * 1000);
 }
 
-export function refreshToken(token) {
+export function refreshToken(token: string) {
   return callAPI({
     types: User.LOGIN,
     endpoint: '//authorization/token-auth/refresh/',
@@ -169,9 +182,12 @@ export function refreshToken(token) {
   });
 }
 
-export function loginWithExistingToken(token) {
-  return dispatch => {
-    const expirationDate = getExpirationDate(token);
+export function loginWithExistingToken(token: string) {
+  return (dispatch: $FlowFixMe) => {
+    // TODO(ek): Remove $FlowFixMe when we use a flow-typed version
+    // that has correct types for isSame
+    // (fixed in https://github.com/flowtype/flow-typed/commit/f3b9c89b85cdb463edeb707866a764508626cef1).
+    const expirationDate: $FlowFixMe = getExpirationDate(token);
     const now = moment();
 
     if (expirationDate.isSame(now, 'day')) {
@@ -201,7 +217,7 @@ export function loginWithExistingToken(token) {
  * Dispatch a login success if a token exists in local storage.
  */
 export function loginAutomaticallyIfPossible() {
-  return dispatch => {
+  return (dispatch: $FlowFixMe) => {
     const token = loadToken();
 
     if (token) {
@@ -212,8 +228,9 @@ export function loginAutomaticallyIfPossible() {
   };
 }
 
-export function sendRegistrationEmail({ email, captchaResponse }) {
-  return dispatch =>
+type EmailArgs = { email: string, captchaResponse: string };
+export function sendRegistrationEmail({ email, captchaResponse }: EmailArgs) {
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: User.SEND_REGISTRATION_TOKEN,
@@ -230,8 +247,8 @@ export function sendRegistrationEmail({ email, captchaResponse }) {
     );
 }
 
-export function validateRegistrationToken(token) {
-  return dispatch =>
+export function validateRegistrationToken(token: string) {
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: User.VALIDATE_REGISTRATION_TOKEN,
@@ -244,8 +261,8 @@ export function validateRegistrationToken(token) {
     );
 }
 
-export function createUser(token, user) {
-  return dispatch =>
+export function createUser(token: string, user: string) {
+  return (dispatch: $FlowFixMe) =>
     dispatch(
       callAPI({
         types: User.CREATE_USER,
@@ -270,7 +287,7 @@ export function createUser(token, user) {
     });
 }
 
-export function sendStudentConfirmationEmail(user) {
+export function sendStudentConfirmationEmail(user: string) {
   return callAPI({
     types: User.SEND_STUDENT_CONFIRMATION_TOKEN,
     endpoint: `/users-student-confirmation-request/`,
@@ -282,7 +299,7 @@ export function sendStudentConfirmationEmail(user) {
   });
 }
 
-export function confirmStudentUser(token) {
+export function confirmStudentUser(token: string) {
   return callAPI({
     types: User.CONFIRM_STUDENT_USER,
     endpoint: `/users-student-confirmation-perform/?token=${token}`,

--- a/app/types.js
+++ b/app/types.js
@@ -24,7 +24,9 @@ export type Action = {
 export type GalleryPictureEntity = {
   description?: string,
   active: boolean,
-  file: string
+  file: string,
+  galleryId: number,
+  taggees?: Array<Object>
 };
 
 export type GalleryEntity = {


### PR DESCRIPTION
Makes all the files in `app/actions` pass flow. I've added `$FlowFixMe` to the `dispatch` calls, which we need to replace with the proper type from redux eventually (https://flow.org/en/docs/react/redux/).

Note that I just fixed these on a file by file basis - not with actually running `flow` (since there's too many other errors). That means that there might be flow errors in other files calling into these functions, but we'll just have to fix those then. There's also definitely cases where we can type things better, e.g. by not using `Object` - but this is better than nothing.

Fixing this actually revealed three things I'm pretty sure are actual bugs:
* Missing constant: https://github.com/webkom/lego-webapp/compare/actions_flow_errors?expand=1#diff-18e4be09bfc22be85509502785e9cff8R121
* Another missing constant: https://github.com/webkom/lego-webapp/compare/actions_flow_errors?expand=1#diff-18e4be09bfc22be85509502785e9cff8R121
* And a wrong call to `Promise.all`: https://github.com/webkom/lego-webapp/compare/actions_flow_errors?expand=1#diff-e101e5b07f13fccf40b4ec901884043dR188 (I think Bluebird lets you call it like that)

Also, it'd be nice if people could use flow integrations in their editors until we fix #564 - to avoid introducing more errors. It adds a bit of a learning curve, but also saves a decent amount of debugging pain and time in a lot of cases.

