### PR TITLE
Handle actionGrants correctly when result is undefined

### DIFF
--- a/app/utils/createEntityReducer.js
+++ b/app/utils/createEntityReducer.js
@@ -54,15 +54,17 @@ export function entities(key: string, fetchType?: ActionTypeObject) {
     },
     action: any
   ) => {
-    const result = get(action, ['payload', 'entities', key], {});
-    const actionGrant = get(action, ['payload', 'actionGrant'], []);
+    let result = get(action, ['payload', 'entities', key]);
+    let actionGrant = get(action, ['payload', 'actionGrant']);
 
     if (
       !action.payload ||
-      action.type !== get(fetchType, 'SUCCESS', action.type)
+      (!result && actionGrant && action.type !== get(fetchType, 'SUCCESS'))
     )
       return state;
 
+    result = result || {};
+    actionGrant = actionGrant || [];
     return {
       ...state,
       byId: merge(state.byId, result),


### PR DESCRIPTION
The updated createEntityReducer ripped comments insertion because comments has fetch flag set, and therefore the get(fetchType ...) was evaluated wrongly. 
`Event.FETCH.SUCCESS !== Comment.ADD.SUCCESS` gives false, and therefore the comment data wasnt inserted to the state.
Closes #569 