### PR TITLE
Ignore more libraries in flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,9 @@
 .*/node_modules/babel.*
 .*/node_modules/stylelint*
 .*/node_modules/fbjs*
+.*/node_modules/react-motion*
+.*/node_modules/jss/*
+.*/node_modules/findup/*
 
 [libs]
 

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -185,7 +185,7 @@ export function refreshToken(token: string) {
 
 export function loginWithExistingToken(token: string): Thunk<*> {
   return dispatch => {
-    // TODO(ek): Remove $FlowFixMe when we use a flow-typed version
+    // TODO(ek): Remove FlowFixMe when we use a flow-typed version
     // that has correct types for isSame
     // (fixed in https://github.com/flowtype/flow-typed/commit/f3b9c89b85cdb463edeb707866a764508626cef1).
     const expirationDate: $FlowFixMe = getExpirationDate(token);


### PR DESCRIPTION
This ignores a few libraries that were producing flow errors, bringing down the error count from ~500 to 273. I think the rest comes from stuff that belongs to us.