### PR TITLE
Fix border form on EditorField.

### DIFF
--- a/app/components/Form/EditorField.js
+++ b/app/components/Form/EditorField.js
@@ -13,7 +13,7 @@ type Props = {
 function EditorField({ className, ...props }: Props) {
   return (
     <Editor
-      className={cx(styles.textField, className)}
+      className={cx(styles.input, className)}
       {...props}
       {...props.input}
       {...props.meta}


### PR DESCRIPTION
There is no `textField` in the imported .css.