### PR TITLE
Make the CheckBox component <input>, not <Field>

### DIFF
--- a/app/components/Form/CheckBox.js
+++ b/app/components/Form/CheckBox.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React from 'react';
-import { Field } from 'redux-form';
 import { createField } from './Field';
 import styles from './CheckBox.css';
 import cx from 'classnames';
@@ -15,6 +14,23 @@ type Props = {
   className?: string
 };
 
+/*
+
+When using this component as a Field in redux-form, you have to include
+normalize={v => !!v}. This makes the value always end up in redux-form as
+true or false, while otherwise it can end up as an empty string or left
+out of the firn values altogether.
+
+Example:
+<Field
+  name="name"
+  // label, placeholder, etc...
+  component={CheckBox.Field}
+  normalize={v => !!v} // <--
+/>
+
+*/
+
 function CheckBox({
   id,
   label,
@@ -25,12 +41,10 @@ function CheckBox({
 }: Props) {
   return (
     <div className={styles.box}>
-      <Field
+      <input
         {...props}
         className={cx(value ? styles.checked : styles.unchecked)}
-        component="input"
         type="checkbox"
-        normalize={v => !!v}
       />
       <label htmlFor={id} style={labelStyle} className={styles.label}>
         {label}


### PR DESCRIPTION
The CheckBox component should be an `<input>` by default, with the `Field` version being available through `CheckBox.Field`. 

This was changed to `Field` initially because unchecking the `CheckBox` results in the corresponding value in the form either being set to an empty string (instead of the expected `false`, or removed altogether. This is still an issue with this PR, but can be fixed with one line: include 
`normalize={v => !!v)` 
when using CheckBox in redux-form, as such:

```
<Field
          label={'...'}
          name="name"
          normalize={v => !!v) // <--
          component={CheckBox.Field}
/>
```
Perhaps this is a bad way of doing it - I tried, without success, to add this normalizing to the CheckBox component somehow. If anyone else can find a way to accomplish the same behaviour without everyone needing to add `normalize={v => !!v)` every time they use CheckBox in redux-form, feel free to pop a commit to this PR or make another one. 

This PR at least makes sure it's possible to use CheckBox both with and without redux-form – **in master atm, trying to use CheckBox without redux-form causes a complete crash**.