### PR TITLE
Preserve the selected tab in group admin

### DIFF
--- a/app/routes/admin/groups/components/GroupPage.js
+++ b/app/routes/admin/groups/components/GroupPage.js
@@ -10,6 +10,7 @@ import styles from './GroupPage.css';
 type Props = {
   children: React.Element<*>,
   groups: Array<Object>,
+  location: { pathname: string },
   params: { groupId: string }
 };
 
@@ -24,13 +25,13 @@ const GroupPageNavigation = ({ groupId }: { groupId: string }) => {
   );
 };
 
-const GroupPage = ({ groups, children, params }: Props) => {
+const GroupPage = ({ groups, children, location, params }: Props) => {
   return (
     <Content>
       {params.groupId && <GroupPageNavigation groupId={params.groupId} />}
       <div className={styles.groupPage}>
         <section className={styles.sidebar}>
-          <GroupTree groups={groups} />
+          <GroupTree groups={groups} pathname={location.pathname} />
         </section>
 
         <section className={styles.main}>{children}</section>

--- a/app/routes/admin/groups/components/GroupTree.js
+++ b/app/routes/admin/groups/components/GroupTree.js
@@ -1,20 +1,20 @@
-import styles from './GroupTree.css';
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+// @flow
+import React from 'react';
 import TreeView from 'react-treeview';
 import { Link } from 'react-router';
 import { generateTreeStructure } from 'app/utils';
+import styles from './GroupTree.css';
 
-function generateTreeView(groups) {
+function generateTreeView(groups, pathname) {
   return groups.map(group => {
-    const nodeLabel = (
-      <Link to={`/admin/groups/${group.id}/settings`}>{group.name}</Link>
-    );
+    // Re-use the currently selected sub-tab:
+    const href = pathname.replace(/\d+/, group.id);
+    const nodeLabel = <Link to={href}>{group.name}</Link>;
 
     if (group.children.length) {
       return (
         <TreeView key={group.id} nodeLabel={nodeLabel} defaultCollapsed={false}>
-          {generateTreeView(group.children)}
+          {generateTreeView(group.children, pathname)}
         </TreeView>
       );
     }
@@ -27,15 +27,14 @@ function generateTreeView(groups) {
   });
 }
 
-export default class GroupTree extends Component {
-  static propTypes = {
-    groups: PropTypes.array
-  };
+type Props = {
+  groups: Array<Object>,
+  pathname: string
+};
 
-  render() {
-    const { groups } = this.props;
-    const tree = generateTreeStructure(groups);
+const GroupTree = ({ groups, pathname }: Props) => {
+  const tree = generateTreeStructure(groups);
+  return <div className={styles.tree}>{generateTreeView(tree, pathname)}</div>;
+};
 
-    return <div className={styles.tree}>{generateTreeView(tree)}</div>;
-  }
-}
+export default GroupTree;

--- a/app/routes/admin/groups/components/__tests__/GroupTree.spec.js
+++ b/app/routes/admin/groups/components/__tests__/GroupTree.spec.js
@@ -25,7 +25,9 @@ const groups = [
 
 describe('<GroupTree />', () => {
   it('should render the child nodes as links', () => {
-    const wrapper = shallow(<GroupTree groups={groups} />);
+    const wrapper = shallow(
+      <GroupTree groups={groups} pathname="/admin/groups/1/settings" />
+    );
     expect(
       wrapper.containsMatchingElement(
         <Link to="/admin/groups/2/settings">Dog</Link>
@@ -40,15 +42,36 @@ describe('<GroupTree />', () => {
   });
 
   it('should render the root nodes correctly', () => {
-    const children = shallow(<GroupTree groups={groups} />).children();
+    const children = shallow(
+      <GroupTree groups={groups} pathname="/admin/groups/1/settings" />
+    ).children();
     expect(children.at(0).is(TreeView)).toEqual(true);
   });
 
   it('should work with only root groups', () => {
     const rootGroups = groups.slice(0, 1);
-    const wrapper = shallow(<GroupTree groups={rootGroups} />);
+    const wrapper = shallow(
+      <GroupTree groups={rootGroups} pathname="/admin/groups/1/settings" />
+    );
     const links = wrapper.find(Link);
     expect(wrapper.find(TreeView).length).toEqual(0);
     expect(links.length).toEqual(1);
+  });
+
+  it('should preserve the selected tab', () => {
+    const wrapper = shallow(
+      <GroupTree groups={groups} pathname="/admin/groups/1/members" />
+    );
+    expect(
+      wrapper.containsMatchingElement(
+        <Link to="/admin/groups/2/members">Dog</Link>
+      )
+    ).toEqual(true);
+
+    expect(
+      wrapper.containsMatchingElement(
+        <Link to="/admin/groups/3/members">Bird</Link>
+      )
+    ).toEqual(true);
   });
 });


### PR DESCRIPTION
Lets you change between different groups while still seeing the same selected tab (e.g. members).
Fixes #599.