### PR TITLE
Add support for non-numeric ids with leading digit

### DIFF
--- a/app/utils/__tests__/createEntityReducer.spec.js
+++ b/app/utils/__tests__/createEntityReducer.spec.js
@@ -120,6 +120,25 @@ describe('createEntityReducer', () => {
     });
   });
 
+  it('should reduce actionGrant when result is empty', () => {
+    expect(
+      reducer(undefined, {
+        type: FETCH.SUCCESS,
+        payload: {
+          actionGrant: ['list', 'create'],
+          entities: {},
+          result: []
+        }
+      })
+    ).toEqual({
+      actionGrant: ['list', 'create'],
+      byId: {},
+      items: [],
+      fetching: false,
+      smashed: false
+    });
+  });
+
   it('should toggle the fetching flag', () => {
     const state = reducer(undefined, { type: FETCH.BEGIN });
     expect(state.fetching).toEqual(true);

--- a/app/utils/createEntityReducer.js
+++ b/app/utils/createEntityReducer.js
@@ -1,6 +1,7 @@
 // @flow
 
-import { get, union } from 'lodash';
+import { get, union, isEmpty } from 'lodash';
+
 import joinReducers from 'app/utils/joinReducers';
 import mergeObjects from 'app/utils/mergeObjects';
 
@@ -48,24 +49,24 @@ export function entities(key: string, fetchType?: ActionTypeObject) {
     },
     action: any
   ) => {
-    let result = get(action, ['payload', 'entities', key]);
-    let actionGrant = get(action, ['payload', 'actionGrant']);
+    const result = get(action, ['payload', 'entities', key], {});
+    const resultIds = Object.keys(result).map(
+      i => (isNumber(i) ? parseInt(i, 10) : i)
+    );
+    const actionGrant = get(action, ['payload', 'actionGrant'], []);
 
     if (
       !action.payload ||
-      (!result && actionGrant && action.type !== get(fetchType, 'SUCCESS'))
+      (isEmpty(result) &&
+        !isEmpty(actionGrant) &&
+        action.type !== get(fetchType, 'SUCCESS'))
     )
       return state;
 
-    result = result || {};
-    actionGrant = actionGrant || [];
     return {
       ...state,
       byId: mergeObjects(state.byId, result),
-      items: union(
-        state.items,
-        Object.keys(result).map(i => (isNumber(i) ? parseInt(i, 10) : i))
-      ),
+      items: union(state.items, resultIds),
       actionGrant: union(state.actionGrant, actionGrant)
     };
   };


### PR DESCRIPTION
Add support for non-numeric entityIds that starts with a leading digit.
Since 'ParseInt' parses the value '1-abc' to '1', this also uses
'Number(i)' to ensure that only valid numbers are parsed. Number parses
'\t' to '0', while ParseInt parses it to NaN (and then goes to the
fallback).