### PR TITLE
Add prettier config to package.json

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}

--- a/package.json
+++ b/package.json
@@ -164,6 +164,9 @@
     },
     "testRegex": "\\.spec\\.(js|jsx)$"
   },
+  "prettier": {
+    "singleQuote": true
+  },
   "dllPlugin": {
     "path": "dist",
     "exclude": [


### PR DESCRIPTION
I ran into problems with eslint not liking single quotes, even though we
had the .prettierrc.json stuff, since Ale is seemingly moving files
around on save, so prettier doens't find the config file; it only finds
package.json, which I guess is copied over or something.