### PR TITLE
Fix calendar field in Firefox

### DIFF
--- a/app/components/Form/DatePicker.js
+++ b/app/components/Form/DatePicker.js
@@ -99,7 +99,6 @@ class DatePicker extends Component {
         triggerComponent={
           <TextInput
             className={cx(styles.inputField, className)}
-            disabled
             value={this.state.value.format(this.props.dateFormat)}
           />
         }


### PR DESCRIPTION
The input field was disabled, which caused it to be unclickable in
Firefox, so it was not possible to get the time dropdown thing to drop
down. After removing `disabled` in the `Field`, it works in both chrome
and Firefox.