### PR TITLE
Remove "3 friends are going" from the event list.

### DIFF
--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -62,10 +62,6 @@ export function EventItem({ event }: any) {
           />
         </Link>
 
-        <div>
-          <span>3 friends are going</span>
-        </div>
-
         <div className={styles.eventTime}>
           <Time time={event.startTime} format="ll HH:mm" />
           {` • ${event.location}`}


### PR DESCRIPTION
This has been a placeholder for over a year, and friends are not yet a
thing, at least not in the frontend. As we're moving in on release, we
should remove this, and rather file an issue to bring this great
functinoality back.

This fixes #526 