### PR TITLE
Remove strange padding from Dropdown component

### DIFF
--- a/app/components/Dropdown/Dropdown.css
+++ b/app/components/Dropdown/Dropdown.css
@@ -7,7 +7,6 @@
   box-shadow: 0 1px 25px rgba(0, 0, 0, 0.05);
   position: absolute;
   width: 250px;
-  padding: 10px 0;
   margin-top: 10px;
   z-index: 2;
 


### PR DESCRIPTION
Users that require padding can add padding. It is a lot easier for users of this component to add padding, than it is to remove it. :smile: 

Before:
![screenshot from 2017-10-06 01-40-12](https://user-images.githubusercontent.com/1467188/31257354-6f07a9d2-aa38-11e7-9098-937f4ef99cd1.png)
![screenshot from 2017-10-06 01-45-27](https://user-images.githubusercontent.com/1467188/31257356-6f2e0d70-aa38-11e7-967d-daa8cd3c2dea.png)

After:
![screenshot from 2017-10-06 01-45-08](https://user-images.githubusercontent.com/1467188/31257357-6f305300-aa38-11e7-8bca-ecfce080cc34.png)
![screenshot from 2017-10-06 01-43-52](https://user-images.githubusercontent.com/1467188/31257355-6f099e18-aa38-11e7-926e-a14f7def1163.png)
