### PR TITLE
Update Bdb to immedeately submit semesterStatuses instead of user needing to click 'Save'

### DIFF
--- a/app/routes/bdb/components/CompanyList.js
+++ b/app/routes/bdb/components/CompanyList.js
@@ -12,7 +12,6 @@ type Props = {
   startYear: number,
   startSem: number,
   navigateThroughTime: () => void,
-  changedStatuses: Array<any>,
   companySemesters: Array<Object>,
   editSemester: () => void
 };
@@ -62,8 +61,7 @@ export default class CompanyList extends Component {
       navigateThroughTime,
       startYear,
       startSem,
-      editSemester,
-      changedStatuses
+      editSemester
     } = this.props;
 
     /*
@@ -160,7 +158,6 @@ export default class CompanyList extends Component {
                 navigateThroughTime={this.navigateThroughTime}
                 key={i}
                 editSemester={editSemester}
-                changedStatuses={changedStatuses}
               />
             ))}
           </tbody>

--- a/app/routes/bdb/components/CompanySingleRow.js
+++ b/app/routes/bdb/components/CompanySingleRow.js
@@ -9,7 +9,6 @@ type Props = {
   startYear: number,
   startSem: number,
   editSemester: () => void,
-  changedStatuses: Array<Object>,
   companySemesters: Array<Object>
 };
 
@@ -29,7 +28,7 @@ export default class CompanySingleRow extends Component {
   };
 
   render() {
-    const { company, editSemester, changedStatuses } = this.props;
+    const { company, editSemester } = this.props;
 
     const semesters = [
       this.semesterElement(0),
@@ -42,7 +41,6 @@ export default class CompanySingleRow extends Component {
         semesterStatus={status}
         editSemester={editSemester}
         companyId={company.id}
-        changedStatuses={changedStatuses}
       />
     ));
 

--- a/app/routes/bdb/components/SemesterStatus.js
+++ b/app/routes/bdb/components/SemesterStatus.js
@@ -12,7 +12,6 @@ type Props = {
   editSemester: () => void,
   companyId: number,
   semIndex: number,
-  changedStatuses: Array<any>,
   startYear: number,
   startSem: number,
   companySemesters: Array<Object>


### PR DESCRIPTION
Several people who have tested the Bdb were surprised that the semester statuses weren't already saved after they had selected the new choice. This PR removed the logic that saves an array of changedStatuses in state and submits each element in that array once "Save" is clicked, instead submitting each semesterStatuses as it is changed. This has the added advantage of simplifying the code a bit.

<img width="1034" alt="skjermbilde 2017-10-09 kl 13 20 03" src="https://user-images.githubusercontent.com/14221386/31335885-cc31e938-acf4-11e7-8058-c17997b42b2a.png">

<img width="1079" alt="skjermbilde 2017-10-09 kl 13 20 44" src="https://user-images.githubusercontent.com/14221386/31335889-d0a50504-acf4-11e7-9428-d4a123623717.png">
