### PR TITLE
Send interest group type on create

### DIFF
--- a/app/actions/InterestGroupActions.js
+++ b/app/actions/InterestGroupActions.js
@@ -44,7 +44,8 @@ export function createInterestGroup(group: Object): Thunk<*> {
           name,
           description,
           text,
-          logo
+          logo,
+          type: 'interesse'
         },
         meta: {
           group,


### PR DESCRIPTION
We need this for the groups to actually be interest groups. 