### PR TITLE
Remove interest group delete button

### DIFF
--- a/app/routes/interestgroups/components/InterestGroupEdit.js
+++ b/app/routes/interestgroups/components/InterestGroupEdit.js
@@ -35,12 +35,6 @@ export default class InterestGroupEdit extends Component {
         <Flex justifyContent="space-between" alignItems="baseline">
           <div>
             <h1>Endre gruppe</h1>
-            <Button
-              onClick={() => removeInterestGroup(interestGroup.id)}
-              className={styles.deleteButton}
-            >
-              Slett gruppen
-            </Button>
           </div>
         </Flex>
         <GroupForm


### PR DESCRIPTION
I think we decided sometime that we'd make it not possible to delete
groups, so it doens't make any sense having the button here.