### PR TITLE
Remove interest group delete button

### DIFF
--- a/app/routes/interestgroups/components/InterestGroupEdit.js
+++ b/app/routes/interestgroups/components/InterestGroupEdit.js
@@ -35,12 +35,6 @@ export default class InterestGroupEdit extends Component {
         <Flex justifyContent="space-between" alignItems="baseline">
           <div>
             <h1>Endre gruppe</h1>
-            <Button
-              onClick={() => removeInterestGroup(interestGroup.id)}
-              className={styles.deleteButton}
-            >
-              Slett gruppen
-            </Button>
           </div>
         </Flex>
         <GroupForm


### PR DESCRIPTION
I think we decided sometime that we'd make it not possible to delete
groups, so it doens't make any sense having the button here.

IDK exactly who was here, or what we said, but we _did_ decide on that nobody should have permissions to delete interest group, according to [this](https://github.com/webkom/lego/pull/774/commits/07476a240ffeed07d616e930f48e89f586207614) commit. :confused: 

I suppose we figured that this would be a very rare event for someone to want, and that deleting a group is bad, since we `force=True` delete `Membership`s, so we didn't want for someone to delete a group on accident. This might cause us to have to delete quite a few "test" groups, but maybe that would be a problem in any case. 