### PR TITLE
Fix socket event update

### DIFF
--- a/app/reducers/events.js
+++ b/app/reducers/events.js
@@ -8,6 +8,7 @@ import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
 import { normalize } from 'normalizr';
 import { eventSchema } from 'app/reducers';
+import mergeObjects from 'app/utils/mergeObjects';
 
 export type EventEntity = {
   id: number,
@@ -27,10 +28,7 @@ function mutateEvent(state: any, action: any) {
       const events = normalize(action.payload, eventSchema).entities.events;
       return {
         ...state,
-        byId: {
-          ...state.byId,
-          ...events
-        }
+        byId: mergeObjects(state.byId, events)
       };
     }
     case Event.REGISTER.BEGIN: {

--- a/app/routes/events/EventListRoute.js
+++ b/app/routes/events/EventListRoute.js
@@ -23,8 +23,10 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 export default compose(
-  dispatched((props, dispatch) =>
-    dispatch(fetchAll({ dateAfter: moment().format('YYYY-MM-DD') })), {
+  dispatched(
+    (props, dispatch) =>
+      dispatch(fetchAll({ dateAfter: moment().format('YYYY-MM-DD') })),
+    {
       componentWillReceiveProps: false
     }
   ),

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -238,16 +238,22 @@ function EventEditor({
 
         <Flex wrapReverse>
           <Flex column className={styles.join}>
-            <Flex alignItems="center">
-              <Field
-                name="useCaptcha"
-                label="Bruk Captcha ved påmelding"
-                fieldClassName={styles.metaField}
-                className={styles.formField}
-                component={CheckBox.Field}
-                normalize={v => !!v}
-              />
-            </Flex>
+            <Field
+              name="useCaptcha"
+              label="Bruk Captcha ved påmelding"
+              fieldClassName={styles.metaField}
+              className={styles.formField}
+              component={CheckBox.Field}
+              normalize={v => !!v}
+            />
+            <Field
+              name="feedbackRequired"
+              label="Tvungen tilbakemelding"
+              fieldClassName={styles.metaField}
+              className={styles.formField}
+              component={CheckBox.Field}
+              normalize={v => !!v}
+            />
             <Button disabled={pristine || submitting} submit>
               LAGRE
             </Button>


### PR DESCRIPTION
The `SOCKET_EVENT_UPDATED` action was replacing the event, and therefore removing `activationTime` from the state. This disabled JoinEventForm from showing the appropriate content. This merges the object instead using the new `mergeObjects` method

- Add feedbackRequired checkbox
- Remove fetching on new props on EventList (as it is not needed)