### PR TITLE
Fix loading state in group admin panel

### DIFF
--- a/app/routes/admin/groups/components/GroupView.js
+++ b/app/routes/admin/groups/components/GroupView.js
@@ -30,7 +30,7 @@ export default class GroupView extends Component {
     const { group } = this.props;
     return (
       <section>
-        <LoadingIndicator loading={!group || !group.text}>
+        <LoadingIndicator loading={!group}>
           {group && <Group {...this.props} />}
         </LoadingIndicator>
       </section>


### PR DESCRIPTION
The 'selectGroup' selector returns 'undefined' when the group isn't
in the state. It is therefore sufficent to do 'loading={!group}'. The
previously the loading indicator was visible also if the text attribute
was empty.