### PR TITLE
Add id to search mapping for User

### DIFF
--- a/app/reducers/search.js
+++ b/app/reducers/search.js
@@ -27,6 +27,7 @@ const searchMapping = {
     color: '#A1C34A',
     path: '/users/',
     value: 'username',
+    id: 'id',
     profilePicture: 'profilePicture'
   },
   'articles.article': {


### PR DESCRIPTION
Sometimes the id of the user is neccesary, since the username is now the
default 'value'.