### PR TITLE
Support success messages from sockets

### DIFF
--- a/app/routes/events/EventDetailRoute.js
+++ b/app/routes/events/EventDetailRoute.js
@@ -1,6 +1,6 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { dispatched } from '@webkom/react-prepare';
+import prepare from 'app/utils/prepare';
 import {
   fetchEvent,
   deleteEvent,
@@ -88,8 +88,6 @@ const loadData = ({ params: { eventId }, currentUser }, dispatch) => {
 };
 
 export default compose(
-  dispatched(loadData, {
-    componentWillReceiveProps: false
-  }),
+  prepare(loadData, ['params.eventId']),
   connect(mapStateToProps, mapDispatchToProps)
 )(EventDetail);

--- a/app/utils/websockets.js
+++ b/app/utils/websockets.js
@@ -17,8 +17,9 @@ export default function createWebSocketMiddleware() {
       socket.onmessage = event => {
         const { type, payload, meta } = JSON.parse(event.data);
         store.dispatch({ type, payload, meta });
-        if (meta.errorMessage) {
-          store.dispatch(addNotification({ message: meta.errorMessage }));
+        const message = meta.successMessage || meta.errorMessage;
+        if (message) {
+          store.dispatch(addNotification({ message }));
         }
       };
 


### PR DESCRIPTION
We needed a notification message when a payment succeeds, this way we allow backend to send socket successMessages as well.

- Add usage of prepare in event as well