### PR TITLE
Some small designchanges to the 'Festet arrangement'

### DIFF
--- a/app/styles/utilities.css
+++ b/app/styles/utilities.css
@@ -78,9 +78,14 @@
   .u-ui-heading {
     color: #666;
     text-transform: uppercase;
-    padding: 10px 20px;
+    padding: 10px;
     font-size: 18px;
     font-weight: 400;
     letter-spacing: 1px;
+
+    @media (--mobile-device) {
+      padding: 0;
+      margin-bottom: 10px;
+    }
   }
 }


### PR DESCRIPTION
 Made some changes to the 'Festet arrangement' on the front page. It was far from in-line. Not sure if it breaks something else on the page, but the other headlines using the [u-ui-heading] already has overwriting values for padding and margin. It also makes it look a little better on desktop.

Before on phone
![before](https://user-images.githubusercontent.com/23152018/31790467-da2bfe38-b515-11e7-87c2-d10fe3cc1332.png)

After on phone
![after1](https://user-images.githubusercontent.com/23152018/31790506-012d5eb4-b516-11e7-82ce-ba48f0ac3956.png)

Before on desktop
![before2](https://user-images.githubusercontent.com/23152018/31790999-82b7ed22-b517-11e7-8b7e-5c6436d4f0bd.png)

After on desktop
![after2](https://user-images.githubusercontent.com/23152018/31791002-8932811c-b517-11e7-9697-69e87b064d89.png)


