### PR TITLE
Subtract two hours to set closing time before start time

### DIFF
--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -61,9 +61,10 @@ class JoinEventForm extends Component {
     let duration = moment.duration(diffTime, 'milliseconds');
     if (
       (!registration && !activationTime) ||
-      currentTime.isAfter(moment(startTime))
+      currentTime.isAfter(moment(startTime).subtract(2, 'hours'))
     ) {
       // Do nothing
+      // TODO: the 2 hour subtract is a hardcoded close time and should be improved
     } else if (poolActivationTime.isBefore(currentTime) || registration) {
       this.setState({
         formOpen: true,


### PR DESCRIPTION
https://github.com/webkom/lego/pull/848
This makes the frontend match the closing time set by the backend. We should however consider changing this, but we are better off with this in the meantime. https://github.com/webkom/lego/issues/846