### PR TITLE
Only push to parent if the group has a parent

### DIFF
--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -45,7 +45,9 @@ export function generateTreeStructure<
       roots.push(node);
     } else {
       const parent = tree[node.parent];
-      parent.children.push(node);
+      if (parent) {
+        parent.children.push(node);
+      }
     }
 
     return roots;


### PR DESCRIPTION
This is only a safeguard - groups are expected to have a parent, but _if
they don't_, it's OK to not fail hard.