### PR TITLE
Update various frontpage elements

### DIFF
--- a/app/routes/overview/components/CompactEvents.js
+++ b/app/routes/overview/components/CompactEvents.js
@@ -16,10 +16,6 @@ const TITLE_MAX_LENGTH = 25;
 export default class CompactEvents extends Component {
   props: Props;
 
-  state = {
-    eventsToShow: 5
-  };
-
   render() {
     const { events } = this.props;
 
@@ -31,7 +27,7 @@ export default class CompactEvents extends Component {
             event.startTime > moment.now() &&
             eventTypes.indexOf(event.eventType) !== -1
         )
-        .slice(0, this.state.eventsToShow)
+        .slice(0, 5)
         .map((event, key) => (
           <li key={key}>
             <span>
@@ -77,20 +73,6 @@ export default class CompactEvents extends Component {
             <h3 className="u-ui-heading">Arrangementer</h3>
             <ul className={styles.innerList}>{rightEvents}</ul>
           </Flex>
-        </Flex>
-        <Flex style={{ alignSelf: 'center' }}>
-          <a
-            style={{ marginRight: '10px' }}
-            onClick={() =>
-              this.setState({ eventsToShow: this.state.eventsToShow + 5 })}
-          >
-            Vis flere <i className="fa fa-angle-double-down " />
-          </a>
-          {this.state.eventsToShow > 5 && (
-            <a onClick={() => this.setState({ eventsToShow: 5 })}>
-              Vis færre <i className="fa fa-angle-double-up " />
-            </a>
-          )}
         </Flex>
       </Flex>
     );

--- a/app/routes/overview/components/Feed.css
+++ b/app/routes/overview/components/Feed.css
@@ -20,7 +20,7 @@
   border-radius: 3px;
   padding: 20px;
   overflow-y: auto;
-  height: 480px;
+  height: 459px;
   flex: 1;
   background-color: rgba(255, 255, 255, 0.4);
 }

--- a/app/routes/overview/components/LatestReadme.css
+++ b/app/routes/overview/components/LatestReadme.css
@@ -1,6 +1,6 @@
 .latestReadme {
   flex: 1;
-  background: #333;
+  background: #555;
   color: #fff;
   border-radius: 3px;
   padding: 10px 20px;

--- a/app/routes/overview/components/PublicFrontpage.js
+++ b/app/routes/overview/components/PublicFrontpage.js
@@ -150,6 +150,7 @@ class PublicFrontpage extends Component {
                 height: '500px',
                 width: '420px'
               }}
+              title="facebook"
               scrolling="no"
               frameBorder="0"
               allowTransparency="true"


### PR DESCRIPTION
Removes the "Vis flere" button for the compact events and makes the `readme` area a lighter gray so that it grabs less attention.