### PR TITLE
Fix event_socket_update triggering errors

### DIFF
--- a/app/reducers/pools.js
+++ b/app/reducers/pools.js
@@ -2,6 +2,8 @@ import { Event } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { normalize } from 'normalizr';
 import { eventSchema } from 'app/reducers';
+import { union } from 'lodash';
+import mergeObjects from 'app/utils/mergeObjects';
 
 export default createEntityReducer({
   key: 'pools',
@@ -15,8 +17,8 @@ export default createEntityReducer({
           normalize(action.payload, eventSchema).entities.pools || {};
         return {
           ...state,
-          byId: pools,
-          items: Object.keys(pools)
+          byId: mergeObjects(state.byId, pools),
+          items: union(state.items, Object.keys(pools).map(Number))
         };
       }
       case Event.SOCKET_REGISTRATION.SUCCESS: {

--- a/app/reducers/registrations.js
+++ b/app/reducers/registrations.js
@@ -4,7 +4,7 @@ import { union } from 'lodash';
 import { Event } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { normalize } from 'normalizr';
-import { registrationSchema } from 'app/reducers';
+import { eventSchema, registrationSchema } from 'app/reducers';
 import mergeObjects from 'app/utils/mergeObjects';
 import moment from 'moment';
 
@@ -13,6 +13,15 @@ export default createEntityReducer({
   types: {},
   mutate(state, action) {
     switch (action.type) {
+      case Event.SOCKET_EVENT_UPDATED: {
+        const registrations =
+          normalize(action.payload, eventSchema).entities.registrations || {};
+        return {
+          ...state,
+          byId: mergeObjects(state.byId, registrations),
+          items: union(state.items, Object.keys(registrations).map(Number))
+        };
+      }
       case Event.ADMIN_REGISTER.SUCCESS:
       case Event.SOCKET_REGISTRATION.SUCCESS:
       case Event.PAYMENT_QUEUE.SUCCESS:

--- a/app/reducers/users.js
+++ b/app/reducers/users.js
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
 import { User, Event } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { normalize } from 'normalizr';
-import { registrationSchema } from 'app/reducers';
+import { eventSchema, registrationSchema } from 'app/reducers';
 import mergeObjects from 'app/utils/mergeObjects';
 
 export type UserEntity = {
@@ -25,6 +25,15 @@ export default createEntityReducer({
   },
   mutate(state, action) {
     switch (action.type) {
+      case Event.SOCKET_EVENT_UPDATED: {
+        const users =
+          normalize(action.payload, eventSchema).entities.users || {};
+        return {
+          ...state,
+          byId: mergeObjects(state.byId, users),
+          items: union(state.items, Object.keys(users))
+        };
+      }
       case Event.SOCKET_REGISTRATION.SUCCESS:
       case Event.ADMIN_REGISTER.SUCCESS: {
         const users = normalize(action.payload, registrationSchema).entities


### PR DESCRIPTION
Event socket update is passing detailed event, but this was not correctly applied to the redux state. Raising multiple registration TypeErrors in the frontend. The error was only happening when admin actually edited events and users got socket message. 

#764 is probably not needed as of this.