### PR TITLE
Use object-fit: contain in events

### DIFF
--- a/app/routes/events/components/EventList.css
+++ b/app/routes/events/components/EventList.css
@@ -48,7 +48,7 @@
 .companyLogo img {
   min-width: 120px;
   height: 80px;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .bottomBorder {


### PR DESCRIPTION
Fixes #783. From that issue:

There's an argument to be made for `object-fit: cover`, but we should at least be consistent. Since we use object-fit: contain and a while background on the front page, we should do so in the event list page as well. 

From
<img width="1067" alt="skjermbilde 2017-10-20 kl 23 20 14" src="https://user-images.githubusercontent.com/14221386/31842214-435a3e4c-b5ed-11e7-9156-ef63ffcad627.png">


to 

<img width="1069" alt="skjermbilde 2017-10-20 kl 23 19 05" src="https://user-images.githubusercontent.com/14221386/31842181-1845f4e4-b5ed-11e7-8b00-db1e4f1fa25c.png">
 