### PR TITLE
Use IgnorePlugin to remove moment locales

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -3,6 +3,7 @@
 
 import 'babel-polyfill';
 import moment from 'moment-timezone';
+import 'moment/locale/nb';
 import { browserHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import { isEmpty } from 'lodash';

--- a/config/webpack.client.js
+++ b/config/webpack.client.js
@@ -47,6 +47,9 @@ module.exports = {
 
   plugins: getDependencyHandlers().concat(
     compact([
+      // Explicitly import the moment locales we care about:
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+
       new webpack.DefinePlugin({
         __DEV__: JSON.stringify(!isProduction),
         __CLIENT__: true,
@@ -59,9 +62,6 @@ module.exports = {
       !isProduction && new webpack.HotModuleReplacementPlugin(),
       !isProduction && new webpack.NoEmitOnErrorsPlugin(),
       new webpack.optimize.ModuleConcatenationPlugin(),
-
-      // Only include the Norwegian moment locale:
-      new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /nb-NO/),
 
       new webpack.optimize.UglifyJsPlugin({
         compress: {


### PR DESCRIPTION
`ContextReplacementPlugin` didn't work with our prod bundle. This fixes it by ignoring all locales, then explicitly importing the Norwegian one. It increases the bundle size somewhat, but much less than without the `IgnorePlugin` at all, so it might just be that the Norwegian locale itself takes up some space.