### PR TITLE
Add 'loggedIn' as a default watchProp in prepare

### DIFF
--- a/app/routes/events/EventListRoute.js
+++ b/app/routes/events/EventListRoute.js
@@ -3,7 +3,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import { dispatched } from '@webkom/react-prepare';
+import prepare from 'app/utils/prepare';
 import { fetchList } from 'app/actions/EventActions';
 import EventList from './components/EventList';
 import { selectSortedEvents } from 'app/reducers/events';
@@ -45,8 +45,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-  dispatched((props, dispatch) => dispatch(fetchData()), {
-    componentWillReceiveProps: false
-  }),
+  prepare((props, dispatch) => dispatch(fetchData())),
   connect(mapStateToProps, mapDispatchToProps)
 )(EventList);

--- a/app/utils/prepare.js
+++ b/app/utils/prepare.js
@@ -13,12 +13,13 @@ type PrepareFn = (props: Object, dispatch: Dispatch<*>) => Promise<*>;
  */
 export default function prepare(
   prepareFn: PrepareFn,
-  watchProps: ?Array<string>
+  watchProps?: Array<string> = []
 ) {
   // Returns true if any of the given watchProps have changed:
   const componentWillReceiveProps = (oldProps, newProps) =>
-    watchProps &&
-    watchProps.some(key => get(oldProps, key) !== get(newProps, key));
+    watchProps
+      .concat('loggedIn')
+      .some(key => get(oldProps, key) !== get(newProps, key));
 
   return dispatched(prepareFn, { componentWillReceiveProps });
 }


### PR DESCRIPTION
It is annoying when you as a user stays on a page, and then logges in - and you still can't see any content. This can be achived to add `loggedIn` as a watchProp in all routes, but imo this is a better approach. When a user logges out, we clear the whole state (and then setting it to `initialState`). We could (and probably should) do something similar with login, but this is how far I got today.

Thoughts anyone?