### PR TITLE
Fix fetching of meta on SSR

### DIFF
--- a/app/reducers/allowed.js
+++ b/app/reducers/allowed.js
@@ -11,7 +11,8 @@ const initialState = {
   announcements: false,
   groups: false,
   email: false,
-  users: false
+  users: false,
+  bdb: false
 };
 
 // export type Allowed = {

--- a/app/routes/app/AppRoute.js
+++ b/app/routes/app/AppRoute.js
@@ -122,7 +122,9 @@ function mapStateToProps(state) {
 }
 
 function fetchInitialOnServer(props, dispatch) {
-  return dispatch(loginAutomaticallyIfPossible()).then(dispatch(fetchMeta()));
+  return dispatch(loginAutomaticallyIfPossible()).then(() =>
+    dispatch(fetchMeta())
+  );
 }
 
 const mapDispatchToProps = {


### PR DESCRIPTION
When using SSR `fetchMeta` was executed without returning it's promise to SSR. Therefore the action was executed, but SSR didn't wait for the result. Therefore it worked on routes fetching other (and slower) stuff, but on routes like (for unauthorized users) `/` `fetchMeta` suecceded after SSR returned - aka. never actually returned :smile: 