### PR TITLE
Add FETCH_PARTIAL aciton, to fetch all memberships of a group

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -94,7 +94,8 @@ export const Group = {
   FETCH_ALL: generateStatuses('Group.FETCH_ALL'),
   CREATE: generateStatuses('Group.CREATE'),
   REMOVE: generateStatuses('Group.REMOVE'),
-  MEMBERSHIP_FETCH: generateStatuses('Group.MEMBERSHIP_FETCH')
+  MEMBERSHIP_FETCH: generateStatuses('Group.MEMBERSHIP_FETCH'),
+  MEMBERSHIP_FETCH_PARTIAL: generateStatuses('Group.MEMBERSHIP_FETCH_PARTIAL')
 };
 
 export const CompanyInterestForm = {

--- a/app/reducers/groups.js
+++ b/app/reducers/groups.js
@@ -44,6 +44,20 @@ export default createEntityReducer({
           }
         };
       }
+      case Group.MEMBERSHIP_FETCH_PARTIAL.SUCCESS: {
+        const id = action.meta.groupId;
+        const currentMemberships = state.byId[id].memberships || [];
+        return {
+          ...state,
+          byId: {
+            ...state.byId,
+            [id]: {
+              ...state.byId[id],
+              memberships: currentMemberships.concat(action.payload.result)
+            }
+          }
+        };
+      }
       default:
         return state;
     }


### PR DESCRIPTION
We want to get all memberships of the group we're looking at, and the
API uses pagination. Now we fetch memberships using the `next` from the
payload until there is nothing left. Since we want to add memberships to
the group on the `next` fetches, but not on the initial fetch, we make a
new action type.