### PR TITLE
Update dependency react-overlays

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-helmet": "^5.2.0",
     "react-motion": "^0.5.1",
     "react-notification": "^6.6.0",
-    "react-overlays": "^0.7.3",
+    "react-overlays": "0.8.2",
     "react-portal": "^3.1.0",
     "react-redux": "^5.0.1",
     "react-router": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,6 +1502,10 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
+
 chalk@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
@@ -2378,7 +2382,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.1:
+dom-helpers@^3.2.0, dom-helpers@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
@@ -6909,14 +6913,15 @@ react-notification@^6.6.0:
   dependencies:
     prop-types "^15.5.10"
 
-react-overlays@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.3.tgz#e4caa690ce7cd7d40b2cf9cdc26356cddaf5a0e9"
+react-overlays@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.2.tgz#ec6e2dc3e73afadca35c1be534082a473ef28177"
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.1"
     prop-types "^15.5.10"
     prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.0"
     warning "^3.0.0"
 
 react-portal@^3.1.0:
@@ -7058,6 +7063,17 @@ react-textarea-autosize@^5.1.0:
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.1.0.tgz#ffbf8164fce217c79443c1c17dedf730592df224"
   dependencies:
     prop-types "^15.5.10"
+
+react-transition-group@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
+  dependencies:
+    chain-function "^1.0.0"
+    classnames "^2.2.5"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.8"
+    warning "^3.0.0"
 
 react-treeview@^0.4.6:
   version "0.4.7"


### PR DESCRIPTION
"Downgrade" react-overlays from 0.7.3 to 0.8.2.

The `react-overlays`-team have a strange release policy..

This fixes the dropdowns, including login and datepicker