### PR TITLE
Fix encoding bug with SSR

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1,6 +1,6 @@
 const config =
   typeof window !== 'undefined' && window.__CONFIG__
-    ? JSON.parse(atob(window.__CONFIG__))
+    ? JSON.parse(new Buffer(window.__CONFIG__, 'base64').toString())
     : require('../config/env');
 
 export default config;

--- a/app/index.js
+++ b/app/index.js
@@ -19,7 +19,9 @@ global.log = function log(self = this) {
   return this;
 };
 
-const preloadedState = JSON.parse(atob(window.__PRELOADED_STATE__));
+const preloadedState = JSON.parse(
+  new Buffer(window.__PRELOADED_STATE__, 'base64').toString()
+);
 delete window.__PRELOADED_STATE__;
 
 const store = configureStore(preloadedState);


### PR DESCRIPTION
Turns out atob only supports ASCII, resulting in strange encoding. It
also tuns out that webpack has a polyfill for node 'Buffer', and buffer
with base64 encoding is fully 'UTF-8' compatible.