### PR TITLE
Use serialize-javascript for initial state

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1,6 +1,6 @@
 const config =
   typeof window !== 'undefined' && window.__CONFIG__
-    ? JSON.parse(new Buffer(window.__CONFIG__, 'base64').toString())
+    ? window.__CONFIG__
     : require('../config/env');
 
 export default config;

--- a/app/index.js
+++ b/app/index.js
@@ -19,11 +19,7 @@ global.log = function log(self = this) {
   return this;
 };
 
-const preloadedState = JSON.parse(
-  new Buffer(window.__PRELOADED_STATE__, 'base64').toString()
-);
-delete window.__PRELOADED_STATE__;
-
+const preloadedState = window.__PRELOADED_STATE__;
 const store = configureStore(preloadedState);
 
 if (isEmpty(preloadedState)) {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "redux-logger": "^3.0.1",
     "redux-thunk": "^2.2.0",
     "reselect": "2.5.4",
+    "serialize-javascript": "^1.4.0",
     "slate": "^0.24.5",
     "slate-auto-replace": "0.6.2",
     "slate-html-serializer": "^0.1.5",

--- a/server/render.js
+++ b/server/render.js
@@ -8,6 +8,7 @@ import cookie from 'react-cookie';
 import { prepare } from '@webkom/react-prepare';
 import Helmet from 'react-helmet';
 import Raven from 'raven';
+import serialize from 'serialize-javascript';
 import routes from '../app/routes';
 import configureStore from '../app/utils/configureStore';
 import config from '../config/env';
@@ -134,12 +135,8 @@ function renderPage({ body, state, helmet }) {
       <body>
         <div id="root">${body}</div>
         <script>
-           window.__CONFIG__ = "${Buffer.from(
-             JSON.stringify(config).replace(/</g, '\\u003c')
-           ).toString('base64')}"
-           window.__PRELOADED_STATE__ = "${Buffer.from(
-             JSON.stringify(state).replace(/</g, '\\u003c')
-           ).toString('base64')}"
+           window.__CONFIG__ = ${serialize(config, { isJSON: true })};
+           window.__PRELOADED_STATE__ = ${serialize(state, { isJSON: true })};
         </script>
 
         <script async src="https://js.stripe.com/v2/"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7623,6 +7623,10 @@ send@0.15.4:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+serialize-javascript@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
+
 serve-index@^1.7.2:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.0.tgz#d2b280fc560d616ee81b48bf0fa82abed2485ce7"


### PR DESCRIPTION
This is probably an unnecessary precaution since we're already base64 encoding the state, but at least this makes the script tag escaping and such slightly cleaner.

https://medium.com/node-security/the-most-common-xss-vulnerability-in-react-js-applications-2bdffbcc1fa0