### PR TITLE
Fix token refreshing

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -211,7 +211,8 @@ export const User = {
   SEND_FORGOT_PASSWORD_REQUEST: generateStatuses(
     'User.SEND_FORGOT_PASSWORD_REQUEST'
   ),
-  RESET_PASSWORD: generateStatuses('User.RESET_PASSWORD')
+  RESET_PASSWORD: generateStatuses('User.RESET_PASSWORD'),
+  REFRESH_TOKEN: generateStatuses('User.REFRESH_TOKEN')
 };
 
 /**

--- a/app/reducers/auth.js
+++ b/app/reducers/auth.js
@@ -37,6 +37,7 @@ export default function auth(state: State = initialState, action: any): State {
 
     case User.CREATE_USER.SUCCESS:
     case User.LOGIN.SUCCESS:
+    case User.REFRESH_TOKEN.SUCCESS:
       return {
         ...state,
         loggingIn: false,


### PR DESCRIPTION
The token refreshing was completely broke, should work now. I changed the logic a bit too, it now refreshes the token after completing the login to prevent the user from noticing that anything happened. It also refreshes the token once per day, as it doesn't really hurt and it creates a better user experience.

Tested with the server side renderer as well.