### PR TITLE
Use https for readme.abakus.no

### DIFF
--- a/app/components/Search/utils.js
+++ b/app/components/Search/utils.js
@@ -40,7 +40,7 @@ const LINKS: Array<Link> = [
   {
     key: 'readme',
     title: 'readme',
-    url: 'http://readme.abakus.no'
+    url: 'https://readme.abakus.no'
   },
   {
     key: 'interestGroups',

--- a/app/routes/overview/components/LatestReadme.js
+++ b/app/routes/overview/components/LatestReadme.js
@@ -52,11 +52,11 @@ class LatestReadme extends Component<Props, State> {
             {[1, 2, 3, 4].map(issue => (
               <a
                 key={issue}
-                href={`http://readme.abakus.no/utgaver/2017/2017-0${issue}.pdf`}
+                href={`https://readme.abakus.no/utgaver/2017/2017-0${issue}.pdf`}
                 className={styles.thumb}
               >
                 <Image
-                  src={`http://readme.abakus.no/bilder/2017/2017-0${issue}.jpg`}
+                  src={`https://readme.abakus.no/bilder/2017/2017-0${issue}.jpg`}
                 />
               </a>
             ))}


### PR DESCRIPTION
Avoids browser warnings (and we just turned HTTPS on for readme.abakus.no in cloudflare)