### PR TITLE
Make sure pages with titles >1 line looks like one element in navigation

### DIFF
--- a/app/routes/pages/components/PageHierarchy.css
+++ b/app/routes/pages/components/PageHierarchy.css
@@ -9,6 +9,11 @@
 
 .pageList {
   text-align: left;
+  line-height: 18px;
+
+  & li {
+    margin-bottom: 10px;
+  }
 }
 
 .pageList a {


### PR DESCRIPTION
<img width="237" alt="skjermbilde 2017-10-24 kl 21 45 56" src="https://user-images.githubusercontent.com/14221386/31964597-de851abc-b904-11e7-8b10-5109a563437e.png">
