### PR TITLE
Add support for admin registration to waiting list

### DIFF
--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -193,7 +193,7 @@ export function unregister(
 export function adminRegister(
   eventId: number,
   userId: number,
-  poolId: number,
+  poolId?: number,
   feedback: string,
   reason: string
 ) {
@@ -203,7 +203,7 @@ export function adminRegister(
     method: 'POST',
     body: {
       user: userId,
-      pool: poolId ? poolId : undefined,
+      pool: poolId,
       feedback,
       admin_reason: reason
     },

--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -203,7 +203,7 @@ export function adminRegister(
     method: 'POST',
     body: {
       user: userId,
-      pool: poolId,
+      pool: poolId ? poolId : undefined,
       feedback,
       admin_reason: reason
     },

--- a/app/routes/events/components/EventAdministrate/AdminRegisterForm.js
+++ b/app/routes/events/components/EventAdministrate/AdminRegisterForm.js
@@ -40,7 +40,7 @@ const AdminRegister = ({
           label="Pool"
           options={pools
             .map(pool => ({ value: pool.id, label: pool.name }))
-            .concat([{ value: 0, label: 'Venteliste' }])}
+            .concat([{ value: -1, label: 'Venteliste' }])}
           simpleValue
         />
         <Field
@@ -65,7 +65,7 @@ function validateForm(data) {
     errors.reason = 'Forklaring er påkrevet';
   }
 
-  if (!data.pool && data.pool !== 0) {
+  if (!data.pool) {
     errors.pool = 'Pool er påkrevet';
   }
 

--- a/app/routes/events/components/EventAdministrate/AdminRegisterForm.js
+++ b/app/routes/events/components/EventAdministrate/AdminRegisterForm.js
@@ -38,7 +38,9 @@ const AdminRegister = ({
           component={SelectInput.Field}
           placeholder="Pool"
           label="Pool"
-          options={pools.map(pool => ({ value: pool.id, label: pool.name }))}
+          options={pools
+            .map(pool => ({ value: pool.id, label: pool.name }))
+            .concat([{ value: 0, label: 'Venteliste' }])}
           simpleValue
         />
         <Field
@@ -63,7 +65,7 @@ function validateForm(data) {
     errors.reason = 'Forklaring er påkrevet';
   }
 
-  if (!data.pool) {
+  if (!data.pool && data.pool !== 0) {
     errors.pool = 'Pool er påkrevet';
   }
 

--- a/app/routes/events/components/EventAdministrate/index.js
+++ b/app/routes/events/components/EventAdministrate/index.js
@@ -34,7 +34,7 @@ export type Props = {
   unregister: (ID, ID, boolean) => Promise<*>,
   updatePresence: (number, number, string) => Promise<*>,
   updatePayment: (ID, ID, EventRegistrationChargeStatus) => Promise<*>,
-  adminRegister: (ID, ID, ID, string, string) => Promise<*>,
+  adminRegister: (ID, ID, ?ID, string, string) => Promise<*>,
   usersResult: Array<User>,
   actionGrant: ActionGrant,
   onQueryChanged: (value: string) => any,
@@ -84,14 +84,15 @@ export default class EventAdministrate extends Component<Props, State> {
     reason
   }: {
     user: User,
-    pool: number,
+    pool?: number,
     feedback: string,
     reason: string
   }) => {
+    const poolId = pool !== -1 ? pool : undefined;
     this.props.adminRegister(
       this.props.eventId,
       user.id,
-      pool,
+      poolId,
       feedback,
       reason
     );


### PR DESCRIPTION
Kinda hacky, but since there is no pool with `id=0` we can use that as an "id" for the waiting list.

Depends on this PR in the backend: https://github.com/webkom/lego/pull/894