### PR TITLE
Set correct cookie options

### DIFF
--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -20,7 +20,17 @@ function loadToken() {
 }
 
 function saveToken(token) {
-  return cookie.save(USER_STORAGE_KEY, token, { path: '/' });
+  const decoded = jwtDecode(token);
+  const expires = moment.unix(decoded.exp);
+  // milliseconds -> seconds:
+  const maxAge = expires.diff(moment()) / 1000;
+  return cookie.save(USER_STORAGE_KEY, token, {
+    path: '/',
+    maxAge,
+    expires: expires.toDate(),
+    // Only HTTPS in prod:
+    secure: !__DEV__
+  });
 }
 
 function removeToken() {


### PR DESCRIPTION
Previously the cookie would be set as a session cookie, so it'd get deleted when users closed their browsers. This fixes that, and sets it to `secure` in prod as well. 