### PR TITLE
Fix previous events & joblistings for company

### DIFF
--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -82,7 +82,7 @@ export function fetchEventsForCompany(companyId: string) {
     );
 }
 
-export function fetchJobListingsForCompany(companyId: string) {
+export function fetchJoblistingsForCompany(companyId: string) {
   return (dispatch: Dispatch) =>
     dispatch(
       callAPI({
@@ -90,7 +90,7 @@ export function fetchJobListingsForCompany(companyId: string) {
         endpoint: `/joblistings/?company=${companyId}`,
         schema: [joblistingsSchema],
         meta: {
-          errorMessage: 'Henting av tilknyttede arrangementer feilet'
+          errorMessage: 'Henting av tilknyttede jobbannonser feilet'
         }
       })
     );
@@ -99,7 +99,6 @@ export function fetchJobListingsForCompany(companyId: string) {
 export function addCompany(data: Object): Thunk<*> {
   return dispatch => {
     dispatch(startSubmit('company'));
-
     return dispatch(
       callAPI({
         types: Company.ADD,
@@ -177,7 +176,7 @@ export function addSemesterStatus(
         method: 'POST',
         body: data,
         meta: {
-          errorMessage: 'Legg til semester status feilet',
+          errorMessage: 'Legg til semesterstatus feilet',
           companyId
         }
       })
@@ -210,7 +209,7 @@ export function editSemesterStatus(
         }
       })
     ).then(() => {
-      dispatch(addNotification({ message: 'Semester status endret.' }));
+      dispatch(addNotification({ message: 'Semesterstatus endret.' }));
       if (options.detail) {
         dispatch(push(`/bdb/${companyId}/`));
       } else {
@@ -233,7 +232,7 @@ export function deleteSemesterStatus(
         meta: {
           companyId,
           semesterId,
-          errorMessage: 'Sletting av semester status feilet'
+          errorMessage: 'Sletting av semesterstatus feilet'
         }
       })
     ).then(() => {
@@ -249,7 +248,7 @@ export function fetchCompanyContact({ companyId }: { companyId: number }) {
     endpoint: `/companies/${companyId}/company-contacts/`,
     method: 'GET',
     meta: {
-      errorMessage: 'Henting av bedriftkontakt feilet'
+      errorMessage: 'Henting av bedriftskontakt feilet'
     }
   });
 }
@@ -274,7 +273,7 @@ export function addCompanyContact({
           phone
         },
         meta: {
-          errorMessage: 'Legg til bedriftkontakt feilet',
+          errorMessage: 'Legg til bedriftskontakt feilet',
           companyId
         }
       })
@@ -306,7 +305,7 @@ export function editCompanyContact({
           phone
         },
         meta: {
-          errorMessage: 'Endring av bedriftkontakt feilet',
+          errorMessage: 'Endring av bedriftskontakt feilet',
           companyId
         }
       })
@@ -330,7 +329,7 @@ export function deleteCompanyContact(
         meta: {
           companyId,
           companyContactId,
-          errorMessage: 'Sletting av bedriftkontakt feilet'
+          errorMessage: 'Sletting av bedriftskontakt feilet'
         }
       })
     ).then(() => {
@@ -348,7 +347,7 @@ export function fetchSemesters({ companyInterest }: Object = {}) {
     })}`,
     schema: [companySemesterSchema],
     meta: {
-      errorMessage: 'Fetching company semesters failed'
+      errorMessage: 'Henting av semestre feilet'
     },
     propagateError: true
   });
@@ -371,7 +370,7 @@ export function addSemester({ year, semester }: SemesterInput): Thunk<*> {
           semester
         },
         meta: {
-          errorMessage: 'Adding semester failed'
+          errorMessage: 'Legge til semester feilet'
         }
       })
     );

--- a/app/reducers/companies.js
+++ b/app/reducers/companies.js
@@ -10,6 +10,7 @@ import { selectCompanySemesters } from './companySemesters';
 import mergeObjects from 'app/utils/mergeObjects';
 import type { UserEntity } from 'app/reducers/users';
 import type { CompanySemesterContactedStatus, Semester } from 'app/models';
+import { selectJoblistings } from 'app/reducers/joblistings';
 
 export type BaseCompanyEntity = {
   name: string,
@@ -226,12 +227,25 @@ export const selectCompanyById = createSelector(
 );
 
 export const selectEventsForCompany = createSelector(
-  selectCompanyById,
+  (state, props) => props.companyId,
   selectEvents,
-  (company, events) => {
-    if (!company || !events) return [];
+  (companyId, events) => {
+    if (!companyId || !events) return [];
     return events.filter(
-      event => event.company && event.company.id === company.id
+      event => event.company && Number(event.company.id) === Number(companyId)
+    );
+  }
+);
+
+export const selectJoblistingsForCompany = createSelector(
+  (state, props) => props.companyId,
+  selectJoblistings,
+  (companyId, joblistings) => {
+    if (!companyId || !joblistings) return [];
+    return joblistings.filter(
+      joblisting =>
+        joblisting.company &&
+        Number(joblisting.company.id) === Number(companyId)
     );
   }
 );

--- a/app/reducers/joblistings.js
+++ b/app/reducers/joblistings.js
@@ -24,6 +24,13 @@ export default createEntityReducer({
   }
 });
 
+export const selectJoblistings = createSelector(
+  state => state.joblistings.byId,
+  state => state.joblistings.items,
+  (joblistingsById, joblistingIds) =>
+    joblistingIds.map(id => joblistingsById[id])
+);
+
 export const selectJoblistingById = createSelector(
   state => state.joblistings.byId,
   (state, props) => props.joblistingId,

--- a/app/routes/company/CompanyDetailRoute.js
+++ b/app/routes/company/CompanyDetailRoute.js
@@ -3,20 +3,32 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { dispatched } from '@webkom/react-prepare';
-import { fetch as fetchCompany } from 'app/actions/CompanyActions';
+import {
+  fetch as fetchCompany,
+  fetchEventsForCompany,
+  fetchJoblistingsForCompany
+} from 'app/actions/CompanyActions';
 import CompanyDetail from './components/CompanyDetail';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
-import { selectEventsForCompany } from 'app/reducers/companies';
+import {
+  selectEventsForCompany,
+  selectJoblistingsForCompany
+} from 'app/reducers/companies';
+
+const fetchData = (props, dispatch) =>
+  Promise.all([
+    dispatch(fetchCompany(props.params.companyId)),
+    dispatch(fetchEventsForCompany(props.params.companyId)),
+    dispatch(fetchJoblistingsForCompany(props.params.companyId))
+  ]);
 
 const mapStateToProps = (state, props) => {
   const { companyId } = props.params;
   const { query } = props.location;
   const company = state.companies.byId[companyId];
   const companyEvents = selectEventsForCompany(state, { companyId });
-  const joblistings = state.joblistings.items.map(
-    id => state.joblistings.byId[id]
-  );
+  const joblistings = selectJoblistingsForCompany(state, { companyId });
 
   return {
     company,
@@ -30,12 +42,9 @@ const mapStateToProps = (state, props) => {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  dispatched(
-    ({ params: { companyId } }, dispatch) => dispatch(fetchCompany(companyId)),
-    {
-      componentWillReceiveProps: false
-    }
-  ),
+  dispatched(fetchData, {
+    componentWillReceiveProps: false
+  }),
   // $FlowFixMe
   connect(mapStateToProps, null)
 )(CompanyDetail);

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -7,10 +7,7 @@
 .checkboxWrapper {
   margin-top: 5px;
   margin-bottom: -5px;
-
-  @media (--small-viewport) {
-    flex-wrap: wrap;
-  }
+  flex-wrap: wrap;
 }
 
 .remove {


### PR DESCRIPTION
Created selectors and actions for fetching the right events and joblistings for each company. Previously, there was a bug were each company would get all events and joblistings available for all companies.
Also fixed some small typos regarding error messages.
Fixed a minor style bug in companyInterest by adding flex-wrap: wrap #819 