### PR TITLE
Add pagination and fix previous events & joblistings for companies

### DIFF
--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -14,17 +14,26 @@ import { push } from 'react-router-redux';
 import type { Thunk } from 'app/types';
 import { addNotification } from 'app/actions/NotificationActions';
 
-export function fetchAll() {
-  return callAPI({
-    types: Company.FETCH,
-    endpoint: '/companies/',
-    schema: [companySchema],
-    meta: {
-      errorMessage: 'Henting av bedrifter feilet'
-    },
-    propagateError: true
-  });
-}
+export const fetchAll = ({ fetchMore }: { fetchMore: boolean }): Thunk<*> => (
+  dispatch,
+  getState
+) => {
+  const endpoint = fetchMore
+    ? getState().companies.pagination[''].nextPage
+    : '/companies/';
+  return dispatch(
+    callAPI({
+      types: Company.FETCH,
+      endpoint,
+      schema: [companySchema],
+      meta: {
+        errorMessage: 'Henting av bedrifter feilet',
+        queryString: ''
+      },
+      propagateError: true
+    })
+  );
+};
 
 export function fetchAllAdmin() {
   return callAPI({

--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -82,7 +82,7 @@ export function fetchEventsForCompany(companyId: string) {
     );
 }
 
-export function fetchJobListingsForCompany(companyId: string) {
+export function fetchJoblistingsForCompany(companyId: string) {
   return (dispatch: Dispatch) =>
     dispatch(
       callAPI({
@@ -90,7 +90,7 @@ export function fetchJobListingsForCompany(companyId: string) {
         endpoint: `/joblistings/?company=${companyId}`,
         schema: [joblistingsSchema],
         meta: {
-          errorMessage: 'Henting av tilknyttede arrangementer feilet'
+          errorMessage: 'Henting av tilknyttede jobbannonser feilet'
         }
       })
     );
@@ -99,7 +99,6 @@ export function fetchJobListingsForCompany(companyId: string) {
 export function addCompany(data: Object): Thunk<*> {
   return dispatch => {
     dispatch(startSubmit('company'));
-
     return dispatch(
       callAPI({
         types: Company.ADD,
@@ -177,7 +176,7 @@ export function addSemesterStatus(
         method: 'POST',
         body: data,
         meta: {
-          errorMessage: 'Legg til semester status feilet',
+          errorMessage: 'Legg til semesterstatus feilet',
           companyId
         }
       })
@@ -210,7 +209,7 @@ export function editSemesterStatus(
         }
       })
     ).then(() => {
-      dispatch(addNotification({ message: 'Semester status endret.' }));
+      dispatch(addNotification({ message: 'Semesterstatus endret.' }));
       if (options.detail) {
         dispatch(push(`/bdb/${companyId}/`));
       } else {
@@ -233,7 +232,7 @@ export function deleteSemesterStatus(
         meta: {
           companyId,
           semesterId,
-          errorMessage: 'Sletting av semester status feilet'
+          errorMessage: 'Sletting av semesterstatus feilet'
         }
       })
     ).then(() => {
@@ -249,7 +248,7 @@ export function fetchCompanyContact({ companyId }: { companyId: number }) {
     endpoint: `/companies/${companyId}/company-contacts/`,
     method: 'GET',
     meta: {
-      errorMessage: 'Henting av bedriftkontakt feilet'
+      errorMessage: 'Henting av bedriftskontakt feilet'
     }
   });
 }
@@ -274,7 +273,7 @@ export function addCompanyContact({
           phone
         },
         meta: {
-          errorMessage: 'Legg til bedriftkontakt feilet',
+          errorMessage: 'Legg til bedriftskontakt feilet',
           companyId
         }
       })
@@ -306,7 +305,7 @@ export function editCompanyContact({
           phone
         },
         meta: {
-          errorMessage: 'Endring av bedriftkontakt feilet',
+          errorMessage: 'Endring av bedriftskontakt feilet',
           companyId
         }
       })
@@ -330,7 +329,7 @@ export function deleteCompanyContact(
         meta: {
           companyId,
           companyContactId,
-          errorMessage: 'Sletting av bedriftkontakt feilet'
+          errorMessage: 'Sletting av bedriftskontakt feilet'
         }
       })
     ).then(() => {
@@ -348,7 +347,7 @@ export function fetchSemesters({ companyInterest }: Object = {}) {
     })}`,
     schema: [companySemesterSchema],
     meta: {
-      errorMessage: 'Fetching company semesters failed'
+      errorMessage: 'Henting av semestre feilet'
     },
     propagateError: true
   });
@@ -371,7 +370,7 @@ export function addSemester({ year, semester }: SemesterInput): Thunk<*> {
           semester
         },
         meta: {
-          errorMessage: 'Adding semester failed'
+          errorMessage: 'Legge til semester feilet'
         }
       })
     );

--- a/app/components/Search/utils.js
+++ b/app/components/Search/utils.js
@@ -63,6 +63,11 @@ const LINKS: Array<Link> = [
     url: '/quotes'
   },
   {
+    key: 'companies',
+    title: 'Bedrifter',
+    url: '/companies'
+  },
+  {
     key: 'jobListings',
     title: 'Jobbannonser',
     url: '/joblistings'

--- a/app/reducers/companies.js
+++ b/app/reducers/companies.js
@@ -10,6 +10,7 @@ import { selectCompanySemesters } from './companySemesters';
 import mergeObjects from 'app/utils/mergeObjects';
 import type { UserEntity } from 'app/reducers/users';
 import type { CompanySemesterContactedStatus, Semester } from 'app/models';
+import { selectJoblistings } from 'app/reducers/joblistings';
 
 export type BaseCompanyEntity = {
   name: string,
@@ -226,12 +227,25 @@ export const selectCompanyById = createSelector(
 );
 
 export const selectEventsForCompany = createSelector(
-  selectCompanyById,
+  (state, props) => props.companyId,
   selectEvents,
-  (company, events) => {
-    if (!company || !events) return [];
+  (companyId, events) => {
+    if (!companyId || !events) return [];
     return events.filter(
-      event => event.company && event.company.id === company.id
+      event => event.company && Number(event.company.id) === Number(companyId)
+    );
+  }
+);
+
+export const selectJoblistingsForCompany = createSelector(
+  (state, props) => props.companyId,
+  selectJoblistings,
+  (companyId, joblistings) => {
+    if (!companyId || !joblistings) return [];
+    return joblistings.filter(
+      joblisting =>
+        joblisting.company &&
+        Number(joblisting.company.id) === Number(companyId)
     );
   }
 );

--- a/app/reducers/joblistings.js
+++ b/app/reducers/joblistings.js
@@ -24,6 +24,13 @@ export default createEntityReducer({
   }
 });
 
+export const selectJoblistings = createSelector(
+  state => state.joblistings.byId,
+  state => state.joblistings.items,
+  (joblistingsById, joblistingIds) =>
+    joblistingIds.map(id => joblistingsById[id])
+);
+
 export const selectJoblistingById = createSelector(
   state => state.joblistings.byId,
   (state, props) => props.joblistingId,

--- a/app/routes/company/CompaniesRoute.js
+++ b/app/routes/company/CompaniesRoute.js
@@ -7,24 +7,32 @@ import { fetchAll } from 'app/actions/CompanyActions';
 import CompaniesPage from './components/CompaniesPage';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
+import { selectPagination } from '../../reducers/selectors';
+import { selectCompanies } from 'app/reducers/companies';
 
 const mapStateToProps = (state, props) => {
   const { query } = props.location;
-  const companies = state.companies.items.map(
-    item => state.companies.byId[item]
+  const companies = selectCompanies(state, props);
+  const showFetchMore = selectPagination('companies', { queryString: '' })(
+    state
   );
   return {
+    showFetchMore,
     companies,
     query,
     loggedIn: props.loggedIn
   };
 };
 
+const mapDispatchToProps = {
+  fetchMore: () => fetchAll({ fetchMore: true })
+};
+
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  dispatched((props, dispatch) => dispatch(fetchAll()), {
+  dispatched((props, dispatch) => dispatch(fetchAll({ fetchMore: false })), {
     componentWillReceiveProps: false
   }),
   // $FlowFixMe connect
-  connect(mapStateToProps, null)
+  connect(mapStateToProps, mapDispatchToProps)
 )(CompaniesPage);

--- a/app/routes/company/CompanyDetailRoute.js
+++ b/app/routes/company/CompanyDetailRoute.js
@@ -3,20 +3,32 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { dispatched } from '@webkom/react-prepare';
-import { fetch as fetchCompany } from 'app/actions/CompanyActions';
+import {
+  fetch as fetchCompany,
+  fetchEventsForCompany,
+  fetchJoblistingsForCompany
+} from 'app/actions/CompanyActions';
 import CompanyDetail from './components/CompanyDetail';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
-import { selectEventsForCompany } from 'app/reducers/companies';
+import {
+  selectEventsForCompany,
+  selectJoblistingsForCompany
+} from 'app/reducers/companies';
+
+const fetchData = (props, dispatch) =>
+  Promise.all([
+    dispatch(fetchCompany(props.params.companyId)),
+    dispatch(fetchEventsForCompany(props.params.companyId)),
+    dispatch(fetchJoblistingsForCompany(props.params.companyId))
+  ]);
 
 const mapStateToProps = (state, props) => {
   const { companyId } = props.params;
   const { query } = props.location;
   const company = state.companies.byId[companyId];
   const companyEvents = selectEventsForCompany(state, { companyId });
-  const joblistings = state.joblistings.items.map(
-    id => state.joblistings.byId[id]
-  );
+  const joblistings = selectJoblistingsForCompany(state, { companyId });
 
   return {
     company,
@@ -30,12 +42,9 @@ const mapStateToProps = (state, props) => {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  dispatched(
-    ({ params: { companyId } }, dispatch) => dispatch(fetchCompany(companyId)),
-    {
-      componentWillReceiveProps: false
-    }
-  ),
+  dispatched(fetchData, {
+    componentWillReceiveProps: false
+  }),
   // $FlowFixMe
   connect(mapStateToProps, null)
 )(CompanyDetail);

--- a/app/routes/company/components/CompaniesPage.js
+++ b/app/routes/company/components/CompaniesPage.js
@@ -6,9 +6,12 @@ import LoadingIndicator from 'app/components/LoadingIndicator';
 import { Link } from 'react-router';
 import { Image } from 'app/components/Image';
 import type { Company } from 'app/models';
+import { Button } from 'app/components/Form';
 
 type Props = {
-  companies: Array<Company>
+  companies: Array<Company>,
+  showFetchMore: () => void,
+  fetchMore: () => void
 };
 
 export function CompanyItem({ company }: any) {
@@ -47,14 +50,16 @@ function CompanyList({ name, companies = [] }: CompanyListProps) {
   );
 }
 
-const CompaniesPage = ({ companies }: Props) => {
-  if (companies.length < 1) {
+const CompaniesPage = (props: Props) => {
+  if (props.companies.length < 1) {
     return <LoadingIndicator loading />;
   }
-
   return (
     <div className={styles.root}>
-      <CompanyList name="Bedrifter" companies={companies} />
+      <CompanyList name={'Bedrifter'} companies={props.companies} />
+      {props.showFetchMore && (
+        <Button onClick={() => props.fetchMore()}>Flere bedrifter</Button>
+      )}
     </div>
   );
 };

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -7,10 +7,7 @@
 .checkboxWrapper {
   margin-top: 5px;
   margin-bottom: -5px;
-
-  @media (--small-viewport) {
-    flex-wrap: wrap;
-  }
+  flex-wrap: wrap;
 }
 
 .remove {


### PR DESCRIPTION
Add pagination for companies. #776
Add link to /companies in the search bar.
Created selectors and actions for fetching the right events and joblistings for each company. Previously, there was a bug were each company would get all events and joblistings available for all companies.
Fixed some small typos regarding error messages.
Fixed a minor style bug in companyInterest by adding flex-wrap: wrap #819