### PR TITLE
Fix cookie security level

### DIFF
--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -2,6 +2,7 @@
 
 import jwtDecode from 'jwt-decode';
 import { normalize } from 'normalizr';
+import config from 'app/config';
 import cookie from 'js-cookie';
 import moment from 'moment-timezone';
 import { push, replace } from 'react-router-redux';
@@ -22,7 +23,7 @@ function saveToken(token) {
     path: '/',
     expires: expires.toDate(),
     // Only HTTPS in prod:
-    secure: !__DEV__
+    secure: config.environment === 'production'
   });
 }
 


### PR DESCRIPTION
Use the config to determine the environment instead of __DEV__. This
makes it possible to test PROD build localy, together with SSR.

Use the same way as the red development header, https://github.com/webkom/lego-webapp/blob/74b9ee8ca4f4c9aa5f2c223cb899930e7ecd90e7/app/routes/app/AppRoute.js#L81