### PR TITLE
Mark notifications as read after opening notification box

### DIFF
--- a/app/actions/NotificationsFeedActions.js
+++ b/app/actions/NotificationsFeedActions.js
@@ -31,15 +31,3 @@ export function markAllNotifications() {
     }
   });
 }
-
-export function markNotification(notificationId: number) {
-  return callAPI({
-    types: NotificationsFeed.MARK,
-    endpoint: `/feed-notifications/${notificationId}/mark/`,
-    method: 'POST',
-    body: {
-      read: true,
-      seen: true
-    }
-  });
-}

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -26,7 +26,6 @@ type Props = {
   fetchNotifications: () => void,
   notifications: Array<Object>,
   markAllNotifications: () => Promise<void>,
-  markNotification: number => Promise<void>,
   fetchNotificationData: () => Promise<void>
 };
 
@@ -131,7 +130,6 @@ class Header extends Component<Props, State> {
                   fetchNotifications={this.props.fetchNotifications}
                   notifications={this.props.notifications}
                   markAllNotifications={this.props.markAllNotifications}
-                  markNotification={this.props.markNotification}
                   fetchNotificationData={this.props.fetchNotificationData}
                 />
               )}

--- a/app/components/HeaderNotifications/HeaderNotifications.css
+++ b/app/components/HeaderNotifications/HeaderNotifications.css
@@ -16,16 +16,6 @@
   }
 }
 
-.seeAllWrapper {
-  text-align: center;
-  padding: 10px;
-  border-top: 1px solid lightgray;
-}
-
-.seeAll {
-  align-self: center;
-}
-
 .notification {
   border-bottom: 1px solid lightgray;
   padding: 15px;

--- a/app/components/HeaderNotifications/index.js
+++ b/app/components/HeaderNotifications/index.js
@@ -6,7 +6,6 @@ import Icon from '../Icon';
 import { activityRenderers } from '../Feed';
 import Time from 'app/components/Time';
 import styles from './HeaderNotifications.css';
-import { Link } from 'react-router';
 
 type Props = {
   notificationsData: Object,
@@ -37,7 +36,7 @@ const NotificationElement = ({
           styles.notification,
           !notification.read ? styles.unRead : null
         )}
-        onClick={() => markNotification(notification.id)}
+        onClick={() => this.props.markNotification(notification.id)}
       >
         <div className={styles.innerNotification}>
           <div className={styles.icon}>{renders.icon(notification)}</div>
@@ -58,7 +57,8 @@ const NotificationElement = ({
 
 export default class NotificationsDropdown extends Component<Props, State> {
   state: State = {
-    notificationsOpen: false
+    notificationsOpen: false,
+    hideUnreadCount: false
   };
 
   seeAll = () => {
@@ -100,12 +100,20 @@ export default class NotificationsDropdown extends Component<Props, State> {
         toggle={() =>
           this.setState(
             {
-              notificationsOpen: !this.state.notificationsOpen
+              notificationsOpen: !this.state.notificationsOpen,
+              hideUnreadCount: true
             },
-            () => (this.state.notificationsOpen ? fetchNotifications() : null)
+            () =>
+              this.state.notificationsOpen
+                ? fetchNotifications()
+                : this.props.markAllNotifications().then(this.fetch)
           )}
         triggerComponent={
-          <Icon.Badge name="notifications" size={30} badgeCount={unreadCount} />
+          <Icon.Badge
+            name="notifications"
+            size={30}
+            badgeCount={!this.state.hideUnreadCount && unreadCount}
+          />
         }
         contentClassName={styles.notifications}
       >
@@ -114,11 +122,6 @@ export default class NotificationsDropdown extends Component<Props, State> {
           <div style={{ width: '100%' }}>
             <div style={{ maxHeight: '300px', overflowY: 'overlay' }}>
               {this.renderNotifications(notifications)}
-            </div>
-            <div className={styles.seeAllWrapper}>
-              <Link onClick={this.seeAll} className={styles.seeAll}>
-                Marker alle som sett
-              </Link>
             </div>
           </div>
         ) : (

--- a/app/components/HeaderNotifications/index.js
+++ b/app/components/HeaderNotifications/index.js
@@ -12,7 +12,6 @@ type Props = {
   fetchNotifications: () => void,
   notifications: Array<Object>,
   markAllNotifications: () => Promise<void>,
-  markNotification: number => Promise<void>,
   fetchNotificationData: () => Promise<void>
 };
 
@@ -20,13 +19,7 @@ type State = {
   notificationsOpen: boolean
 };
 
-const NotificationElement = ({
-  notification,
-  markNotification
-}: {
-  notification: Object,
-  markNotification: number => void
-}) => {
+const NotificationElement = ({ notification }: { notification: Object }) => {
   const renders = activityRenderers[notification.verb];
 
   if (renders) {
@@ -36,7 +29,6 @@ const NotificationElement = ({
           styles.notification,
           !notification.read ? styles.unRead : null
         )}
-        onClick={() => this.props.markNotification(notification.id)}
       >
         <div className={styles.innerNotification}>
           <div className={styles.icon}>{renders.icon(notification)}</div>
@@ -57,18 +49,7 @@ const NotificationElement = ({
 
 export default class NotificationsDropdown extends Component<Props, State> {
   state: State = {
-    notificationsOpen: false,
-    hideUnreadCount: false
-  };
-
-  seeAll = () => {
-    this.setState({ notificationsOpen: false });
-    this.props.markAllNotifications().then(this.fetch);
-  };
-
-  markNotification = (notificationId: number) => {
-    this.setState({ notificationsOpen: false });
-    this.props.markNotification(notificationId).then(this.fetch);
+    notificationsOpen: false
   };
 
   fetch = () => {
@@ -80,11 +61,7 @@ export default class NotificationsDropdown extends Component<Props, State> {
     return (
       <div>
         {notifications.map((notification, i) => (
-          <NotificationElement
-            key={i}
-            notification={notification}
-            markNotification={this.markNotification}
-          />
+          <NotificationElement key={i} notification={notification} />
         ))}
       </div>
     );
@@ -100,19 +77,18 @@ export default class NotificationsDropdown extends Component<Props, State> {
         toggle={() =>
           this.setState(
             {
-              notificationsOpen: !this.state.notificationsOpen,
-              hideUnreadCount: true
+              notificationsOpen: !this.state.notificationsOpen
             },
             () =>
               this.state.notificationsOpen
                 ? fetchNotifications()
-                : this.props.markAllNotifications().then(this.fetch)
+                : this.props.markAllNotifications()
           )}
         triggerComponent={
           <Icon.Badge
             name="notifications"
             size={30}
-            badgeCount={!this.state.hideUnreadCount && unreadCount}
+            badgeCount={this.state.notificationsOpen ? 0 : unreadCount}
           />
         }
         contentClassName={styles.notifications}

--- a/app/components/HeaderNotifications/index.js
+++ b/app/components/HeaderNotifications/index.js
@@ -60,8 +60,11 @@ export default class NotificationsDropdown extends Component<Props, State> {
   renderNotifications = (notifications: Array<Object>) => {
     return (
       <div>
-        {notifications.map((notification, i) => (
-          <NotificationElement key={i} notification={notification} />
+        {notifications.map(notification => (
+          <NotificationElement
+            key={notification.id}
+            notification={notification}
+          />
         ))}
       </div>
     );

--- a/app/reducers/notificationsFeed.js
+++ b/app/reducers/notificationsFeed.js
@@ -20,6 +20,8 @@ export default function notificationsFeed(
         ...state,
         ...action.payload
       };
+    case NotificationsFeed.MARK_ALL.SUCCESS:
+      return initialState;
     default: {
       return state;
     }

--- a/app/routes/app/AppRoute.js
+++ b/app/routes/app/AppRoute.js
@@ -14,8 +14,7 @@ import {
 } from 'app/actions/UserActions';
 import {
   fetchNotificationData,
-  markAllNotifications,
-  markNotification
+  markAllNotifications
 } from 'app/actions/NotificationsFeedActions';
 import { fetchNotificationFeed } from 'app/actions/FeedActions';
 import { fetchMeta } from 'app/actions/MetaActions';
@@ -101,7 +100,6 @@ class App extends PureComponent<AppProps> {
           notificationsData={this.props.notificationsData}
           fetchNotifications={this.props.fetchNotificationFeed}
           notifications={this.props.notifications}
-          markNotification={this.props.markNotification}
           markAllNotifications={this.props.markAllNotifications}
           fetchNotificationData={this.props.fetchNotificationData}
         />
@@ -146,7 +144,6 @@ const mapDispatchToProps = {
   logout,
   login,
   fetchNotificationFeed,
-  markNotification,
   markAllNotifications,
   fetchNotificationData,
   setStatusCode


### PR DESCRIPTION
Fixes #832
Hides unread count from notification icon when opening the notification box and marks all notifications as read after closing, removed "Marker alle som sett"
![notification](https://user-images.githubusercontent.com/16608915/32077148-aeda8e10-baa2-11e7-9ddd-cc7f9ae7702a.png)
![notificationbox](https://user-images.githubusercontent.com/16608915/32077154-b68ce220-baa2-11e7-919a-bdb49002db12.png)
