### PR TITLE
Add support for reversed sorting of comments

### DIFF
--- a/app/components/Comments/CommentView.js
+++ b/app/components/Comments/CommentView.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { generateTreeStructure } from 'app/utils';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import CommentForm from 'app/components/CommentForm';
+import { Flex } from 'app/components/Layout';
 import type { CommentEntity } from 'app/reducers/comments';
 import type { UserEntity } from 'app/reducers/users';
 import CommentTree from './CommentTree';
@@ -15,8 +16,12 @@ type Props = {
   user: UserEntity,
   loggedIn: boolean,
   displayTitle?: boolean,
-  style?: Object
+  style?: Object,
+  newOnTop?: boolean
 };
+
+const Title = ({ displayTitle }: { displayTitle: boolean }) =>
+  displayTitle && <h3>Kommentarer</h3>;
 
 const CommentView = (props: Props) => {
   const {
@@ -26,28 +31,38 @@ const CommentView = (props: Props) => {
     user,
     loggedIn,
     style,
-    displayTitle = true
+    displayTitle = true,
+    newOnTop = false
   } = props;
   const commentFormProps = { commentTarget, user, loggedIn };
   const tree = generateTreeStructure(comments);
 
   return (
     <div style={style}>
-      {displayTitle && <h3>Kommentarer</h3>}
-      <LoadingIndicator loading={!comments}>
-        {comments && (
-          <CommentTree comments={tree} commentFormProps={commentFormProps} />
-        )}
-      </LoadingIndicator>
+      <Title displayTitle={displayTitle} />
+      <Flex
+        style={{
+          flexDirection: newOnTop ? 'column-reverse' : 'column'
+        }}
+      >
+        <LoadingIndicator loading={!comments}>
+          {comments && (
+            <CommentTree
+              comments={newOnTop ? tree.reverse() : tree}
+              commentFormProps={commentFormProps}
+            />
+          )}
+        </LoadingIndicator>
 
-      {!formDisabled && (
-        <div>
-          <CommentForm
-            form={`comment.${commentFormProps.commentTarget}`}
-            {...commentFormProps}
-          />
-        </div>
-      )}
+        {!formDisabled && (
+          <div>
+            <CommentForm
+              form={`comment.${commentFormProps.commentTarget}`}
+              {...commentFormProps}
+            />
+          </div>
+        )}
+      </Flex>
     </div>
   );
 };

--- a/app/routes/bdb/components/BdbDetail.js
+++ b/app/routes/bdb/components/BdbDetail.js
@@ -385,9 +385,8 @@ export default class BdbDetail extends Component<Props, State> {
               user={currentUser}
               commentTarget={company.commentTarget}
               loggedIn={loggedIn}
-              comments={comments.sort(
-                (a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt)
-              )}
+              comments={comments}
+              newOnTop
             />
           )}
         </div>


### PR DESCRIPTION
The prop 'newOnTop' for CommentView allows comments to be sorted (only
the first level in the tree) with the newest comments on top. The
comment form will then also be on the top.

![screenshot from 2017-10-27 01-01-10](https://user-images.githubusercontent.com/1467188/32080934-ae59ef52-bab2-11e7-8833-e4f8d80b8ac7.png)
