### PR TITLE
Fix issue where callAPI promise isn't fulfilled

### DIFF
--- a/app/actions/callAPI.js
+++ b/app/actions/callAPI.js
@@ -105,7 +105,7 @@ export default function callAPI({
     if (shouldUseCache) {
       const cachedRequest = getCachedRequest(state, endpoint, cacheSeconds);
       if (cachedRequest) {
-        return new Promise(() => dispatch(cachedRequest));
+        return Promise.resolve(dispatch(cachedRequest));
       }
     }
 


### PR DESCRIPTION
When callAPI used a cached value, the returned promise never fulfilled,
and therefore all the '.then' functions chained together with the
promise was never executed. This fixes the issue, by returning a promise
that when executed will resolve with the cached value.

Since the action doesn't contain a promise, the `promiseMiddleware` doesn't do it's magic - and therefore the promise isn't fulfilled via `resolve`.

And isn't it closer to `cachedResponse`, instead of `cachedRequest`??

This fixes #847 and fixes #775 :smile: 