### PR TITLE
Fix typos in Editor

### DIFF
--- a/app/components/Editor/constants.js
+++ b/app/components/Editor/constants.js
@@ -11,7 +11,7 @@ export type TagKind = 'mark' | 'block';
 export type MarkType =
   | 'italic'
   | 'bold'
-  | 'underlined'
+  | 'underline'
   | 'code'
   | 'link'
   | 'strikethrough';

--- a/app/components/Editor/index.js
+++ b/app/components/Editor/index.js
@@ -154,7 +154,7 @@ class CustomEditor extends Component<Props, State> {
     } else if (isItalicHotkey(e)) {
       mark = 'italic';
     } else if (isUnderlinedHotkey(e)) {
-      mark = 'underlined';
+      mark = 'underline';
     } else if (isCodeHotkey(e)) {
       mark = 'code';
     } else {


### PR DESCRIPTION
Fix typos that resulted in a crash when setting text underline