### PR TITLE
Only create body if it exists

### DIFF
--- a/app/utils/fetchJSON.js
+++ b/app/utils/fetchJSON.js
@@ -60,7 +60,7 @@ export function stringifyBody(requestOptions: HttpRequestOptions) {
     return JSON.stringify(body);
   }
 
-  return null;
+  return;
 }
 
 function makeFormData(files, rawBody) {
@@ -98,7 +98,7 @@ export default function fetchJSON<T>(
   let body;
   if (files && files.length > 0) {
     body = makeFormData(files, requestOptions.body);
-  } else {
+  } else if (body) {
     body = stringifyBody(requestOptions);
     requestOptions.headers['Content-Type'] = 'application/json';
   }


### PR DESCRIPTION
Can't say for sure, but I'm guessing that all the `Failed to construct 'Request': HEAD or GET Requests cannot have a body.` (https://sentry.abakus.no/webkom/lego-webapp/issues/3796/) errors in IE Edge comes from us passing in `body` as null.