### PR TITLE
Bdb improvements

### DIFF
--- a/app/reducers/companies.js
+++ b/app/reducers/companies.js
@@ -237,8 +237,8 @@ export const selectEventsForCompany = createSelector(
 );
 
 export const selectCompanyContactById = createSelector(
-  selectCompanyById,
-  (state, props) => props.companyId,
+  (state, props) => selectCompanyById(state, props),
+  (state, props) => props.companyContactId,
   (company, companyContactId) => {
     if (!company || !company.companyContacts) return {};
     return company.companyContacts.find(

--- a/app/routes/bdb/AddCompanyContactRoute.js
+++ b/app/routes/bdb/AddCompanyContactRoute.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
-import { fetch, addCompanyContact } from '../../actions/CompanyActions';
+import { fetchAdmin, addCompanyContact } from '../../actions/CompanyActions';
 import CompanyContactEditor from './components/CompanyContactEditor';
 import { selectCompanyById } from 'app/reducers/companies';
 import { LoginPage } from 'app/components/LoginForm';
@@ -21,8 +21,9 @@ const mapDispatchToProps = { submitFunction: addCompanyContact };
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  prepare(({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)), [
-    'params.companyId'
-  ]),
+  prepare(
+    ({ params: { companyId } }, dispatch) => dispatch(fetchAdmin(companyId)),
+    ['params.companyId']
+  ),
   connect(mapStateToProps, mapDispatchToProps)
 )(CompanyContactEditor);

--- a/app/routes/bdb/AddCompanyContactRoute.js
+++ b/app/routes/bdb/AddCompanyContactRoute.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { dispatched } from '@webkom/react-prepare';
+import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
 import { fetch, addCompanyContact } from '../../actions/CompanyActions';
 import CompanyContactEditor from './components/CompanyContactEditor';
@@ -21,11 +21,8 @@ const mapDispatchToProps = { submitFunction: addCompanyContact };
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  dispatched(
-    ({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)),
-    {
-      componentWillReceiveProps: false
-    }
-  ),
+  prepare(({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)), [
+    'params.companyId'
+  ]),
   connect(mapStateToProps, mapDispatchToProps)
 )(CompanyContactEditor);

--- a/app/routes/bdb/AddSemesterRoute.js
+++ b/app/routes/bdb/AddSemesterRoute.js
@@ -5,7 +5,7 @@ import {
   addSemesterStatus,
   fetchSemesters,
   addSemester,
-  fetchAll,
+  fetchAllAdmin,
   deleteCompany
 } from '../../actions/CompanyActions';
 import { selectCompanies } from 'app/reducers/companies';
@@ -74,7 +74,7 @@ export default compose(
   replaceUnlessLoggedIn(LoginPage),
   prepare(
     (props, dispatch) =>
-      Promise.all([dispatch(fetchSemesters()), dispatch(fetchAll())]),
+      Promise.all([dispatch(fetchSemesters()), dispatch(fetchAllAdmin())]),
     ['params.companyId']
   ),
   connect(mapStateToProps, mapDispatchToProps),

--- a/app/routes/bdb/AddSemesterRoute.js
+++ b/app/routes/bdb/AddSemesterRoute.js
@@ -14,7 +14,7 @@ import moment from 'moment-timezone';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { uploadFile } from 'app/actions/FileActions';
-import { dispatched } from '@webkom/react-prepare';
+import prepare from 'app/utils/prepare';
 import { selectCompanySemesters } from 'app/reducers/companySemesters';
 import { semesterCodeToName } from './utils.js';
 
@@ -72,12 +72,10 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  dispatched(
+  prepare(
     (props, dispatch) =>
       Promise.all([dispatch(fetchSemesters()), dispatch(fetchAll())]),
-    {
-      componentWillReceiveProps: false
-    }
+    ['params.companyId']
   ),
   connect(mapStateToProps, mapDispatchToProps),
   reduxForm({

--- a/app/routes/bdb/BdbRoute.js
+++ b/app/routes/bdb/BdbRoute.js
@@ -13,6 +13,7 @@ import { selectCompanies } from 'app/reducers/companies';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { selectCompanySemesters } from 'app/reducers/companySemesters';
+import { push } from 'react-router-redux';
 
 const loadData = (props, dispatch) =>
   dispatch(fetchSemesters()).then(() => dispatch(fetchAllAdmin()));
@@ -24,11 +25,16 @@ const mapStateToProps = (state, props) => ({
   fetching: state.companies.fetching
 });
 
-const mapDispatchToProps = {
-  editSemesterStatus,
-  addSemesterStatus,
-  addSemester
-};
+function mapDispatchToProps(dispatch) {
+  return {
+    editSemesterStatus: (semesterStatus, options) =>
+      dispatch(editSemesterStatus(semesterStatus, options)),
+    addSemesterStatus: (semesterStatus, options) =>
+      dispatch(addSemesterStatus(semesterStatus, options)),
+    addSemester: semester => dispatch(addSemester(semester)),
+    push: uri => dispatch(push(uri))
+  };
+}
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),

--- a/app/routes/bdb/BdbRoute.js
+++ b/app/routes/bdb/BdbRoute.js
@@ -25,16 +25,12 @@ const mapStateToProps = (state, props) => ({
   fetching: state.companies.fetching
 });
 
-function mapDispatchToProps(dispatch) {
-  return {
-    editSemesterStatus: (semesterStatus, options) =>
-      dispatch(editSemesterStatus(semesterStatus, options)),
-    addSemesterStatus: (semesterStatus, options) =>
-      dispatch(addSemesterStatus(semesterStatus, options)),
-    addSemester: semester => dispatch(addSemester(semester)),
-    push: uri => dispatch(push(uri))
-  };
-}
+const mapDispatchToProps = {
+  editSemesterStatus,
+  addSemesterStatus,
+  addSemester,
+  push
+};
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),

--- a/app/routes/bdb/EditCompanyContactRoute.js
+++ b/app/routes/bdb/EditCompanyContactRoute.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
 import {
-  fetch,
+  fetchAdmin,
   editCompanyContact,
   deleteCompany
 } from '../../actions/CompanyActions';
@@ -45,9 +45,9 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  prepare(({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)), [
-    'params.companyId',
-    'params.companyContactId'
-  ]),
+  prepare(
+    ({ params: { companyId } }, dispatch) => dispatch(fetchAdmin(companyId)),
+    ['params.companyId', 'params.companyContactId']
+  ),
   connect(mapStateToProps, mapDispatchToProps)
 )(CompanyContactEditor);

--- a/app/routes/bdb/EditCompanyContactRoute.js
+++ b/app/routes/bdb/EditCompanyContactRoute.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { dispatched } from '@webkom/react-prepare';
+import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
 import {
   fetch,
@@ -45,11 +45,9 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  dispatched(
-    ({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)),
-    {
-      componentWillReceiveProps: false
-    }
-  ),
+  prepare(({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)), [
+    'params.companyId',
+    'params.companyContactId'
+  ]),
   connect(mapStateToProps, mapDispatchToProps)
 )(CompanyContactEditor);

--- a/app/routes/bdb/EditCompanyRoute.js
+++ b/app/routes/bdb/EditCompanyRoute.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { dispatched } from '@webkom/react-prepare';
+import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
 import {
   editCompany,
@@ -49,11 +49,8 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  dispatched(
-    ({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)),
-    {
-      componentWillReceiveProps: false
-    }
-  ),
+  prepare(({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)), [
+    'params.companyId'
+  ]),
   connect(mapStateToProps, mapDispatchToProps)
 )(CompanyEditor);

--- a/app/routes/bdb/EditCompanyRoute.js
+++ b/app/routes/bdb/EditCompanyRoute.js
@@ -3,7 +3,7 @@ import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
 import {
   editCompany,
-  fetch,
+  fetchAdmin,
   deleteCompany
 } from '../../actions/CompanyActions';
 import CompanyEditor from './components/CompanyEditor';
@@ -49,8 +49,9 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  prepare(({ params: { companyId } }, dispatch) => dispatch(fetch(companyId)), [
-    'params.companyId'
-  ]),
+  prepare(
+    ({ params: { companyId } }, dispatch) => dispatch(fetchAdmin(companyId)),
+    ['params.companyId']
+  ),
   connect(mapStateToProps, mapDispatchToProps)
 )(CompanyEditor);

--- a/app/routes/bdb/components/BdbDetail.js
+++ b/app/routes/bdb/components/BdbDetail.js
@@ -53,6 +53,10 @@ export default class BdbDetail extends Component<Props, State> {
     eventsToDisplay: 3
   };
 
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
   semesterStatusOnChange = (
     semesterStatus: SemesterStatusEntity,
     statusString: CompanySemesterContactedStatus
@@ -181,7 +185,7 @@ export default class BdbDetail extends Component<Props, State> {
     const events =
       companyEvents &&
       companyEvents
-        .sort((a, b) => new Date(b.startTime) - new Date(a.startTime))
+        .sort((a, b) => Date.parse(b.startTime) - Date.parse(a.startTime))
         .splice(0, this.state.eventsToDisplay)
         .map((event, i) => (
           <tr key={i}>

--- a/app/routes/bdb/components/BdbPage.js
+++ b/app/routes/bdb/components/BdbPage.js
@@ -22,7 +22,8 @@ type Props = {
   editSemesterStatus: (BaseSemesterStatusEntity, ?Object) => Promise<*>,
   addSemesterStatus: (BaseSemesterStatusEntity, ?Object) => Promise<*>,
   addSemester: CompanySemesterEntity => Promise<*>,
-  companySemesters: Array<CompanySemesterEntity>
+  companySemesters: Array<CompanySemesterEntity>,
+  push: string => void
 };
 
 type State = {
@@ -165,7 +166,7 @@ export default class BdbPage extends Component<Props, State> {
   };
 
   render() {
-    const { query, companies, fetching } = this.props;
+    const { query, companies, fetching, push } = this.props;
 
     if (!companies) {
       return <LoadingIndicator loading />;
@@ -178,13 +179,24 @@ export default class BdbPage extends Component<Props, State> {
       this.state.startSem
     );
 
+    const filteredCompanies = this.filterCompanies(sortedCompanies);
+
+    const searchKeyPress = (event: Object) => {
+      if (event.key === 'Enter' && filteredCompanies.length === 1) {
+        push(`/bdb/${filteredCompanies[0].id}`);
+      }
+    };
+
     return (
       <div className={styles.root}>
         <ListNavigation title="Bedriftsdatabase" />
 
         <div className={styles.search}>
           <h2>Søk</h2>
-          <TextInput onChange={this.updateSearchQuery} />
+          <TextInput
+            onChange={this.updateSearchQuery}
+            onKeyPress={searchKeyPress}
+          />
         </div>
 
         <OptionsBox
@@ -199,7 +211,7 @@ export default class BdbPage extends Component<Props, State> {
         </i>
 
         <CompanyList
-          companies={this.filterCompanies(sortedCompanies)}
+          companies={filteredCompanies}
           startYear={this.state.startYear}
           startSem={this.state.startSem}
           query={query}


### PR DESCRIPTION
- Order events in bdb by newest first (Fixes #876)
- Scroll to top when navigating to detail view
- Use `prepare` in all the routes
- Autonavigate when search yields only one result (type Bekk -> only one result -> press enter -> get navigated to Bekk's detail view)
- use `fetchAdmin` and `fetchAllAdmin` in all bdb routes instead of `fetch` and `fetchAll`