### PR TITLE
Redirect to correct page after changing user settings

### DIFF
--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -11,7 +11,6 @@ import callAPI from 'app/actions/callAPI';
 import { User } from './ActionTypes';
 import { uploadFile } from './FileActions';
 import { fetchMeta } from './MetaActions';
-import { addNotification } from 'app/actions/NotificationActions';
 import type { Thunk, Action } from 'app/types';
 
 const USER_STORAGE_KEY = 'lego.auth';
@@ -111,7 +110,7 @@ export function updateUser(
     ).then(action => {
       if (!action || !action.payload) return;
       if (!options.noRedirect) {
-        dispatch(push(`/users/${action.payload.result || 'me'}`));
+        dispatch(push(`/users/${username}`));
       }
     });
 }
@@ -140,23 +139,11 @@ export function changePassword({
         },
         schema: userSchema,
         meta: {
-          errorMessage: 'Oppdatering av passord feilet'
+          errorMessage: 'Oppdatering av passord feilet',
+          successMessage: 'Passordet ble endret'
         }
       })
-    ).then(action => {
-      dispatch(
-        push(
-          `/users/${(action && action.payload && action.payload.result) ||
-            'me'}`
-        )
-      );
-      dispatch(
-        addNotification({
-          message: 'Passordet ble endret',
-          dismissAfter: 5000
-        })
-      );
-    });
+    );
 }
 
 export function updatePicture({

--- a/app/routes/users/UserProfileRoute.js
+++ b/app/routes/users/UserProfileRoute.js
@@ -17,17 +17,9 @@ import prepare from 'app/utils/prepare';
 import { LoginPage } from 'app/components/LoginForm';
 
 const loadData = ({ params: { username } }, dispatch) => {
-  return dispatch(fetchUser(username)).then(action => {
-    /**
-     * /users/me has no username property and the application fetches "me"
-     * when that happens. Extract the current username from the fetch response
-     * and then lookup the user ID.
-     * This hack exists because User is the only entity that doesn't use ID as
-     * the lookup field.
-     */
-    const userId = action.payload.entities.users[action.payload.result].id;
-    return dispatch(fetchUserFeed(userId));
-  });
+  return dispatch(fetchUser(username)).then(action =>
+    dispatch(fetchUserFeed(action.payload.result))
+  );
 };
 
 const mapStateToProps = (state, props) => {

--- a/app/routes/users/UserSettingsRoute.js
+++ b/app/routes/users/UserSettingsRoute.js
@@ -3,6 +3,7 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { dispatched } from '@webkom/react-prepare';
+import { push } from 'react-router-redux';
 import UserSettings from './components/UserSettings';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import { selectUserByUsername } from 'app/reducers/users';
@@ -27,7 +28,7 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-const mapDispatchToProps = { updateUser, updatePicture, changePassword };
+const mapDispatchToProps = { updateUser, updatePicture, changePassword, push };
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),

--- a/app/routes/users/components/ChangePassword.js
+++ b/app/routes/users/components/ChangePassword.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { reduxForm, Field, SubmissionError } from 'redux-form';
+import type { FieldProps } from 'redux-form';
 import Button from 'app/components/Button';
 import { TextInput, Form } from 'app/components/Form';
 import {
@@ -11,11 +12,8 @@ import {
   sameAs
 } from 'app/utils/validation';
 
-type Props = {
-  invalid: boolean,
-  pristine: boolean,
-  submitting: boolean,
-  handleSubmit: Function => Promise<void>,
+type Props = FieldProps & {
+  push: string => void,
   changePassword: Object => Promise<void>
 };
 
@@ -25,15 +23,18 @@ const ChangePassword = ({
   pristine,
   submitting,
   changePassword,
+  push,
   ...props
 }: Props) => {
   const disabledButton = invalid || pristine || submitting;
   const onSubmit = data =>
-    changePassword(data).catch(err => {
-      if (err.payload && err.payload.response) {
-        throw new SubmissionError(err.payload.response.jsonData);
-      }
-    });
+    changePassword(data)
+      .then(() => push('/users/me'))
+      .catch(err => {
+        if (err.payload && err.payload.response) {
+          throw new SubmissionError(err.payload.response.jsonData);
+        }
+      });
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>

--- a/app/routes/users/components/UserSettings.js
+++ b/app/routes/users/components/UserSettings.js
@@ -29,6 +29,7 @@ type Props = FieldProps & {
   updateUser: Object => Promise<void>,
   user: any,
   isMe: boolean,
+  push: string => void,
   updatePicture: Object => void
 };
 
@@ -42,6 +43,7 @@ const UserSettings = (props: Props) => {
     pristine,
     submitting,
     updatePicture,
+    push,
     user
   } = props;
 
@@ -123,7 +125,7 @@ const UserSettings = (props: Props) => {
       {isMe && (
         <div className={styles.changePassword}>
           <h2>Endre passord</h2>
-          <ChangePassword changePassword={changePassword} />
+          <ChangePassword push={push} changePassword={changePassword} />
         </div>
       )}
     </div>


### PR DESCRIPTION
Always redirects to `/users/me` for password changes, since you can only change your own password. Redirects to `/users/<username>` otherwise (doesn't really matter if it's `me` or `username`).