### PR TITLE
Make confirm modal take promises instead of funcs

### DIFF
--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -228,27 +228,18 @@ export function editSemesterStatus(
   };
 }
 
-export function deleteSemesterStatus(
-  companyId: number,
-  semesterId: number
-): Thunk<*> {
-  return dispatch => {
-    return dispatch(
-      callAPI({
-        types: Company.DELETE_SEMESTER_STATUS,
-        endpoint: `/companies/${companyId}/semester-statuses/${semesterId}/`,
-        method: 'DELETE',
-        meta: {
-          companyId,
-          semesterId,
-          errorMessage: 'Sletting av semesterstatus feilet'
-        }
-      })
-    ).then(() => {
-      dispatch(addNotification({ message: 'Semester Status slettet' }));
-      dispatch(push(`/bdb/${companyId}/`));
-    });
-  };
+export function deleteSemesterStatus(companyId: number, semesterId: number) {
+  return callAPI({
+    types: Company.DELETE_SEMESTER_STATUS,
+    endpoint: `/companies/${companyId}/semester-statuses/${semesterId}/`,
+    method: 'DELETE',
+    meta: {
+      companyId,
+      semesterId,
+      errorMessage: 'Sletting av semesterstatus feilet',
+      successMessage: 'Semesterstatus slettet'
+    }
+  });
 }
 
 export function fetchCompanyContacts({ companyId }: { companyId: number }) {
@@ -328,24 +319,18 @@ export function editCompanyContact({
 export function deleteCompanyContact(
   companyId: number,
   companyContactId: number
-): Thunk<*> {
-  return dispatch => {
-    return dispatch(
-      callAPI({
-        types: Company.DELETE_COMPANY_CONTACT,
-        endpoint: `/companies/${companyId}/company-contacts/${companyContactId}/`,
-        method: 'DELETE',
-        meta: {
-          companyId,
-          companyContactId,
-          errorMessage: 'Sletting av bedriftskontakt feilet'
-        }
-      })
-    ).then(() => {
-      dispatch(addNotification({ message: 'Bedriftskontakt slettet.' }));
-      dispatch(push(`/bdb/${companyId}/`));
-    });
-  };
+) {
+  return callAPI({
+    types: Company.DELETE_COMPANY_CONTACT,
+    endpoint: `/companies/${companyId}/company-contacts/${companyContactId}/`,
+    method: 'DELETE',
+    meta: {
+      companyId,
+      companyContactId,
+      errorMessage: 'Sletting av bedriftskontakt feilet',
+      successMessage: 'Bedriftskontakt slettet'
+    }
+  });
 }
 
 export function fetchSemesters({ companyInterest }: Object = {}) {

--- a/app/components/Modal/ConfirmModal.js
+++ b/app/components/Modal/ConfirmModal.js
@@ -8,7 +8,6 @@ import Button from '../Button';
 type ConfirmModalProps = {
   onConfirm?: () => Promise<*>,
   onCancel?: () => Promise<*>,
-  autoClose?: boolean,
   message: string,
   title: string,
   children: Node
@@ -39,8 +38,9 @@ type State = {
 type withModalProps = {
   /* Close the modal after confirm promise is resolved*/
   closeOnConfirm?: boolean,
-  /* Close the modal after cancel promise is resolved*/
-  closeOnCancel?: boolean
+  /* Close the modal after confirm promise is resolved*/
+  closeOnCancel?: boolean,
+  children: Node
 };
 
 export default function withModal<Props>(
@@ -64,8 +64,8 @@ export default function withModal<Props>(
 
     render() {
       const {
-        onConfirm = Promise.resolve(),
-        onCancel = Promise.resolve(),
+        onConfirm = () => Promise.resolve(),
+        onCancel = () => Promise.resolve(),
         message,
         title,
         closeOnCancel = true,
@@ -85,19 +85,18 @@ export default function withModal<Props>(
           return result;
         });
 
-      return (
-        <div>
-          {/* $FlowFixMe rest props hoc behaviour */}
-          <WrappedComponent {...props} onClick={this.toggleModal} />
-          <Modal show={this.state.modalVisible} onHide={this.toggleModal}>
-            <ConfirmModal
-              onCancel={modalOnCancel}
-              onConfirm={modalOnConfirm}
-              {...this.props}
-            />
-          </Modal>
-        </div>
-      );
+      return [
+        <WrappedComponent key={0} {...props} onClick={this.toggleModal} />,
+        <Modal key={1} show={this.state.modalVisible} onHide={this.toggleModal}>
+          <ConfirmModal
+            onCancel={modalOnCancel}
+            onConfirm={modalOnConfirm}
+            message={message}
+            title={title}
+            disabled={this.state.working}
+          />
+        </Modal>
+      ];
     }
   };
 }

--- a/app/routes/bdb/components/AddSemester.js
+++ b/app/routes/bdb/components/AddSemester.js
@@ -25,7 +25,7 @@ type Props = {
   autoFocus: any,
   companySemesters: Array<Object>,
   addSemester: CompanySemesterEntity => Promise<*>,
-  deleteCompany: number => ?Promise<*>
+  deleteCompany: number => Promise<*>
 };
 
 type State = {

--- a/app/routes/bdb/components/BdbDetail.js
+++ b/app/routes/bdb/components/BdbDetail.js
@@ -39,7 +39,7 @@ type Props = {
   companyEvents: Array<Object>,
   fetching: boolean,
   editCompany: Object => void,
-  deleteCompany: number => ?Promise<*>
+  deleteCompany: number => Promise<*>
 };
 
 type State = {
@@ -173,6 +173,7 @@ export default class BdbDetail extends Component<Props, State> {
                   title="Slett bedriftskontakt"
                   message="Er du sikker på at du vil slette denne bedriftskontakten?"
                   onConfirm={() => this.deleteCompanyContact(contact.id)}
+                  closeOnConfirm
                 >
                   <i className="fa fa-times" style={{ color: '#d13c32' }} />
                 </ConfirmModalWithParent>

--- a/app/routes/bdb/components/BdbDetail.js
+++ b/app/routes/bdb/components/BdbDetail.js
@@ -136,12 +136,11 @@ export default class BdbDetail extends Component<Props, State> {
 
     const semesters = company.semesterStatuses
       .sort(sortByYearThenSemester)
-      .map((semesterStatus, i) => (
+      .map(semesterStatus => (
         <SemesterStatusDetail
           semesterStatus={semesterStatus}
-          key={i}
+          key={semesterStatus.id}
           companyId={company.id}
-          index={i}
           deleteSemesterStatus={this.deleteSemesterStatus}
           editFunction={this.semesterStatusOnChange}
           addFileToSemester={this.addFileToSemester}
@@ -150,8 +149,8 @@ export default class BdbDetail extends Component<Props, State> {
 
     const companyContacts =
       company.companyContacts &&
-      company.companyContacts.map((contact, i) => (
-        <tr key={i}>
+      company.companyContacts.map(contact => (
+        <tr key={contact.id}>
           <td>{contact.name || '-'}</td>
           <td>{contact.role || '-'}</td>
           <td>{contact.mail || '-'}</td>
@@ -188,8 +187,8 @@ export default class BdbDetail extends Component<Props, State> {
       companyEvents
         .sort((a, b) => Date.parse(b.startTime) - Date.parse(a.startTime))
         .splice(0, this.state.eventsToDisplay)
-        .map((event, i) => (
-          <tr key={i}>
+        .map(event => (
+          <tr key={event.id}>
             <td>
               <Link to={`events/${event.id}`}>{event.title}</Link>
             </td>
@@ -344,8 +343,8 @@ export default class BdbDetail extends Component<Props, State> {
               {!company.files || company.length === 0 ? (
                 <i>Ingen filer.</i>
               ) : (
-                company.files.map((file, i) => (
-                  <li key={i}>
+                company.files.map(file => (
+                  <li key={file.id}>
                     <a href={file.file}>{truncateString(file.file, 100)}</a>
                   </li>
                 ))

--- a/app/routes/bdb/components/CompanyEditor.js
+++ b/app/routes/bdb/components/CompanyEditor.js
@@ -30,7 +30,7 @@ type Props = {
   autoFocus: any,
   fetching: boolean,
   submitFunction: (SubmitCompanyEntity, ?number) => Promise<*>,
-  deleteCompany: number => ?Promise<*>
+  deleteCompany: number => Promise<*>
 };
 
 class CompanyEditor extends Component<Props> {

--- a/app/routes/bdb/components/SemesterStatusDetail.js
+++ b/app/routes/bdb/components/SemesterStatusDetail.js
@@ -21,7 +21,7 @@ type Props = {
   semesterStatus: SemesterStatusEntity,
   index: number,
   companyId: number,
-  deleteSemesterStatus: number => ?Promise<*>,
+  deleteSemesterStatus: number => Promise<*>,
   editFunction: (
     semesterStatus: SemesterStatusEntity,
     statusString: CompanySemesterContactedStatus
@@ -38,9 +38,8 @@ export default class SemesterStatusDetail extends Component<Props, State> {
     editing: false
   };
 
-  deleteSemesterStatus = (id: number) => {
-    this.props.deleteSemesterStatus(id);
-  };
+  deleteSemesterStatus = () =>
+    this.props.deleteSemesterStatus(this.props.semesterStatus.id);
 
   addFile = (fileName: string, fileToken: string, type: string) => {
     this.props.addFileToSemester(
@@ -63,16 +62,21 @@ export default class SemesterStatusDetail extends Component<Props, State> {
   fileNameToShow = (name: string, url?: string) =>
     name ? <a href={url}>{truncateString(name, FILE_NAME_LENGTH)}</a> : '-';
 
+  semesterToHumanReadable = () => {
+    const { year, semester } = this.props.semesterStatus;
+    const semesterName = semesterCodeToName(semester);
+    return `${year} ${semesterName}`;
+  };
+
   render() {
     const { semesterStatus, index, editFunction } = this.props;
 
     if (!semesterStatus) return <LoadingIndicator />;
 
+    const humanReadableSemester = this.semesterToHumanReadable();
     return (
       <tr key={index}>
-        <td>
-          {semesterStatus.year} {semesterCodeToName(semesterStatus.semester)}
-        </td>
+        <td>{humanReadableSemester}</td>
         <td
           className={
             styles[
@@ -116,8 +120,8 @@ export default class SemesterStatusDetail extends Component<Props, State> {
             </a>
             <ConfirmModalWithParent
               title="Slett semesterstatus"
-              message="Er du sikker på at du vil slette denne semesterstatusen? Alle filer for dette semesteret vil bli slettet."
-              onConfirm={() => this.deleteSemesterStatus(semesterStatus.id)}
+              message={`Er du sikker på at du vil slette semesterstatusen for ${humanReadableSemester}? Alle filer for dette semesteret vil bli slettet.`}
+              onConfirm={this.deleteSemesterStatus}
             >
               <i className="fa fa-times" style={{ color: '#d13c32' }} />
             </ConfirmModalWithParent>

--- a/app/routes/bdb/components/SemesterStatusDetail.js
+++ b/app/routes/bdb/components/SemesterStatusDetail.js
@@ -19,7 +19,6 @@ const FILE_NAME_LENGTH = 30;
 
 type Props = {
   semesterStatus: SemesterStatusEntity,
-  index: number,
   companyId: number,
   deleteSemesterStatus: number => Promise<*>,
   editFunction: (
@@ -69,13 +68,13 @@ export default class SemesterStatusDetail extends Component<Props, State> {
   };
 
   render() {
-    const { semesterStatus, index, editFunction } = this.props;
+    const { semesterStatus, editFunction } = this.props;
 
     if (!semesterStatus) return <LoadingIndicator />;
 
     const humanReadableSemester = this.semesterToHumanReadable();
     return (
-      <tr key={index}>
+      <tr key={semesterStatus.id}>
         <td>{humanReadableSemester}</td>
         <td
           className={
@@ -122,6 +121,7 @@ export default class SemesterStatusDetail extends Component<Props, State> {
               title="Slett semesterstatus"
               message={`Er du sikker på at du vil slette semesterstatusen for ${humanReadableSemester}? Alle filer for dette semesteret vil bli slettet.`}
               onConfirm={this.deleteSemesterStatus}
+              closeOnConfirm
             >
               <i className="fa fa-times" style={{ color: '#d13c32' }} />
             </ConfirmModalWithParent>

--- a/app/routes/bdb/utils.js
+++ b/app/routes/bdb/utils.js
@@ -178,7 +178,7 @@ export const DetailNavigation = ({
 }: {
   title: Node,
   companyId: number,
-  deleteFunction: number => ?Promise<*>
+  deleteFunction: number => Promise<*>
 }) => (
   <NavigationTab title={title}>
     <NavigationLink to="/bdb">Tilbake til liste</NavigationLink>

--- a/app/routes/joblistings/components/JoblistingEditor.js
+++ b/app/routes/joblistings/components/JoblistingEditor.js
@@ -75,11 +75,10 @@ class JoblistingEditor extends Component<Props, State> {
       });
   };
 
-  onDeleteJoblisting = () => {
+  onDeleteJoblisting = () =>
     this.props.deleteJoblisting(this.props.joblisting.id).then(() => {
       this.props.push('/joblistings/');
     });
-  };
 
   fetchContacts = (company: SelectInputObject) => {
     return this.props


### PR DESCRIPTION
This adds autoClose functionality, useful when the route isn't changed
in the action executed. The closing is executed when the given promises
resolve.