### PR TITLE
Fix modal

### DIFF
--- a/app/components/Modal/index.js
+++ b/app/components/Modal/index.js
@@ -51,6 +51,7 @@ class Modal extends Component<Props> {
         onHide={onHide}
         show={show}
         backdrop={closeOnBackdropClick ? backdrop : false}
+        autoFocus={false}
         {...props}
       >
         <div>

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-infinite-scroller": "^1.0.15",
     "react-motion": "^0.5.1",
     "react-notification": "^6.6.0",
-    "react-overlays": "^0.7.3",
+    "react-overlays": "0.8.3",
     "react-portal": "^3.1.0",
     "react-redux": "^5.0.1",
     "react-router": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,6 +1502,10 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
+
 chalk@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
@@ -2385,7 +2389,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.1:
+dom-helpers@^3.2.0, dom-helpers@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
@@ -6889,14 +6893,15 @@ react-notification@^6.6.0:
   dependencies:
     prop-types "^15.5.10"
 
-react-overlays@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.3.tgz#e4caa690ce7cd7d40b2cf9cdc26356cddaf5a0e9"
+react-overlays@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.1"
     prop-types "^15.5.10"
     prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.0"
     warning "^3.0.0"
 
 react-portal@^3.1.0:
@@ -7038,6 +7043,17 @@ react-textarea-autosize@^5.1.0:
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.1.0.tgz#ffbf8164fce217c79443c1c17dedf730592df224"
   dependencies:
     prop-types "^15.5.10"
+
+react-transition-group@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
+  dependencies:
+    chain-function "^1.0.0"
+    classnames "^2.2.5"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.8"
+    warning "^3.0.0"
 
 react-treeview@^0.4.6:
   version "0.4.7"


### PR DESCRIPTION
Bump react-overlays to a version with "react-16" support.

This also fixes the scrolling when opening the modal, mentioned in #889