### PR TITLE
Style comments

### DIFF
--- a/app/components/CommentForm/CommentForm.css
+++ b/app/components/CommentForm/CommentForm.css
@@ -6,6 +6,7 @@
   flex-direction: row;
   align-items: center;
   padding: 20px;
+  margin-bottom: 15px;
 }
 
 .inlineForm {


### PR DESCRIPTION
Adds some very simple margin to make the new comments with `newOnTop = true` look better.

<img width="257" alt="skjermbilde 2017-10-30 kl 17 16 59" src="https://user-images.githubusercontent.com/14221386/32182082-2d201a92-bd96-11e7-9b45-95e4760c7a0c.png">

Becomes

<img width="283" alt="skjermbilde 2017-10-30 kl 17 14 42" src="https://user-images.githubusercontent.com/14221386/32182008-03a61112-bd96-11e7-8df1-c0a682cf7e98.png">

For the regular comment positioning the margin might be a little out of place, but some extra white at the bottom of a page never hurt anyone 🤷‍♂️ 

<img width="401" alt="skjermbilde 2017-10-30 kl 17 14 13" src="https://user-images.githubusercontent.com/14221386/32182131-4442a140-bd96-11e7-8945-848eed76a86a.png">
