### PR TITLE
Remove empty scrollbars in modals

### DIFF
--- a/app/components/Modal/ConfirmModal.css
+++ b/app/components/Modal/ConfirmModal.css
@@ -28,7 +28,7 @@
   padding: 40px;
   outline: none;
   max-height: 80vh;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .closeButton {

--- a/app/components/Modal/Modal.css
+++ b/app/components/Modal/Modal.css
@@ -28,7 +28,7 @@
   padding: 40px;
   outline: none;
   max-height: calc(100vh - 40px);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .closeButton {

--- a/app/components/Search/Search.css
+++ b/app/components/Search/Search.css
@@ -57,7 +57,7 @@
 
 .resultsContainer {
   background: rgba(255, 255, 255, 0.8);
-  overflow-y: scroll;
+  overflow-y: auto;
   height: 100%;
   max-height: calc(100vh - 120px);
   border-radius: 0 0 7px 7px;

--- a/app/components/UserAttendance/AttendanceModal.css
+++ b/app/components/UserAttendance/AttendanceModal.css
@@ -4,7 +4,7 @@
   max-height: calc(100vh - 210px);
   padding: 0 30px;
   margin-bottom: 5px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .list > li {


### PR DESCRIPTION
Fix #751
Put overflow-y to auto instead of scroll to remove empty scrollbars in modals and search results