### PR TITLE
Add (forgotten password) and (create new user) to every page

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -91,6 +91,25 @@
   flex-direction: row;
 }
 
+.toggleButton {
+  color: var(--lego-link-color);
+  font-size: 14px;
+}
+
+.dropdown {
+  width: 355px;
+  padding: 15px;
+
+  @media (--small-viewport) {
+    width: 100%;
+
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
+}
+
 .navigation {
   display: flex;
   flex-direction: row;

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -109,11 +109,9 @@ class Header extends Component<Props, State> {
 
   render() {
     const { loggedIn } = this.props;
-
-    const { registerUser, forgotPassword, mode } = this.state;
-
+    const isLogin = this.state.mode === 'login';
     let title, form;
-    switch (mode) {
+    switch (this.state.mode) {
       case 'login':
         title = 'Logg inn';
         form = <LoginForm />;
@@ -223,7 +221,7 @@ class Header extends Component<Props, State> {
                       style={{ whiteSpace: 'nowrap' }}
                     >
                       {title}
-                      {!(registerUser || forgotPassword) && (
+                      {isLogin && (
                         <div>
                           <button
                             onClick={this.toggleForgotPassword}
@@ -240,7 +238,7 @@ class Header extends Component<Props, State> {
                           </button>
                         </div>
                       )}
-                      {(registerUser || forgotPassword) && (
+                      {!isLogin && (
                         <button
                           onClick={this.toggleBack}
                           className={styles.toggleButton}

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -39,8 +39,7 @@ type Props = {
 type State = {
   accountOpen: boolean,
   shake: boolean,
-  forgotPassword: boolean,
-  registerUser: boolean
+  mode: 'login' | 'register' | 'forgotPassword'
 };
 
 type AccountDropdownItemsProps = {
@@ -90,40 +89,43 @@ class Header extends Component<Props, State> {
   state: State = {
     accountOpen: false,
     shake: false,
-    forgotPassword: false,
-    registerUser: false
+    mode: 'login'
   };
 
   toggleRegisterUser = (e: Event) => {
-    this.setState({ registerUser: true });
+    this.setState({ mode: 'register' });
     e.stopPropagation();
   };
 
   toggleForgotPassword = (e: Event) => {
-    this.setState({ forgotPassword: true });
+    this.setState({ mode: 'forgotPassword' });
     e.stopPropagation();
   };
 
   toggleBack = (e: Event) => {
-    this.setState({ registerUser: false, forgotPassword: false });
+    this.setState({ mode: 'login' });
     e.stopPropagation();
   };
 
   render() {
     const { loggedIn } = this.props;
 
-    const { registerUser, forgotPassword } = this.state;
+    const { registerUser, forgotPassword, mode } = this.state;
 
     let title, form;
-    if (registerUser) {
-      title = 'Registrer bruker';
-      form = <RegisterForm />;
-    } else if (forgotPassword) {
-      title = 'Glemt passord';
-      form = <ForgotPasswordForm />;
-    } else {
-      title = 'Logg inn';
-      form = <LoginForm />;
+    switch (mode) {
+      case 'login':
+        title = 'Logg inn';
+        form = <LoginForm />;
+        break;
+      case 'register':
+        title = 'Registrer bruker';
+        form = <RegisterForm />;
+        break;
+      case 'forgotPassword':
+        title = 'Glemt passord';
+        form = <ForgotPasswordForm />;
+        break;
     }
 
     return (

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -18,7 +18,6 @@ import {
   ForgotPasswordForm
 } from 'app/components/LoginForm';
 import styles from './Header.css';
-
 import type { UserEntity } from 'app/reducers/users';
 
 type Props = {

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -6,11 +6,17 @@ import { Modal } from 'react-overlays';
 import logoImage from 'app/assets/logo-dark.png';
 import Dropdown from '../Dropdown';
 import Icon from '../Icon';
+import cx from 'classnames';
 import Search from '../Search';
-import LoginForm from '../LoginForm/LoginForm';
 import { ProfilePicture } from '../Image';
 import FancyNodesCanvas from './FancyNodesCanvas';
 import NotificationsDropdown from '../HeaderNotifications';
+import { Flex } from 'app/components/Layout';
+import {
+  LoginForm,
+  RegisterForm,
+  ForgotPasswordForm
+} from 'app/components/LoginForm';
 import styles from './Header.css';
 
 import type { UserEntity } from 'app/reducers/users';
@@ -32,7 +38,9 @@ type Props = {
 
 type State = {
   accountOpen: boolean,
-  shake: boolean
+  shake: boolean,
+  forgotPassword: boolean,
+  registerUser: boolean
 };
 
 type AccountDropdownItemsProps = {
@@ -81,11 +89,42 @@ function AccountDropdownItems({
 class Header extends Component<Props, State> {
   state: State = {
     accountOpen: false,
-    shake: false
+    shake: false,
+    forgotPassword: false,
+    registerUser: false
+  };
+
+  toggleRegisterUser = (e: Event) => {
+    this.setState({ registerUser: true });
+    e.stopPropagation();
+  };
+
+  toggleForgotPassword = (e: Event) => {
+    this.setState({ forgotPassword: true });
+    e.stopPropagation();
+  };
+
+  toggleBack = (e: Event) => {
+    this.setState({ registerUser: false, forgotPassword: false });
+    e.stopPropagation();
   };
 
   render() {
     const { loggedIn } = this.props;
+
+    const { registerUser, forgotPassword } = this.state;
+
+    let title, form;
+    if (registerUser) {
+      title = 'Registrer bruker';
+      form = <RegisterForm />;
+    } else if (forgotPassword) {
+      title = 'Glemt passord';
+      form = <ForgotPasswordForm />;
+    } else {
+      title = 'Logg inn';
+      form = <LoginForm />;
+    }
 
     return (
       <header className={styles.header}>
@@ -167,21 +206,48 @@ class Header extends Component<Props, State> {
                       accountOpen: !state.accountOpen,
                       shake: false
                     }))}
-                  contentClassName={this.state.shake ? 'animated shake' : ''}
+                  contentClassName={cx(
+                    this.state.shake ? 'animated shake' : '',
+                    styles.dropdown
+                  )}
                   triggerComponent={<Icon name="contact" size={30} />}
                 >
                   <div style={{ padding: 10 }}>
-                    <LoginForm
-                      form="HeaderLoginForm"
-                      postLoginSuccess={res => {
-                        this.setState({ shake: false, accountOpen: false });
-                        return res;
-                      }}
-                      postLoginFail={error => {
-                        this.setState({ shake: true });
-                        throw error;
-                      }}
-                    />
+                    <Flex
+                      component="h2"
+                      justifyContent="space-between"
+                      alignItems="center"
+                      className="u-mb"
+                      style={{ whiteSpace: 'nowrap' }}
+                    >
+                      {title}
+                      {!(registerUser || forgotPassword) && (
+                        <div>
+                          <button
+                            onClick={this.toggleForgotPassword}
+                            className={styles.toggleButton}
+                          >
+                            Glemt passord
+                          </button>
+                          <span className={styles.toggleButton}>&bull;</span>
+                          <button
+                            onClick={this.toggleRegisterUser}
+                            className={styles.toggleButton}
+                          >
+                            Jeg er ny
+                          </button>
+                        </div>
+                      )}
+                      {(registerUser || forgotPassword) && (
+                        <button
+                          onClick={this.toggleBack}
+                          className={styles.toggleButton}
+                        >
+                          Tilbake
+                        </button>
+                      )}
+                    </Flex>
+                    {form}
                   </div>
                 </Dropdown>
               )}

--- a/app/components/LoginForm/ForgotPasswordForm.js
+++ b/app/components/LoginForm/ForgotPasswordForm.js
@@ -59,7 +59,10 @@ class ForgotPasswordForm extends Component<Props, State> {
       );
     }
     return (
-      <Form onSubmit={handleSubmit(this.onSubmit)}>
+      <Form
+        onSubmit={handleSubmit(this.onSubmit)}
+        onClick={e => e.stopPropagation()}
+      >
         <Field name="email" component={TextInput.Field} placeholder="E-post" />
         <Button submit disabled={invalid | pristine | submitting} dark>
           Tilbakestill passord

--- a/app/components/LoginForm/Login.css
+++ b/app/components/LoginForm/Login.css
@@ -12,6 +12,10 @@
 
 .window {
   width: 600px;
+
+  @media (--mobile-device) {
+    width: 100%;
+  }
 }
 
 .detailTitle {

--- a/app/components/LoginForm/Login.css
+++ b/app/components/LoginForm/Login.css
@@ -4,3 +4,21 @@
   composes: contentContainer from 'app/styles/utilities.css';
   max-width: 500px;
 }
+
+.toggleButton {
+  color: var(--lego-link-color);
+  font-size: 14px;
+}
+
+.window {
+  width: 600px;
+}
+
+.detailTitle {
+  margin-bottom: 0;
+  width: 100%;
+
+  & h1 {
+    margin-bottom: 0;
+  }
+}

--- a/app/components/LoginForm/LoginPage.js
+++ b/app/components/LoginForm/LoginPage.js
@@ -1,15 +1,71 @@
-import React from 'react';
-import styles from './Login.css';
+// @flow
+
+import React, { Component } from 'react';
 import { Container } from '../Layout';
-import LoginForm from './LoginForm';
+import { LoginForm, RegisterForm, ForgotPasswordForm } from '../LoginForm';
+import styles from './Login.css';
+import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import { Link } from 'react-router';
 
-const LoginPage = props => (
-  <Container>
-    <div className={styles.root}>
-      <h2>Logg inn</h2>
-      <LoginForm />
-    </div>
-  </Container>
-);
+type State = {
+  mode: 'login' | 'register' | 'forgotPassword'
+};
 
+class LoginPage extends Component<null, State> {
+  state: State = {
+    mode: 'login'
+  };
+
+  toggleRegisterUser = (e: Event) => {
+    this.setState({ mode: 'register' });
+  };
+
+  toggleForgotPassword = (e: Event) => {
+    this.setState({ mode: 'forgotPassword' });
+  };
+
+  toggleBack = (e: Event) => {
+    this.setState({ mode: 'login' });
+  };
+
+  render() {
+    const isLogin = this.state.mode === 'login';
+    let title, form;
+    switch (this.state.mode) {
+      case 'login':
+        title = 'Logg inn';
+        form = <LoginForm />;
+        break;
+      case 'register':
+        title = 'Registrer bruker';
+        form = <RegisterForm />;
+        break;
+      case 'forgotPassword':
+        title = 'Glemt passord';
+        form = <ForgotPasswordForm />;
+        break;
+    }
+    return (
+      <Container className={styles.window}>
+        {isLogin ? (
+          <NavigationTab title={title} className={styles.detailTitle}>
+            <NavigationLink to="">
+              <Link onClick={this.toggleForgotPassword}>Glemt passord</Link>
+            </NavigationLink>
+            <NavigationLink to="">
+              <Link onClick={this.toggleRegisterUser}>Jeg er ny</Link>
+            </NavigationLink>
+          </NavigationTab>
+        ) : (
+          <NavigationTab title={title} className={styles.detailTitle}>
+            <NavigationLink to="">
+              <Link onClick={this.toggleBack}>Tilbake</Link>
+            </NavigationLink>
+          </NavigationTab>
+        )}
+        {form}
+      </Container>
+    );
+  }
+}
 export default LoginPage;

--- a/app/components/LoginForm/RegisterForm.js
+++ b/app/components/LoginForm/RegisterForm.js
@@ -58,7 +58,10 @@ class RegisterForm extends Component<Props, State> {
       );
     }
     return (
-      <Form onSubmit={handleSubmit(this.onSubmit)}>
+      <Form
+        onSubmit={handleSubmit(this.onSubmit)}
+        onClick={e => e.stopPropagation()}
+      >
         <Field name="email" component={TextInput.Field} placeholder="E-post" />
         <Field
           name="captchaResponse"


### PR DESCRIPTION
Fixes #851 
Now you can press the profile icon on every page and be able to create a new user or reset your password. 
![screenshot from 2017-11-02 21-05-23](https://user-images.githubusercontent.com/23152018/32348450-15cfbc14-c014-11e7-8a1e-6ce88934eba5.png)
![screenshot from 2017-11-02 21-05-47](https://user-images.githubusercontent.com/23152018/32348451-15ef10fa-c014-11e7-8fea-e8bca4f8eea6.png)
![screenshot from 2017-11-02 21-05-58](https://user-images.githubusercontent.com/23152018/32348452-160ce666-c014-11e7-90e8-6f19a925f4ef.png)
Small device
![screenshot from 2017-11-02 21-06-37](https://user-images.githubusercontent.com/23152018/32348453-162be80e-c014-11e7-91a6-3c569a1aaafe.png)