### PR TITLE
Style NavigationTab to give menu items precedence

### DIFF
--- a/app/components/NavigationTab/NavigationTab.css
+++ b/app/components/NavigationTab/NavigationTab.css
@@ -3,21 +3,28 @@
 .container {
   display: flex;
   justify-content: space-between;
-  flex-wrap: wrap;
   margin-bottom: 15px;
+  align-items: baseline;
 }
 
 .header {
   display: inline;
   font-weight: 400;
+  line-height: 34px;
   text-transform: uppercase;
+  flex-shrink: 99999;
 }
 
 .navigator {
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
   align-items: center;
+}
+
+@media (--mobile-device) {
+  .container {
+    flex-wrap: wrap;
+  }
 }
 
 @media (--small-viewport) {


### PR DESCRIPTION
On pages with short titles in NavigationTab, this does nothing:

<img width="1119" alt="skjermbilde 2017-11-02 kl 22 38 59" src="https://user-images.githubusercontent.com/14221386/32351745-bf213842-c01e-11e7-88f6-b4a5db4e999a.png">

However, when the titles and menus both grow long, this PR makes the title split into multiple lines so that the menu can stay intact.

From:
<img width="1116" alt="skjermbilde 2017-11-02 kl 22 43 38" src="https://user-images.githubusercontent.com/14221386/32351902-4bc81522-c01f-11e7-856e-0d8d6823f4c9.png">

To:
<img width="1119" alt="skjermbilde 2017-11-02 kl 22 36 27" src="https://user-images.githubusercontent.com/14221386/32351913-54653b9c-c01f-11e7-89cd-feed954c8181.png">

On smaller screens, the title would have gotten split into very many lines, so it reverts to the previous functionality there:
<img width="699" alt="skjermbilde 2017-11-02 kl 22 46 26" src="https://user-images.githubusercontent.com/14221386/32352015-b54a4560-c01f-11e7-82c0-5171114f3841.png">

