### PR TITLE
Update the uncoordinated design of the titles/headers

### DIFF
--- a/app/routes/events/components/Toolbar.js
+++ b/app/routes/events/components/Toolbar.js
@@ -51,7 +51,7 @@ class Toolbar extends Component<Props, State> {
         <div className={styles.section}>
           {actionGrant &&
             actionGrant.includes('create') && (
-              <Link to={'/events/create'}>
+              <Link to="/events/create">
                 <Button>Lag nytt arrangement</Button>
               </Link>
             )}

--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -36,12 +36,12 @@ type TitleProps = {
 
 const Title = ({ group: { name, id }, showEdit }: TitleProps) => (
   <NavigationTab title={name}>
+    <NavigationLink to={`/interestgroups/`}>
+      <i className="fa fa-angle-left" /> Tilbake
+    </NavigationLink>
     {showEdit && (
-      <NavigationLink to={`/interestgroups/${id}/edit`}>
-        [Rediger]
-      </NavigationLink>
+      <NavigationLink to={`/interestgroups/${id}/edit`}>Rediger</NavigationLink>
     )}
-    <NavigationLink to={`/interestgroups/`}>[Tilbake]</NavigationLink>
   </NavigationTab>
 );
 

--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -36,7 +36,7 @@ type TitleProps = {
 
 const Title = ({ group: { name, id }, showEdit }: TitleProps) => (
   <NavigationTab title={name}>
-    <NavigationLink to={`/interestgroups/`}>
+    <NavigationLink to="/interestgroups/">
       <i className="fa fa-angle-left" /> Tilbake
     </NavigationLink>
     {showEdit && (

--- a/app/routes/interestgroups/components/InterestGroupList.js
+++ b/app/routes/interestgroups/components/InterestGroupList.js
@@ -24,7 +24,7 @@ const InterestGroupList = (props: Props) => {
       <div className={styles.section}>
         <div>
           <NavigationTab title="Interessegrupper">
-            <NavigationLink to={`/`}>
+            <NavigationLink to="">
               <i className="fa fa-angle-left" /> Hjem
             </NavigationLink>
           </NavigationTab>
@@ -33,7 +33,7 @@ const InterestGroupList = (props: Props) => {
             våre interessegrupper.
           </p>
           {showCreate && (
-            <Link to={'/interestgroups/create'} className={styles.link}>
+            <Link to="/interestgroups/create" className={styles.link}>
               <Button>Lag ny interessegruppe</Button>
             </Link>
           )}

--- a/app/routes/interestgroups/components/InterestGroupList.js
+++ b/app/routes/interestgroups/components/InterestGroupList.js
@@ -24,7 +24,9 @@ const InterestGroupList = (props: Props) => {
       <div className={styles.section}>
         <div>
           <NavigationTab title="Interessegrupper">
-            <NavigationLink to={`/`}>Hjem</NavigationLink>
+            <NavigationLink to={`/`}>
+              <i className="fa fa-angle-left" /> Hjem
+            </NavigationLink>
           </NavigationTab>
           <p>
             <strong>Her</strong> finner du all praktisk informasjon knyttet til

--- a/app/routes/meetings/components/MeetingDetail.css
+++ b/app/routes/meetings/components/MeetingDetail.css
@@ -2,7 +2,6 @@
 
 .root {
   composes: contentContainer from 'app/styles/utilities.css';
-  margin-top: 2rem;
 }
 
 .heading {

--- a/app/routes/meetings/components/MeetingEditor.css
+++ b/app/routes/meetings/components/MeetingEditor.css
@@ -2,7 +2,6 @@
 
 .root {
   composes: contentContainer from 'app/styles/utilities.css';
-  margin-top: 2rem;
 }
 
 .heading {

--- a/app/routes/meetings/components/MeetingEditor.js
+++ b/app/routes/meetings/components/MeetingEditor.js
@@ -2,11 +2,11 @@
 
 import React from 'react';
 
-import { Link } from 'react-router';
 import styles from './MeetingEditor.css';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { reduxForm, Field, SubmissionError } from 'redux-form';
 import { AttendanceStatus } from 'app/components/UserAttendance';
+import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
 
 import {
   Form,
@@ -98,13 +98,11 @@ function MeetingEditor({
 
   return (
     <div className={styles.root}>
-      <h2>
-        <Link to={isEditPage ? `/meetings/${meeting.id}` : `/meetings/`}>
-          <i className="fa fa-angle-left" />
-          {isEditPage ? ` ${meeting.title}` : ' Mine møter'}
-        </Link>
-      </h2>
-      <h1>{isEditPage ? 'Endre møte' : 'Nytt møte'} </h1>
+      <NavigationTab title={'Nytt møte'} className={styles.detailTitle}>
+        <NavigationLink to={`/meetings/`}>
+          <i className="fa fa-angle-left" /> Mine møter
+        </NavigationLink>
+      </NavigationTab>
       <Form onSubmit={handleSubmit(onSubmit)}>
         <Field
           name="title"

--- a/app/routes/meetings/components/MeetingEditor.js
+++ b/app/routes/meetings/components/MeetingEditor.js
@@ -98,8 +98,8 @@ function MeetingEditor({
 
   return (
     <div className={styles.root}>
-      <NavigationTab title={'Nytt møte'} className={styles.detailTitle}>
-        <NavigationLink to={`/meetings/`}>
+      <NavigationTab title="Nytt møte" className={styles.detailTitle}>
+        <NavigationLink to="/meetings/">
           <i className="fa fa-angle-left" /> Mine møter
         </NavigationLink>
       </NavigationTab>

--- a/app/routes/meetings/components/Toolbar.css
+++ b/app/routes/meetings/components/Toolbar.css
@@ -4,6 +4,15 @@
   margin-bottom: 40px;
 }
 
+.detailTitle {
+  margin-bottom: 0;
+  width: 100%;
+
+  & h1 {
+    margin-bottom: 0;
+  }
+}
+
 .section {
   flex: 1;
   display: flex;

--- a/app/routes/meetings/components/Toolbar.js
+++ b/app/routes/meetings/components/Toolbar.js
@@ -1,25 +1,19 @@
 // @flow
 
 import React from 'react';
-import { Link } from 'react-router';
-import Button from 'app/components/Button';
 import styles from './Toolbar.css';
+import { Flex } from 'app/components/Layout';
+import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
 
 type Props = {};
 
 const Toolbar = (props: Props) => {
   return (
-    <div className={styles.root}>
-      <div className={styles.section}>
-        <h2> Dine Møter </h2>
-      </div>
-
-      <div className={styles.section}>
-        <Link to="/meetings/create/">
-          <Button>Nytt møte</Button>
-        </Link>
-      </div>
-    </div>
+    <Flex wrap alignItems="center" justifyContent="space-between">
+      <NavigationTab title={'Dine Møter'} className={styles.detailTitle}>
+        <NavigationLink to={'/meetings/create/'}>Nytt møte</NavigationLink>
+      </NavigationTab>
+    </Flex>
   );
 };
 

--- a/app/routes/meetings/components/Toolbar.js
+++ b/app/routes/meetings/components/Toolbar.js
@@ -10,8 +10,8 @@ type Props = {};
 const Toolbar = (props: Props) => {
   return (
     <Flex wrap alignItems="center" justifyContent="space-between">
-      <NavigationTab title={'Dine Møter'} className={styles.detailTitle}>
-        <NavigationLink to={'/meetings/create/'}>Nytt møte</NavigationLink>
+      <NavigationTab title="Dine Møter" className={styles.detailTitle}>
+        <NavigationLink to="/meetings/create/">Nytt møte</NavigationLink>
       </NavigationTab>
     </Flex>
   );

--- a/app/routes/pages/components/PageDetail.js
+++ b/app/routes/pages/components/PageDetail.js
@@ -91,9 +91,9 @@ function PageDetail<T: Object>({
     <Content>
       <NavigationTab title={title}>
         {actionGrant.includes('edit') &&
-          editUrl && <NavigationLink to={`${editUrl}`}>ENDRE</NavigationLink>}
+          editUrl && <NavigationLink to={`${editUrl}`}>Endre</NavigationLink>}
         {actionGrant.includes('create') && (
-          <NavigationLink to={`/pages/new`}> NY </NavigationLink>
+          <NavigationLink to={`/pages/new`}>Ny</NavigationLink>
         )}
       </NavigationTab>
       <Flex className={styles.page} wrap>

--- a/app/routes/pages/components/PageDetail.js
+++ b/app/routes/pages/components/PageDetail.js
@@ -91,9 +91,9 @@ function PageDetail<T: Object>({
     <Content>
       <NavigationTab title={title}>
         {actionGrant.includes('edit') &&
-          editUrl && <NavigationLink to={`${editUrl}`}>Endre</NavigationLink>}
+          editUrl && <NavigationLink to={editUrl}>Endre</NavigationLink>}
         {actionGrant.includes('create') && (
-          <NavigationLink to={`/pages/new`}>Ny</NavigationLink>
+          <NavigationLink to="/pages/new">Ny</NavigationLink>
         )}
       </NavigationTab>
       <Flex className={styles.page} wrap>

--- a/app/routes/photos/components/GalleryDetail.js
+++ b/app/routes/photos/components/GalleryDetail.js
@@ -2,7 +2,6 @@
 
 import React, { Component, cloneElement, type Element } from 'react';
 import GalleryDetailsRow from './GalleryDetailsRow';
-import Button from 'app/components/Button';
 import EmptyState from 'app/components/EmptyState';
 import { Link } from 'react-router';
 import ImageUpload from 'app/components/Upload/ImageUpload';
@@ -67,14 +66,10 @@ export default class GalleryDetail extends Component<Props, State> {
               <i className="fa fa-angle-left" /> Tilbake
             </NavigationLink>
             <NavigationLink to="">
-              <Button onClick={() => this.toggleUpload()}>
-                Last opp bilder
-              </Button>
+              <a onClick={() => this.toggleUpload()}>Last opp bilder</a>
             </NavigationLink>
             <NavigationLink to="">
-              <Button>
-                <Link to={`/photos/${gallery.id}/edit`}>Rediger</Link>
-              </Button>
+              <Link to={`/photos/${gallery.id}/edit`}>Rediger</Link>
             </NavigationLink>
           </NavigationTab>
         </Flex>


### PR DESCRIPTION
So the title/header of each page, with its links and buttons are a bit of a mess, to put it mildly.
We got a mix of buttons, uppercase, lowercase, Square brackets, bold font. MeetingDetail has a top-margin, MeetingList does not use NavigationTab + NavigationLink and so forth.

I suggest we make it a bit more coordinated like this, left being the old and right being the new. 
Was supposed to make the same changes to "New Meeting", but for some reason i cant access the page on Staging :(
![edit](https://user-images.githubusercontent.com/23152018/32419813-80d89a44-c280-11e7-82e4-bd084caf56f1.jpg)
