### PR TITLE
Remove height from event banner

### DIFF
--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -16,7 +16,6 @@
   padding: 0;
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
-  height: 300px;
   overflow: hidden;
   position: relative;
 


### PR DESCRIPTION
The image covers the entire container anyway, so this makes the page more responsive.