### PR TITLE
Add a banner prop to <Content />

### DIFF
--- a/app/components/Content/Content.css
+++ b/app/components/Content/Content.css
@@ -17,3 +17,8 @@
   width: 100%;
   padding-top: 20px;
 }
+
+.contentWithBanner {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}

--- a/app/components/Content/Content.css
+++ b/app/components/Content/Content.css
@@ -1,3 +1,17 @@
+.cover {
+  composes: contentContainer from 'app/styles/utilities.css';
+  max-height: 300px;
+  padding: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  overflow: hidden;
+  position: relative;
+
+  img {
+    object-fit: cover;
+  }
+}
+
 .content {
   composes: contentContainer from 'app/styles/utilities.css';
   width: 100%;

--- a/app/components/Content/Content.js
+++ b/app/components/Content/Content.js
@@ -3,8 +3,10 @@
 import React, { type Node } from 'react';
 import cx from 'classnames';
 import styles from './Content.css';
+import { Image } from 'app/components/Image';
 
 type Props = {
+  banner?: string,
   className?: string,
   children: Node
 };
@@ -25,8 +27,18 @@ type Props = {
  * </Content>
  * ```
  */
-function Content({ children, className }: Props) {
-  return <div className={cx(styles.content, className)}>{children}</div>;
+function Content({ banner, children, className }: Props) {
+  return (
+    <div>
+      {banner && (
+        <div className={cx(styles.cover, className)}>
+          <Image src={banner} />
+        </div>
+      )}
+
+      <div className={cx(styles.content, className)}>{children}</div>
+    </div>
+  );
 }
 
 export default Content;

--- a/app/components/Content/Content.js
+++ b/app/components/Content/Content.js
@@ -36,7 +36,13 @@ function Content({ banner, children, className }: Props) {
         </div>
       )}
 
-      <div className={cx(styles.content, className)}>{children}</div>
+      <div
+        className={cx(styles.content, className, {
+          [styles.contentWithBanner]: banner
+        })}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -6,24 +6,6 @@
   overflow: hidden;
 }
 
-.content {
-  border-top-right-radius: 0;
-  border-top-left-radius: 0;
-}
-
-.coverImage {
-  composes: contentContainer from 'app/styles/utilities.css';
-  padding: 0;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-  overflow: hidden;
-  position: relative;
-
-  img {
-    object-fit: cover;
-  }
-}
-
 .mainRow {
   margin-bottom: 1em;
   margin-top: 0.5em;

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -2,7 +2,6 @@
 
 import styles from './EventDetail.css';
 import React, { Component } from 'react';
-import { Image } from 'app/components/Image';
 import CommentView from 'app/components/Comments/CommentView';
 import Icon from 'app/components/Icon';
 import JoinEventForm from '../JoinEventForm';
@@ -173,11 +172,7 @@ export default class EventDetail extends Component<Props> {
 
     return (
       <div>
-        <div className={styles.coverImage}>
-          <Image src={event.cover} />
-        </div>
-
-        <Content className={styles.content}>
+        <Content banner={event.cover} className={styles.content}>
           <ContentHeader
             borderColor={color}
             onClick={onRegisterClick}

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -172,7 +172,7 @@ export default class EventDetail extends Component<Props> {
 
     return (
       <div>
-        <Content banner={event.cover} className={styles.content}>
+        <Content banner={event.cover}>
           <ContentHeader
             borderColor={color}
             onClick={onRegisterClick}

--- a/app/routes/joblistings/components/JoblistingDetail.js
+++ b/app/routes/joblistings/components/JoblistingDetail.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import { Link } from 'react-router';
 import LoadingIndicator from 'app/components/LoadingIndicator/';
-import { Image } from 'app/components/Image';
 import DisplayContent from 'app/components/DisplayContent';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import styles from './JoblistingDetail.css';
@@ -59,12 +58,7 @@ const JoblistingDetail = ({
   const canDelete = actionGrant.includes('delete');
 
   return (
-    <Content>
-      {joblisting.company.logo && (
-        <div className={styles.coverImage}>
-          <Image src={joblisting.company.logo} />
-        </div>
-      )}
+    <Content banner={joblisting.company.logo}>
       <ContentHeader>{joblisting.title}</ContentHeader>
       <ContentSection>
         <ContentMain>


### PR DESCRIPTION
Lets you set a `banner` on `Content` to emulate the behavior of the event detail page. Also adds it to job listings (cc @tmsolber) so that the banner covers the entire page like on event.