### PR TITLE
Handle non-existant users in selectUsersWithGroups

### DIFF
--- a/app/reducers/users.js
+++ b/app/reducers/users.js
@@ -71,8 +71,11 @@ export const selectUserByUsername = createSelector(
 export const selectUserWithGroups = createSelector(
   selectUserByUsername,
   state => state.groups.byId,
-  (user, groupsById) => ({
-    ...user,
-    abakusGroups: (user.abakusGroups || []).map(groupId => groupsById[groupId])
-  })
+  (user, groupsById) => {
+    if (!user) return;
+    return {
+      ...user,
+      abakusGroups: user.abakusGroups.map(groupId => groupsById[groupId])
+    };
+  }
 );

--- a/app/routes/users/UserProfileRoute.js
+++ b/app/routes/users/UserProfileRoute.js
@@ -28,11 +28,14 @@ const mapStateToProps = (state, props) => {
     params.username === 'me' ? state.auth.username : params.username;
 
   const user = selectUserWithGroups(state, { username });
-
-  const feed = selectFeedById(state, { feedId: feedIdByUserId(user.id) });
-  const feedItems = selectFeedActivitesByFeedId(state, {
-    feedId: feedIdByUserId(user.id)
-  });
+  let feed;
+  let feedItems;
+  if (user) {
+    feed = selectFeedById(state, { feedId: feedIdByUserId(user.id) });
+    feedItems = selectFeedActivitesByFeedId(state, {
+      feedId: feedIdByUserId(user.id)
+    });
+  }
 
   const isMe =
     params.username === 'me' || params.username === state.auth.username;


### PR DESCRIPTION
Other people's user profiles crash in master now because we removed the `|| {}` from `selectUserByUsername` - this handles that.