### PR TITLE
 Fix infinite fetch after 401 response

### DIFF
--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -5,7 +5,7 @@ import { normalize } from 'normalizr';
 import config from 'app/config';
 import cookie from 'js-cookie';
 import moment from 'moment-timezone';
-import { push, replace } from 'react-router-redux';
+import { push } from 'react-router-redux';
 import { userSchema } from 'app/reducers';
 import callAPI from 'app/actions/callAPI';
 import { User } from './ActionTypes';
@@ -63,11 +63,17 @@ export function login(
     });
 }
 
+export function logoutWithRedirect() {
+  return (dispatch: Dispatch<*>) => {
+    dispatch(logout());
+    dispatch(push('/'));
+  };
+}
+
 export function logout() {
   return (dispatch: Dispatch<*>) => {
     removeToken();
     dispatch({ type: User.LOGOUT });
-    dispatch(replace('/'));
     dispatch(fetchMeta());
   };
 }

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -89,7 +89,12 @@ const appReducer = combineReducers(reducers);
 
 export default function rootReducer(state: State, action: Action) {
   if (action.type === User.LOGOUT) {
-    return appReducer(undefined, action);
+    return appReducer(
+      {
+        routing: state.routing
+      },
+      action
+    );
   }
 
   return appReducer(state, action);

--- a/app/routes/app/AppRoute.js
+++ b/app/routes/app/AppRoute.js
@@ -9,7 +9,7 @@ import Helmet from 'react-helmet';
 import Raven from 'raven-js';
 import {
   loginAutomaticallyIfPossible,
-  logout,
+  logoutWithRedirect,
   login
 } from 'app/actions/UserActions';
 import {
@@ -141,7 +141,7 @@ function fetchInitialOnServer(props, dispatch) {
 
 const mapDispatchToProps = {
   toggleSearch,
-  logout,
+  logout: logoutWithRedirect,
   login,
   fetchNotificationFeed,
   markAllNotifications,


### PR DESCRIPTION
Only run logout after getting a 401 response when the user is loggedIn
(has authentication info in the state). The previous behavior resulted
in an infinite loop.