### PR TITLE
Revert "Sort by IDs first in frontpage"

### DIFF
--- a/app/reducers/frontpage.js
+++ b/app/reducers/frontpage.js
@@ -9,8 +9,6 @@ export const selectFrontpage = createSelector(
   selectEvents,
   (articles, events) =>
     sortBy(articles.concat(events), [
-      // Sort by IDs first to differ between events that start at the same time:
-      item => item.id,
       // Always sort pinned items first:
       item => !item.pinned,
       item => {


### PR DESCRIPTION
This didn't work as I thought it would, since we have two sets of IDs (articles and events).