### PR TITLE
Sort frontpage events by `id`, after `pinned` and start time.

### DIFF
--- a/app/reducers/frontpage.js
+++ b/app/reducers/frontpage.js
@@ -16,6 +16,7 @@ export const selectFrontpage = createSelector(
         // we look at when it was written:
         const timeField = item.eventType ? item.startTime : item.createdAt;
         return Math.abs(moment().diff(timeField));
-      }
+      },
+      item => item.id
     ])
 );


### PR DESCRIPTION
The functions passed to `lodash.sortBy` are ran on each element,
producing a new list `[f(x), g(x), h(x), ...]`, and it is _this_ list
that is sorted. With the previous attempted solution to this problem we
had the `id` as the first element. This causes the list to only look at
`pinned` and start time, if there are collisions in the IDs (whic is
unlikely). With this change, we first sort by pinned. If there are
multiple items with the same value (which there will be, since `pinned`
is either `true` or `false`), we look at the start time abs thing.
Then, if there are elements that still compare as equals, we look at the
ID. This is the indended semantics of the previous PR (#961).