### PR TITLE
Add support for validating fields without touch

### DIFF
--- a/app/components/Form/Field.js
+++ b/app/components/Form/Field.js
@@ -25,7 +25,8 @@ type FieldProps = {
   fieldStyle: any,
   fieldClassName: string,
   labelClassName: string,
-  showErrors: boolean
+  showErrors: boolean,
+  validateUntouched?: boolean
 };
 
 /**
@@ -46,10 +47,12 @@ export function createField(Component: ComponentType<*>) {
       labelClassName,
       showErrors = true,
       className = null,
+      validateUntouched = false,
       ...props
     } = field;
     const { error, touched } = meta;
-    const hasError = showErrors && touched && error && error.length > 0;
+    const shouldValidate = validateUntouched || touched;
+    const hasError = showErrors && shouldValidate && error && error.length > 0;
     return (
       <div className={cx(styles.field, fieldClassName)} style={fieldStyle}>
         <label className={cx(styles.label, labelClassName)}>

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -201,6 +201,7 @@ class JoinEventForm extends Component<Props> {
               <Flex style={{ marginBottom: '20px' }}>
                 <Field
                   id={feedbackName}
+                  validateUntouched
                   placeholder="Melding til arrangører"
                   name={feedbackName}
                   component={TextEditor.Field}


### PR DESCRIPTION
This is _one_ way of solving #904. Not sure if it is the right way of doing it tho. Feel free to suggest a better name than `validateUntouched` - but it was the best i was able to find... :laughing: 

This is how it looks when you open an event with registration open, and with required feedback..
![screenshot from 2017-11-13 16-36-20](https://user-images.githubusercontent.com/1467188/32734070-35017bc4-c891-11e7-95a5-5a87ffed5241.png)
