### PR TITLE
Add support for /interesse

### DIFF
--- a/app/routes/companyInterest/index.js
+++ b/app/routes/companyInterest/index.js
@@ -1,25 +1,22 @@
 import resolveAsyncRoute from 'app/routes/resolveAsyncRoute';
 
-export default {
-  path: 'companyInterest',
-  indexRoute: resolveAsyncRoute(
-    () => import('./CompanyInterestListRoute'),
-    () => require('./CompanyInterestListRoute')
-  ),
-  childRoutes: [
-    {
-      path: 'create',
-      ...resolveAsyncRoute(
-        () => import('./CompanyInterestRoute'),
-        () => require('./CompanyInterestRoute')
-      )
-    },
-    {
-      path: ':companyInterestId/edit',
-      ...resolveAsyncRoute(
-        () => import('./CompanyInterestEditRoute'),
-        () => require('./CompanyInterestEditRoute')
-      )
-    }
-  ]
-};
+export default [
+  {
+    path: 'interesse',
+    ...resolveAsyncRoute(() => import('./CompanyInterestRoute'))
+  },
+  {
+    path: 'companyInterest',
+    indexRoute: resolveAsyncRoute(() => import('./CompanyInterestListRoute')),
+    childRoutes: [
+      {
+        path: 'create',
+        ...resolveAsyncRoute(() => import('./CompanyInterestRoute'))
+      },
+      {
+        path: ':companyInterestId/edit',
+        ...resolveAsyncRoute(() => import('./CompanyInterestEditRoute'))
+      }
+    ]
+  }
+];

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -40,7 +40,7 @@ export default {
     bdb,
     contact,
     timeline,
-    companyInterest,
+    ...companyInterest,
     {
       path: '*',
       component: HTTPError


### PR DESCRIPTION
What do you think of this approach?

Alternatively we can do something like

```
export const interesse = {
  path: 'interesse',
  ...resolve(..)
}

export companyInterest = {
  path: 'companyInterest',
  indexRoute: ...
  childRoutes: [
    {...},
  ]
}
```
and `import { interesse, companyInterest } from './companyInterest/';`

instead of the spreading and exporting an array. But I am not sure what I prefer.