### PR TITLE
Align user profiles properly

### DIFF
--- a/app/routes/users/components/UserProfile.css
+++ b/app/routes/users/components/UserProfile.css
@@ -8,7 +8,7 @@
   align-items: center;
   justify-content: space-between;
 
-  @media (--small-viewport) {
+  @media (--medium-viewport) {
     justify-content: space-around;
   }
 }
@@ -29,13 +29,13 @@
   min-width: 320px;
 }
 
-.feed {
+.rightContent {
   flex: 2;
   min-width: 320px;
   padding-left: 30px;
   width: 100%;
 
-  @media (--small-viewport) {
+  @media (--medium-viewport) {
     padding-left: 0;
     align-items: center;
   }

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -139,7 +139,7 @@ export default class UserProfile extends Component<Props> {
               )}
           </div>
 
-          <div className={styles.feed}>
+          <div className={styles.rightContent}>
             <h3>Nylig Aktivitet</h3>
             {feed ? (
               <Feed items={feedItems} feed={feed} />


### PR DESCRIPTION
Makes sure that the profile picture is still left aligned for users with a lot of group memberships.

![image](https://user-images.githubusercontent.com/3536982/32786853-55c50596-c955-11e7-9ceb-7baecaf6c4b3.png)
