### PR TITLE
Use overflow-y auto for firefox compatibility

### DIFF
--- a/app/components/HeaderNotifications/index.js
+++ b/app/components/HeaderNotifications/index.js
@@ -100,7 +100,7 @@ export default class NotificationsDropdown extends Component<Props, State> {
         {/* TODO FIXME - do same as the menu element*/}
         {notifications.length ? (
           <div style={{ width: '100%' }}>
-            <div style={{ maxHeight: '300px', overflowY: 'overlay' }}>
+            <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
               {this.renderNotifications(notifications)}
             </div>
           </div>


### PR DESCRIPTION
Firefox doesn't support `overlay` (and `auto` behaves almost the same anyway). This fixes this:

![image](https://user-images.githubusercontent.com/3536982/32888018-3814651a-cac6-11e7-9bc3-d83afc499b60.png)

@hanswilw 