### PR TITLE
Add member list for interestgroups

### DIFF
--- a/app/routes/interestgroups/components/InterestGroup.css
+++ b/app/routes/interestgroups/components/InterestGroup.css
@@ -1,3 +1,5 @@
+@import 'app/styles/variables.css';
+
 .logo {
   max-height: 250px;
   max-width: 250px;
@@ -33,4 +35,13 @@
 
 .deleteButton {
   margin-bottom: 16px;
+}
+
+.showMemberList {
+  color: var(--lego-link-color);
+
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
 }

--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -18,6 +18,7 @@ import { ProfilePicture } from 'app/components/Image';
 import DisplayContent from 'app/components/DisplayContent';
 import AnnouncementInLine from 'app/components/AnnouncementInLine';
 import type { InterestGroup, User, GroupMembership, ID } from 'app/models';
+import InterestGroupMemberList from './InterestGroupMemberList';
 
 // TODO: this is from the event detail page.
 // We can probably move this out to somewhere common.
@@ -59,6 +60,9 @@ const Members = ({ group, members }: MembersProps) => (
           .slice(0, 10)
           .map(reg => <RegisteredCell key={reg.user.id} user={reg.user} />)}
     </Flex>
+    <InterestGroupMemberList memberships={members}>
+      <Flex className={styles.showMemberList}>Vis alle medlemmer</Flex>
+    </InterestGroupMemberList>
   </Flex>
 );
 

--- a/app/routes/interestgroups/components/InterestGroupMemberList.css
+++ b/app/routes/interestgroups/components/InterestGroupMemberList.css
@@ -1,0 +1,34 @@
+.list {
+  width: 100%;
+  min-height: 100px;
+  max-height: calc(100vh - 210px);
+  padding: 0 30px;
+  margin-bottom: 5px;
+  overflow-y: auto;
+}
+
+.list > li {
+  border-bottom: 1px solid #ccc;
+}
+
+.list > li:last-child {
+  border-bottom: none;
+}
+
+.row {
+  display: flex;
+  height: 50px;
+  align-items: center;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.row > img {
+  width: 50px;
+  height: 50px;
+  margin-right: 10px;
+}
+
+.row i {
+  margin-right: 5px;
+}

--- a/app/routes/interestgroups/components/InterestGroupMemberList.js
+++ b/app/routes/interestgroups/components/InterestGroupMemberList.js
@@ -9,6 +9,7 @@ import Tooltip from 'app/components/Tooltip';
 import { Flex } from 'app/components/Layout';
 import Icon from 'app/components/Icon';
 import type { User, GroupMembership } from 'app/models';
+import sortBy from 'lodash/sortBy';
 
 const iconName = (role: string) => {
   switch (role) {
@@ -21,7 +22,7 @@ const iconName = (role: string) => {
   }
 };
 
-const icon = (role: string) => {
+const RoleIcon = ({ role }: { role: string }) => {
   const props = iconName(role);
   if (props) {
     const [name, tooltip] = props;
@@ -31,21 +32,21 @@ const icon = (role: string) => {
       </Tooltip>
     );
   }
+  return null;
 };
 
-const ListedUser = ({ user, role }: { user: User, role: string }) => {
-  return (
-    <li>
-      <Flex className={styles.row}>
-        <ProfilePicture size={30} user={user} />
-        {icon(role)}
-        <Link to={`/users/${user.username}`}>{user.fullName}</Link>
-      </Flex>
-    </li>
-  );
-};
+const ListedUser = ({ user, role }: { user: User, role: string }) => (
+  <li>
+    <Flex className={styles.row}>
+      <ProfilePicture size={30} user={user} />
+      <RoleIcon role={role} />
+      <Link to={`/users/${user.username}`}>{user.fullName}</Link>
+    </Flex>
+  </li>
+);
 
-const rolePriority = ['leader', 'co-leader'];
+// Reversed sort order
+const SORT_ORDER = ['member', 'co-leader', 'leader'];
 
 type Props = {
   children: any,
@@ -66,20 +67,16 @@ export default class InterestGroupMemberList extends Component<Props, State> {
   };
 
   render() {
-    this.props.memberships.sort((a, b) => {
-      for (let i = 0; i < rolePriority.length; i++) {
-        if (a.role === rolePriority[i]) return -1;
-        if (b.role === rolePriority[i]) return 1;
-      }
-      return 0;
-    });
+    const sorted = sortBy(this.props.memberships, ({ role }) =>
+      SORT_ORDER.indexOf(role)
+    ).reverse();
     return (
       <div>
         <div onClick={this.toggleModal}>{this.props.children}</div>
         <Modal show={this.state.modalVisible} onHide={this.toggleModal}>
           <h2>Medlemmer</h2>
           <ul className={styles.list}>
-            {this.props.memberships.map(membership => (
+            {sorted.map(membership => (
               <ListedUser
                 key={membership.user.id}
                 user={membership.user}

--- a/app/routes/interestgroups/components/InterestGroupMemberList.js
+++ b/app/routes/interestgroups/components/InterestGroupMemberList.js
@@ -82,7 +82,7 @@ export default class InterestGroupMemberList extends Component<Props, State> {
                 user={membership.user}
                 role={membership.role}
               />
-            ))};
+            ))}
           </ul>
         </Modal>
       </div>

--- a/app/routes/interestgroups/components/InterestGroupMemberList.js
+++ b/app/routes/interestgroups/components/InterestGroupMemberList.js
@@ -1,0 +1,94 @@
+// @flow
+
+import React, { Component } from 'react';
+import Modal from 'app/components/Modal';
+import styles from './InterestGroupMemberList.css';
+import { Link } from 'react-router';
+import { ProfilePicture } from 'app/components/Image';
+import Tooltip from 'app/components/Tooltip';
+import { Flex } from 'app/components/Layout';
+import Icon from 'app/components/Icon';
+import type { User, GroupMembership } from 'app/models';
+
+const iconName = (role: string) => {
+  switch (role) {
+    case 'leader':
+      return ['star', 'Leder'];
+    case 'co-leader':
+      return ['star-outline', 'Nestleder'];
+    default:
+      return;
+  }
+};
+
+const icon = (role: string) => {
+  const props = iconName(role);
+  if (props) {
+    const [name, tooltip] = props;
+    return (
+      <Tooltip content={tooltip}>
+        <Icon name={name} />
+      </Tooltip>
+    );
+  }
+};
+
+const ListedUser = ({ user, role }: { user: User, role: string }) => {
+  return (
+    <li>
+      <Flex className={styles.row}>
+        <ProfilePicture size={30} user={user} />
+        {icon(role)}
+        <Link to={`/users/${user.username}`}>{user.fullName}</Link>
+      </Flex>
+    </li>
+  );
+};
+
+const rolePriority = ['leader', 'co-leader'];
+
+type Props = {
+  children: any,
+  memberships: Array<GroupMembership>
+};
+
+type State = {
+  modalVisible: boolean
+};
+
+export default class InterestGroupMemberList extends Component<Props, State> {
+  state = { modalVisible: false };
+
+  toggleModal = () => {
+    this.setState(state => ({
+      modalVisible: !state.modalVisible
+    }));
+  };
+
+  render() {
+    this.props.memberships.sort((a, b) => {
+      for (let i = 0; i < rolePriority.length; i++) {
+        if (a.role === rolePriority[i]) return -1;
+        if (b.role === rolePriority[i]) return 1;
+      }
+      return 0;
+    });
+    return (
+      <div>
+        <div onClick={this.toggleModal}>{this.props.children}</div>
+        <Modal show={this.state.modalVisible} onHide={this.toggleModal}>
+          <h2>Medlemmer</h2>
+          <ul className={styles.list}>
+            {this.props.memberships.map(membership => (
+              <ListedUser
+                key={membership.user.id}
+                user={membership.user}
+                role={membership.role}
+              />
+            ))};
+          </ul>
+        </Modal>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Fix #989
Adds a modal with all members of interestgroup
![screenshot](https://user-images.githubusercontent.com/16608915/32906811-67147912-cafe-11e7-8671-77da1618ff22.png)
Here the leader and co-leader are sorted to the top of the list, and given an icon (with tooltip)