### PR TITLE
Disable form reinitialize in eventForm

### DIFF
--- a/app/routes/events/EventEditRoute.js
+++ b/app/routes/events/EventEditRoute.js
@@ -8,6 +8,7 @@ import {
   deleteEvent,
   setCoverPhoto
 } from 'app/actions/EventActions';
+import loadingIndicator from 'app/utils/loadingIndicator';
 import { uploadFile } from 'app/actions/FileActions';
 import EventEditor from './components/EventEditor';
 import {
@@ -77,5 +78,6 @@ export default compose(
       componentWillReceiveProps: false
     }
   ),
-  connect(mapStateToProps, mapDispatchToProps)
+  connect(mapStateToProps, mapDispatchToProps),
+  loadingIndicator(['event.title'])
 )(EventEditor);

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -318,7 +318,6 @@ function EventEditor({
 
 export default reduxForm({
   form: 'eventEditor',
-  enableReinitialize: true,
   validate(data) {
     const errors = {};
     if (!data.title) {


### PR DESCRIPTION
Due to the 'componentDidMount' hack in ImageUploadFiled, clicking edit
event after the `fetchEvent` cache is invlidated (10sec?), result in a
new form initialize after the event is fetched, and the 'cover' value in
the form is replaced with the original url - resulting in a 404 when
posting the `imageurl`.

This is just as the comment says, a huge and ugly hack that creates bugs that are hard to track down...
https://github.com/webkom/lego-webapp/blob/6c5df1d27e80046508890da9eecd491fdcb7256b/app/components/Form/ImageUploadField.js#L24


Fixes stuff like this:
https://sentry.abakus.no/webkom/lego-webapp/issues/3801/events/1999164/

This works here; but would be nice with some more testing..