### PR TITLE
Add error boundary to feed

### DIFF
--- a/app/components/ErrorBoundary/index.js
+++ b/app/components/ErrorBoundary/index.js
@@ -6,7 +6,8 @@ import awSnap from 'app/assets/sentry-aw-snap.svg';
 
 type Props = {
   openReportDialog?: boolean,
-  children: any
+  children: any,
+  hidden?: boolean
 };
 
 type State = {
@@ -31,9 +32,9 @@ class ErrorBoundary extends React.Component<Props, State> {
   }
 
   render() {
-    const { openReportDialog, children, ...rest } = this.props;
+    const { openReportDialog, hidden = false, children, ...rest } = this.props;
     if (this.state.error) {
-      return (
+      return hidden ? null : (
         <div className={styles.container}>
           <div
             className={styles.snap}

--- a/app/components/Feed/activity.js
+++ b/app/components/Feed/activity.js
@@ -20,7 +20,7 @@ type State = {
   expanded: boolean
 };
 
-export default class CommentRenderer extends Component<Props, State> {
+export default class ActivityRenderer extends Component<Props, State> {
   state: State = {
     expanded: false
   };

--- a/app/components/Feed/index.js
+++ b/app/components/Feed/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import Activity from './activity';
 import type { AggregatedActivity } from './types';
 import EmptyState from 'app/components/EmptyState';
+import ErrorBoundary from 'app/components/ErrorBoundary';
 
 export const activityRenderers = {
   comment: require('./renders/comment'),
@@ -16,13 +17,17 @@ export const activityRenderers = {
   event_register: require('./renders/event_register')
 };
 
-const Feed = ({ items }: { items: Array<AggregatedActivity> }) => (
+type Props = { items: Array<AggregatedActivity> };
+
+const Feed = ({ items }: Props) => (
   <div style={{ width: '100%' }}>
     {items.length ? (
       items.map((item, i) => {
         const renders = activityRenderers[item.verb];
         return renders ? (
-          <Activity aggregatedActivity={item} key={i} renders={renders} />
+          <ErrorBoundary key={item.id}>
+            <Activity aggregatedActivity={item} renders={renders} />
+          </ErrorBoundary>
         ) : null;
       })
     ) : (
@@ -32,5 +37,4 @@ const Feed = ({ items }: { items: Array<AggregatedActivity> }) => (
     )}
   </div>
 );
-
 export default Feed;

--- a/app/components/Feed/index.js
+++ b/app/components/Feed/index.js
@@ -25,7 +25,7 @@ const Feed = ({ items }: Props) => (
       items.map((item, i) => {
         const renders = activityRenderers[item.verb];
         return renders ? (
-          <ErrorBoundary key={item.id}>
+          <ErrorBoundary hidden key={item.id}>
             <Activity aggregatedActivity={item} renders={renders} />
           </ErrorBoundary>
         ) : null;


### PR DESCRIPTION
This fixes the error caused by feed activities
without the context (eg. the joined group is deleted).
This should therefore be properly fixed in the backend.

We can switch back to a single error boundary per feed when the backend issue is resolved. :smile: 