### PR TITLE
Styling fixes

### DIFF
--- a/app/components/DisplayContent/DisplayContent.css
+++ b/app/components/DisplayContent/DisplayContent.css
@@ -1,0 +1,3 @@
+.base {
+  word-break: break-word;
+}

--- a/app/components/DisplayContent/index.js
+++ b/app/components/DisplayContent/index.js
@@ -2,6 +2,8 @@
 
 import React from 'react';
 import { Parser, ProcessNodeDefinitions } from 'html-to-react';
+import styles from './DisplayContent.css';
+import cx from 'classnames';
 
 type Props = {
   /** The content to be displayed - the text */
@@ -72,7 +74,7 @@ function DisplayContent({ content, id, style, className }: Props) {
   );
 
   return (
-    <div className={className} id={className} style={style}>
+    <div className={cx(styles.base, className)} id={className} style={style}>
       {react}
     </div>
   );

--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -26,7 +26,8 @@
 
 .registeredThumbnails {
   flex-wrap: wrap;
-  max-height: 138px;
+  max-height: 130px;
+  justify-content: space-between;
   overflow: hidden;
 }
 

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -203,7 +203,7 @@ export default class EventDetail extends Component<Props> {
                   <h3>Påmeldte</h3>
                   <Flex className={styles.registeredThumbnails}>
                     {registrations
-                      .slice(0, 10)
+                      .slice(0, 12)
                       .map(reg => (
                         <RegisteredCell key={reg.user.id} user={reg.user} />
                       ))}


### PR DESCRIPTION
- https://github.com/webkom/lego-webapp/commit/c27de0ae8f63a915de4126b058a5fcab046e835c Fix defualt "styling" in DisplayContent. Long urls use to break mobile view.
- https://github.com/webkom/lego-webapp/commit/9d4d3d7106967b73c95f94d59de676526e7c4d57 Make registered thumbnails less obscure on mobile (used to look like only 10 people was registered, since there were two empty spots)

![screenshot from 2017-12-12 13-15-41](https://user-images.githubusercontent.com/1467188/33884293-6d8a5e1a-df3f-11e7-85ec-6ed73a065f0f.png)
![screenshot from 2017-12-12 13-15-52](https://user-images.githubusercontent.com/1467188/33884294-6da7bb22-df3f-11e7-9014-e7aae290019a.png)
