### PR TITLE
Add initial support for urls in DisplayContent

### DIFF
--- a/app/components/DisplayContent/index.js
+++ b/app/components/DisplayContent/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { Parser, ProcessNodeDefinitions } from 'html-to-react';
 import styles from './DisplayContent.css';
 import cx from 'classnames';
+import urlifyString from 'app/utils/urlifyString';
 
 type Props = {
   /** The content to be displayed - the text */
@@ -53,6 +54,24 @@ const processingInstructions = [
     },
     processNode: (node, children) => {
       return node.data.toUpperCase();
+    }
+  },
+  {
+    /*
+    * Custom handler that renders urls (including mails) as a-tags with the
+    * corresponding src
+    */
+    replaceChildren: true,
+    shouldProcessNode: function(node) {
+      return node.name === 'p';
+    },
+    processNode: function(node, children, index) {
+      return children.map(child => {
+        if (typeof child === 'string') {
+          return urlifyString(child);
+        }
+        return child;
+      });
     }
   },
   {

--- a/app/utils/__tests__/urlifyString.spec.js
+++ b/app/utils/__tests__/urlifyString.spec.js
@@ -1,0 +1,59 @@
+//@flow
+import urlifyString from '../urlifyString';
+import * as React from 'react';
+
+describe('UrlifyString', () => {
+  const data: Array<{
+    input: string,
+    expected: Array<React.Node | string>,
+    desc: string
+  }> = [
+    {
+      input: 'https://abakus.no https://vg.no',
+      desc: 'urls',
+      expected: [
+        <a key="https://abakus.no" href="https://abakus.no">
+          https://abakus.no
+        </a>,
+        <a key="https://vg.no" href="https://vg.no">
+          https://vg.no
+        </a>
+      ]
+    },
+    {
+      input: 'Hei På deg',
+      desc: 'text',
+      expected: ['Hei På deg']
+    },
+    {
+      input: 'mailto:hs@abakus.no',
+      desc: 'mailto url ',
+      expected: [
+        <a key="mailto:hs@abakus.no" href="mailto:hs@abakus.no">
+          hs@abakus.no
+        </a>
+      ]
+    },
+    {
+      input:
+        'Hei på Deg https://abakus.no er kult, og mailto:webkom@abakus.no test',
+      desc: 'nested strings, mailto-links and urls',
+      expected: [
+        'Hei på Deg ',
+        <a key="https://abakus.no" href="https://abakus.no">
+          https://abakus.no
+        </a>,
+        ' er kult, og ',
+        <a key="mailto:webkom@abakus.no" href="mailto:webkom@abakus.no">
+          webkom@abakus.no
+        </a>,
+        ' test'
+      ]
+    }
+  ];
+
+  data.forEach(({ input, desc, expected }) => {
+    it(`Should handle ${desc}`, () =>
+      expect(urlifyString(input)).toEqual(expected));
+  });
+});

--- a/app/utils/urlifyString.js
+++ b/app/utils/urlifyString.js
@@ -1,0 +1,47 @@
+//@flow
+import * as React from 'react';
+
+type Urlified = Array<React.Node | string>;
+
+export const isUrl = (data: string) =>
+  data.match(
+    /^(https?:\/\/|mailto:)?([\da-z.-@]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/
+  );
+
+export const urlToLink = (url: string): React.Node => (
+  <a key={url} href={url}>
+    {url.replace('mailto:', '')}
+  </a>
+);
+
+const urlifyString = (data: string): Urlified =>
+  data
+    .split(' ')
+    .reduce(
+      (
+        accumulator: Urlified,
+        value: string,
+        index: number,
+        { length }: Array<string>
+      ) => {
+        if (isUrl(value)) {
+          return accumulator.concat(urlToLink(value));
+        }
+        const prevIndex = accumulator.length - 1;
+        const postfix = index === length - 1 ? '' : ' ';
+        const text = `${value}${postfix}`;
+
+        if (prevIndex === -1) {
+          return [text];
+        }
+
+        const prev = accumulator[prevIndex];
+        if (typeof prev !== 'string') {
+          return accumulator.concat(` ${text}`);
+        }
+        return accumulator.slice(0, prevIndex).concat(`${prev}${text}`);
+      },
+      []
+    );
+
+export default urlifyString;


### PR DESCRIPTION
Add initial support for url rendering when displaying content. It just wraps all urls (including mailto) as normal link tags. This is a temporary solution, since the editor doesn't support links yet. It is kind of a hack, so look at the test to get a brief understanding of the thing, 

It currently removes `:mailto` from the rendered text. It is possible to do the same thing with `https|http` too


![screenshot from 2017-12-12 16-27-00](https://user-images.githubusercontent.com/1467188/33892747-e042222a-df59-11e7-97f6-735b708ba300.png)