### PR TITLE
Add support for resetting error boundary

### DIFF
--- a/app/components/ErrorBoundary/index.js
+++ b/app/components/ErrorBoundary/index.js
@@ -7,7 +7,9 @@ import awSnap from 'app/assets/sentry-aw-snap.svg';
 type Props = {
   openReportDialog?: boolean,
   children: any,
-  hidden?: boolean
+  hidden?: boolean,
+  /* Reset error when this prop changes */
+  resetOnChange?: any
 };
 
 type State = {
@@ -23,6 +25,14 @@ class ErrorBoundary extends React.Component<Props, State> {
     Raven.lastEventId() && Raven.showReportDialog({});
   };
 
+  componentWillReceiveProps(nextProps: Props) {
+    const { resetOnChange } = this.props;
+    const { error } = this.state;
+    if (error && nextProps.resetOnChange !== resetOnChange) {
+      this.setState({ error: null });
+    }
+  }
+
   componentDidCatch(error: Error, errorInfo: Object) {
     this.setState({ error });
     Raven.captureException(error, { extra: errorInfo });
@@ -33,32 +43,38 @@ class ErrorBoundary extends React.Component<Props, State> {
 
   render() {
     const { openReportDialog, hidden = false, children, ...rest } = this.props;
-    if (this.state.error) {
-      return hidden ? null : (
-        <div className={styles.container}>
-          <div
-            className={styles.snap}
-            onClick={() => !openReportDialog && this.openDialog()}
-          >
-            <img src={awSnap} alt="snap" />
-            <div className={styles.message}>
-              <h3>En feil har oppstått</h3>
-              <p>
-                Webkom har fått beskjed om feilen.{' '}
-                {!openReportDialog &&
-                  Raven.lastEventId() && (
-                    <span>
-                      Klikk <b>her</b> for å sende en rapport.
-                    </span>
-                  )}
-              </p>
-            </div>
+
+    if (!this.state.error) {
+      return React.Children.map(children, child =>
+        React.cloneElement(child, { ...rest })
+      );
+    }
+    if (hidden) {
+      return null;
+    }
+
+    return (
+      <div className={styles.container}>
+        <div
+          className={styles.snap}
+          onClick={() => !openReportDialog && this.openDialog()}
+        >
+          <img src={awSnap} alt="snap" />
+          <div className={styles.message}>
+            <h3>En feil har oppstått</h3>
+            <p>
+              Webkom har fått beskjed om feilen.{' '}
+              {!openReportDialog &&
+                Raven.lastEventId() && (
+                  <span>
+                    Klikk <b>her</b> for å sende en rapport.
+                  </span>
+                )}
+            </p>
           </div>
         </div>
-      );
-    } else {
-      return React.cloneElement(children, rest);
-    }
+      </div>
+    );
   }
 }
 

--- a/app/routes/app/AppRoute.js
+++ b/app/routes/app/AppRoute.js
@@ -43,19 +43,21 @@ class AppChildren extends PureComponent<Props> {
   render() {
     return (
       <div style={{ flex: 1 }}>
-        <ToastContainer />
-        {this.props.statusCode ? (
-          <HTTPError
-            statusCode={this.props.statusCode}
-            setStatusCode={this.props.setStatusCode}
-            location={this.props.location}
-          />
-        ) : (
-          React.cloneElement(this.props.children, {
-            currentUser: this.props.currentUser,
-            loggedIn: this.props.loggedIn
-          })
-        )}
+        <ErrorBoundary resetOnChange={this.props.location}>
+          <ToastContainer />
+          {this.props.statusCode ? (
+            <HTTPError
+              statusCode={this.props.statusCode}
+              setStatusCode={this.props.setStatusCode}
+              location={this.props.location}
+            />
+          ) : (
+            React.cloneElement(this.props.children, {
+              currentUser: this.props.currentUser,
+              loggedIn: this.props.loggedIn
+            })
+          )}
+        </ErrorBoundary>
       </div>
     );
   }
@@ -105,17 +107,15 @@ class App extends PureComponent<AppProps> {
           fetchNotificationData={this.props.fetchNotificationData}
         />
 
-        <ErrorBoundary>
-          <AppChildren
-            currentUser={this.props.currentUser}
-            loggedIn={this.props.loggedIn}
-            statusCode={this.props.statusCode}
-            setStatusCode={this.props.setStatusCode}
-            location={this.props.location}
-          >
-            {this.props.children}
-          </AppChildren>
-        </ErrorBoundary>
+        <AppChildren
+          currentUser={this.props.currentUser}
+          loggedIn={this.props.loggedIn}
+          statusCode={this.props.statusCode}
+          setStatusCode={this.props.setStatusCode}
+          location={this.props.location}
+        >
+          {this.props.children}
+        </AppChildren>
 
         <Footer {...this.props} />
       </div>


### PR DESCRIPTION
Add new prop to error boundary, that resets the error when it is changed. It is useful when a route crashes, because then the router location change can be used to reset the error. :smile:

Also moved the error boundary inside the `AppChildren`, since that fixes the styling issue (the footer is now on the bottom of the page after an error occur)