### PR TITLE
Add CreateNewUser and ForgotPassword on header

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -91,6 +91,25 @@
   flex-direction: row;
 }
 
+.toggleButton {
+  color: var(--lego-link-color);
+  font-size: 14px;
+}
+
+.dropdown {
+  width: 355px;
+  padding: 15px;
+
+  @media (--small-viewport) {
+    width: 100%;
+
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
+}
+
 .navigation {
   display: flex;
   flex-direction: row;

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -19,7 +19,7 @@ import {
 import { Flex } from 'app/components/Layout';
 import cx from 'classnames';
 
-import type { UserEntity } from 'app/reducyarners/users';
+import type { UserEntity } from 'app/reducers/users';
 
 type Props = {
   searchOpen: boolean,
@@ -179,7 +179,8 @@ class Header extends Component<Props, State> {
                   toggle={() =>
                     this.setState(state => ({
                       accountOpen: !state.accountOpen
-                    }))}
+                    }))
+                  }
                   triggerComponent={
                     <ProfilePicture
                       size={30}
@@ -203,7 +204,8 @@ class Header extends Component<Props, State> {
                     this.setState(state => ({
                       accountOpen: !state.accountOpen,
                       shake: false
-                    }))}
+                    }))
+                  }
                   contentClassName={cx(
                     this.state.shake ? 'animated shake' : '',
                     styles.dropdown

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -7,13 +7,19 @@ import logoImage from 'app/assets/logo-dark.png';
 import Dropdown from '../Dropdown';
 import Icon from '../Icon';
 import Search from '../Search';
-import LoginForm from '../LoginForm/LoginForm';
 import { ProfilePicture } from '../Image';
 import FancyNodesCanvas from './FancyNodesCanvas';
 import NotificationsDropdown from '../HeaderNotifications';
 import styles from './Header.css';
+import {
+  LoginForm,
+  RegisterForm,
+  ForgotPasswordForm
+} from 'app/components/LoginForm';
+import { Flex } from 'app/components/Layout';
+import cx from 'classnames';
 
-import type { UserEntity } from 'app/reducers/users';
+import type { UserEntity } from 'app/reducyarners/users';
 
 type Props = {
   searchOpen: boolean,
@@ -31,7 +37,8 @@ type Props = {
 
 type State = {
   accountOpen: boolean,
-  shake: boolean
+  shake: boolean,
+  mode: 'login' | 'register' | 'forgotPassword'
 };
 
 type AccountDropdownItemsProps = {
@@ -80,11 +87,43 @@ function AccountDropdownItems({
 class Header extends Component<Props, State> {
   state: State = {
     accountOpen: false,
-    shake: false
+    shake: false,
+    mode: 'login'
+  };
+
+  toggleRegisterUser = (e: Event) => {
+    this.setState({ mode: 'register' });
+    e.stopPropagation();
+  };
+
+  toggleForgotPassword = (e: Event) => {
+    this.setState({ mode: 'forgotPassword' });
+    e.stopPropagation();
+  };
+
+  toggleBack = (e: Event) => {
+    this.setState({ mode: 'login' });
+    e.stopPropagation();
   };
 
   render() {
     const { loggedIn } = this.props;
+    const isLogin = this.state.mode === 'login';
+    let title, form;
+    switch (this.state.mode) {
+      case 'login':
+        title = 'Logg inn';
+        form = <LoginForm />;
+        break;
+      case 'register':
+        title = 'Register';
+        form = <RegisterForm />;
+        break;
+      case 'forgotPassword':
+        title = 'Glemt passord';
+        form = <ForgotPasswordForm />;
+        break;
+    }
 
     return (
       <header className={styles.header}>
@@ -140,8 +179,7 @@ class Header extends Component<Props, State> {
                   toggle={() =>
                     this.setState(state => ({
                       accountOpen: !state.accountOpen
-                    }))
-                  }
+                    }))}
                   triggerComponent={
                     <ProfilePicture
                       size={30}
@@ -165,23 +203,50 @@ class Header extends Component<Props, State> {
                     this.setState(state => ({
                       accountOpen: !state.accountOpen,
                       shake: false
-                    }))
-                  }
-                  contentClassName={this.state.shake ? 'animated shake' : ''}
+                    }))}
+                  contentClassName={cx(
+                    this.state.shake ? 'animated shake' : '',
+                    styles.dropdown
+                  )}
                   triggerComponent={<Icon name="contact" size={30} />}
                 >
                   <div style={{ padding: 10 }}>
-                    <LoginForm
-                      form="HeaderLoginForm"
-                      postLoginSuccess={res => {
-                        this.setState({ shake: false, accountOpen: false });
-                        return res;
-                      }}
-                      postLoginFail={error => {
-                        this.setState({ shake: true });
-                        throw error;
-                      }}
-                    />
+                    <Flex
+                      component="h2"
+                      justifyContent="space-between"
+                      allignItems="center"
+                      className="u-mb"
+                      style={{ whitespace: 'nowrap' }}
+                    >
+                      {title}
+                      {isLogin && (
+                        <div>
+                          <button
+                            onClick={this.toggleForgotPassword}
+                            className={styles.toggleButton}
+                          >
+                            Glemt passord
+                          </button>
+                          <span className={styles.toggleButton}>&bull;</span>
+                          <button
+                            onClick={this.toggleRegisterUser}
+                            className={styles.toggleButton}
+                          >
+                            Jeg er ny
+                          </button>
+                        </div>
+                      )}
+
+                      {!isLogin && (
+                        <button
+                          onClick={this.toggleBack}
+                          className={styles.toggleButton}
+                        >
+                          Tilbake
+                        </button>
+                      )}
+                    </Flex>
+                    {form}
                   </div>
                 </Dropdown>
               )}

--- a/app/components/LoginForm/ForgotPasswordForm.js
+++ b/app/components/LoginForm/ForgotPasswordForm.js
@@ -59,7 +59,10 @@ class ForgotPasswordForm extends Component<Props, State> {
       );
     }
     return (
-      <Form onSubmit={handleSubmit(this.onSubmit)}>
+      <Form
+        onSubmit={handleSubmit(this.onSubmit)}
+        onClick={e => e.stopPropagation()}
+      >
         <Field name="email" component={TextInput.Field} placeholder="E-post" />
         <Button submit disabled={invalid | pristine | submitting} dark>
           Tilbakestill passord

--- a/app/components/LoginForm/Login.css
+++ b/app/components/LoginForm/Login.css
@@ -4,3 +4,25 @@
   composes: contentContainer from 'app/styles/utilities.css';
   max-width: 500px;
 }
+
+.toggleButton {
+  color: var(--lego-link-color);
+  font-size: 14px;
+}
+
+.window {
+  width: 600px;
+
+  @media (--mobile-device) {
+    width: 100%;
+  }
+}
+
+.detailTitle {
+  margin-bottom: 0;
+  width: 100%;
+}
+
+& h1 {
+  margin-bottom: 0;
+}

--- a/app/components/LoginForm/RegisterForm.js
+++ b/app/components/LoginForm/RegisterForm.js
@@ -58,7 +58,10 @@ class RegisterForm extends Component<Props, State> {
       );
     }
     return (
-      <Form onSubmit={handleSubmit(this.onSubmit)}>
+      <Form
+        onSubmit={handleSubmit(this.onSubmit)}
+        onClick={e => e.stopPropagation()}
+      >
         <Field name="email" component={TextInput.Field} placeholder="E-post" />
         <Field
           name="captchaResponse"


### PR DESCRIPTION
Made a new pull request for this feature since the old one got a bit outdated compared to prod. 
It appends the ability to create a new user and to reset your password by just pressing the profile icon while not logged in.  

-Mobile-
![screenshot from 2018-01-11 21-38-14](https://user-images.githubusercontent.com/23152018/34846776-93614efe-f719-11e7-8d54-0ed4a5db7fa9.png)
-Desktop-
![screenshot from 2018-01-11 21-39-14](https://user-images.githubusercontent.com/23152018/34846794-9d9931fc-f719-11e7-995f-5d14c7c992dc.png)
