### PR TITLE
Fix member listing in pages

### DIFF
--- a/app/reducers/pages.js
+++ b/app/reducers/pages.js
@@ -7,6 +7,8 @@ import { selectGroupsWithType } from './groups';
 import { selectGroup } from 'app/reducers/groups';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
 
+import { sortBy, groupBy } from 'lodash';
+
 export type PageEntity = {
   id: number,
   title: string,
@@ -107,8 +109,12 @@ export const selectCommitteeForPages = createSelector(
       title: group && group.name,
       editUrl: `/admin/groups/${group.id}/settings`
     };
+    const membershipsByRole = groupBy(
+      sortBy(memberships, 'user.fullName'),
+      'role'
+    );
     return {
-      selectedPage: group && { ...group, memberships },
+      selectedPage: group && { ...group, membershipsByRole },
       selectedPageInfo
     };
   }

--- a/app/reducers/pages.js
+++ b/app/reducers/pages.js
@@ -98,6 +98,22 @@ export const selectFlatpageForPages = createSelector(
   })
 );
 
+const separateRoles = [
+  'retiree',
+  'active_retiree',
+  'alumni',
+  'retiree_email',
+  'leader'
+];
+// Map all the other roles as if they were regular members
+const defaultRole = 'member';
+
+const groupMemberships = memberships =>
+  groupBy(
+    sortBy(memberships, 'user.fullName'),
+    ({ role }) => (separateRoles.includes(role) ? role : defaultRole)
+  );
+
 export const selectCommitteeForPages = createSelector(
   (state, props) => selectGroup(state, { groupId: Number(props.pageSlug) }),
   (state, props) =>
@@ -109,10 +125,7 @@ export const selectCommitteeForPages = createSelector(
       title: group && group.name,
       editUrl: `/admin/groups/${group.id}/settings`
     };
-    const membershipsByRole = groupBy(
-      sortBy(memberships, 'user.fullName'),
-      'role'
-    );
+    const membershipsByRole = groupMemberships(memberships);
     return {
       selectedPage: group && { ...group, membershipsByRole },
       selectedPageInfo

--- a/app/routes/pages/components/PageDetail.js
+++ b/app/routes/pages/components/PageDetail.js
@@ -8,7 +8,6 @@ import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import PageHierarchy from './PageHierarchy';
 import { Content } from 'app/components/Content';
-import sortBy from 'lodash/sortBy';
 import DisplayContent from 'app/components/DisplayContent';
 
 import type { HierarchySectionEntity } from './PageHierarchy';
@@ -47,13 +46,10 @@ const RenderUser = ({ user }: Object) => (
 );
 
 export const GroupRenderer = ({ page }: { page: Object }) => {
-  const { memberships, text, logo } = page;
-  const leader = memberships.find(membership => membership.role == 'leader');
+  const { membershipsByRole, text, logo } = page;
 
-  const members = sortBy(
-    memberships.filter(m => m != leader).map(m => m.user),
-    'fullName'
-  );
+  const { leader: leaders = [], member: members = [] } = membershipsByRole;
+
   return (
     <article className={styles.detail}>
       {logo && (
@@ -65,10 +61,14 @@ export const GroupRenderer = ({ page }: { page: Object }) => {
 
       <h3>Medlemmer:</h3>
       <ul>
-        {leader && <li>Leder: {<RenderUser user={leader.user} />}</li>}
-        {members.map((member, key) => (
+        {leaders.map(({ user }, key) => (
           <li key={key}>
-            <RenderUser user={member} />
+            Leder: <RenderUser user={user} />
+          </li>
+        ))}
+        {members.map(({ user }, key) => (
+          <li key={key}>
+            <RenderUser user={user} />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
This fixes #1041.

Moved the sorting/grouping to the selector instead.

```jsx
const separateRoles = [
  'retiree',
  'active_retiree',
  'alumni',
  'retiree_email',
  'leader'
];
// Map all the other roles as if they were regular members
const defaultRole = 'member';
```

