### PR TITLE
Add and Edit Surveys

### DIFF
--- a/app/assets/manifest.json
+++ b/app/assets/manifest.json
@@ -5,7 +5,8 @@
   "display": "standalone",
   "background_color": "#f2f2f1",
   "theme_color": "#f2f2f1",
-  "description": "Abakus: Linjeforening for datateknikk og kommunikasjonsteknologi på NTNU",
+  "description":
+    "Abakus: Linjeforening for datateknikk og kommunikasjonsteknologi på NTNU",
   "icons": [
     {
       "src": "/icon-48x48.png",

--- a/app/components/Form/CheckBox.js
+++ b/app/components/Form/CheckBox.js
@@ -19,7 +19,7 @@ type Props = {
 When using this component as a Field in redux-form, you have to include
 normalize={v => !!v}. This makes the value always end up in redux-form as
 true or false, while otherwise it can end up as an empty string or left
-out of the firn values altogether.
+out of the form values altogether.
 
 Example:
 <Field
@@ -40,7 +40,7 @@ function CheckBox({
   ...props
 }: Props) {
   return (
-    <div className={styles.box}>
+    <div className={cx(styles.box, className)}>
       <input
         {...props}
         defaultChecked={!!value}

--- a/app/components/Form/RadioButton.js
+++ b/app/components/Form/RadioButton.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import { createField } from './Field';
 import styles from './RadioButton.css';
+import cx from 'classnames';
 
 type Props = {
   id: string,
@@ -22,7 +23,7 @@ function RadioButton({
   ...props
 }: Props) {
   return (
-    <div className={styles.box}>
+    <div className={cx(styles.box, className)}>
       <input
         {...props}
         className={styles.input}

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -24,15 +24,15 @@ export type SubmmissionEntity = {
 };
 
 export type QuestionEntity = {
-  id?: number,
-  questionType: string,
+  id: number,
+  questionType: number,
   questionText: string,
   mandatory?: boolean,
-  alternatives?: Array<AlternativeEntity>
+  options?: Array<OptionEntity>
 };
 
 export type AnswerEntity = {
-  id?: number,
+  id: number,
   user: number,
   survey: number,
   submitted?: boolean,
@@ -40,10 +40,10 @@ export type AnswerEntity = {
   answers?: Array<AnswerEntity>
 };
 
-export type AlternativeEntity = {
-  id?: number,
-  alternativeText?: string,
-  alternativeType: string
+export type OptionEntity = {
+  id: number,
+  optionText?: string,
+  optionType: string
 };
 
 function mutateSurveys(state, action) {

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -28,7 +28,8 @@ export type QuestionEntity = {
   questionType: number,
   questionText: string,
   mandatory?: boolean,
-  options?: Array<OptionEntity>
+  options?: Array<OptionEntity>,
+  relativeIndex: number
 };
 
 export type AnswerEntity = {

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -25,7 +25,7 @@ export type SubmmissionEntity = {
 
 export type QuestionEntity = {
   id: number,
-  questionType: number,
+  questionType: string,
   questionText: string,
   mandatory?: boolean,
   options: Array<OptionEntity>,

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -10,7 +10,7 @@ export type SurveyEntity = {
   title: string,
   event: any,
   activeFrom?: string,
-  questions?: Array<QuestionEntity>,
+  questions: Array<QuestionEntity>,
   submissions?: Array<SubmmissionEntity>
 };
 
@@ -28,7 +28,7 @@ export type QuestionEntity = {
   questionType: number,
   questionText: string,
   mandatory?: boolean,
-  options?: Array<OptionEntity>,
+  options: Array<OptionEntity>,
   relativeIndex: number
 };
 

--- a/app/routes/surveys/AddSurveyRoute.js
+++ b/app/routes/surveys/AddSurveyRoute.js
@@ -16,11 +16,13 @@ const time = (hours, minutes) =>
 const mapStateToProps = (state, props) => {
   return {
     initialValues: {
-      title: '',
-      isClone: 'false',
       activeFrom: time(12, 0),
-      questions: [],
-      event: ''
+      event: '',
+      title: '',
+      isClone: true
+    },
+    survey: {
+      questions: []
     }
   };
 };

--- a/app/routes/surveys/EditSurveyRoute.js
+++ b/app/routes/surveys/EditSurveyRoute.js
@@ -24,7 +24,7 @@ const mapStateToProps = (state, props) => {
             value: survey.event.id,
             label: survey.event.title
           },
-          isClone: String(survey.isClone)
+          isClone: !!survey.isClone
         }
       : null
   };

--- a/app/routes/surveys/components/Option.js
+++ b/app/routes/surveys/components/Option.js
@@ -1,12 +1,7 @@
 // @flow
 
 import React from 'react';
-import {
-  RadioButton,
-  TextInput,
-  TextArea,
-  CheckBox
-} from 'app/components/Form';
+import { RadioButton, TextInput, CheckBox } from 'app/components/Form';
 import styles from './surveys.css';
 
 type Props = {
@@ -16,10 +11,10 @@ type Props = {
   nr: number
 };
 
-function makeOption(text: string, nr: number) {
+function makeOption(optionText: string, option: Object) {
   return {
-    optionText: text,
-    nr
+    ...option,
+    optionText
   };
 }
 
@@ -36,7 +31,9 @@ const MultipleChoice = (props: Props) => {
     <li>
       <RadioButton value={false} className={styles.option} />
       <TextInput
-        onInput={e => props.updateOptions(makeOption(e.target.value, props.nr))}
+        onInput={e =>
+          props.updateOptions(makeOption(e.target.value, props.option))
+        }
         placeholder="Alternativ..."
         className={styles.optionInput}
         value={props.option.optionText}
@@ -50,7 +47,9 @@ const Checkbox = (props: Props) => {
     <li>
       <CheckBox checked={false} className={styles.option} />
       <TextInput
-        onInput={e => props.updateOptions(makeOption(e.target.value, props.nr))}
+        onInput={e =>
+          props.updateOptions(makeOption(e.target.value, props.option))
+        }
         placeholder="Alternativ..."
         className={styles.optionInput}
         value={props.option.optionText}

--- a/app/routes/surveys/components/Option.js
+++ b/app/routes/surveys/components/Option.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import { RadioButton, TextInput, CheckBox } from 'app/components/Form';
 import styles from './surveys.css';
+import { QuestionTypes } from '../utils';
 
 type Props = {
   questionType: string,
@@ -19,7 +20,7 @@ function makeOption(optionText: string, option: Object) {
 }
 
 const Option = (props: Props) => {
-  return props.questionType === 'single_choice' ? (
+  return props.questionType === QuestionTypes('single') ? (
     <MultipleChoice {...props} />
   ) : (
     <Checkbox {...props} />

--- a/app/routes/surveys/components/Option.js
+++ b/app/routes/surveys/components/Option.js
@@ -5,7 +5,7 @@ import { RadioButton, TextInput, CheckBox } from 'app/components/Form';
 import styles from './surveys.css';
 
 type Props = {
-  questionType: number,
+  questionType: string,
   updateOptions: (Object, number) => void,
   option: Object,
   index: number
@@ -19,7 +19,7 @@ function makeOption(optionText: string, option: Object) {
 }
 
 const Option = (props: Props) => {
-  return props.questionType === 1 ? (
+  return props.questionType === 'single_choice' ? (
     <MultipleChoice {...props} />
   ) : (
     <Checkbox {...props} />

--- a/app/routes/surveys/components/Option.js
+++ b/app/routes/surveys/components/Option.js
@@ -1,30 +1,61 @@
 // @flow
 
 import React from 'react';
-import type { OptionEntity } from 'app/reducers/surveys';
-import { RadioButton, SelectInput } from 'app/components/Form';
-import { Field } from 'redux-form';
+import {
+  RadioButton,
+  TextInput,
+  TextArea,
+  CheckBox
+} from 'app/components/Form';
 import styles from './surveys.css';
 
 type Props = {
-  questionType: number
+  questionType: number,
+  updateOptions: Object => void,
+  option: Object,
+  nr: number
 };
 
-const Option = (props: Props) => {
-  const { questionType } = props;
+function makeOption(text: string, nr: number) {
+  return {
+    optionText: text,
+    nr
+  };
+}
 
-  return questionType === 1 ? (
-    <Field
-      name="option"
-      component={RadioButton.Field}
-      className={styles.option}
-    />
+const Option = (props: Props) => {
+  return props.questionType === 1 ? (
+    <MultipleChoice {...props} />
   ) : (
-    <Field
-      name="option"
-      component={SelectInput.Field}
-      className={styles.option}
-    />
+    <Checkbox {...props} />
+  );
+};
+
+const MultipleChoice = (props: Props) => {
+  return (
+    <li>
+      <RadioButton value={false} className={styles.option} />
+      <TextInput
+        onInput={e => props.updateOptions(makeOption(e.target.value, props.nr))}
+        placeholder="Alternativ..."
+        className={styles.optionInput}
+        value={props.option.optionText}
+      />
+    </li>
+  );
+};
+
+const Checkbox = (props: Props) => {
+  return (
+    <li>
+      <CheckBox checked={false} className={styles.option} />
+      <TextInput
+        onInput={e => props.updateOptions(makeOption(e.target.value, props.nr))}
+        placeholder="Alternativ..."
+        className={styles.optionInput}
+        value={props.option.optionText}
+      />
+    </li>
   );
 };
 

--- a/app/routes/surveys/components/Option.js
+++ b/app/routes/surveys/components/Option.js
@@ -1,0 +1,31 @@
+// @flow
+
+import React from 'react';
+import type { OptionEntity } from 'app/reducers/surveys';
+import { RadioButton, SelectInput } from 'app/components/Form';
+import { Field } from 'redux-form';
+import styles from './surveys.css';
+
+type Props = {
+  questionType: number
+};
+
+const Option = (props: Props) => {
+  const { questionType } = props;
+
+  return questionType === 1 ? (
+    <Field
+      name="option"
+      component={RadioButton.Field}
+      className={styles.option}
+    />
+  ) : (
+    <Field
+      name="option"
+      component={SelectInput.Field}
+      className={styles.option}
+    />
+  );
+};
+
+export default Option;

--- a/app/routes/surveys/components/Option.js
+++ b/app/routes/surveys/components/Option.js
@@ -6,9 +6,9 @@ import styles from './surveys.css';
 
 type Props = {
   questionType: number,
-  updateOptions: Object => void,
+  updateOptions: (Object, number) => void,
   option: Object,
-  nr: number
+  index: number
 };
 
 function makeOption(optionText: string, option: Object) {
@@ -32,7 +32,10 @@ const MultipleChoice = (props: Props) => {
       <RadioButton value={false} className={styles.option} />
       <TextInput
         onInput={e =>
-          props.updateOptions(makeOption(e.target.value, props.option))
+          props.updateOptions(
+            makeOption(e.target.value, props.option),
+            props.index
+          )
         }
         placeholder="Alternativ..."
         className={styles.optionInput}
@@ -48,7 +51,10 @@ const Checkbox = (props: Props) => {
       <CheckBox checked={false} className={styles.option} />
       <TextInput
         onInput={e =>
-          props.updateOptions(makeOption(e.target.value, props.option))
+          props.updateOptions(
+            makeOption(e.target.value, props.option),
+            props.index
+          )
         }
         placeholder="Alternativ..."
         className={styles.optionInput}

--- a/app/routes/surveys/components/Question.js
+++ b/app/routes/surveys/components/Question.js
@@ -21,28 +21,28 @@ type State = {
 };
 
 type QuestionTypeSelectorProps = {
-  questionType: number
+  questionType: string
 };
 
 function QuestionTypeSelector({ questionType }: QuestionTypeSelectorProps) {
-  const questionTypeIntToString = {
-    '1': 'Multiple Choice',
-    '2': 'Sjekkboks',
-    '3': 'Fritekst'
+  const questionTypeToString = {
+    single_choice: 'Multiple Choice',
+    multiple_choice: 'Sjekkboks',
+    text_field: 'Fritekst'
   };
-  const questionTypeIntToIcon = {
-    '1': 'radio-button-on',
-    '2': 'checkbox',
-    '3': 'more'
+  const questionTypeToIcon = {
+    single_choice: 'radio-button-on',
+    multiple_choice: 'checkbox',
+    text_field: 'more'
   };
   return (
     <Link className={styles.questionTypeSelector}>
       <span style={{ width: '170px', display: 'inline-block' }}>
         <Icon
-          name={questionTypeIntToIcon[String(questionType)]}
+          name={questionTypeToIcon[questionType]}
           style={{ marginRight: '15px' }}
         />
-        {questionTypeIntToString[String(questionType)]}
+        {questionTypeToString[questionType]}
       </span>
       <Icon name="arrow-down" size={24} className={styles.typeIcon} />
     </Link>
@@ -50,26 +50,26 @@ function QuestionTypeSelector({ questionType }: QuestionTypeSelectorProps) {
 }
 
 type DropdownItemsProps = {
-  setQuestionType: number => void
+  setQuestionType: string => void
 };
 
 function DropdownItems({ setQuestionType }: DropdownItemsProps) {
   return (
     <Dropdown.List>
       <Dropdown.ListItem>
-        <Link onClick={() => setQuestionType(1)}>
+        <Link onClick={() => setQuestionType('single_choice')}>
           <strong>Multiple Choice</strong>
           <Icon name="radio-button-on" size={24} />
         </Link>
       </Dropdown.ListItem>
       <Dropdown.ListItem>
-        <Link onClick={() => setQuestionType(2)}>
+        <Link onClick={() => setQuestionType('multiple_choice')}>
           Sjekkboks
           <Icon name="checkbox" size={24} />
         </Link>
       </Dropdown.ListItem>
       <Dropdown.ListItem>
-        <Link onClick={() => setQuestionType(3)}>
+        <Link onClick={() => setQuestionType('text_field')}>
           Fritekst
           <Icon name="more" size={24} />
         </Link>
@@ -101,7 +101,7 @@ class Question extends Component<Props, State> {
     }));
   };
 
-  setQuestionType = (questionType: number) => {
+  setQuestionType = (questionType: string) => {
     this.props.updateQuestion(
       { ...this.props.question, questionType },
       this.props.index
@@ -129,7 +129,7 @@ class Question extends Component<Props, State> {
               }
             />
           </div>
-          {this.props.question.questionType === 3 ? (
+          {this.props.question.questionType === 'text_field' ? (
             <TextArea
               className={styles.freeText}
               placeholder="Fritekst"

--- a/app/routes/surveys/components/Question.js
+++ b/app/routes/surveys/components/Question.js
@@ -8,6 +8,7 @@ import styles from './surveys.css';
 import Icon from 'app/components/Icon';
 import { Link } from 'react-router';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
+import { QuestionTypes, PresentableQuestionType } from '../utils';
 
 type Props = {
   updateQuestion: (Object, number) => void,
@@ -25,11 +26,6 @@ type QuestionTypeSelectorProps = {
 };
 
 function QuestionTypeSelector({ questionType }: QuestionTypeSelectorProps) {
-  const questionTypeToString = {
-    single_choice: 'Multiple Choice',
-    multiple_choice: 'Sjekkboks',
-    text_field: 'Fritekst'
-  };
   const questionTypeToIcon = {
     single_choice: 'radio-button-on',
     multiple_choice: 'checkbox',
@@ -42,7 +38,7 @@ function QuestionTypeSelector({ questionType }: QuestionTypeSelectorProps) {
           name={questionTypeToIcon[questionType]}
           style={{ marginRight: '15px' }}
         />
-        {questionTypeToString[questionType]}
+        {PresentableQuestionType(questionType)}
       </span>
       <Icon name="arrow-down" size={24} className={styles.typeIcon} />
     </Link>
@@ -57,19 +53,19 @@ function DropdownItems({ setQuestionType }: DropdownItemsProps) {
   return (
     <Dropdown.List>
       <Dropdown.ListItem>
-        <Link onClick={() => setQuestionType('single_choice')}>
+        <Link onClick={() => setQuestionType(QuestionTypes('single'))}>
           <strong>Multiple Choice</strong>
           <Icon name="radio-button-on" size={24} />
         </Link>
       </Dropdown.ListItem>
       <Dropdown.ListItem>
-        <Link onClick={() => setQuestionType('multiple_choice')}>
+        <Link onClick={() => setQuestionType(QuestionTypes('multiple'))}>
           Sjekkboks
           <Icon name="checkbox" size={24} />
         </Link>
       </Dropdown.ListItem>
       <Dropdown.ListItem>
-        <Link onClick={() => setQuestionType('text_field')}>
+        <Link onClick={() => setQuestionType(QuestionTypes('text'))}>
           Fritekst
           <Icon name="more" size={24} />
         </Link>
@@ -129,7 +125,7 @@ class Question extends Component<Props, State> {
               }
             />
           </div>
-          {this.props.question.questionType === 'text_field' ? (
+          {this.props.question.questionType === QuestionTypes('text') ? (
             <TextArea
               className={styles.freeText}
               placeholder="Fritekst"

--- a/app/routes/surveys/components/Question.js
+++ b/app/routes/surveys/components/Question.js
@@ -2,69 +2,234 @@
 
 import React, { Component } from 'react';
 import Option from './Option';
-import { TextArea, TextInput, RadioButton } from 'app/components/Form';
-import { Field } from 'redux-form';
+import { TextInput, TextArea, CheckBox } from 'app/components/Form';
+import Dropdown from 'app/components/Dropdown';
 import styles from './surveys.css';
+import Icon from 'app/components/Icon';
+import { Link } from 'react-router';
+import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 
 type Props = {
-  updateQuestion: Object => void
+  updateQuestion: Object => void,
+  deleteQuestion: number => Promise<*>,
+  question: Object,
+  nr: number
 };
 
 type State = {
+  shouldUpdate: boolean,
   options: Array<any>,
+  pickerOpen: boolean
+};
+
+type QuestionTypeSelectorProps = {
   questionType: number
 };
 
+function QuestionTypeSelector({ questionType }: QuestionTypeSelectorProps) {
+  const questionTypeIntToString = {
+    '1': 'Multiple Choice',
+    '2': 'Sjekkboks',
+    '3': 'Fritekst'
+  };
+  const questionTypeIntToIcon = {
+    '1': 'radio-button-on',
+    '2': 'checkbox',
+    '3': 'more'
+  };
+  return (
+    <Link className={styles.questionTypeSelector}>
+      <span style={{ width: '170px', display: 'inline-block' }}>
+        <Icon
+          name={questionTypeIntToIcon[String(questionType)]}
+          style={{ marginRight: '15px' }}
+        />
+        {questionTypeIntToString[String(questionType)]}
+      </span>
+      <Icon name="arrow-down" size={24} className={styles.typeIcon} />
+    </Link>
+  );
+}
+
+type DropdownItemsProps = {
+  setQuestionType: number => void
+};
+
+function DropdownItems({ setQuestionType }: DropdownItemsProps) {
+  return (
+    <Dropdown.List>
+      <Dropdown.ListItem>
+        <Link onClick={() => setQuestionType(1)}>
+          <strong>Multiple Choice</strong>
+          <Icon name="radio-button-on" size={24} />
+        </Link>
+      </Dropdown.ListItem>
+      <Dropdown.ListItem>
+        <Link onClick={() => setQuestionType(2)}>
+          Sjekkboks
+          <Icon name="checkbox" size={24} />
+        </Link>
+      </Dropdown.ListItem>
+      <Dropdown.ListItem>
+        <Link onClick={() => setQuestionType(3)}>
+          Fritekst
+          <Icon name="more" size={24} />
+        </Link>
+      </Dropdown.ListItem>
+    </Dropdown.List>
+  );
+}
+
 class Question extends Component<Props, State> {
   state = {
-    options: [],
-    questionType: -1
+    shouldUpdate: false,
+    options: [{ nr: 0, optionText: '' }],
+    pickerOpen: false
+  };
+
+  componentDidUpdate() {
+    if (this.state.shouldUpdate) {
+      const { questionText, nr, questionType } = this.props.question;
+      this.props.updateQuestion(
+        this.makeQuestion(questionText, nr, questionType)
+      );
+      this.setState({ shouldUpdate: false });
+    }
+  }
+
+  makeQuestion = (questionText: string, nr: number, questionType: number) => {
+    const { options } = this.state;
+    return {
+      questionType,
+      questionText,
+      options,
+      nr,
+      mandatory: false // TODO
+    };
   };
 
   updateOptions = (option: Object) => {
     const options = this.state.options.slice();
-    const oldOption = options.find(o => o && o.id === option.id);
+
+    const oldOption = options.find(o => o && o.nr === option.nr);
     const changedOptionIndex = options.indexOf(oldOption);
-    if (changedOptionIndex) {
+
+    if (changedOptionIndex !== -1) {
+      // This inner "if" adds another empty option below the current one if
+      // the current option is the last one, which is how several options
+      // functionality is implemented.
+      if (
+        option.nr === options.length - 1 &&
+        (oldOption || {}).optionText === ''
+      ) {
+        options.push({
+          optionText: '',
+          nr: this.state.options.length
+        });
+      }
+      // Afterwards, outside that inner if, the current option is then updated.
       options[changedOptionIndex] = option;
     } else {
       options.push(option);
     }
 
-    this.setState({ options });
+    this.setState({ options, shouldUpdate: true });
+  };
+
+  toggleDropdown = () => {
+    this.setState(prevState => ({
+      pickerOpen: !prevState.pickerOpen
+    }));
+  };
+
+  setQuestionType = (questionType: number) => {
+    this.props.updateQuestion({ ...this.props.question, questionType });
   };
 
   render() {
+    const { updateQuestion, nr, question, deleteQuestion } = this.props;
     return (
-      <div>
-        <Field
-          name="questionTitle"
-          component={TextInput.Field}
-          placeholder={'Hva syntes du?'}
-          className={styles.title}
-          label="Spørsmålstekst"
-        />
+      <div className={styles.question}>
+        <div className={styles.left}>
+          <div className={styles.questionTop}>
+            <TextInput
+              value={question.questionText}
+              className={styles.questionTitle}
+              placeholder="Spørsmål"
+              onInput={e =>
+                updateQuestion({
+                  ...this.props.question,
+                  questionText: e.target.value,
+                  nr
+                })
+              }
+            />
+          </div>
+          {this.props.question.questionType === 3 ? (
+            <TextArea
+              className={styles.freeText}
+              placeholder="Fritekst"
+              value=""
+            />
+          ) : (
+            <ul className={styles.options}>
+              {this.state.options.map((option, i) => (
+                <Option
+                  key={i}
+                  nr={i}
+                  questionType={this.props.question.questionType}
+                  option={option || {}}
+                  updateOptions={this.updateOptions}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className={styles.right}>
+          <div className={styles.questionType}>
+            <Dropdown
+              show={this.state.pickerOpen}
+              toggle={this.toggleDropdown}
+              triggerComponent={
+                <QuestionTypeSelector
+                  questionType={question.questionType}
+                  toggleDropdown={this.toggleDropdown}
+                />
+              }
+              componentClass="div"
+              contentClassName={styles.dropdown}
+              style={{ flex: 1 }}
+            >
+              <DropdownItems setQuestionType={this.setQuestionType} />
+            </Dropdown>
+          </div>
 
-        <Field
-          label="Radio button"
-          component={RadioButton.Field}
-          inputValue="1"
-          name="questionType"
-        />
-        <Field
-          label="Multiple Choice"
-          component={RadioButton.Field}
-          inputValue="2"
-          name="questionType"
-        />
-        <Field
-          label="Fritekst"
-          component={RadioButton.Field}
-          inputValue="3"
-          name="questionType"
-        />
+          <div className={styles.bottom}>
+            <div className={styles.required}>
+              Obligatorisk
+              <CheckBox
+                name="mandatory"
+                value={question.mandatory}
+                onChange={e =>
+                  updateQuestion({
+                    ...question,
+                    mandatory: !question.mandatory
+                  })
+                }
+              />
+            </div>
 
-        <Option questionType={this.state.questionType} />
+            <ConfirmModalWithParent
+              title="Slett spørsmål"
+              message="Er du sikker på at du vil slette dette spørsmålet?"
+              onConfirm={() => deleteQuestion(nr)}
+              closeOnConfirm
+              className={styles.deleteQuestion}
+            >
+              <Icon name="trash" />
+            </ConfirmModalWithParent>
+          </div>
+        </div>
       </div>
     );
   }

--- a/app/routes/surveys/components/Question.js
+++ b/app/routes/surveys/components/Question.js
@@ -1,0 +1,73 @@
+// @flow
+
+import React, { Component } from 'react';
+import Option from './Option';
+import { TextArea, TextInput, RadioButton } from 'app/components/Form';
+import { Field } from 'redux-form';
+import styles from './surveys.css';
+
+type Props = {
+  updateQuestion: Object => void
+};
+
+type State = {
+  options: Array<any>,
+  questionType: number
+};
+
+class Question extends Component<Props, State> {
+  state = {
+    options: [],
+    questionType: -1
+  };
+
+  updateOptions = (option: Object) => {
+    const options = this.state.options.slice();
+    const oldOption = options.find(o => o && o.id === option.id);
+    const changedOptionIndex = options.indexOf(oldOption);
+    if (changedOptionIndex) {
+      options[changedOptionIndex] = option;
+    } else {
+      options.push(option);
+    }
+
+    this.setState({ options });
+  };
+
+  render() {
+    return (
+      <div>
+        <Field
+          name="questionTitle"
+          component={TextInput.Field}
+          placeholder={'Hva syntes du?'}
+          className={styles.title}
+          label="Spørsmålstekst"
+        />
+
+        <Field
+          label="Radio button"
+          component={RadioButton.Field}
+          inputValue="1"
+          name="questionType"
+        />
+        <Field
+          label="Multiple Choice"
+          component={RadioButton.Field}
+          inputValue="2"
+          name="questionType"
+        />
+        <Field
+          label="Fritekst"
+          component={RadioButton.Field}
+          inputValue="3"
+          name="questionType"
+        />
+
+        <Option questionType={this.state.questionType} />
+      </div>
+    );
+  }
+}
+
+export default Question;

--- a/app/routes/surveys/components/Question.js
+++ b/app/routes/surveys/components/Question.js
@@ -18,7 +18,7 @@ type Props = {
 
 type State = {
   shouldUpdate: boolean,
-  options: Array<any>,
+  options: Array<Object>,
   pickerOpen: boolean
 };
 
@@ -87,32 +87,31 @@ class Question extends Component<Props, State> {
     pickerOpen: false
   };
 
+  componentDidMount() {
+    const options = this.props.question.options
+      .map((option, i) => ({ ...option, nr: i }))
+      .concat({
+        nr: this.props.question.options.length,
+        optionText: ''
+      });
+    this.setState({ options });
+  }
+
   componentDidUpdate() {
     if (this.state.shouldUpdate) {
-      const { questionText, nr, questionType } = this.props.question;
-      this.props.updateQuestion(
-        this.makeQuestion(questionText, nr, questionType)
-      );
+      this.props.updateQuestion({
+        ...this.props.question,
+        options: this.state.options
+      });
       this.setState({ shouldUpdate: false });
     }
   }
 
-  makeQuestion = (questionText: string, nr: number, questionType: number) => {
-    const { options } = this.state;
-    return {
-      questionType,
-      questionText,
-      options,
-      nr,
-      mandatory: false // TODO
-    };
-  };
-
   updateOptions = (option: Object) => {
     const options = this.state.options.slice();
 
-    const oldOption = options.find(o => o && o.nr === option.nr);
-    const changedOptionIndex = options.indexOf(oldOption);
+    const oldOption = options.find(o => o.nr === option.nr);
+    const changedOptionIndex = options.indexOf(oldOption || {});
 
     if (changedOptionIndex !== -1) {
       // This inner "if" adds another empty option below the current one if

--- a/app/routes/surveys/components/SurveyDetail.js
+++ b/app/routes/surveys/components/SurveyDetail.js
@@ -38,7 +38,7 @@ const SurveyDetail = (props: Props) => {
       </div>
 
       <ul className={styles.detailQuestions}>
-        {(survey.questions || []).map(question => (
+        {survey.questions.map(question => (
           <li key={question.id}>
             <h3 className={styles.questionTextDetail}>
               {question.questionText}
@@ -55,7 +55,7 @@ const SurveyDetail = (props: Props) => {
               />
             ) : (
               <ul className={styles.detailOptions}>
-                {(question.options || []).map(option => (
+                {question.options.map(option => (
                   <li key={option.id}>
                     {question.questionType === 1 ? (
                       <RadioButton value={false} className={styles.option} />

--- a/app/routes/surveys/components/SurveyDetail.js
+++ b/app/routes/surveys/components/SurveyDetail.js
@@ -6,7 +6,7 @@ import Time from 'app/components/Time';
 import styles from './surveyDetail.css';
 import type { SurveyEntity } from 'app/reducers/surveys';
 import LoadingIndicator from 'app/components/LoadingIndicator';
-import { DetailNavigation } from '../utils.js';
+import { DetailNavigation, QuestionTypes } from '../utils.js';
 import { Content } from 'app/components/Content';
 import { TextArea, CheckBox, RadioButton } from 'app/components/Form';
 
@@ -47,7 +47,7 @@ const SurveyDetail = (props: Props) => {
               )}
             </h3>
 
-            {question.questionType === 'text_field' ? (
+            {question.questionType === QuestionTypes('text') ? (
               <TextArea
                 value=""
                 placeholder="Fritekst..."
@@ -57,7 +57,7 @@ const SurveyDetail = (props: Props) => {
               <ul className={styles.detailOptions}>
                 {question.options.map(option => (
                   <li key={option.id}>
-                    {question.questionType === 'single_choice' ? (
+                    {question.questionType === QuestionTypes('single') ? (
                       <RadioButton value={false} className={styles.option} />
                     ) : (
                       <CheckBox checked={false} className={styles.option} />

--- a/app/routes/surveys/components/SurveyDetail.js
+++ b/app/routes/surveys/components/SurveyDetail.js
@@ -47,7 +47,7 @@ const SurveyDetail = (props: Props) => {
               )}
             </h3>
 
-            {question.questionType === 3 ? (
+            {question.questionType === 'text_field' ? (
               <TextArea
                 value=""
                 placeholder="Fritekst..."
@@ -57,7 +57,7 @@ const SurveyDetail = (props: Props) => {
               <ul className={styles.detailOptions}>
                 {question.options.map(option => (
                   <li key={option.id}>
-                    {question.questionType === 1 ? (
+                    {question.questionType === 'single_choice' ? (
                       <RadioButton value={false} className={styles.option} />
                     ) : (
                       <CheckBox checked={false} className={styles.option} />

--- a/app/routes/surveys/components/SurveyDetail.js
+++ b/app/routes/surveys/components/SurveyDetail.js
@@ -8,6 +8,7 @@ import type { SurveyEntity } from 'app/reducers/surveys';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { DetailNavigation } from '../utils.js';
 import { Content } from 'app/components/Content';
+import { TextArea, CheckBox, RadioButton } from 'app/components/Form';
 
 type Props = {
   survey: SurveyEntity,
@@ -35,6 +36,40 @@ const SurveyDetail = (props: Props) => {
       <div className={styles.surveyTime}>
         Aktiv fra <Time time={survey.activeFrom} format="ll HH:mm" />
       </div>
+
+      <ul className={styles.detailQuestions}>
+        {(survey.questions || []).map(question => (
+          <li key={question.id}>
+            <h3 className={styles.questionTextDetail}>
+              {question.questionText}
+              {question.mandatory && (
+                <span className={styles.mandatory}> *</span>
+              )}
+            </h3>
+
+            {question.questionType === 3 ? (
+              <TextArea
+                value=""
+                placeholder="Fritekst..."
+                className={styles.freeText}
+              />
+            ) : (
+              <ul className={styles.detailOptions}>
+                {(question.options || []).map(option => (
+                  <li key={option.id}>
+                    {question.questionType === 1 ? (
+                      <RadioButton value={false} className={styles.option} />
+                    ) : (
+                      <CheckBox checked={false} className={styles.option} />
+                    )}
+                    {option.optionText}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
     </Content>
   );
 };

--- a/app/routes/surveys/components/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor.js
@@ -2,7 +2,7 @@
 
 import styles from './surveys.css';
 import React, { Component } from 'react';
-import { DetailNavigation, ListNavigation } from '../utils.js';
+import { DetailNavigation, ListNavigation, QuestionTypes } from '../utils.js';
 import Question from './Question';
 import { Field } from 'redux-form';
 import Button from 'app/components/Button';
@@ -10,10 +10,11 @@ import {
   TextInput,
   CheckBox,
   SelectInput,
-  DatePicker
+  DatePicker,
+  withSubmissionError,
+  legoForm
 } from 'app/components/Form';
 import { createValidator, required } from 'app/utils/validation';
-import { reduxForm } from 'redux-form';
 import type { SurveyEntity } from 'app/reducers/surveys';
 import { Content } from 'app/components/Content';
 import type { FieldProps } from 'redux-form';
@@ -43,7 +44,7 @@ class SurveyEditor extends Component<Props, State> {
         ? [
             {
               questionText: '',
-              questionType: 'single_choice',
+              questionType: QuestionTypes('single'),
               options: []
             }
           ]
@@ -63,7 +64,7 @@ class SurveyEditor extends Component<Props, State> {
         relativeIndex: i
       };
 
-      if (question.questionType === 'text_field') {
+      if (question.questionType === QuestionTypes('text')) {
         question.options = [];
       } else {
         question.options = question.options.filter(
@@ -123,7 +124,7 @@ class SurveyEditor extends Component<Props, State> {
 
     return (
       <Content className={styles.detail}>
-        <form onSubmit={handleSubmit(this.onSubmit)}>
+        <form onSubmit={handleSubmit(withSubmissionError(this.onSubmit))}>
           {survey && survey.id ? (
             <DetailNavigation
               title={titleField}
@@ -177,7 +178,7 @@ class SurveyEditor extends Component<Props, State> {
             onClick={() => {
               const newQuestion = {
                 questionText: '',
-                questionType: 'single_choice',
+                questionType: QuestionTypes('single'),
                 mandatory: false,
                 options: []
               };
@@ -203,8 +204,7 @@ const validate = createValidator({
   event: [required()]
 });
 
-export default reduxForm({
+export default legoForm({
   form: 'surveyEditor',
-  validate,
-  enableReinitialize: true
+  validate
 })(SurveyEditor);

--- a/app/routes/surveys/components/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor.js
@@ -3,6 +3,7 @@
 import styles from './surveys.css';
 import React, { Component } from 'react';
 import { DetailNavigation, ListNavigation } from '../utils.js';
+import Question from './Question';
 import { Field } from 'redux-form';
 import Button from 'app/components/Button';
 import {
@@ -26,7 +27,15 @@ type Props = FieldProps & {
   push: string => void
 };
 
-class SurveyEditor extends Component<Props> {
+type State = {
+  questions: Array<any>
+};
+
+class SurveyEditor extends Component<Props, State> {
+  state = {
+    questions: []
+  };
+
   onSubmit = (formContent: Object) => {
     const { survey, submitFunction, push } = this.props;
     return submitFunction({
@@ -37,6 +46,19 @@ class SurveyEditor extends Component<Props> {
       const id = survey ? survey.id : result.payload.result;
       push(`/surveys/${String(id)}`);
     });
+  };
+
+  updateQuestion = (question: Object) => {
+    const questions = this.state.questions.slice();
+    const oldQuestion = questions.find(q => q && q.id === question.id);
+    const changedQuestionIndex = questions.indexOf(oldQuestion);
+    if (changedQuestionIndex) {
+      questions[changedQuestionIndex] = question;
+    } else {
+      questions.push(question);
+    }
+
+    this.setState({ questions });
   };
 
   render() {
@@ -82,12 +104,14 @@ class SurveyEditor extends Component<Props> {
                   label="Ja"
                   component={RadioButton.Field}
                   inputValue="true"
+                  name="clone"
                 />
                 <Field
                   label="Nei"
                   component={RadioButton.Field}
                   inputValue="false"
                   value="false"
+                  name="clone"
                 />
               </RadioButtonGroup>
             </div>
@@ -109,6 +133,10 @@ class SurveyEditor extends Component<Props> {
             className={styles.editEvent}
             component={DatePicker.Field}
           />
+
+          <div className={styles.questions}>
+            <Question updateQuestion={this.updateQuestion} />
+          </div>
 
           <div className={styles.clear} />
           <Button className={styles.submit} disabled={submitting} submit>

--- a/app/routes/surveys/components/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor.js
@@ -43,7 +43,7 @@ class SurveyEditor extends Component<Props, State> {
         ? [
             {
               questionText: '',
-              questionType: 1,
+              questionType: 'single_choice',
               options: []
             }
           ]
@@ -63,7 +63,7 @@ class SurveyEditor extends Component<Props, State> {
         relativeIndex: i
       };
 
-      if (question.questionType === 3) {
+      if (question.questionType === 'text_field') {
         question.options = [];
       } else {
         question.options = question.options.filter(
@@ -177,7 +177,7 @@ class SurveyEditor extends Component<Props, State> {
             onClick={() => {
               const newQuestion = {
                 questionText: '',
-                questionType: 1,
+                questionType: 'single_choice',
                 mandatory: false,
                 options: []
               };

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -60,3 +60,13 @@
   height: 80px;
   object-fit: contain;
 }
+
+.questions {
+  margin-top: 30px;
+  padding-top: 30px;
+  border-top: 1px solid #ccc;
+}
+
+.questionTitle {
+  width: 200px;
+}

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -100,9 +100,6 @@
   width: 100%;
 }
 
-.questionType {
-}
-
 .questionTypeSelector {
   padding: 14px 20px;
   border: 1px solid #ccc;
@@ -192,4 +189,24 @@
   &:hover {
     cursor: pointer;
   }
+}
+
+.detailQuestions > li {
+  margin-top: 30px;
+}
+
+.detailQuestions .freeText {
+  max-width: 600px;
+}
+
+.detailOptions > li {
+  margin-top: 10px;
+}
+
+.detailOptions .option {
+  margin-right: 10px;
+}
+
+.mandatory {
+  color: var(--lego-link-color);
 }

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -27,7 +27,7 @@
 }
 
 .editEvent {
-  width: 300px;
+  margin-right: 30px;
 }
 
 .bottomBorder {
@@ -62,11 +62,134 @@
 }
 
 .questions {
-  margin-top: 30px;
-  padding-top: 30px;
-  border-top: 1px solid #ccc;
+  margin: 30px 0 0;
+}
+
+.question {
+  border: 2px solid #ccc;
+  border-left: 3px solid var(--lego-link-color);
+  padding: 20px 25px;
+  margin-bottom: 35px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.left {
+  width: 70%;
+  order: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.right {
+  display: flex;
+  order: 2;
+  margin-top: 19px;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 247px;
+}
+
+.questionTop {
+  margin-bottom: 15px;
 }
 
 .questionTitle {
-  width: 200px;
+  margin-top: 10px;
+  font-size: 22px;
+  width: 100%;
+}
+
+.questionType {
+}
+
+.questionTypeSelector {
+  padding: 14px 20px;
+  border: 1px solid #ccc;
+}
+
+.addQuestion {
+  color: var(--lego-link-color);
+  margin: 0 auto;
+  width: 25px;
+  display: flex;
+}
+
+.addOption {
+  color: var(--lego-link-color);
+  width: 20px;
+  display: block;
+  margin: 20px 0 0 150px;
+}
+
+.submit {
+  margin-top: 20px;
+}
+
+.dropdown {
+  margin-top: 20px;
+}
+
+.typeIcon {
+  margin: 5px 0 0 20px;
+}
+
+.options li {
+  margin: 5px 0 10px;
+}
+
+.option {
+  display: inline-block;
+  margin-bottom: -3px;
+  width: 21px;
+
+  &:hover {
+    cursor: default;
+  }
+}
+
+.optionInput {
+  width: calc(100% - 51px); /* 30px (margin) + 21px (icon width) = 51px */
+  margin-left: 30px;
+  margin-right: 0;
+}
+
+.checkBox div {
+  display: inline-block;
+  margin-right: 5px;
+}
+
+.checkBox > div {
+  margin-bottom: 10px;
+}
+
+.freeText {
+  min-height: 100px;
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
+.bottom {
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.bottom div {
+  display: inline-block;
+}
+
+.required {
+  margin-right: 40px;
+}
+
+.required > div {
+  margin-left: 10px;
+  margin-bottom: -3px;
+}
+
+.deleteQuestion {
+  &:hover {
+    cursor: pointer;
+  }
 }

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -5,6 +5,25 @@ import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 
+const questionStrings = {
+  single: 'single_choice',
+  multiple: 'multiple_choice',
+  text: 'text_field'
+};
+
+export const QuestionTypes = (choice: string) => {
+  return questionStrings[choice] || questionStrings[0];
+};
+
+export const PresentableQuestionType = (choice: string) => {
+  const questionTypeToString = {
+    single_choice: 'Multiple Choice',
+    multiple_choice: 'Sjekkboks',
+    text_field: 'Fritekst'
+  };
+  return questionTypeToString[choice] || questionTypeToString[0];
+};
+
 export const ListNavigation = ({ title }: { title: Node }) => (
   <NavigationTab title={title}>
     <NavigationLink to="/surveys">Liste</NavigationLink>

--- a/package.json
+++ b/package.json
@@ -8,10 +8,14 @@
   "scripts": {
     "start": "webpack --config config/webpack.server.js",
     "build": "concurrently \"yarn run build:server\" \"yarn run build:client\"",
-    "build:all": "concurrently \"yarn build:server\" \"yarn build:client\" \"yarn styleguide:build\"",
-    "build:client": "NODE_ENV=production webpack --config config/webpack.client.js",
-    "build:server": "NODE_ENV=production webpack --config config/webpack.server.js -p",
-    "build:dll": "BUILDING_DLL=true webpack --display-chunks --color --config config/webpack.dll.js",
+    "build:all":
+      "concurrently \"yarn build:server\" \"yarn build:client\" \"yarn styleguide:build\"",
+    "build:client":
+      "NODE_ENV=production webpack --config config/webpack.client.js",
+    "build:server":
+      "NODE_ENV=production webpack --config config/webpack.server.js -p",
+    "build:dll":
+      "BUILDING_DLL=true webpack --display-chunks --color --config config/webpack.dll.js",
     "delete-sourcemaps": "find ./dist-client -name '*.map' -delete",
     "postinstall": "yarn run build:dll",
     "test": "NODE_ENV=test jest",
@@ -23,8 +27,10 @@
     "lint:prettier": "prettier '**/*.{js,css,md}' --list-different",
     "prettier": "prettier '**/*.{js,css,md}' --write",
     "flow": "flow",
-    "styleguide": "bash lib/generateCssDocs.sh && NODE_ENV=production styleguidist server",
-    "styleguide:build": "bash lib/generateCssDocs.sh && NODE_ENV=production styleguidist build"
+    "styleguide":
+      "bash lib/generateCssDocs.sh && NODE_ENV=production styleguidist server",
+    "styleguide:build":
+      "bash lib/generateCssDocs.sh && NODE_ENV=production styleguidist build"
   },
   "repository": {
     "type": "git",
@@ -157,9 +163,7 @@
       "selector-pseudo-class-no-unknown": [
         true,
         {
-          "ignorePseudoClasses": [
-            "global"
-          ]
+          "ignorePseudoClasses": ["global"]
         }
       ]
     }
@@ -169,12 +173,10 @@
       "__DEV__": false,
       "__CLIENT__": true
     },
-    "moduleDirectories": [
-      "<rootDir>",
-      "node_modules"
-    ],
+    "moduleDirectories": ["<rootDir>", "node_modules"],
     "moduleNameMapper": {
-      "^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp3|mp4|webm)$": "<rootDir>/testing/FileStub.js",
+      "^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp3|mp4|webm)$":
+        "<rootDir>/testing/FileStub.js",
       "^.+\\.css$": "<rootDir>/testing/CSSStub.js"
     },
     "testRegex": "\\.spec\\.(js|jsx)$",
@@ -198,7 +200,5 @@
       "meow"
     ]
   },
-  "moduleRoots": [
-    "./"
-  ]
+  "moduleRoots": ["./"]
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "lint": "yarn run lint:js && yarn run lint:css && yarn run lint:prettier",
     "lint:js": "eslint . --ignore-path .prettierignore",
     "lint:css": "stylelint './app/**/*.css'",
-    "lint:prettier": "prettier '**/*.{js,css,md}' --list-different",
-    "prettier": "prettier '**/*.{js,css,md}' --write",
+    "lint:prettier": "prettier '**/*.{js,css,md,json}' --list-different",
+    "prettier": "prettier '**/*.{js,css,md,json}' --write",
     "flow": "flow",
     "styleguide":
       "bash lib/generateCssDocs.sh && NODE_ENV=production styleguidist server",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7093,9 +7093,9 @@ react-treeview@^0.4.6:
   dependencies:
     prop-types "^15.5.8"
 
-react@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+react@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7093,7 +7093,7 @@ react-treeview@^0.4.6:
   dependencies:
     prop-types "^15.5.8"
 
-react@^16.2.0:
+react@^16.0.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:


### PR DESCRIPTION
This PR continues the Survey project #986, checking the next two todo items:
- [x] Components to render actual forms: Question, Answer, and Option.
- [x] Using those components in detail view, and making them editable and sendable in SurveyEditor.

With this PR, the Editor ( `surveys/add` and `surveys/someId/edit`) should be mostly finished.

<img width="885" alt="skjermbilde 2018-01-22 kl 20 45 54" src="https://user-images.githubusercontent.com/14221386/35240952-48d30d38-ffb5-11e7-8d3b-d50210162fb2.png">

<img width="568" alt="skjermbilde 2018-01-22 kl 20 46 47" src="https://user-images.githubusercontent.com/14221386/35241320-60d25bd6-ffb6-11e7-8d05-7e0f3dae2a6f.png">

In addition, a basic display of the questions in each survey has been added to the detail page.

<img width="563" alt="skjermbilde 2018-01-22 kl 20 52 40" src="https://user-images.githubusercontent.com/14221386/35241265-364662d6-ffb6-11e7-86af-9ee460a14a2f.png">

