### PR TITLE
Use timezone when formatting date/time in datepicker

### DIFF
--- a/app/components/Form/DatePicker.js
+++ b/app/components/Form/DatePicker.js
@@ -10,6 +10,7 @@ import { createField } from './Field';
 import TextInput from './TextInput';
 import TimePicker from './TimePicker';
 import styles from './DatePicker.css';
+import config from 'app/config';
 
 type Props = {
   onChange: string => void,
@@ -103,7 +104,9 @@ class DatePicker extends Component<Props, State> {
         triggerComponent={
           <TextInput
             className={cx(styles.inputField, className)}
-            value={this.state.value.format(this.props.dateFormat)}
+            value={moment
+              .tz(this.state.value, config.timezone)
+              .format(this.props.dateFormat)}
           />
         }
         componentClass="div"


### PR DESCRIPTION
The containers we run the webapp in use "no" timezone, aka. they just
use +00:00. This results in strange behavior when the server side
renderer formats the date/time on the server. When the datepicker is
re-rendered in the browser, it use out timezone (Europe/Oslo). This
results in a wrong date label, and an annoying flash when clicking
around. :clock1: :clock2: :clock3: 

![image](https://user-images.githubusercontent.com/1467188/35360124-f2bb42e0-015c-11e8-835e-e46c4867e0fc.png)
Source: [youtube](https://www.youtube.com/watch?v=-5wpm-gesOY)

This fixes #1050. Nice catch @ekmartin. This will save all of us (including bedkom & fagkom) from scratching our head, wondering why the hell we shifted all the timestamps with 1 (or 2) hour(s).


**PS**: Do we format time other places, without using the `<Time />` component?? :thinking: 