### PR TITLE
Add pretty console output for tty

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@webkom/react-prepare": "^0.5.3",
     "animate.css": "3.5.2",
     "bunyan": "^1.8.12",
+    "bunyan-pretty": "^0.0.1",
     "child-process-promise": "^2.2.1",
     "classnames": "2.2.5",
     "cookie-parser": "^1.4.3",
@@ -191,6 +192,7 @@
       "animate.css",
       "minireset.css",
       "bunyan",
+      "bunyan-pretty",
       "raven",
       "child-process-promise",
       "meow"

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ import express from 'express';
 import morgan from 'morgan';
 import moment from 'moment-timezone';
 import bunyan from 'bunyan';
+import bunyanPretty from 'bunyan-pretty';
 import Raven from 'raven';
 import cookieParser from 'cookie-parser';
 import render from './render';
@@ -18,6 +19,7 @@ app.use(cookieParser());
 const log = bunyan.createLogger({
   name: 'lego-webapp',
   release: config.release,
+  stream: process.stdout.isTTY ? bunyanPretty() : process.stdout,
   environment: config.environment
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1401,6 +1401,12 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bunyan-pretty@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/bunyan-pretty/-/bunyan-pretty-0.0.1.tgz#d7a8afe592779804b1ca0453a573d9eec084cb3b"
+  dependencies:
+    through "^2.3.6"
+
 bunyan@^1.8.12:
   version "1.8.12"
   resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"


### PR DESCRIPTION
Use a pretty output instead of json when the server is running in a tty
(valid terminal). Will still output json when piped, written to a file
or just running in headless.

![screenshot from 2018-01-28 13-40-31](https://user-images.githubusercontent.com/1467188/35482121-d55d16f2-0430-11e8-8ced-4b94e7313bca.png)
Left: json
Right: pretty-print

This is a way better approach than just using __DEV__ or NODE_ENV,
becuase it also prints pretty when running a containerized version of
the server with an pseudo-TTY.
```bash
$ docker run -t lego-webapp   # pretty
$ docker run lego-webapp      # json
$ node dist/server.js         # pretty
$ node dist/server.js | cat   # json
$ yarn start                  # pretty
$ yarn start | cat            # json
```

This can also be achived using: `yarn start | ./node_modules/.bin/bunyan`, but that is rather annoying. When you have a tty, you will always prefer pretty-print over json. :tada:

