### PR TITLE
Add better reducer for registrations

### DIFF
--- a/app/reducers/registrations.js
+++ b/app/reducers/registrations.js
@@ -71,13 +71,15 @@ export default createEntityReducer({
         };
       }
       case Event.UPDATE_REGISTRATION.SUCCESS: {
+        const registration = normalize(action.payload, registrationSchema)
+          .entities.registrations[action.payload.id];
         return {
           ...state,
           byId: {
             ...state.byId,
             [action.payload.id]: {
               ...state.byId[action.payload.id],
-              ...action.payload
+              ...registration
             }
           }
         };


### PR DESCRIPTION
This fixes #1042.

Together with the PR in the lego repo https://github.com/webkom/lego/pull/1029, this will
successfully reduce the response into the registration object.

Maybe we can get this to prod before "Kurs med BEKK, del 1" tomorrow? :smile: