### PR TITLE
Refactor Image component

### DIFF
--- a/app/components/Image/Image.css
+++ b/app/components/Image/Image.css
@@ -1,9 +1,4 @@
 .image {
-  transition: opacity 0.2s;
   width: 100%;
   height: 100%;
-}
-
-.loaded {
-  opacity: 1;
 }

--- a/app/components/Image/Image.js
+++ b/app/components/Image/Image.js
@@ -7,47 +7,25 @@ import styles from './Image.css';
 type Props = {
   src: string,
   className?: string,
-  alt: string
+  alt: string,
+  style: Object
 };
 
-type State = {
-  loaded: boolean
-};
-
-class Image extends Component<Props, State> {
+class Image extends Component<Props> {
   static defaultProps = {
     alt: 'image'
   };
 
-  state = {
-    loaded: false
-  };
-
-  // https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html
-  _isMounted = false;
-
-  componentDidMount() {
-    this._isMounted = true;
-    const image = new global.Image();
-    image.src = this.props.src;
-    image.onload = () => this._isMounted && this.setState({ loaded: true });
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
   render() {
-    const { src, className, alt, ...props } = this.props;
+    const { src, className, alt, style, ...props } = this.props;
+    const finalClass = cx(styles.image, className);
+    if (!src) return <div className={finalClass} style={style} />;
     return (
       <img
-        className={cx(
-          styles.image,
-          this.state.loaded && styles.loaded,
-          className
-        )}
+        className={finalClass}
         src={src}
         alt={alt}
+        style={style}
         {...props}
       />
     );


### PR DESCRIPTION
I'm not completely sure, but I think we were doing the `componentDidMount` stuff to add an opacity transition to the images, however since we weren't setting `opacity: 0` this wasn't actually happening. This removes it altogether and simplifies the component. That also fixes a bug where we'd try to load an undefined image while the `src` prop was getting ready.