### PR TITLE
Title of penalty section

### DIFF
--- a/app/routes/users/components/Penalties.js
+++ b/app/routes/users/components/Penalties.js
@@ -16,7 +16,7 @@ type Props = {
 
 function Penalties({ penalties }: Props) {
   if (!penalties.length) {
-    return <div>Du har ingen prikker.</div>;
+    return <div>Ingen prikker.</div>;
   }
 
   return (
@@ -27,7 +27,7 @@ function Penalties({ penalties }: Props) {
           <li key={penalty.id} style={{ marginBottom: '10px' }}>
             <div>
               <strong>
-                Du har fått {penalty.weight} {word}
+                Har {penalty.weight} {word}
               </strong>
             </div>
             <div>


### PR DESCRIPTION
Fix issue #1070 so that the title of the penalty section is universal for all users.

<img width="383" alt="screen shot 2018-02-05 at 19 12 07" src="https://user-images.githubusercontent.com/31897129/35821940-fbe77706-0aaa-11e8-8336-246254b0ac67.png">
<img width="361" alt="screen shot 2018-02-05 at 18 55 36" src="https://user-images.githubusercontent.com/31897129/35821944-fedaa3f2-0aaa-11e8-9266-411041ba9cda.png">
