### PR TITLE
Changes to the email pages + add filter to email accounts

### DIFF
--- a/app/components/Table/Table.css
+++ b/app/components/Table/Table.css
@@ -19,6 +19,32 @@
   position: relative;
 }
 
+.filterIcon {
+  display: inline-block;
+  margin-left: 10px;
+  vertical-align: middle;
+  line-height: 1;
+  cursor: pointer;
+  position: relative;
+}
+
+.checkbox {
+  position: absolute;
+  min-width: 100px;
+  padding: 8px;
+  border-radius: 5px;
+  background: #fff;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.2);
+}
+
+.checkbox div {
+  margin-bottom: 10px;
+}
+
+.checkbox a {
+  font-size: 15px;
+}
+
 .loader {
   border-bottom: none;
 }

--- a/app/routes/admin/email/components/EmailLists.js
+++ b/app/routes/admin/email/components/EmailLists.js
@@ -3,6 +3,8 @@
 import React, { Component } from 'react';
 import Table from 'app/components/Table';
 import { Link } from 'react-router';
+import Button from 'app/components/Button';
+import Flex from 'app/components/Layout/Flex';
 
 type Props = {
   fetching: boolean,
@@ -42,6 +44,12 @@ export default class EmailLists extends Component<Props> {
           sende epost til disse. Ønsker brukere å sende mail fra en @abakus.no
           adresse må de få opprettet en personlig adresse under Brukere.
         </p>
+        <Flex justifyContent="space-between" style={{ marginBottom: '10px' }}>
+          <h3>Aktive epostlister</h3>
+          <Link to={`/admin/email/lists/new`}>
+            <Button>Ny epostliste</Button>
+          </Link>
+        </Flex>
         <Table
           infiniteScroll
           columns={columns}

--- a/app/routes/admin/email/components/EmailRoute.js
+++ b/app/routes/admin/email/components/EmailRoute.js
@@ -4,38 +4,22 @@ import React, { type Node } from 'react';
 import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import { Content } from 'app/components/Content';
-import { Link } from 'react-router';
 
 type Props = {
   children: Node,
   groups: Array<Object>,
-  location: { pathname: string },
   params: { groupId: string }
 };
 
-const CreateAction = ({ pathname }: { pathname: string }) => {
-  switch (pathname) {
-    case '/admin/email/lists':
-      return <Link to={`/admin/email/lists/new`}>Ny epostliste</Link>;
-    case '/admin/email/users':
-      return <Link to={'/admin/email/users/new'}>Ny bruker</Link>;
-    case '/admin/email/restricted':
-      return <Link to={'/admin/email/restricted/new'}>Ny begrenset epost</Link>;
-    default:
-      return null;
-  }
-};
-
-const EmailPage = ({ groups, children, location, params }: Props) => (
+const EmailPage = ({ groups, children, params }: Props) => (
   <Content>
     <NavigationTab title="Epost">
-      <NavigationLink to={'/admin/email/lists'}>Lister</NavigationLink>
+      <NavigationLink to={'/admin/email'}>Lister</NavigationLink>
       <NavigationLink to={'/admin/email/users'}>Brukere</NavigationLink>
       <NavigationLink to={'/admin/email/restricted'}>
         Begrenset epost
       </NavigationLink>
     </NavigationTab>
-    <CreateAction pathname={location.pathname} />
     {children}
   </Content>
 );

--- a/app/routes/admin/email/components/EmailUsers.js
+++ b/app/routes/admin/email/components/EmailUsers.js
@@ -4,6 +4,8 @@ import React, { Component } from 'react';
 import Table from 'app/components/Table';
 import Tag from 'app/components/Tags/Tag';
 import { Link } from 'react-router';
+import Button from 'app/components/Button';
+import Flex from 'app/components/Layout/Flex';
 
 type Props = {
   fetching: boolean,
@@ -35,6 +37,16 @@ export default class EmailUsers extends Component<Props> {
       {
         title: 'Status',
         dataIndex: 'internalEmailEnabled',
+        filter: [
+          {
+            label: 'Aktiv',
+            value: true
+          },
+          {
+            label: 'Inaktiv',
+            value: false
+          }
+        ],
         render: enabled =>
           enabled ? (
             <Tag tag="aktiv" color="orange" />
@@ -57,6 +69,12 @@ export default class EmailUsers extends Component<Props> {
           denne. Adressen kan deaktiveres når brukeren ikke lengre er aktiv i
           Abakus, men adressen vil ikke bli tilgjengelig for andre brukere.
         </p>
+        <Flex justifyContent="space-between" style={{ marginBottom: '10px' }}>
+          <h3>Aktive/Inaktive epostkontoer</h3>
+          <Link to={'/admin/email/users/new'}>
+            <Button>Ny bruker</Button>
+          </Link>
+        </Flex>
         <Table
           infiniteScroll
           columns={columns}

--- a/app/routes/admin/email/components/RestrictedMailEditor.js
+++ b/app/routes/admin/email/components/RestrictedMailEditor.js
@@ -72,10 +72,10 @@ const RestrictedMailEditor = ({
       />
       <Field
         disabled={restrictedMailId}
-        label="Eventer"
+        label="Arrangementer"
         name="events"
         multi
-        placeholder="Eventer du ønsker å sende epost til"
+        placeholder="Arrangementer du ønsker å sende epost til"
         filter={['events.event']}
         component={SelectInput.AutocompleteField}
       />

--- a/app/routes/admin/email/components/RestrictedMails.js
+++ b/app/routes/admin/email/components/RestrictedMails.js
@@ -4,6 +4,8 @@ import Table from 'app/components/Table';
 import Tag from 'app/components/Tags/Tag';
 import { Link } from 'react-router';
 import moment from 'moment';
+import Button from 'app/components/Button';
+import Flex from 'app/components/Layout/Flex';
 
 type Props = {
   fetching: boolean,
@@ -72,6 +74,12 @@ export default class RestrictedMails extends Component<Props> {
             <li>Send eposten</li>
           </ul>
         </p>
+        <Flex justifyContent="space-between" style={{ marginBottom: '10px' }}>
+          <h3>Dine begrensede e-poster</h3>
+          <Link to={'/admin/email/restricted/new'}>
+            <Button>Ny begrenset epost</Button>
+          </Link>
+        </Flex>
         <Table
           infiniteScroll
           columns={columns}

--- a/app/routes/admin/email/index.js
+++ b/app/routes/admin/email/index.js
@@ -3,11 +3,8 @@ import resolveAsyncRoute from 'app/routes/resolveAsyncRoute';
 export default {
   path: 'email',
   ...resolveAsyncRoute(() => import('./components/EmailRoute')),
+  indexRoute: resolveAsyncRoute(() => import('./EmailListsRoute')),
   childRoutes: [
-    {
-      path: 'lists',
-      ...resolveAsyncRoute(() => import('./EmailListsRoute'))
-    },
     {
       path: 'lists/new',
       ...resolveAsyncRoute(() => import('./CreateEmailListRoute'))


### PR DESCRIPTION
Made some changes to the email pages. This page does no longer exist.
![screenshot from 2018-02-06 00-11-49](https://user-images.githubusercontent.com/23152018/35833699-81d0303e-0ad2-11e8-9e9e-4aae577f9f4b.png)
So the first email page you arrive at is the list of lists. The page with users can now be filtered with active and inactive as a criteria. The table now has a title and a dedicated button for the creation of whatever the table displays 
![screenshot from 2018-02-06 00-12-20](https://user-images.githubusercontent.com/23152018/35833744-bcfb722c-0ad2-11e8-8e7e-f32dc1ee878c.png)


