### PR TITLE
Only cache requests on the server

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -293,7 +293,6 @@ export const Feed = {
 };
 
 export const FetchHistory = {
-  SET_HISTORY: 'FetchHistory.SET_HISTORY',
   CLEAR_HISTORY: 'FetchHistory.CLEAR_HISTORY'
 };
 

--- a/app/reducers/__tests__/fetchHistory.spec.js
+++ b/app/reducers/__tests__/fetchHistory.spec.js
@@ -4,6 +4,15 @@ import timekeeper from 'timekeeper';
 describe('fetchHistory', () => {
   let time = Date.now();
   timekeeper.freeze(time);
+
+  beforeEach(() => {
+    global.__CLIENT__ = false;
+  });
+
+  afterEach(() => {
+    global.__CLIENT__ = true;
+  });
+
   it('should have correct initialState', () => {
     const prevState = {};
     expect(fetchHistory(prevState, {})).toEqual({});
@@ -27,7 +36,7 @@ describe('fetchHistory', () => {
     expect(fetchHistory(prevState, action)).toEqual({});
   });
 
-  it('should set Date.now()', () => {
+  it('should set Date.now() on the server', () => {
     const prevState = {};
     const action = {
       type: 'Event.SUCCESS',
@@ -43,6 +52,24 @@ describe('fetchHistory', () => {
         }
       }
     });
+  });
+
+  it('should not cache on the frontend', () => {
+    global.__CLIENT__ = true;
+    const prevState = {
+      'company/': {
+        timestamp: new Date(1504090888011),
+        action: {}
+      }
+    };
+
+    const action = {
+      type: 'Event.SUCCESS',
+      payload: {},
+      meta: { endpoint: 'events/1/', success: 'Event.SUCCESS' }
+    };
+
+    expect(fetchHistory(prevState, action)).toEqual(prevState);
   });
 
   it('should append new history entry', () => {

--- a/app/reducers/fetchHistory.js
+++ b/app/reducers/fetchHistory.js
@@ -10,9 +10,10 @@ export default function fetchHistory(state: State = initialState, action: any) {
   const success = action.meta && action.meta.success;
   switch (action.type) {
     case success: {
-      if (!success || action.cached) {
-        return state;
-      }
+      // We only want to cache on the server-side, to avoid having to redo all
+      // the requests during the initial render. Caching on the client is sort
+      // of annoying, as it creates a lot of weird issues.
+      if (!success || action.cached || __CLIENT__) return state;
       return {
         ...state,
         [action.meta.endpoint]: {
@@ -20,14 +21,6 @@ export default function fetchHistory(state: State = initialState, action: any) {
             ...action,
             cached: true
           },
-          timestamp: Date.now()
-        }
-      };
-    }
-    case FetchHistory.SET_HISTORY: {
-      return {
-        ...state,
-        [action.payload]: {
           timestamp: Date.now()
         }
       };


### PR DESCRIPTION
We don't really need to cache stuff on the frontend. This should hopefully fix some of the cache issues, while still keeping the benefits of not having to fetch stuff again after the server side render. 

In the future we could probably replace this altogether with something where we make sure that we never fetch initial data if we have it in the store from before, as that's mostly what we use the cache for anyway.

Also removed the `SET_HISTORY` action, as it's not being used anywhere.