### PR TITLE
Filter by endTime

### DIFF
--- a/app/routes/overview/components/CompactEvents.js
+++ b/app/routes/overview/components/CompactEvents.js
@@ -7,7 +7,6 @@ import colorForEvent from 'app/routes/events/colorForEvent';
 import truncateString from 'app/utils/truncateString';
 import { Flex } from 'app/components/Layout';
 import Time from 'app/components/Time';
-import moment from 'moment-timezone';
 
 type Props = {
   events: Array<Object>
@@ -24,8 +23,7 @@ export default class CompactEvents extends Component<Props> {
         .sort((a, b) => a.startTime - b.startTime)
         .filter(
           event =>
-            event.startTime > moment.now() &&
-            eventTypes.indexOf(event.eventType) !== -1
+            event.endTime.isAfter() && eventTypes.includes(event.eventType)
         )
         .slice(0, 5)
         .map((event, key) => (


### PR DESCRIPTION
Upon request we should support showing events that are currently happening on the frontpage, this basically just filters by endTime instead of startTime.

Dependant on https://github.com/webkom/lego/pull/1070 to work, but does not break without it 👍 