### PR TITLE
Fix superannoying event registration bug

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -20,7 +20,7 @@ export const Event = {
   ADMINISTRATE_FETCH: generateStatuses('Event.ADMINISTRATE_FETCH'),
   REQUEST_REGISTER: generateStatuses('Event.REQUEST_REGISTER'),
   ADMIN_REGISTER: generateStatuses('Event.ADMIN_REGISTER'),
-  UNREGISTER: generateStatuses('Event.UNREGISTER'),
+  REQUEST_UNREGISTER: generateStatuses('Event.REQUEST_UNREGISTER'),
   PAYMENT_QUEUE: generateStatuses('Event.PAYMENT_QUEUE'),
   UPDATE_REGISTRATION: generateStatuses('Event.UPDATE_REGISTRATION'),
   SOCKET_REGISTRATION: generateStatuses('Event.SOCKET_REGISTRATION'),

--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -18,7 +18,7 @@ export const Event = {
   EDIT: generateStatuses('Event.EDIT'),
   DELETE: generateStatuses('Event.DELETE'),
   ADMINISTRATE_FETCH: generateStatuses('Event.ADMINISTRATE_FETCH'),
-  REGISTER: generateStatuses('Event.REGISTER'),
+  REQUEST_REGISTER: generateStatuses('Event.REQUEST_REGISTER'),
   ADMIN_REGISTER: generateStatuses('Event.ADMIN_REGISTER'),
   UNREGISTER: generateStatuses('Event.UNREGISTER'),
   PAYMENT_QUEUE: generateStatuses('Event.PAYMENT_QUEUE'),

--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -156,11 +156,17 @@ export function setCoverPhoto(id: number, token: string) {
   });
 }
 
-export function register(
+export function register({
+  eventId,
+  captchaResponse,
+  feedback,
+  userId
+}: {
   eventId: number,
   captchaResponse: string,
-  feedback: string
-) {
+  feedback: string,
+  userId: number
+}) {
   return callAPI({
     types: Event.REQUEST_REGISTER,
     endpoint: `/events/${eventId}/registrations/`,
@@ -171,16 +177,23 @@ export function register(
     },
     meta: {
       id: eventId,
+      userId,
       errorMessage: 'Registering til hendelse feilet'
     }
   });
 }
 
-export function unregister(
+export function unregister({
+  eventId,
+  registrationId,
+  userId,
+  admin = false
+}: {
   eventId: number,
   registrationId: number,
-  admin: boolean = false
-) {
+  userId: number,
+  admin: boolean
+}) {
   return callAPI({
     types: Event.UNREGISTER,
     endpoint: `/events/${eventId}/registrations/${registrationId}/`,
@@ -189,6 +202,7 @@ export function unregister(
     meta: {
       errorMessage: 'Avregistrering fra hendelse feilet',
       admin,
+      userId,
       id: Number(registrationId)
     }
   });

--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -195,7 +195,7 @@ export function unregister({
   admin: boolean
 }) {
   return callAPI({
-    types: Event.UNREGISTER,
+    types: Event.REQUEST_UNREGISTER,
     endpoint: `/events/${eventId}/registrations/${registrationId}/`,
     method: 'DELETE',
     body: {},

--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -162,7 +162,7 @@ export function register(
   feedback: string
 ) {
   return callAPI({
-    types: Event.REGISTER,
+    types: Event.REQUEST_REGISTER,
     endpoint: `/events/${eventId}/registrations/`,
     method: 'POST',
     body: {

--- a/app/reducers/events.js
+++ b/app/reducers/events.js
@@ -39,7 +39,7 @@ function mutateEvent(state: any, action: any) {
         pagination: {}
       };
     }
-    case Event.REGISTER.BEGIN: {
+    case Event.REQUEST_REGISTER.BEGIN: {
       return {
         ...state,
         byId: {
@@ -114,7 +114,7 @@ function mutateEvent(state: any, action: any) {
         }
       };
     }
-    case Event.REGISTER.FAILURE: {
+    case Event.REQUEST_REGISTER.FAILURE: {
       return {
         ...state,
         byId: {

--- a/app/reducers/forms.js
+++ b/app/reducers/forms.js
@@ -10,21 +10,14 @@ export default formReducer.plugin({
       case Event.UNREGISTER.BEGIN: {
         return {
           ...state,
-          registrationId: null,
+          userId: action.meta.userId,
           submitting: true
         };
       }
-      case Event.REQUEST_REGISTER.SUCCESS:
-      case Event.UNREGISTER.SUCCESS:
-        return {
-          ...state,
-          registrationId: action.payload.id
-        };
       case Event.REQUEST_REGISTER.FAILURE:
       case Event.UNREGISTER.FAILURE: {
         return {
           ...state,
-          registrationId: null,
           submitting: false,
           submitSucceeded: false
         };
@@ -32,12 +25,11 @@ export default formReducer.plugin({
       case Event.SOCKET_UNREGISTRATION.SUCCESS:
       case Event.SOCKET_REGISTRATION.SUCCESS: {
         if (!state) return;
-        if (action.payload.id !== state.registrationId) {
+        if (action.payload.user.id !== state.userId) {
           return state;
         }
         return {
           ...state,
-          registrationId: null,
           submitting: false,
           submitSucceeded: true
         };

--- a/app/reducers/forms.js
+++ b/app/reducers/forms.js
@@ -6,7 +6,7 @@ import { Event } from '../actions/ActionTypes';
 export default formReducer.plugin({
   joinEvent: (state, action) => {
     switch (action.type) {
-      case Event.REGISTER.BEGIN:
+      case Event.REQUEST_REGISTER.BEGIN:
       case Event.UNREGISTER.BEGIN: {
         return {
           ...state,
@@ -14,13 +14,13 @@ export default formReducer.plugin({
           submitting: true
         };
       }
-      case Event.REGISTER.SUCCESS:
+      case Event.REQUEST_REGISTER.SUCCESS:
       case Event.UNREGISTER.SUCCESS:
         return {
           ...state,
           registrationId: action.payload.id
         };
-      case Event.REGISTER.FAILURE:
+      case Event.REQUEST_REGISTER.FAILURE:
       case Event.UNREGISTER.FAILURE: {
         return {
           ...state,

--- a/app/reducers/forms.js
+++ b/app/reducers/forms.js
@@ -7,7 +7,7 @@ export default formReducer.plugin({
   joinEvent: (state, action) => {
     switch (action.type) {
       case Event.REQUEST_REGISTER.BEGIN:
-      case Event.UNREGISTER.BEGIN: {
+      case Event.REQUEST_UNREGISTER.BEGIN: {
         return {
           ...state,
           userId: action.meta.userId,
@@ -15,7 +15,7 @@ export default formReducer.plugin({
         };
       }
       case Event.REQUEST_REGISTER.FAILURE:
-      case Event.UNREGISTER.FAILURE: {
+      case Event.REQUEST_UNREGISTER.FAILURE: {
         return {
           ...state,
           submitting: false,

--- a/app/reducers/registrations.js
+++ b/app/reducers/registrations.js
@@ -23,7 +23,7 @@ export default createEntityReducer({
           items: union(state.items, Object.keys(registrations).map(Number))
         };
       }
-      case Event.REGISTER.SUCCESS:
+      case Event.REQUEST_REGISTER.SUCCESS:
       case Event.ADMIN_REGISTER.SUCCESS:
       case Event.SOCKET_REGISTRATION.SUCCESS:
       case Event.PAYMENT_QUEUE.SUCCESS:

--- a/app/reducers/registrations.js
+++ b/app/reducers/registrations.js
@@ -46,7 +46,7 @@ export default createEntityReducer({
           items: union(state.items, [registration.id])
         };
       }
-      case Event.UNREGISTER.BEGIN: {
+      case Event.REQUEST_UNREGISTER.BEGIN: {
         return {
           ...state,
           byId: {
@@ -58,7 +58,7 @@ export default createEntityReducer({
           }
         };
       }
-      case Event.UNREGISTER.FAILURE: {
+      case Event.REQUEST_UNREGISTER.FAILURE: {
         return {
           ...state,
           byId: {

--- a/app/routes/events/components/EventAdministrate/Attendees.js
+++ b/app/routes/events/components/EventAdministrate/Attendees.js
@@ -29,7 +29,9 @@ export type Props = {
   loading: boolean,
   registered: Array<EventRegistration>,
   unregistered: Array<EventRegistration>,
-  unregister: (ID, ID, boolean) => Promise<*>,
+  unregister: ({ eventId: ID, registrationId: ID, admin: boolean }) => Promise<
+    *
+  >,
   updatePresence: (number, number, string) => Promise<*>,
   updatePayment: (ID, ID, EventRegistrationChargeStatus) => Promise<*>,
   usersResult: Array<User>,
@@ -48,8 +50,13 @@ export default class Attendees extends Component<Props, State> {
   };
 
   handleUnregister = (registrationId: number) => {
+    const { unregister, eventId } = this.props;
     if (this.state.clickedUnregister === registrationId) {
-      this.props.unregister(this.props.eventId, registrationId, true);
+      unregister({
+        eventId,
+        registrationId,
+        admin: true
+      });
       this.setState({
         clickedUnregister: 0
       });

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -53,14 +53,19 @@ type Props = {
   registrations: Array<Object>,
   currentRegistration: Object,
   waitingRegistrations: Array<Object>,
-  register: (
+  register: ({
     eventId: string,
     captchaResponse: string,
-    feedback: string
-  ) => Promise<*>,
+    feedback: string,
+    userId: number
+  }) => Promise<*>,
   follow: (eventId: string, userId: string) => Promise<*>,
   unfollow: (eventId: string, userId: string) => Promise<*>,
-  unregister: (eventId: string, registrationId: number) => Promise<*>,
+  unregister: ({
+    eventId: string,
+    registrationId: number,
+    userId: number
+  }) => Promise<*>,
   payment: (eventId: string, token: string) => Promise<*>,
   updateFeedback: (
     eventId: string,
@@ -81,17 +86,27 @@ export default class EventDetail extends Component<Props> {
       currentRegistration,
       register,
       unregister,
-      updateFeedback
+      updateFeedback,
+      currentUser: { id: userId }
     } = this.props;
     switch (type) {
       case 'feedback':
         return updateFeedback(eventId, currentRegistration.id, feedback);
       case 'register':
         // Note that we do not return this promise due to custom submitting handling
-        register(eventId, captchaResponse, feedback);
+        register({
+          eventId,
+          captchaResponse,
+          feedback,
+          userId
+        });
         return;
       case 'unregister':
-        unregister(eventId, currentRegistration.id);
+        unregister({
+          eventId,
+          registrationId: currentRegistration.id,
+          userId
+        });
         return;
       default:
         return undefined;


### PR DESCRIPTION
Fix #1103 🚤

Use user id instead of potential null registration id to distinguish between oneself or other users when registering or unregistering.