### PR TITLE
UI for changing semesters in companyInterestForm

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -186,7 +186,8 @@ export const Company = {
   EDIT_COMPANY_CONTACT: generateStatuses('Company.EDIT_COMPANY_CONTACT'),
   DELETE_COMPANY_CONTACT: generateStatuses('Company.DELETE_COMPANY_CONTACT'),
   FETCH_SEMESTERS: generateStatuses('Company.FETCH_SEMESTERS'),
-  ADD_SEMESTER: generateStatuses('Company.ADD_SEMESTER')
+  ADD_SEMESTER: generateStatuses('Company.ADD_SEMESTER'),
+  TOGGLE_ACTIVE_SEMESTER: generateStatuses('Company.TOGGLE_ACTIVE_SEMESTER')
 };
 
 /**

--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -187,7 +187,7 @@ export const Company = {
   DELETE_COMPANY_CONTACT: generateStatuses('Company.DELETE_COMPANY_CONTACT'),
   FETCH_SEMESTERS: generateStatuses('Company.FETCH_SEMESTERS'),
   ADD_SEMESTER: generateStatuses('Company.ADD_SEMESTER'),
-  TOGGLE_ACTIVE_SEMESTER: generateStatuses('Company.TOGGLE_ACTIVE_SEMESTER')
+  EDIT_SEMESTER: generateStatuses('Company.EDIT_SEMESTER')
 };
 
 /**

--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -334,7 +334,7 @@ export function deleteCompanyContact(
 }
 
 export function fetchSemestersForInterestform() {
-  return fetchSemesters({ company_inerest: 'True' });
+  return fetchSemesters({ company_interest: 'True' });
 }
 
 export function fetchSemesters(
@@ -353,7 +353,8 @@ export function fetchSemesters(
 
 type SemesterInput = {
   year: number,
-  semester: number
+  semester: number,
+  activeInterestForm: boolean
 };
 
 export function addSemester({ year, semester }: SemesterInput): Thunk<*> {
@@ -369,6 +370,22 @@ export function addSemester({ year, semester }: SemesterInput): Thunk<*> {
         },
         meta: {
           errorMessage: 'Legge til semester feilet'
+        }
+      })
+    );
+  };
+}
+
+export function toggleActiveSemester(semesterId: number): Thunk<*> {
+  return dispatch => {
+    return dispatch(
+      callAPI({
+        types: Company.TOGGLE_ACTIVE_SEMESTER,
+        endpoint: `/company-semesters/${semesterId}`,
+        method: 'PATCH',
+        meta: {
+          errorMessage: 'Sletting av semester feilet',
+          successMessage: 'Semester slettet'
         }
       })
     );

--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -352,6 +352,7 @@ export function fetchSemesters(
 }
 
 type SemesterInput = {
+  id: number,
   year: number,
   semester: number,
   activeInterestForm: boolean
@@ -376,13 +377,23 @@ export function addSemester({ year, semester }: SemesterInput): Thunk<*> {
   };
 }
 
-export function toggleActiveSemester(semesterId: number): Thunk<*> {
+export function toggleActiveSemester({
+  id,
+  year,
+  semester
+}: SemesterInput): Thunk<*> {
   return dispatch => {
     return dispatch(
       callAPI({
         types: Company.TOGGLE_ACTIVE_SEMESTER,
-        endpoint: `/company-semesters/${semesterId}`,
+        endpoint: `/company-semesters/${id}`,
         method: 'PATCH',
+        body: {
+          id,
+          year,
+          semester,
+          activeInterestForm: true
+        },
         meta: {
           errorMessage: 'Sletting av semester feilet',
           successMessage: 'Semester slettet'

--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -13,6 +13,7 @@ import { startSubmit, stopSubmit } from 'redux-form';
 import { push } from 'react-router-redux';
 import type { Thunk } from 'app/types';
 import { addToast } from 'app/actions/ToastActions';
+import { semesterToText } from 'app/routes/companyInterest/components/CompanyInterestPage';
 
 export const fetchAll = ({ fetchMore }: { fetchMore: boolean }): Thunk<*> => (
   dispatch,
@@ -358,7 +359,11 @@ type SemesterInput = {
   activeInterestForm: boolean
 };
 
-export function addSemester({ year, semester }: SemesterInput): Thunk<*> {
+export function addSemester({
+  year,
+  semester,
+  activeInterestForm
+}: SemesterInput): Thunk<*> {
   return dispatch => {
     return dispatch(
       callAPI({
@@ -367,7 +372,8 @@ export function addSemester({ year, semester }: SemesterInput): Thunk<*> {
         method: 'POST',
         body: {
           year,
-          semester
+          semester,
+          activeInterestForm: true
         },
         meta: {
           errorMessage: 'Legge til semester feilet',
@@ -387,9 +393,10 @@ export function editSemester({
   return dispatch => {
     return dispatch(
       callAPI({
-        types: Company.TOGGLE_ACTIVE_SEMESTER,
-        endpoint: `/company-semesters/${id}`,
+        types: Company.EDIT_SEMESTER,
+        endpoint: `/company-semesters/${id}/`,
         method: 'PATCH',
+        schema: companySemesterSchema,
         body: {
           id,
           year,
@@ -398,7 +405,12 @@ export function editSemester({
         },
         meta: {
           errorMessage: 'Endring av semester feilet',
-          successMessage: 'Semester endret!'
+          successMessage: `${semesterToText({
+            id,
+            year,
+            semester,
+            activeInterestForm
+          })} er nå ${activeInterestForm ? 'aktivt' : 'deaktivert'}!`
         }
       })
     );

--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -370,17 +370,19 @@ export function addSemester({ year, semester }: SemesterInput): Thunk<*> {
           semester
         },
         meta: {
-          errorMessage: 'Legge til semester feilet'
+          errorMessage: 'Legge til semester feilet',
+          successMessage: 'Semest lagt til!'
         }
       })
     );
   };
 }
 
-export function toggleActiveSemester({
+export function editSemester({
   id,
   year,
-  semester
+  semester,
+  activeInterestForm
 }: SemesterInput): Thunk<*> {
   return dispatch => {
     return dispatch(
@@ -392,11 +394,11 @@ export function toggleActiveSemester({
           id,
           year,
           semester,
-          activeInterestForm: true
+          activeInterestForm
         },
         meta: {
-          errorMessage: 'Sletting av semester feilet',
-          successMessage: 'Semester slettet'
+          errorMessage: 'Endring av semester feilet',
+          successMessage: 'Semester endret!'
         }
       })
     );

--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -14,6 +14,7 @@ import { push } from 'react-router-redux';
 import type { Thunk } from 'app/types';
 import { addToast } from 'app/actions/ToastActions';
 import { semesterToText } from 'app/routes/companyInterest/components/CompanyInterestPage';
+import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 
 export const fetchAll = ({ fetchMore }: { fetchMore: boolean }): Thunk<*> => (
   dispatch,
@@ -352,18 +353,10 @@ export function fetchSemesters(
   });
 }
 
-type SemesterInput = {
-  id: number,
-  year: number,
-  semester: number,
-  activeInterestForm: boolean
-};
-
 export function addSemester({
   year,
-  semester,
-  activeInterestForm
-}: SemesterInput): Thunk<*> {
+  semester
+}: CompanySemesterEntity): Thunk<*> {
   return dispatch => {
     return dispatch(
       callAPI({
@@ -389,7 +382,12 @@ export function editSemester({
   year,
   semester,
   activeInterestForm
-}: SemesterInput): Thunk<*> {
+}: {
+  id: number,
+  year: string,
+  semester: string,
+  activeInterestForm: boolean
+}): Thunk<*> {
   return dispatch => {
     return dispatch(
       callAPI({

--- a/app/reducers/companySemesters.js
+++ b/app/reducers/companySemesters.js
@@ -5,9 +5,10 @@ import createEntityReducer from 'app/utils/createEntityReducer';
 import { createSelector } from 'reselect';
 
 export type CompanySemesterEntity = {
+  id?: number,
   semester: string,
   year: number,
-  id?: number
+  activeInterestForm: boolean
 };
 
 export default createEntityReducer({
@@ -42,7 +43,7 @@ export const selectCompanySemesters = createSelector(
   }
 );
 
-export const selectCompanySemestersForInterestform = createSelector(
+export const selectCompanySemestersForInterestForm = createSelector(
   selectCompanySemesters,
   companySemesters =>
     companySemesters

--- a/app/reducers/companySemesters.js
+++ b/app/reducers/companySemesters.js
@@ -37,10 +37,11 @@ export default createEntityReducer({
 export const selectCompanySemesters = createSelector(
   state => state.companySemesters.items,
   state => state.companySemesters.byId,
-  (semesterIds, semestersById) =>
-    !semesterIds || !semestersById
+  (semesterIds, semestersById) => {
+    return !semesterIds || !semestersById
       ? []
-      : semesterIds.map(id => semestersById[id])
+      : semesterIds.map(id => semestersById[id]);
+  }
 );
 
 export const selectCompanySemestersForInterestForm = createSelector(

--- a/app/reducers/companySemesters.js
+++ b/app/reducers/companySemesters.js
@@ -4,13 +4,12 @@ import { Company } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { createSelector } from 'reselect';
 import { sortSemesterChronologically } from 'app/routes/companyInterest/utils';
-import { sortBy } from 'lodash';
 
 export type CompanySemesterEntity = {
   id?: number,
-  semester: number,
+  semester: string,
   year: number,
-  activeInterestForm: boolean
+  activeInterestForm?: boolean
 };
 
 export default createEntityReducer({

--- a/app/reducers/companySemesters.js
+++ b/app/reducers/companySemesters.js
@@ -37,30 +37,14 @@ export default createEntityReducer({
 export const selectCompanySemesters = createSelector(
   state => state.companySemesters.items,
   state => state.companySemesters.byId,
-  (semesterIds, semestersById) => {
-    if (!semesterIds || !semestersById) return [];
-    return semesterIds.map(id => semestersById[id]);
-  }
+  (semesterIds, semestersById) =>
+    !semesterIds || !semestersById
+      ? []
+      : semesterIds.map(id => semestersById[id])
 );
 
 export const selectCompanySemestersForInterestForm = createSelector(
   selectCompanySemesters,
   companySemesters =>
-    companySemesters
-      .filter(semester => {
-        const currentDate = new Date();
-        const currentYear = currentDate.getFullYear();
-        const currentMonth = currentDate.getMonth();
-        if (currentYear > semester.year) return false;
-        if (currentYear === semester.year) {
-          if (semester.semester === 'spring') {
-            return false;
-          }
-          if (semester.semester === 'autumn' && currentMonth > 5) {
-            return false;
-          }
-        }
-        return true;
-      })
-      .slice(0, 4)
+    companySemesters.filter(semester => semester.activeInterestForm)
 );

--- a/app/reducers/companySemesters.js
+++ b/app/reducers/companySemesters.js
@@ -3,10 +3,12 @@
 import { Company } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { createSelector } from 'reselect';
+import { sortSemesterChronologically } from 'app/routes/companyInterest/utils';
+import { sortBy } from 'lodash';
 
 export type CompanySemesterEntity = {
   id?: number,
-  semester: string,
+  semester: number,
   year: number,
   activeInterestForm: boolean
 };
@@ -47,5 +49,7 @@ export const selectCompanySemesters = createSelector(
 export const selectCompanySemestersForInterestForm = createSelector(
   selectCompanySemesters,
   companySemesters =>
-    companySemesters.filter(semester => semester.activeInterestForm)
+    companySemesters
+      .filter(semester => semester.activeInterestForm)
+      .sort(sortSemesterChronologically)
 );

--- a/app/reducers/companySemesters.js
+++ b/app/reducers/companySemesters.js
@@ -8,7 +8,7 @@ import { sortSemesterChronologically } from 'app/routes/companyInterest/utils';
 export type CompanySemesterEntity = {
   id?: number,
   semester: string,
-  year: number,
+  year: number | string,
   activeInterestForm?: boolean
 };
 

--- a/app/routes/companyInterest/CompanyInterestEditRoute.js
+++ b/app/routes/companyInterest/CompanyInterestEditRoute.js
@@ -11,7 +11,7 @@ import CompanyInterestPage, {
   OTHER_TYPES
 } from './components/CompanyInterestPage';
 import { selectCompanyInterestById } from 'app/reducers/companyInterest';
-import { selectCompanySemestersForInterestform } from 'app/reducers/companySemesters';
+import { selectCompanySemestersForInterestForm } from 'app/reducers/companySemesters';
 import { push } from 'react-router-redux';
 import prepare from 'app/utils/prepare';
 
@@ -29,7 +29,7 @@ const mapStateToProps = (state, props) => {
   });
   // TODO show an intersection of the currently active semesters, and
   // the semester chosen when the interestform was created
-  const semesters = selectCompanySemestersForInterestform(state);
+  const semesters = selectCompanySemestersForInterestForm(state);
   if (!companyInterest || !semesters)
     return {
       edit: true,

--- a/app/routes/companyInterest/CompanyInterestEditRoute.js
+++ b/app/routes/companyInterest/CompanyInterestEditRoute.js
@@ -1,7 +1,7 @@
 // @flow
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { fetchSemestersForInterestform } from 'app/actions/CompanyActions';
+import { fetchSemesters } from 'app/actions/CompanyActions';
 import {
   fetchCompanyInterest,
   updateCompanyInterest
@@ -11,13 +11,13 @@ import CompanyInterestPage, {
   OTHER_TYPES
 } from './components/CompanyInterestPage';
 import { selectCompanyInterestById } from 'app/reducers/companyInterest';
-import { selectCompanySemestersForInterestForm } from 'app/reducers/companySemesters';
+import { selectCompanySemesters } from 'app/reducers/companySemesters';
 import { push } from 'react-router-redux';
 import prepare from 'app/utils/prepare';
 
 const loadCompanyInterests = (props, dispatch) => {
   const { companyInterestId } = props.params;
-  return dispatch(fetchSemestersForInterestform()).then(() =>
+  return dispatch(fetchSemesters()).then(() =>
     dispatch(fetchCompanyInterest(Number(companyInterestId)))
   );
 };
@@ -27,9 +27,7 @@ const mapStateToProps = (state, props) => {
   const companyInterest = selectCompanyInterestById(state, {
     companyInterestId
   });
-  // TODO show an intersection of the currently active semesters, and
-  // the semester chosen when the interestform was created
-  const semesters = selectCompanySemestersForInterestForm(state);
+  const semesters = selectCompanySemesters(state);
   if (!companyInterest || !semesters)
     return {
       edit: true,
@@ -54,12 +52,14 @@ const mapStateToProps = (state, props) => {
           companyInterest.otherOffers &&
           companyInterest.otherOffers.includes(offer)
       })),
-      semesters: semesters.map(semester => ({
-        ...semester,
-        checked:
-          companyInterest.semesters &&
-          companyInterest.semesters.includes(semester.id)
-      }))
+      semesters: semesters
+        .map(semester => ({
+          ...semester,
+          checked:
+            companyInterest.semesters &&
+            companyInterest.semesters.includes(semester.id)
+        }))
+        .filter(semester => semester.activeInterestForm || semester.checked)
     },
     companyInterestId,
     companyInterest,

--- a/app/routes/companyInterest/CompanyInterestRoute.js
+++ b/app/routes/companyInterest/CompanyInterestRoute.js
@@ -8,7 +8,7 @@ import CompanyInterestPage, {
   EVENT_TYPES,
   OTHER_TYPES
 } from './components/CompanyInterestPage';
-import { selectCompanySemestersForInterestform } from 'app/reducers/companySemesters';
+import { selectCompanySemestersForInterestForm } from 'app/reducers/companySemesters';
 import prepare from 'app/utils/prepare';
 import { sortSemesterChronologically } from './utils.js';
 
@@ -16,7 +16,7 @@ const loadSemesters = (props, dispatch) =>
   dispatch(fetchSemestersForInterestform());
 
 const mapStateToProps = state => {
-  const semesters = selectCompanySemestersForInterestform(state);
+  const semesters = selectCompanySemestersForInterestForm(state);
   if (!semesters) {
     return {
       edit: false

--- a/app/routes/companyInterest/CompanySemesterGUIRoute.js
+++ b/app/routes/companyInterest/CompanySemesterGUIRoute.js
@@ -3,19 +3,22 @@ import { compose } from 'redux';
 import prepare from 'app/utils/prepare';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { LoginPage } from 'app/components/LoginForm';
-import { selectCompanySemestersForInterestForm } from 'app/reducers/companySemesters';
-import { sortSemesterChronologically } from './utils.js';
+import {
+  selectCompanySemesters,
+  selectCompanySemestersForInterestForm
+} from 'app/reducers/companySemesters';
 import { addSemester, editSemester } from 'app/actions/CompanyActions';
 import CompanySemesterGUI from './components/CompanySemesterGUI';
-import { fetchSemestersForInterestform } from 'app/actions/CompanyActions';
+import { fetchSemesters } from 'app/actions/CompanyActions';
 
-const loadSemesters = (props, dispatch) =>
-  dispatch(fetchSemestersForInterestform());
+const loadSemesters = (props, dispatch) => dispatch(fetchSemesters());
 
 const mapStateToProps = state => {
-  const semesters = selectCompanySemestersForInterestForm(state);
+  const semesters = selectCompanySemesters(state);
+  const activeSemesters = selectCompanySemestersForInterestForm(state);
   return {
-    semesters: semesters.sort(sortSemesterChronologically)
+    semesters,
+    activeSemesters
   };
 };
 

--- a/app/routes/companyInterest/CompanySemesterGUIRoute.js
+++ b/app/routes/companyInterest/CompanySemesterGUIRoute.js
@@ -17,6 +17,9 @@ const mapStateToProps = state => {
   const semesters = selectCompanySemesters(state);
   const activeSemesters = selectCompanySemestersForInterestForm(state);
   return {
+    initialValues: {
+      semester: 'spring'
+    },
     semesters,
     activeSemesters
   };

--- a/app/routes/companyInterest/CompanySemesterGUIRoute.js
+++ b/app/routes/companyInterest/CompanySemesterGUIRoute.js
@@ -1,0 +1,38 @@
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { reduxForm } from 'redux-form';
+import prepare from 'app/utils/prepare';
+import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
+import { LoginPage } from 'app/components/LoginForm';
+import selectCompanySemestersForInterestForm from 'app/reducers/companySemesters';
+import { sortSemesterChronologically } from './utils.js';
+
+import {
+  addSemester,
+  deleteSemester,
+  fetchSemesters
+} from 'app/actions/CompanyActions';
+import CompanySemesterGUI from './components/CompanySemesterGUI';
+
+const mapStateToProps = (state, props) => {
+  const semesters = selectCompanySemestersForInterestForm(state, props);
+  return {
+    semesters: semesters.sort(sortSemesterChronologically)
+  };
+};
+
+const mapDispatchToProps = {
+  addSemester,
+  deleteSemester
+};
+
+export default compose(
+  replaceUnlessLoggedIn(LoginPage),
+  prepare((props, dispatch) => dispatch(fetchSemesters)),
+  connect(mapStateToProps, mapDispatchToProps),
+  reduxForm({
+    form: 'addSemester',
+    validate: 'validateSemesterStatus',
+    enableReinitialize: true
+  })
+)(CompanySemesterGUI);

--- a/app/routes/companyInterest/CompanySemesterGUIRoute.js
+++ b/app/routes/companyInterest/CompanySemesterGUIRoute.js
@@ -1,21 +1,19 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { reduxForm } from 'redux-form';
 import prepare from 'app/utils/prepare';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { LoginPage } from 'app/components/LoginForm';
-import selectCompanySemestersForInterestForm from 'app/reducers/companySemesters';
+import { selectCompanySemestersForInterestForm } from 'app/reducers/companySemesters';
 import { sortSemesterChronologically } from './utils.js';
-
-import {
-  addSemester,
-  deleteSemester,
-  fetchSemesters
-} from 'app/actions/CompanyActions';
+import { addSemester, editSemester } from 'app/actions/CompanyActions';
 import CompanySemesterGUI from './components/CompanySemesterGUI';
+import { fetchSemestersForInterestform } from 'app/actions/CompanyActions';
 
-const mapStateToProps = (state, props) => {
-  const semesters = selectCompanySemestersForInterestForm(state, props);
+const loadSemesters = (props, dispatch) =>
+  dispatch(fetchSemestersForInterestform());
+
+const mapStateToProps = state => {
+  const semesters = selectCompanySemestersForInterestForm(state);
   return {
     semesters: semesters.sort(sortSemesterChronologically)
   };
@@ -23,16 +21,11 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = {
   addSemester,
-  deleteSemester
+  editSemester
 };
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  prepare((props, dispatch) => dispatch(fetchSemesters)),
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: 'addSemester',
-    validate: 'validateSemesterStatus',
-    enableReinitialize: true
-  })
+  prepare(loadSemesters),
+  connect(mapStateToProps, mapDispatchToProps)
 )(CompanySemesterGUI);

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -12,6 +12,7 @@
 
 .guiWrapper {
   margin-right: 30px;
+  flex-wrap: wrap;
 }
 
 .guiBoxes {
@@ -86,7 +87,7 @@
 .content {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-end;
 
   @media (--small-viewport) {
     flex-direction: column;

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -10,12 +10,27 @@
   flex-wrap: wrap;
 }
 
+.guiWrapper {
+  margin-right: 30px;
+}
+
+.guiBoxes {
+  justify-content: flex-end;
+  margin: 10px 0;
+}
+
 .remove {
   font-size: 30px;
   margin: 0 5px;
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  cursor: pointer;
+}
+
+.yearForm {
+  width: 100px;
+  display: block;
 }
 
 .mobileHeader {
@@ -27,30 +42,10 @@
   border-top: 1px solid var(--color-gray-3);
 }
 
-.flex {
-  display: flex;
-}
-
-.upload {
-  width: 400px;
-
-  @media (--small-viewport) {
-    width: 300px;
-  }
-}
-
 .textEditor {
   @media (--small-viewport) {
     width: 300px;
   }
-}
-
-.smallHeading {
-  color: var(--color-gray-1);
-  letter-spacing: 2px;
-  font-weight: 400;
-  text-transform: uppercase;
-  font-size: 16px;
 }
 
 .createButton {
@@ -70,15 +65,9 @@
   font-weight: bold;
 }
 
-.checkbox {
-  display: flex;
-  flex-direction: row;
-  margin-right: 30px;
-}
-
-.checkboxSpan {
-  width: 130px;
-  heigth: 20px;
+.semesterBox {
+  justify-content: space-between;
+  width: 125px;
 }
 
 .heading {
@@ -94,32 +83,6 @@
   width: 30px;
 }
 
-.inputField {
-  width: 410px;
-
-  @media (--small-viewport) {
-    width: 300px;
-  }
-}
-
-.nameField {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  margin-right: 200px;
-
-  @media (--small-viewport) {
-    flex-direction: column;
-  }
-}
-
-.companyInterest {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  margin-bottom: 40px;
-}
-
 .content {
   display: flex;
   flex-direction: row;
@@ -130,14 +93,19 @@
   }
 }
 
-.paragraph {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
 .bold {
   font-weight: bold;
+}
+
+.submit {
+  padding: 10px 20px;
+  font-size: 14px;
+  margin: 10px 0 50px;
+  width: 200px;
+
+  &:disabled {
+    color: #ccc;
+  }
 }
 
 .section {

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -80,6 +80,13 @@
   border-bottom: 1px solid var(--color-gray-3) !important;
 }
 
+.underline {
+  margin: 15px 0;
+  padding: 10px 0;
+  border-top: 1px solid var(--color-gray-3);
+  border-bottom: 1px solid var(--color-gray-3);
+}
+
 .checkboxField {
   width: 30px;
 }

--- a/app/routes/companyInterest/components/CompanyInterestList.js
+++ b/app/routes/companyInterest/components/CompanyInterestList.js
@@ -7,9 +7,10 @@ import { Link } from 'react-router';
 import Icon from 'app/components/Icon';
 import { Content } from 'app/components/Content';
 import Flex from 'app/components/Layout/Flex';
+import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
 
 export type Props = {
-  companyInterestList: Array<Object>,
+  companyInterestList: Array<CompanyInterestEntity>,
   deleteCompanyInterest: number => void
 };
 

--- a/app/routes/companyInterest/components/CompanyInterestList.js
+++ b/app/routes/companyInterest/components/CompanyInterestList.js
@@ -6,7 +6,7 @@ import Button from 'app/components/Button';
 import { Link } from 'react-router';
 import Icon from 'app/components/Icon';
 import { Content } from 'app/components/Content';
-import { FlexRow, FlexColumn } from 'app/components/FlexBox';
+import Flex from 'app/components/Layout/Flex';
 
 export type Props = {
   companyInterestList: Array<Object>,
@@ -63,42 +63,44 @@ const CompanyInterestList = (props: Props) => {
 
   const interestsMobile = props.companyInterestList.map((company, key) => (
     <table key={key} className={styles.companyInterestListMobile}>
-      <thead className={styles.flex}>
-        <tr className={styles.mobileHeader}>
-          <td>
-            <h3 className={styles.companyInterestListMobile}>
-              {company.companyName}
-            </h3>
-          </td>
-          <td>
-            <Icon
-              name="close-circle"
-              onClick={() => props.deleteCompanyInterest(company.id)}
-              className={styles.remove}
-            />
-          </td>
-        </tr>
-      </thead>
-      <tbody className={styles.companyInterestListMobile}>
-        {generateMobileValues(company)}
-      </tbody>
+      <Flex>
+        <thead>
+          <tr className={styles.mobileHeader}>
+            <td>
+              <h3 className={styles.companyInterestListMobile}>
+                {company.companyName}
+              </h3>
+            </td>
+            <td>
+              <Icon
+                name="close-circle"
+                onClick={() => props.deleteCompanyInterest(company.id)}
+                className={styles.remove}
+              />
+            </td>
+          </tr>
+        </thead>
+        <tbody className={styles.companyInterestListMobile}>
+          {generateMobileValues(company)}
+        </tbody>
+      </Flex>
     </table>
   ));
 
   return (
     <Content>
       <ListNavigation title="Bedriftsinteresser" />
-      <FlexRow className={styles.section}>
-        <FlexColumn>
+      <Flex className={styles.section}>
+        <Flex column>
           <p>
-            <strong>Her</strong> finner du all praktisk informasjon knyttet til
-            bedriftsinteresser.
+            Her finner du all praktisk informasjon knyttet til
+            <strong> bedriftsinteresser</strong>.
           </p>
-        </FlexColumn>
+        </Flex>
         <Link to={'/companyInterest/create'} className={styles.link}>
           <Button>Opprett ny bedriftsinteresse</Button>
         </Link>
-      </FlexRow>
+      </Flex>
       <table className={styles.companyInterestList}>
         <thead>
           <tr className={styles.companyInterestList}>

--- a/app/routes/companyInterest/components/CompanyInterestList.js
+++ b/app/routes/companyInterest/components/CompanyInterestList.js
@@ -63,7 +63,7 @@ const CompanyInterestList = (props: Props) => {
 
   const interestsMobile = props.companyInterestList.map((company, key) => (
     <table key={key} className={styles.companyInterestListMobile}>
-      <Flex>
+      <Flex column>
         <thead>
           <tr className={styles.mobileHeader}>
             <td>
@@ -97,6 +97,9 @@ const CompanyInterestList = (props: Props) => {
             <strong> bedriftsinteresser</strong>.
           </p>
         </Flex>
+        <Link to={'/companyInterest/semesters'} className={styles.link}>
+          <Button>Endre aktive semestre</Button>
+        </Link>
         <Link to={'/companyInterest/create'} className={styles.link}>
           <Button>Opprett ny bedriftsinteresse</Button>
         </Link>

--- a/app/routes/companyInterest/components/CompanyInterestPage.js
+++ b/app/routes/companyInterest/components/CompanyInterestPage.js
@@ -11,7 +11,8 @@ import {
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { reduxForm, Field, SubmissionError, FieldArray } from 'redux-form';
 import type { FieldProps } from 'redux-form';
-import { FlexRow, FlexColumn, FlexItem } from 'app/components/FlexBox';
+import { FlexItem } from 'app/components/FlexBox';
+import Flex from 'app/components/Layout/Flex';
 import { Content } from 'app/components/Content';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
 
@@ -53,9 +54,9 @@ export const semesterToText = (semester: companySemester) =>
   `${SEMESTER_TRANSLATION[semester.semester]} ${semester.year}`;
 
 const SemesterBox = ({ fields }: FieldProps) => (
-  <FlexRow className={styles.checkboxWrapper}>
+  <Flex column className={styles.checkboxWrapper}>
     {fields.map((item, index) => (
-      <div key={index} className={styles.checkbox}>
+      <Flex key={index}>
         <div className={styles.checkboxField}>
           <Field
             key={`semester${index}`}
@@ -67,15 +68,15 @@ const SemesterBox = ({ fields }: FieldProps) => (
         <span className={styles.checkboxSpan}>
           {semesterToText(fields.get(index))}
         </span>
-      </div>
+      </Flex>
     ))}
-  </FlexRow>
+  </Flex>
 );
 
 const EventBox = ({ fields }: FieldProps) => (
-  <FlexRow className={styles.checkboxWrapper}>
+  <Flex column className={styles.checkboxWrapper}>
     {fields.map((key, index) => (
-      <div key={index} className={styles.checkbox}>
+      <Flex key={index}>
         <div className={styles.checkboxField}>
           <Field
             key={`events[${index}]`}
@@ -87,15 +88,15 @@ const EventBox = ({ fields }: FieldProps) => (
         <span className={styles.checkboxSpan}>
           {EVENT_TYPES[eventToString(key)]}
         </span>
-      </div>
+      </Flex>
     ))}
-  </FlexRow>
+  </Flex>
 );
 
 const OtherBox = ({ fields }: FieldProps) => (
-  <FlexRow className={styles.checkboxWrapper}>
+  <Flex column className={styles.checkboxWrapper}>
     {fields.map((key, index) => (
-      <div key={index} className={styles.checkbox}>
+      <Flex key={index}>
         <div className={styles.checkboxField}>
           <Field
             key={`otherOffers[${index}]`}
@@ -107,9 +108,9 @@ const OtherBox = ({ fields }: FieldProps) => (
         <span className={styles.checkboxSpan}>
           {OTHER_TYPES[otherOffersToString(key)]}
         </span>
-      </div>
+      </Flex>
     ))}
-  </FlexRow>
+  </Flex>
 );
 
 type Props = FieldProps & {
@@ -183,25 +184,28 @@ const CompanyInterestPage = (props: Props) => {
           component={TextInput.Field}
         />
 
-        <FlexColumn>
-          <label htmlFor="semesters" className={styles.heading}>
-            Semester
-          </label>
+        <Flex justifyContent="space-between">
+          <Flex column>
+            <label htmlFor="semesters" className={styles.heading}>
+              Semester
+            </label>
+            <FieldArray name="semesters" component={SemesterBox} />
+          </Flex>
 
-          <FieldArray name="semesters" component={SemesterBox} />
+          <Flex column>
+            <label htmlFor="events" className={styles.heading}>
+              Arrangementer
+            </label>
+            <FieldArray name="events" component={EventBox} />
+          </Flex>
 
-          <label htmlFor="events" className={styles.heading}>
-            Arrangementer
-          </label>
-
-          <FieldArray name="events" component={EventBox} />
-
-          <label htmlFor="otherOffers" className={styles.heading}>
-            Annet
-          </label>
-
-          <FieldArray name="otherOffers" component={OtherBox} />
-        </FlexColumn>
+          <Flex column>
+            <label htmlFor="otherOffers" className={styles.heading}>
+              Annet
+            </label>
+            <FieldArray name="otherOffers" component={OtherBox} />
+          </Flex>
+        </Flex>
 
         <Field
           placeholder="Skriv eventuell kommentar"
@@ -211,7 +215,7 @@ const CompanyInterestPage = (props: Props) => {
           label="Kommentar"
         />
 
-        <FlexColumn className={styles.content}>
+        <Flex column className={styles.content}>
           <FlexItem />
           <FlexItem>
             <Button type="submit" submit className={styles.createButton}>
@@ -220,7 +224,7 @@ const CompanyInterestPage = (props: Props) => {
                 : 'Opprett bedriftsinteresse'}
             </Button>
           </FlexItem>
-        </FlexColumn>
+        </Flex>
       </Form>
     </Content>
   );

--- a/app/routes/companyInterest/components/CompanyInterestPage.js
+++ b/app/routes/companyInterest/components/CompanyInterestPage.js
@@ -43,7 +43,7 @@ const SEMESTER_TRANSLATION = {
   autumn: 'Høst'
 };
 
-const semesterToText = semesterObject =>
+export const semesterToText = semesterObject =>
   `${SEMESTER_TRANSLATION[semesterObject.semester]} ${semesterObject.year}`;
 
 const SemesterBox = ({ fields }: FieldProps) => (

--- a/app/routes/companyInterest/components/CompanyInterestPage.js
+++ b/app/routes/companyInterest/components/CompanyInterestPage.js
@@ -14,6 +14,7 @@ import type { FieldProps } from 'redux-form';
 import Flex from 'app/components/Layout/Flex';
 import { Content } from 'app/components/Content';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
+import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 
 import { createValidator, required, isEmail } from 'app/utils/validation';
 
@@ -22,7 +23,7 @@ export const EVENT_TYPES = {
   lunch_presentation: 'Lunsjpresentasjon',
   course: 'Faglig arrangement',
   bedex: 'Bedex',
-  other: 'Annet'
+  other: 'Alternativt arrangement'
 };
 
 export const OTHER_TYPES = {
@@ -43,13 +44,7 @@ const SEMESTER_TRANSLATION = {
   autumn: 'Høst'
 };
 
-type companySemester = {
-  id: number,
-  semester: number,
-  year: number
-};
-
-export const semesterToText = (semester: companySemester) =>
+export const semesterToText = (semester: CompanySemesterEntity) =>
   `${SEMESTER_TRANSLATION[semester.semester]} ${semester.year}`;
 
 const SemesterBox = ({ fields }: FieldProps) => (
@@ -117,7 +112,7 @@ type Props = FieldProps & {
   onSubmit: CompanyInterestEntity => Promise<*>,
   push: string => void,
   events: Array<Object>,
-  semesters: Array<Object>,
+  semesters: Array<CompanySemesterEntity>,
   otherOffers: Array<Object>,
   edit: boolean,
   companyInterest?: CompanyInterestEntity
@@ -212,6 +207,15 @@ const CompanyInterestPage = (props: Props) => {
             <FieldArray name="otherOffers" component={OtherBox} />
           </Flex>
         </Flex>
+
+        <div className={styles.underline}>
+          Vi i Abakus ønsker å kunne tilby et bredt spekter av arrangementer som
+          er gunstig for våre studenter. Dersom dere ønsker noe utenfor de
+          vanlige rammene, huk gjerne av på {'"Alternativt arrangement"'} og
+          skriv en kommentar om hva dere kunne tenkt dere å gjøre i
+          kommentarfeltet. Kommentarfeltet kan også brukes til å spesifisere
+          annen informasjon.
+        </div>
 
         <Field
           placeholder="Skriv eventuell kommentar"

--- a/app/routes/companyInterest/components/CompanyInterestPage.js
+++ b/app/routes/companyInterest/components/CompanyInterestPage.js
@@ -11,7 +11,6 @@ import {
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { reduxForm, Field, SubmissionError, FieldArray } from 'redux-form';
 import type { FieldProps } from 'redux-form';
-import { FlexItem } from 'app/components/FlexBox';
 import Flex from 'app/components/Layout/Flex';
 import { Content } from 'app/components/Content';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
@@ -170,26 +169,33 @@ const CompanyInterestPage = (props: Props) => {
           placeholder="Bedriftsnavn"
           name="companyName"
           component={TextInput.Field}
+          required
         />
         <Field
           label="Kontaktperson"
           placeholder="Ola Nordmann"
           name="contactPerson"
           component={TextInput.Field}
+          required
         />
         <Field
           label="Mail"
           placeholder="example@gmail.com"
           name="mail"
           component={TextInput.Field}
+          required
         />
 
-        <Flex justifyContent="space-between">
+        <Flex wrap justifyContent="space-between">
           <Flex column>
             <label htmlFor="semesters" className={styles.heading}>
               Semester
             </label>
-            <FieldArray name="semesters" component={SemesterBox} />
+            <FieldArray
+              label="semesters"
+              name="semesters"
+              component={SemesterBox}
+            />
           </Flex>
 
           <Flex column>
@@ -216,14 +222,11 @@ const CompanyInterestPage = (props: Props) => {
         />
 
         <Flex column className={styles.content}>
-          <FlexItem />
-          <FlexItem>
-            <Button type="submit" submit className={styles.createButton}>
-              {props.edit
-                ? 'Oppdater bedriftsinteresse'
-                : 'Opprett bedriftsinteresse'}
-            </Button>
-          </FlexItem>
+          <Button type="submit" submit className={styles.createButton}>
+            {props.edit
+              ? 'Oppdater bedriftsinteresse'
+              : 'Opprett bedriftsinteresse'}
+          </Button>
         </Flex>
       </Form>
     </Content>

--- a/app/routes/companyInterest/components/CompanyInterestPage.js
+++ b/app/routes/companyInterest/components/CompanyInterestPage.js
@@ -43,8 +43,14 @@ const SEMESTER_TRANSLATION = {
   autumn: 'Høst'
 };
 
-export const semesterToText = semesterObject =>
-  `${SEMESTER_TRANSLATION[semesterObject.semester]} ${semesterObject.year}`;
+type companySemester = {
+  id: number,
+  semester: number,
+  year: number
+};
+
+export const semesterToText = (semester: companySemester) =>
+  `${SEMESTER_TRANSLATION[semester.semester]} ${semester.year}`;
 
 const SemesterBox = ({ fields }: FieldProps) => (
   <FlexRow className={styles.checkboxWrapper}>

--- a/app/routes/companyInterest/components/CompanySemesterGUI.js
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.js
@@ -22,10 +22,10 @@ type Props = FieldProps & {
   onSubmit: CompanySemesterEntity => Promise<*>,
   push: string => void,
   events: Array<Object>,
-  semesters: Array<Object>,
+  semesters: Array<CompanySemesterEntity>,
   autoFocus: any,
   edit: boolean,
-  editSemester: (Array<Object>) => void
+  editSemester: CompanySemesterEntity => void
 };
 
 const CompanySemesterGUI = (props: Props) => {

--- a/app/routes/companyInterest/components/CompanySemesterGUI.js
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.js
@@ -2,15 +2,17 @@
 
 import React from 'react';
 import type { FieldProps } from 'redux-form';
+import { reduxForm } from 'redux-form';
 import { Field } from 'redux-form';
 import { Content } from 'app/components/Content';
-import { semesterToText } from 'app/routes/companyInterest/components/companyInterestPage';
+import { semesterToText } from 'app/routes/companyInterest/components/CompanyInterestPage';
 import styles from './CompanyInterest.css';
 import { Form } from 'app/components/Form';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import { FlexRow } from 'app/components/FlexBox';
 import Icon from 'app/components/Icon';
 import { TextInput, RadioButton, RadioButtonGroup } from 'app/components/Form';
+import Button from 'app/components/Button';
 
 type Props = FieldProps & {
   actionGrant: Array<String>,
@@ -20,12 +22,12 @@ type Props = FieldProps & {
   semesters: Array<Object>,
   autoFocus: any,
   edit: boolean,
-  toggleActiveSemester: (Array<Object>) => void
+  editSemester: (Array<Object>) => void
 };
 
 const CompanySemesterGUI = (props: Props) => {
   const onSubmit = ({ year, semester }: CompanySemesterEntity) => {
-    const { companySemesters, addSemester, toggleActiveSemester } = props;
+    const { companySemesters, addSemester, editSemester } = props;
     const existingCompanySemester = companySemesters.find(companySemester => {
       return (
         companySemester.year == Number(year) &&
@@ -33,11 +35,12 @@ const CompanySemesterGUI = (props: Props) => {
       );
     });
 
-    if (existingCompanySemester) {
-      return toggleActiveSemester(existingCompanySemester);
-    } else {
-      return addSemester({ year, semester }); // Default is activeInterestForm: true
-    }
+    if (existingCompanySemester)
+      return editSemester({
+        ...existingCompanySemester,
+        activeInterestForm: true
+      });
+    else return addSemester({ year, semester }); // Default is activeInterestForm: true
   };
 
   const activeSemesters = semesters => (
@@ -46,7 +49,12 @@ const CompanySemesterGUI = (props: Props) => {
         <div key={index} className={styles.checkbox}>
           <Icon
             name="close-circle"
-            onClick={() => props.toggleActiveSemester(semester.id)}
+            onClick={() =>
+              props.editSemester({
+                ...semester,
+                activeInterestForm: false
+              })
+            }
             className={styles.remove}
           />
           <span className={styles.checkboxSpan}>
@@ -57,11 +65,11 @@ const CompanySemesterGUI = (props: Props) => {
     </FlexRow>
   );
 
-  const { autoFocus } = props;
+  const { handleSubmit, autoFocus } = props;
 
   return (
     <Content>
-      <Form onSubmit={props.handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit(onSubmit)}>
         <label className={styles.heading}>Legg til aktivt semester</label>
         <Field
           autoFocus={autoFocus}
@@ -86,11 +94,15 @@ const CompanySemesterGUI = (props: Props) => {
             />
           </RadioButtonGroup>
         </div>
+        <Button onClick={props.addSemester}>Legg til semester</Button>
         <label className={styles.heading}>Deaktiver semestre</label>
-        {activeSemesters}
+        {activeSemesters(props.semesters)}
       </Form>
     </Content>
   );
 };
 
-export default CompanySemesterGUI;
+export default reduxForm({
+  form: 'addCompanySemester',
+  enableReinitialize: true
+})(CompanySemesterGUI);

--- a/app/routes/companyInterest/components/CompanySemesterGUI.js
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import type { FieldProps } from 'redux-form';
+import { Field } from 'redux-form';
 import { Content } from 'app/components/Content';
 import { semesterToText } from 'app/routes/companyInterest/components/companyInterestPage';
 import styles from './CompanyInterest.css';
@@ -9,6 +10,7 @@ import { Form } from 'app/components/Form';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import { FlexRow } from 'app/components/FlexBox';
 import Icon from 'app/components/Icon';
+import { TextInput, RadioButton, RadioButtonGroup } from 'app/components/Form';
 
 type Props = FieldProps & {
   actionGrant: Array<String>,
@@ -16,6 +18,7 @@ type Props = FieldProps & {
   push: string => void,
   events: Array<Object>,
   semesters: Array<Object>,
+  autoFocus: any,
   edit: boolean,
   toggleActiveSemester: (Array<Object>) => void
 };
@@ -31,7 +34,7 @@ const CompanySemesterGUI = (props: Props) => {
     });
 
     if (existingCompanySemester) {
-      return toggleActiveSemester(existingCompanySemester.id);
+      return toggleActiveSemester(existingCompanySemester);
     } else {
       return addSemester({ year, semester }); // Default is activeInterestForm: true
     }
@@ -53,11 +56,37 @@ const CompanySemesterGUI = (props: Props) => {
       ))}
     </FlexRow>
   );
+
+  const { autoFocus } = props;
+
   return (
     <Content>
       <Form onSubmit={props.handleSubmit(onSubmit)}>
         <label className={styles.heading}>Legg til aktivt semester</label>
-        <label className={styles.heading}>Deaktiver aktive semestre</label>
+        <Field
+          autoFocus={autoFocus}
+          placeholder="2020"
+          label="År"
+          name="year"
+          type="number"
+          component={TextInput.Field}
+          className={styles.yearForm}
+        />
+        <div className={styles.choices}>
+          <RadioButtonGroup name="semester" label="Semester">
+            <Field
+              label="Vår"
+              component={RadioButton.Field}
+              inputValue="spring"
+            />
+            <Field
+              label="Høst"
+              component={RadioButton.Field}
+              inputValue="autumn"
+            />
+          </RadioButtonGroup>
+        </div>
+        <label className={styles.heading}>Deaktiver semestre</label>
         {activeSemesters}
       </Form>
     </Content>

--- a/app/routes/companyInterest/components/CompanySemesterGUI.js
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.js
@@ -1,0 +1,67 @@
+// @flow
+
+import React from 'react';
+import type { FieldProps } from 'redux-form';
+import { Content } from 'app/components/Content';
+import { semesterToText } from 'app/routes/companyInterest/components/companyInterestPage';
+import styles from './CompanyInterest.css';
+import { Form } from 'app/components/Form';
+import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
+import { FlexRow } from 'app/components/FlexBox';
+import Icon from 'app/components/Icon';
+
+type Props = FieldProps & {
+  actionGrant: Array<String>,
+  onSubmit: CompanySemesterEntity => Promise<*>,
+  push: string => void,
+  events: Array<Object>,
+  semesters: Array<Object>,
+  edit: boolean,
+  toggleActiveSemester: (Array<Object>) => void
+};
+
+const CompanySemesterGUI = (props: Props) => {
+  const onSubmit = ({ year, semester }: CompanySemesterEntity) => {
+    const { companySemesters, addSemester, toggleActiveSemester } = props;
+    const existingCompanySemester = companySemesters.find(companySemester => {
+      return (
+        companySemester.year == Number(year) &&
+        companySemester.semester == semester
+      );
+    });
+
+    if (existingCompanySemester) {
+      return toggleActiveSemester(existingCompanySemester.id);
+    } else {
+      return addSemester({ year, semester }); // Default is activeInterestForm: true
+    }
+  };
+
+  const activeSemesters = semesters => (
+    <FlexRow className={styles.checkboxWrapper}>
+      {semesters.map((semester, index) => (
+        <div key={index} className={styles.checkbox}>
+          <Icon
+            name="close-circle"
+            onClick={() => props.toggleActiveSemester(semester.id)}
+            className={styles.remove}
+          />
+          <span className={styles.checkboxSpan}>
+            {semesterToText(semester)}
+          </span>
+        </div>
+      ))}
+    </FlexRow>
+  );
+  return (
+    <Content>
+      <Form onSubmit={props.handleSubmit(onSubmit)}>
+        <label className={styles.heading}>Legg til aktivt semester</label>
+        <label className={styles.heading}>Deaktiver aktive semestre</label>
+        {activeSemesters}
+      </Form>
+    </Content>
+  );
+};
+
+export default CompanySemesterGUI;

--- a/app/routes/companyInterest/components/CompanySemesterGUI.js
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.js
@@ -14,6 +14,8 @@ import Icon from 'app/components/Icon';
 import { TextInput, RadioButton, RadioButtonGroup } from 'app/components/Form';
 import Button from 'app/components/Button';
 import { legoForm } from 'app/components/Form/';
+import { SemesterNavigation } from 'app/routes/companyInterest/utils';
+import { createValidator, required } from 'app/utils/validation';
 
 type Props = FieldProps & {
   actionGrant: Array<String>,
@@ -51,6 +53,7 @@ const CompanySemesterGUI = (props: Props) => {
 
   return (
     <Content>
+      <SemesterNavigation title="Endre aktive semestre" />
       <Form onSubmit={handleSubmit}>
         <Flex className={styles.guiWrapper}>
           <Flex column style={{ marginRight: '50px' }}>
@@ -63,6 +66,7 @@ const CompanySemesterGUI = (props: Props) => {
               type="number"
               component={TextInput.Field}
               className={styles.yearForm}
+              required
             />
             <RadioButtonGroup name="semester" label="Semester">
               <Field
@@ -106,9 +110,15 @@ const onSubmit = ({ year, semester }, dispatch, props: Props) => {
   else return addSemester({ year, semester }); // Default is activeInterestForm: true
 };
 
+const validate = createValidator({
+  year: [required()],
+  semester: [required()]
+});
+
 export default legoForm({
   form: 'addCompanySemester',
   onSubmitSuccess: (result, dispatch) => dispatch(reset('addCompanySemester')),
   onSubmit,
-  enableReinitialize: true
+  enableReinitialize: true,
+  validate
 })(CompanySemesterGUI);

--- a/app/routes/companyInterest/index.js
+++ b/app/routes/companyInterest/index.js
@@ -14,12 +14,12 @@ export default [
         ...resolveAsyncRoute(() => import('./CompanyInterestRoute'))
       },
       {
-        path: ':companyInterestId/edit',
-        ...resolveAsyncRoute(() => import('./CompanyInterestEditRoute'))
-      },
-      {
         path: 'semesters',
         ...resolveAsyncRoute(() => import('./CompanySemesterGUIRoute'))
+      },
+      {
+        path: ':companyInterestId/edit',
+        ...resolveAsyncRoute(() => import('./CompanyInterestEditRoute'))
       }
     ]
   }

--- a/app/routes/companyInterest/index.js
+++ b/app/routes/companyInterest/index.js
@@ -18,7 +18,7 @@ export default [
         ...resolveAsyncRoute(() => import('./CompanyInterestEditRoute'))
       },
       {
-        path: 'editSemesters',
+        path: 'semesters',
         ...resolveAsyncRoute(() => import('./CompanySemesterGUIRoute'))
       }
     ]

--- a/app/routes/companyInterest/index.js
+++ b/app/routes/companyInterest/index.js
@@ -16,6 +16,10 @@ export default [
       {
         path: ':companyInterestId/edit',
         ...resolveAsyncRoute(() => import('./CompanyInterestEditRoute'))
+      },
+      {
+        path: 'editSemesters',
+        ...resolveAsyncRoute(() => import('./CompanySemesterGUIRoute'))
       }
     ]
   }

--- a/app/routes/companyInterest/utils.js
+++ b/app/routes/companyInterest/utils.js
@@ -1,4 +1,9 @@
-export const sortSemesterChronologically = (a, b) => {
+// @flow
+import React, { type Node } from 'react';
+import NavigationTab from 'app/components/NavigationTab';
+import NavigationLink from 'app/components/NavigationTab/NavigationLink';
+
+export const sortSemesterChronologically = (a: Object, b: Object) => {
   const semesterCodeToPriority = {
     spring: 0,
     autumn: 1
@@ -7,3 +12,11 @@ export const sortSemesterChronologically = (a, b) => {
     ? a.year - b.year
     : semesterCodeToPriority[a.semester] - semesterCodeToPriority[b.semester];
 };
+
+export const SemesterNavigation = ({ title }: { title: Node }) => (
+  <NavigationTab title={title}>
+    <NavigationLink to="/companyInterest/">Tilbake til skjema</NavigationLink>
+    <NavigationLink to="/bdb">BDB</NavigationLink>
+    <NavigationLink to="/bdb/add">Ny bedrift</NavigationLink>
+  </NavigationTab>
+);

--- a/app/routes/companyInterest/utils.js
+++ b/app/routes/companyInterest/utils.js
@@ -2,14 +2,18 @@
 import React, { type Node } from 'react';
 import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
+import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 
-export const sortSemesterChronologically = (a: Object, b: Object) => {
+export const sortSemesterChronologically = (
+  a: CompanySemesterEntity,
+  b: CompanySemesterEntity
+) => {
   const semesterCodeToPriority = {
     spring: 0,
     autumn: 1
   };
-  return a.year !== b.year
-    ? a.year - b.year
+  return Number(a.year) !== Number(b.year)
+    ? Number(a.year) - Number(b.year)
     : semesterCodeToPriority[a.semester] - semesterCodeToPriority[b.semester];
 };
 


### PR DESCRIPTION
![3e7893e0e0b4177f72e9225cba97c4e3](https://user-images.githubusercontent.com/22096331/36178397-f2285086-1118-11e8-9e89-8d64af28f193.gif)

This PR solves #831. It is now possible to add/activate and deactive semesters used in companyInterestForm. It is not possible to delete semesters, as an overflow of semesters will not be likely. 

The PR also fixes some styling for the companyInterestForm.

