### PR TITLE
Add border to editor

### DIFF
--- a/app/components/CommentForm/CommentForm.css
+++ b/app/components/CommentForm/CommentForm.css
@@ -57,3 +57,8 @@
   max-width: 150px;
   margin-top: 30px;
 }
+
+.fields > div {
+  border: none !important;
+  margin-bottom: -20px !important;
+}

--- a/app/components/Editor/Editor.css
+++ b/app/components/Editor/Editor.css
@@ -1,0 +1,8 @@
+:global {
+  .md-RichEditor-root {
+    padding: 5px 20px !important;
+    margin-top: 10px !important;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+  }
+}

--- a/app/components/Editor/index.js
+++ b/app/components/Editor/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import './Editor.css';
 import { convertToRaw } from 'draft-js';
 import 'medium-draft/lib/index.css';
 import {


### PR DESCRIPTION
From
<img width="1128" alt="skjermbilde 2018-02-19 kl 23 18 55" src="https://user-images.githubusercontent.com/14221386/36399251-4b8606d0-15cb-11e8-9a92-d4c441dfd0b1.png">

To
<img width="1138" alt="skjermbilde 2018-02-19 kl 23 17 03" src="https://user-images.githubusercontent.com/14221386/36399225-34673a96-15cb-11e8-8e19-7b3349d30eed.png">

Keeps comments without border, and aligns the elements better.

From
<img width="1059" alt="skjermbilde 2018-02-19 kl 23 20 56" src="https://user-images.githubusercontent.com/14221386/36399309-9eb3174e-15cb-11e8-87be-1d9d87411d9d.png">

and (focus)
<img width="1053" alt="skjermbilde 2018-02-19 kl 23 20 07" src="https://user-images.githubusercontent.com/14221386/36399316-a3c28468-15cb-11e8-806f-b57741c33401.png">

To
<img width="1060" alt="skjermbilde 2018-02-19 kl 23 17 30" src="https://user-images.githubusercontent.com/14221386/36399327-b0763c90-15cb-11e8-961d-a2a251d11589.png">

And
<img width="1076" alt="skjermbilde 2018-02-19 kl 23 17 19" src="https://user-images.githubusercontent.com/14221386/36399336-b809b298-15cb-11e8-8461-daa940516dde.png">

