### PR TITLE
Survey templates

### DIFF
--- a/app/actions/SurveyActions.js
+++ b/app/actions/SurveyActions.js
@@ -78,7 +78,7 @@ export function deleteSurvey(surveyId: number): Thunk<*> {
 export function fetchTemplates(): Thunk<*> {
   return callAPI({
     types: Survey.FETCH,
-    endpoint: `/surveys/templates/`,
+    endpoint: `/survey-templates/`,
     schema: [surveySchema],
     meta: {
       errorMessage: 'Henting av spørreundersøkelse maler feilet'
@@ -90,7 +90,7 @@ export function fetchTemplates(): Thunk<*> {
 export function fetchTemplate(template: string): Thunk<*> {
   return callAPI({
     types: Survey.FETCH,
-    endpoint: `/surveys/templates/${template}/`,
+    endpoint: `/survey-templates/${template}/`,
     schema: surveySchema,
     meta: {
       errorMessage: 'Henting av spørreundersøkelse mal feilet'

--- a/app/actions/SurveyActions.js
+++ b/app/actions/SurveyActions.js
@@ -74,3 +74,27 @@ export function deleteSurvey(surveyId: number): Thunk<*> {
     }
   });
 }
+
+export function fetchTemplates(): Thunk<*> {
+  return callAPI({
+    types: Survey.FETCH,
+    endpoint: `/surveys/templates/`,
+    schema: [surveySchema],
+    meta: {
+      errorMessage: 'Henting av spørreundersøkelse maler feilet'
+    },
+    propagateError: true
+  });
+}
+
+export function fetchTemplate(template: string): Thunk<*> {
+  return callAPI({
+    types: Survey.FETCH,
+    endpoint: `/surveys/templates/${template}/`,
+    schema: surveySchema,
+    meta: {
+      errorMessage: 'Henting av spørreundersøkelse mal feilet'
+    },
+    propagateError: true
+  });
+}

--- a/app/reducers/events.js
+++ b/app/reducers/events.js
@@ -218,6 +218,7 @@ export const selectEventById = createSelector(
   (state, props) => props.eventId,
   (eventsById, eventId) => {
     const event = eventsById[eventId];
+
     if (event) {
       return transformEvent(event);
     }

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -4,6 +4,7 @@ import { Survey } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { createSelector } from 'reselect';
 import { selectEvents } from './events';
+import { omit } from 'lodash';
 
 export type SurveyEntity = {
   id: number,
@@ -68,5 +69,30 @@ export const selectSurveyById = createSelector(
   (surveys, surveyId) => {
     const survey = surveys.find(survey => survey.id === surveyId);
     return survey || {};
+  }
+);
+
+export const selectSurveyTemplates = createSelector(
+  (state, props) => selectSurveys(state, props),
+  surveys => surveys.filter(survey => survey.templateType)
+);
+
+export const selectSurveyTemplate = createSelector(
+  (state, props) => selectSurveys(state, props),
+  (state, props) => props.templateType,
+  (surveys, templateType) => {
+    const template = surveys.find(
+      survey => survey.templateType === templateType
+    );
+    if (!template) return false;
+
+    const questions = template.questions.map(question => ({
+      ...omit(question, 'id'),
+      options: question.options.map(option => omit(option, 'id'))
+    }));
+    return {
+      ...omit(template, ['id', 'event', 'activeFrom']),
+      questions
+    };
   }
 );

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -86,12 +86,12 @@ export const selectSurveyTemplate = createSelector(
     );
     if (!template) return false;
 
-    const questions = template.questions.map(question => ({
+    const questions = (template.questions || []).map(question => ({
       ...omit(question, 'id'),
       options: question.options.map(option => omit(option, 'id'))
     }));
     return {
-      ...omit(template, ['id', 'event', 'activeFrom']),
+      ...omit(template, ['id', 'event', 'activeFrom', 'templateType']),
       questions
     };
   }

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -5,13 +5,15 @@ import createEntityReducer from 'app/utils/createEntityReducer';
 import { createSelector } from 'reselect';
 import { selectEvents } from './events';
 import { omit } from 'lodash';
+import type { EventType } from 'app/models';
 
 export type SurveyEntity = {
   id: number,
   title: string,
   event: any,
   activeFrom?: string,
-  questions: Array<QuestionEntity>
+  questions: Array<QuestionEntity>,
+  templateType?: EventType
 };
 
 export type QuestionEntity = {

--- a/app/routes/surveys/AddSubmissionRoute.js
+++ b/app/routes/surveys/AddSubmissionRoute.js
@@ -47,5 +47,5 @@ export default compose(
   replaceUnlessLoggedIn(LoginPage),
   prepare(loadData, ['params.surveyId', 'currentUser.id', 'notFetching']),
   connect(mapStateToProps, mapDispatchToProps),
-  loadingIndicator(['survey.questions', 'survey.event.cover'])
+  loadingIndicator(['survey.questions', 'survey.event'])
 )(SubmissionContainer);

--- a/app/routes/surveys/AddSurveyRoute.js
+++ b/app/routes/surveys/AddSurveyRoute.js
@@ -1,31 +1,85 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { addSurvey, deleteSurvey } from '../../actions/SurveyActions';
+import {
+  addSurvey,
+  deleteSurvey,
+  fetchTemplate
+} from '../../actions/SurveyActions';
 import SurveyEditor from './components/SurveyEditor/SurveyEditor';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { push } from 'react-router-redux';
-import moment from 'moment-timezone';
 import { initialQuestion } from './components/SurveyEditor/SurveyEditor';
+import prepare from 'app/utils/prepare';
+import { selectSurveyTemplate } from 'app/reducers/surveys';
+import { fetchEvent } from 'app/actions/EventActions';
+import { selectEventById } from 'app/reducers/events';
+import { defaultActiveFrom } from './utils';
 
-const time = (hours, minutes) =>
-  moment()
-    .startOf('day')
-    .add({ hours, minutes })
-    .toISOString();
+const loadData = (props, dispatch) => {
+  const { template, event } = props.location.query;
+  if (event) {
+    return dispatch(fetchEvent(event)).then(
+      result =>
+        result.success &&
+        dispatch(fetchTemplate(result.payload.entities.events[event].eventType))
+    );
+  }
+  if (template) {
+    return dispatch(fetchTemplate(template));
+  }
+};
 
 const mapStateToProps = (state, props) => {
-  return {
-    initialValues: {
-      activeFrom: time(12, 0),
-      event: '',
-      title: '',
-      isClone: true,
-      questions: [initialQuestion]
-    },
-    survey: {
-      questions: []
+  const notFetching = !state.surveys.fetching && !state.events.fetching;
+  const { templateType, event } = props.location.query;
+
+  const fullEvent = selectEventById(state, { eventId: event });
+
+  const template = selectSurveyTemplate(state, {
+    ...props,
+    templateType: templateType || fullEvent.eventType
+  });
+
+  const initialEvent = event
+    ? {
+        value: fullEvent.id,
+        label: fullEvent.title
+      }
+    : '';
+  const activeFrom = event ? fullEvent.endTime : defaultActiveFrom(12, 0);
+
+  let initialValues = null;
+  if (
+    !(
+      ((templateType || event) && !template) ||
+      (event && Object.keys(fullEvent).length === 0)
+    )
+  ) {
+    if (template) {
+      initialValues = {
+        ...template,
+        event: initialEvent,
+        activeFrom
+      };
+    } else {
+      initialValues = {
+        activeFrom,
+        event: initialEvent,
+        title: '',
+        questions: [initialQuestion]
+      };
     }
+  }
+
+  return {
+    template,
+    initialValues,
+    survey: {
+      questions: template ? template.questions : [],
+      event: event && fullEvent
+    },
+    notFetching
   };
 };
 
@@ -37,5 +91,10 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
+  prepare(loadData, [
+    'notFetching',
+    'location.query.template',
+    'location.query.event'
+  ]),
   connect(mapStateToProps, mapDispatchToProps)
 )(SurveyEditor);

--- a/app/routes/surveys/EditSurveyRoute.js
+++ b/app/routes/surveys/EditSurveyRoute.js
@@ -1,43 +1,77 @@
 import { connect } from 'react-redux';
 import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
-import { editSurvey, fetch, deleteSurvey } from '../../actions/SurveyActions';
+import {
+  editSurvey,
+  fetch,
+  deleteSurvey,
+  fetchTemplate
+} from '../../actions/SurveyActions';
 import SurveyEditor from './components/SurveyEditor/SurveyEditor';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
-import { selectSurveyById } from 'app/reducers/surveys';
+import { selectSurveyById, selectSurveyTemplate } from 'app/reducers/surveys';
 import { push } from 'react-router-redux';
 import loadingIndicator from 'app/utils/loadingIndicator';
+import { defaultActiveFrom } from './utils';
+
+const loadData = (props, dispatch) => {
+  const { surveyId } = props.params;
+  const template = props.location.query.template;
+  if (template) {
+    return Promise.all([
+      dispatch(fetchTemplate(template)),
+      dispatch(fetch(surveyId))
+    ]);
+  }
+  return dispatch(fetch(surveyId));
+};
 
 const mapStateToProps = (state, props) => {
   const surveyId = Number(props.params.surveyId);
   const survey = selectSurveyById(state, { surveyId });
+  const templateType = props.location.query.template;
+  const template =
+    templateType && selectSurveyTemplate(state, { ...props, templateType });
+
+  let initialValues = null;
+  if (templateType) {
+    initialValues = {
+      ...template,
+      event: '',
+      activeFrom: defaultActiveFrom(12, 0)
+    };
+  } else if (survey) {
+    initialValues = {
+      ...survey,
+      event: survey.event && {
+        value: survey.event.id,
+        label: survey.event.title
+      },
+      questions:
+        survey.questions &&
+        survey.questions.map(
+          question =>
+            question.options
+              ? {
+                  ...question,
+                  options: question.options.concat({ optionText: '' })
+                }
+              : question
+        )
+    };
+  }
+
+  const surveyToSend = templateType
+    ? { questions: template.questions }
+    : survey;
 
   return {
-    survey,
+    surveyToSend,
     surveyId,
     fetching: state.surveys.fetching,
-    initialValues: survey
-      ? {
-          ...survey,
-          event: survey.event && {
-            value: survey.event.id,
-            label: survey.event.title
-          },
-          questions:
-            survey.questions &&
-            survey.questions.map(
-              question =>
-                question.options
-                  ? {
-                      ...question,
-                      options: question.options.concat({ optionText: '' })
-                    }
-                  : question
-            ),
-          isClone: !!survey.isClone
-        }
-      : null
+    templateType,
+    initialValues
   };
 };
 
@@ -49,9 +83,7 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  prepare(({ params: { surveyId } }, dispatch) => dispatch(fetch(surveyId)), [
-    'params.surveyId'
-  ]),
+  prepare(loadData, ['params.surveyId', 'template']),
   connect(mapStateToProps, mapDispatchToProps),
   loadingIndicator(['survey.questions', 'survey.event.cover'])
 )(SurveyEditor);

--- a/app/routes/surveys/EditSurveyRoute.js
+++ b/app/routes/surveys/EditSurveyRoute.js
@@ -31,8 +31,7 @@ const mapStateToProps = (state, props) => {
   const surveyId = Number(props.params.surveyId);
   const survey = selectSurveyById(state, { surveyId });
   const templateType = props.location.query.template;
-  const template =
-    templateType && selectSurveyTemplate(state, { ...props, templateType });
+  const template = selectSurveyTemplate(state, { ...props, templateType });
 
   let initialValues = null;
   if (templateType) {

--- a/app/routes/surveys/SubmissionsRoute.js
+++ b/app/routes/surveys/SubmissionsRoute.js
@@ -30,7 +30,7 @@ const mapStateToProps = (state, props) => {
   return {
     survey: selectSurveyById(state, { surveyId }),
     submissions: selectSurveySubmissions(state, { surveyId }),
-    notFetching: !state.surveys.fetching,
+    notFetching: !state.surveys.fetching && !state.surveySubmissions.fetching,
     actionGrant: state.surveys.actionGrant,
     isSummary
   };
@@ -47,10 +47,5 @@ export default compose(
   replaceUnlessLoggedIn(LoginPage),
   prepare(loadData),
   connect(mapStateToProps, mapDispatchToProps),
-  loadingIndicator([
-    'notFetching',
-    'survey.event.cover',
-    'survey.questions',
-    'submissions'
-  ])
+  loadingIndicator(['notFetching', 'survey.event', 'survey.questions'])
 )(SubmissionPage);

--- a/app/routes/surveys/SurveyDetailRoute.js
+++ b/app/routes/surveys/SurveyDetailRoute.js
@@ -31,5 +31,5 @@ export default compose(
   replaceUnlessLoggedIn(LoginPage),
   prepare(loadData, ['params.surveyId']),
   connect(mapStateToProps, mapDispatchToProps),
-  loadingIndicator(['survey.questions', 'survey.event.cover'])
+  loadingIndicator(['survey.questions', 'survey.event'])
 )(SurveyDetail);

--- a/app/routes/surveys/SurveyRoute.js
+++ b/app/routes/surveys/SurveyRoute.js
@@ -26,5 +26,5 @@ export default compose(
   replaceUnlessLoggedIn(LoginPage),
   prepare(loadData),
   connect(mapStateToProps, mapDispatchToProps),
-  loadingIndicator(['notFetching', 'surveys'])
+  loadingIndicator(['notFetching'])
 )(SurveyPage);

--- a/app/routes/surveys/TemplatesRoute.js
+++ b/app/routes/surveys/TemplatesRoute.js
@@ -30,5 +30,5 @@ export default compose(
   replaceUnlessLoggedIn(LoginPage),
   prepare(loadData),
   connect(mapStateToProps, mapDispatchToProps),
-  loadingIndicator(['notFetching', 'surveys'])
+  loadingIndicator(['notFetching'])
 )(SurveyPage);

--- a/app/routes/surveys/TemplatesRoute.js
+++ b/app/routes/surveys/TemplatesRoute.js
@@ -1,18 +1,22 @@
 import { connect } from 'react-redux';
 import prepare from 'app/utils/prepare';
-import { fetchAll, addSurvey, deleteSurvey } from '../../actions/SurveyActions';
+import {
+  addSurvey,
+  deleteSurvey,
+  fetchTemplates
+} from '../../actions/SurveyActions';
 import SurveyPage from './components/SurveyList/SurveyPage';
 import { compose } from 'redux';
-import { selectSurveys } from 'app/reducers/surveys';
+import { selectSurveyTemplates } from 'app/reducers/surveys';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { push } from 'react-router-redux';
 import loadingIndicator from 'app/utils/loadingIndicator';
 
-const loadData = (props, dispatch) => dispatch(fetchAll());
+const loadData = (props, dispatch) => dispatch(fetchTemplates());
 
 const mapStateToProps = (state, props) => ({
-  surveys: selectSurveys(state, props).filter(survey => !survey.templateType),
+  surveys: selectSurveyTemplates(state, props),
   notFetching: !state.surveys.fetching
 });
 

--- a/app/routes/surveys/components/SurveyDetail.js
+++ b/app/routes/surveys/components/SurveyDetail.js
@@ -42,23 +42,28 @@ class SurveyDetail extends Component<Props> {
 
         <ContentSection>
           <ContentMain>
-            <div className={styles.surveyTime}>
-              Spørreundersøkelse for{' '}
-              <Link to={`/events/${survey.event.id}`}>
-                {survey.event.title}
-              </Link>
-            </div>
+            {survey.templateType ? (
+              <h2 style={{ color: 'red' }}>Dette er en mal!</h2>
+            ) : (
+              <div>
+                <div className={styles.surveyTime}>
+                  Spørreundersøkelse for{' '}
+                  <Link to={`/events/${survey.event.id}`}>
+                    {survey.event.title}
+                  </Link>
+                </div>
 
-            <div className={styles.surveyTime}>
-              Aktiv fra <Time time={survey.activeFrom} format="ll HH:mm" />
-            </div>
+                <div className={styles.surveyTime}>
+                  Aktiv fra <Time time={survey.activeFrom} format="ll HH:mm" />
+                </div>
 
-            <Link to={`/surveys/${survey.id}/answer`}>
-              <Button style={{ marginTop: '30px' }}>
-                Svar på undersøkelsen
-              </Button>
-            </Link>
-
+                <Link to={`/surveys/${survey.id}/answer`}>
+                  <Button style={{ marginTop: '30px' }}>
+                    Svar på undersøkelsen
+                  </Button>
+                </Link>
+              </div>
+            )}
             <StaticSubmission survey={survey} />
           </ContentMain>
 

--- a/app/routes/surveys/components/SurveyDetail.js
+++ b/app/routes/surveys/components/SurveyDetail.js
@@ -45,7 +45,7 @@ class SurveyDetail extends Component<Props> {
           <ContentMain>
             {survey.templateType ? (
               <h2 style={{ color: 'red' }}>
-                Dette er en mal for arrangementer av type{' '}
+                Dette er malen for arrangementer av type{' '}
                 {eventTypes[String(survey.templateType)]}
               </h2>
             ) : (

--- a/app/routes/surveys/components/SurveyDetail.js
+++ b/app/routes/surveys/components/SurveyDetail.js
@@ -11,6 +11,7 @@ import type { ActionGrant } from 'app/models';
 import AdminSideBar from './AdminSideBar';
 import Button from 'app/components/Button';
 import StaticSubmission from './StaticSubmission';
+import { eventTypes } from 'app/routes/events/utils';
 
 type Props = {
   survey: SurveyEntity,
@@ -43,7 +44,10 @@ class SurveyDetail extends Component<Props> {
         <ContentSection>
           <ContentMain>
             {survey.templateType ? (
-              <h2 style={{ color: 'red' }}>Dette er en mal!</h2>
+              <h2 style={{ color: 'red' }}>
+                Dette er en mal for arrangementer av type{' '}
+                {eventTypes[String(survey.templateType)]}
+              </h2>
             ) : (
               <div>
                 <div className={styles.surveyTime}>

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
@@ -64,7 +64,7 @@ function TemplateTypeDropdownItems({
               e.stopPropagation();
               if (
                 confirm(
-                  'Dette vil slette alle uendrete lagringer i undersøkelsen!' +
+                  'Dette vil slette alle uendrete lagringer i undersøkelsen!\n' +
                     'Lagrete endringer vil ikke overskrives før du trykker Lagre.'
                 )
               ) {

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
@@ -51,8 +51,8 @@ function TemplateTypeDropdownItems({
 }: TemplateTypeDropdownItemsProps) {
   const link = eventType =>
     survey && survey.id
-      ? `/surveys/${survey.id}/edit/?template=${eventType}`
-      : `/surveys/add/?template=${eventType}`;
+      ? `/surveys/${survey.id}/edit/?templateType=${eventType}`
+      : `/surveys/add/?templateType=${eventType}`;
 
   return (
     <Dropdown.List>

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
@@ -61,9 +61,11 @@ function TemplateTypeDropdownItems({
           <Link
             onClick={e => {
               e.preventDefault();
+              e.stopPropagation();
               if (
                 confirm(
-                  'Dette vil slette alle uendrete lagringer i undersøkelsen!'
+                  'Dette vil slette alle uendrete lagringer i undersøkelsen!' +
+                    'Lagrete endringer vil ikke overskrives før du trykker Lagre.'
                 )
               ) {
                 destroy();
@@ -146,23 +148,30 @@ class SurveyEditor extends Component<Props, State> {
             />
           </Dropdown>
 
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <Field
-              placeholder="Bekk Miniseminar"
-              label="Arrangement"
-              autoFocus={autoFocus}
-              name="event"
-              component={SelectInput.AutocompleteField}
-              className={styles.editEvent}
-              filter={['events.event']}
-            />
+          {survey.templateType ? (
+            <h2 style={{ color: 'red' }}>
+              Dette er malen for arrangementer av type{' '}
+              {eventTypes[String(survey.templateType)]}
+            </h2>
+          ) : (
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Field
+                placeholder="Bekk Miniseminar"
+                label="Arrangement"
+                autoFocus={autoFocus}
+                name="event"
+                component={SelectInput.AutocompleteField}
+                className={styles.editEvent}
+                filter={['events.event']}
+              />
 
-            <Field
-              label="Aktiveringstidspunkt"
-              name="activeFrom"
-              component={DatePicker.Field}
-            />
-          </div>
+              <Field
+                label="Aktiveringstidspunkt"
+                name="activeFrom"
+                component={DatePicker.Field}
+              />
+            </div>
+          )}
 
           <FieldArray
             name="questions"

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
@@ -1,14 +1,13 @@
 // @flow
 
 import styles from '../surveys.css';
-import React from 'react';
+import React, { Component } from 'react';
 import { DetailNavigation, ListNavigation, QuestionTypes } from '../../utils';
 import Question from './Question';
 import { Field, FieldArray } from 'redux-form';
 import Button from 'app/components/Button';
 import {
   TextInput,
-  CheckBox,
   SelectInput,
   DatePicker,
   legoForm
@@ -19,6 +18,8 @@ import { Content } from 'app/components/Content';
 import type { FieldProps } from 'redux-form';
 import Icon from 'app/components/Icon';
 import { Link } from 'react-router';
+import Dropdown from 'app/components/Dropdown';
+import { eventTypes } from 'app/routes/events/utils';
 
 type Props = FieldProps & {
   survey: SurveyEntity,
@@ -26,81 +27,158 @@ type Props = FieldProps & {
   surveyData: Array<Object>,
   submitFunction: (SurveyEntity, ?number) => Promise<*>,
   deleteSurvey: number => Promise<*>,
-  push: string => void
+  push: string => void,
+  template?: Object,
+  destroy: () => void,
+  initialize: () => void
 };
 
-const SurveyEditor = ({
+type State = {
+  templatePickerOpen: boolean,
+  templateTypeSelected: string
+};
+
+type TemplateTypeDropdownItemsProps = {
+  survey?: Object,
+  push: string => void,
+  destroy: () => void
+};
+
+function TemplateTypeDropdownItems({
   survey,
-  submitting,
-  autoFocus,
-  handleSubmit,
-  deleteSurvey
-}: Props) => {
-  const titleField = (
-    <Field
-      placeholder="Tittel"
-      label=" "
-      autoFocus={autoFocus}
-      name="title"
-      component={TextInput.Field}
-      className={styles.editTitle}
-    />
-  );
+  push,
+  destroy
+}: TemplateTypeDropdownItemsProps) {
+  const link = eventType =>
+    survey && survey.id
+      ? `/surveys/${survey.id}/edit/?template=${eventType}`
+      : `/surveys/add/?template=${eventType}`;
 
   return (
-    <Content className={styles.detail}>
-      <form onSubmit={handleSubmit}>
-        {survey && survey.id ? (
-          <DetailNavigation
-            title={titleField}
-            surveyId={Number(survey.id)}
-            deleteFunction={deleteSurvey}
-          />
-        ) : (
-          <ListNavigation title={titleField} />
-        )}
-
-        <div className={styles.checkBox}>
-          <Field
-            name="isClone"
-            label="Klone av en annen undersøkelse?"
-            component={CheckBox.Field}
-            normalize={v => !!v}
-          />
-        </div>
-
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <Field
-            placeholder="Bekk Miniseminar"
-            label="Arrangement"
-            autoFocus={autoFocus}
-            name="event"
-            component={SelectInput.AutocompleteField}
-            className={styles.editEvent}
-            filter={['events.event']}
-          />
-
-          <Field
-            label="Aktiveringstidspunkt"
-            name="activeFrom"
-            component={DatePicker.Field}
-          />
-        </div>
-
-        <FieldArray
-          name="questions"
-          component={renderQuestions}
-          rerenderOnEveryChange={true}
-        />
-
-        <div className={styles.clear} />
-        <Button className={styles.submit} disabled={submitting} submit>
-          Lagre
-        </Button>
-      </form>
-    </Content>
+    <Dropdown.List>
+      {Object.keys(eventTypes).map(eventType => (
+        <Dropdown.ListItem key={eventType}>
+          <Link
+            onClick={e => {
+              e.preventDefault();
+              if (
+                confirm(
+                  'Dette vil slette alle uendrete lagringer i undersøkelsen!'
+                )
+              ) {
+                destroy();
+                push(link(eventType));
+              }
+            }}
+          >
+            {eventTypes[eventType]}
+          </Link>
+        </Dropdown.ListItem>
+      ))}
+    </Dropdown.List>
   );
-};
+}
+
+class SurveyEditor extends Component<Props, State> {
+  state: State = {
+    templatePickerOpen: false,
+    templateTypeSelected: ''
+  };
+
+  render() {
+    const {
+      survey,
+      submitting,
+      autoFocus,
+      handleSubmit,
+      deleteSurvey,
+      template,
+      push,
+      destroy
+    } = this.props;
+
+    const titleField = (
+      <Field
+        placeholder="Tittel"
+        label=" "
+        autoFocus={autoFocus}
+        name="title"
+        component={TextInput.Field}
+        className={styles.editTitle}
+      />
+    );
+
+    return (
+      <Content className={styles.detail}>
+        <form onSubmit={handleSubmit}>
+          {survey && survey.id ? (
+            <DetailNavigation
+              title={titleField}
+              surveyId={Number(survey.id)}
+              deleteFunction={deleteSurvey}
+            />
+          ) : (
+            <ListNavigation title={titleField} />
+          )}
+
+          <Dropdown
+            show={this.state.templatePickerOpen}
+            toggle={() => {
+              this.setState(state => ({
+                templatePickerOpen: !state.templatePickerOpen
+              }));
+            }}
+            triggerComponent={
+              <Button
+                className={styles.templatePicker}
+                onClick={e => {
+                  e.preventDefault();
+                }}
+              >
+                {template ? 'Bytt mal' : 'Bruk mal'}
+              </Button>
+            }
+          >
+            <TemplateTypeDropdownItems
+              survey={survey}
+              push={push}
+              destroy={destroy}
+            />
+          </Dropdown>
+
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Field
+              placeholder="Bekk Miniseminar"
+              label="Arrangement"
+              autoFocus={autoFocus}
+              name="event"
+              component={SelectInput.AutocompleteField}
+              className={styles.editEvent}
+              filter={['events.event']}
+            />
+
+            <Field
+              label="Aktiveringstidspunkt"
+              name="activeFrom"
+              component={DatePicker.Field}
+            />
+          </div>
+
+          <FieldArray
+            name="questions"
+            component={renderQuestions}
+            rerenderOnEveryChange={true}
+          />
+
+          <div className={styles.clear} />
+          <Button className={styles.submit} disabled={submitting} submit>
+            Lagre
+          </Button>
+        </form>
+      </Content>
+    );
+  }
+}
 
 const renderQuestions = ({ fields, meta: { touched, error } }) => {
   return [
@@ -126,12 +204,14 @@ const renderQuestions = ({ fields, meta: { touched, error } }) => {
     </Link>
   ];
 };
+
 export const initialQuestion = {
   questionText: '',
   questionType: QuestionTypes('single'),
   mandatory: false,
   options: [{ optionText: '' }]
 };
+
 const validate = createValidator({
   title: [required()],
   event: [required()]

--- a/app/routes/surveys/components/SurveyList/SurveyItem.js
+++ b/app/routes/surveys/components/SurveyList/SurveyItem.js
@@ -25,14 +25,24 @@ const SurveyItem = (props: Props) => {
           <h3 className={styles.surveyItemTitle}>{survey.title}</h3>
         </Link>
 
-        <div className={styles.surveyTime}>
-          For arrangement{' '}
-          <Link to={`/events/${survey.event.id}`}>{survey.event.title}</Link>
-        </div>
+        {survey.templateType ? (
+          <div className={styles.surveyTime}>
+            Mal for arrangement av type {String(survey.templateType)}
+          </div>
+        ) : (
+          <div>
+            <div className={styles.surveyTime}>
+              For arrangement{' '}
+              <Link to={`/events/${survey.event.id}`}>
+                {survey.event.title}
+              </Link>
+            </div>
 
-        <div className={styles.surveyTime}>
-          Aktiv fra <Time time={survey.activeFrom} format="ll HH:mm" />
-        </div>
+            <div className={styles.surveyTime}>
+              Aktiv fra <Time time={survey.activeFrom} format="ll HH:mm" />
+            </div>
+          </div>
+        )}
       </div>
 
       <div className={styles.companyLogo}>

--- a/app/routes/surveys/components/SurveyList/SurveyItem.js
+++ b/app/routes/surveys/components/SurveyList/SurveyItem.js
@@ -18,7 +18,11 @@ const SurveyItem = (props: Props) => {
   return (
     <div
       className={styles.surveyItem}
-      style={{ borderColor: colorForEvent(survey.event.eventType) }}
+      style={{
+        borderColor: colorForEvent(
+          survey.templateType || survey.event.eventType
+        )
+      }}
     >
       <div>
         <Link to={`/surveys/${String(survey.id)}`}>

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -161,13 +161,8 @@
   margin-right: 0;
 }
 
-.checkBox div {
-  display: inline-block;
-  margin-right: 5px;
-}
-
-.checkBox > div {
-  margin-bottom: 10px;
+.templatePicker {
+  margin: 0 0 15px;
 }
 
 .freeText {

--- a/app/routes/surveys/index.js
+++ b/app/routes/surveys/index.js
@@ -9,6 +9,10 @@ export default {
       ...resolveAsyncRoute(() => import('./AddSurveyRoute'))
     },
     {
+      path: 'templates',
+      ...resolveAsyncRoute(() => import('./TemplatesRoute'))
+    },
+    {
       path: ':surveyId',
       ...resolveAsyncRoute(() => import('./SurveyDetailRoute'))
     },

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -3,6 +3,7 @@
 import React, { type Node } from 'react';
 import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
+import moment from 'moment-timezone';
 
 const questionStrings = {
   single: 'single_choice',
@@ -31,6 +32,7 @@ export const ListNavigation = ({ title }: { title: Node }) => (
   <NavigationTab title={title}>
     <NavigationLink to="/surveys">Liste</NavigationLink>
     <NavigationLink to="/surveys/add">Ny undersøkelse</NavigationLink>
+    <NavigationLink to="/surveys/templates">Maler</NavigationLink>
   </NavigationTab>
 );
 
@@ -51,3 +53,9 @@ export const DetailNavigation = ({
     </NavigationLink>
   </NavigationTab>
 );
+
+export const defaultActiveFrom = (hours: number, minutes: number) =>
+  moment()
+    .startOf('day')
+    .add({ hours, minutes })
+    .toISOString();


### PR DESCRIPTION
Adds the option to load templates in surveys to reduce the amount of repetetive work survey creators have to do.

Does so using url params: `/surveys/add/?templateType=company_presentation` will issue a fetch for the template used for company presentations, and then use that to initialize the form. Regular users do this by clicking a new "Use template" button, which has a dropdown containing each type from the possible event types found in `events/utils`.

<img width="299" alt="skjermbilde 2018-02-21 kl 02 21 46" src="https://user-images.githubusercontent.com/14221386/36458214-fe20dcf6-16ad-11e8-9b34-ebc0e6c65242.png">

Clicking an item simply links to an url on the form above and reinitializes the form.

Because clicking such an item overrides all changes users have made, I figured there should be a confirm modal. However, the confirm modal component didn't seem to cooperate at all, so for now I use the native `if (confirm("er du sikker?")) { ... }`.

<img width="847" alt="skjermbilde 2018-02-21 kl 02 32 35" src="https://user-images.githubusercontent.com/14221386/36458509-822b6876-16af-11e8-9cb5-2be0c9004549.png">


This works for both adding and editing: `/surveys/someId/edit/?templateType=other` is also implemented. Overriding existing surveys with templates is probably less common functionality than while creating a new survey, but it's there. Loading from an event while editing is **not** supported, as I didn't see what kind of use case this would cover.

Also adds a list view of all templates, separating them from the regular list view (templates aren't included in the regular list view). 

<img width="1122" alt="skjermbilde 2018-02-21 kl 02 26 47" src="https://user-images.githubusercontent.com/14221386/36458349-b1da46f6-16ae-11e8-9014-c536e8ec357f.png">

Because templates are just regular surveys with an additional field set, they can be edited like any other survey. 

**Also adds another cool feature**: initializing surveys from an event id. `/surveys/add/?event=50` will not only set the `survey.event` as expected, but also initialize the form _based on the template for the eventType_ of event 50. `/surveys/add/?event=50` without any inputs:

<img width="1124" alt="skjermbilde 2018-02-21 kl 02 30 38" src="https://user-images.githubusercontent.com/14221386/36458459-3b78d9fe-16af-11e8-8fbb-1c742f996c19.png">

It also sets the "Active from" field to `event.endTime`. 