### PR TITLE
Your upcoming events in profile

### DIFF
--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -23,6 +23,38 @@ export function fetchEvent(eventId: string) {
   });
 }
 
+export function fetchUpcoming() {
+  return dispatch =>
+    dispatch(
+      callAPI({
+        types: Event.FETCH,
+        endpoint: '/events/upcoming/',
+        schema: [eventSchema],
+        meta: {
+          errorMessage: 'Henting av hendelser feilet'
+        },
+        propagateError: true
+      })
+    ).then(result => {
+      console.log('payload', result);
+      const events = result.payload.result.reduce(
+        (total, id) => ({
+          ...total,
+          [id]: {
+            ...result.payload.entities.events[id],
+            isUsersUpcoming: true
+          }
+        }),
+        {}
+      );
+
+      return dispatch({
+        ...result,
+        payload: { entities: { events } }
+      });
+    });
+}
+
 const getEndpoint = (state, loadNextPage, queryString) => {
   const pagination = state.events.pagination;
   let endpoint = `/events/${queryString}`;

--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -23,7 +23,7 @@ export function fetchEvent(eventId: string) {
   });
 }
 
-export function fetchUpcoming() {
+export function fetchUpcoming(): Thunk<*> {
   return dispatch =>
     dispatch(
       callAPI({
@@ -46,7 +46,6 @@ export function fetchUpcoming() {
         }),
         {}
       );
-
       return dispatch({
         ...result,
         payload: { entities: { events } }

--- a/app/actions/EventActions.js
+++ b/app/actions/EventActions.js
@@ -36,7 +36,6 @@ export function fetchUpcoming() {
         propagateError: true
       })
     ).then(result => {
-      console.log('payload', result);
       const events = result.payload.result.reduce(
         (total, id) => ({
           ...total,

--- a/app/components/Feed/Feed.css
+++ b/app/components/Feed/Feed.css
@@ -1,0 +1,8 @@
+@import 'app/styles/variables.css';
+
+.emptyState {
+  color: var(--color-gray-1);
+  font-size: 20px;
+  font-style: italic;
+  font-weight: lighter;
+}

--- a/app/components/Feed/index.js
+++ b/app/components/Feed/index.js
@@ -4,6 +4,7 @@ import Activity from './activity';
 import type { AggregatedActivity } from './types';
 import EmptyState from 'app/components/EmptyState';
 import ErrorBoundary from 'app/components/ErrorBoundary';
+import styles from './Feed.css';
 
 export const activityRenderers = {
   comment: require('./renders/comment'),
@@ -32,7 +33,7 @@ const Feed = ({ items }: Props) => (
       })
     ) : (
       <EmptyState>
-        <h1>Ingen aktiviteter i feeden</h1>
+        <h2 className={styles.emptyState}>Ingen aktiviteter i feeden</h2>
       </EmptyState>
     )}
   </div>

--- a/app/components/LoadingIndicator/index.js
+++ b/app/components/LoadingIndicator/index.js
@@ -6,7 +6,7 @@ import styles from './LoadingIndicator.css';
 export type Props = {
   loading: boolean,
   small?: boolean,
-  margin?: number,
+  margin?: number | string,
   loadingStyle?: Object,
   children?: any
 };

--- a/app/reducers/events.js
+++ b/app/reducers/events.js
@@ -209,6 +209,10 @@ export const selectEvents = createSelector(
   (eventsById, eventIds) => eventIds.map(id => transformEvent(eventsById[id]))
 );
 
+export const selectUpcomingEvents = createSelector(selectEvents, events =>
+  events.filter(event => event.isUsersUpcoming)
+);
+
 export const selectSortedEvents = createSelector(selectEvents, events =>
   events.sort((a, b) => a.startTime - b.startTime)
 );

--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -62,8 +62,11 @@ function Attendance({
     </Pill>
   );
 }
-
-export function EventItem({ event }: any) {
+type EventItemProps = {
+  event: any,
+  showTags?: Boolean
+};
+export function EventItem({ event, showTags = true }: EventItemProps) {
   return (
     <div
       style={{ borderColor: colorForEvent(event.eventType) }}
@@ -83,10 +86,13 @@ export function EventItem({ event }: any) {
           <Time time={event.startTime} format="ll HH:mm" />
           {` • ${event.location}`}
         </div>
-
-        <Flex wrap className={styles.tagList}>
-          {event.tags.map((tag, index) => <Tag key={index} tag={tag} small />)}
-        </Flex>
+        {showTags && (
+          <Flex wrap className={styles.tagList}>
+            {event.tags.map((tag, index) => (
+              <Tag key={index} tag={tag} small />
+            ))}
+          </Flex>
+        )}
       </div>
 
       <div className={styles.companyLogo}>

--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -64,7 +64,7 @@ function Attendance({
 }
 type EventItemProps = {
   event: any,
-  showTags?: Boolean
+  showTags?: boolean
 };
 export function EventItem({ event, showTags = true }: EventItemProps) {
   return (

--- a/app/routes/users/UserProfileRoute.js
+++ b/app/routes/users/UserProfileRoute.js
@@ -15,7 +15,7 @@ import { LoginPage } from 'app/components/LoginForm';
 
 const loadData = ({ params: { username } }, dispatch) => {
   return dispatch(fetchUser(username)).then(action =>
-    dispatch(fetchUpcoming(action.payload.result))
+    dispatch(fetchUpcoming())
   );
   // TODO: re-enable when the user feed is fixed:
   // .then(action =>
@@ -31,7 +31,7 @@ const mapStateToProps = (state, props) => {
   const user = selectUserWithGroups(state, { username });
   let feed;
   let feedItems;
-  let upcomingEvents = selectUpcomingEvents(state);
+  const upcomingEvents = selectUpcomingEvents(state);
   if (user) {
     feed = { type: 'user', activities: [] };
     feedItems = [];

--- a/app/routes/users/UserProfileRoute.js
+++ b/app/routes/users/UserProfileRoute.js
@@ -4,15 +4,19 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import UserProfile from './components/UserProfile';
 import { fetchUser } from 'app/actions/UserActions';
+import { fetchUpcoming } from 'app/actions/EventActions';
 import { fetchUserFeed } from 'app/actions/FeedActions';
 import { selectUserWithGroups } from 'app/reducers/users';
+import { selectUpcomingEvents } from 'app/reducers/events';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import prepare from 'app/utils/prepare';
 import { LoginPage } from 'app/components/LoginForm';
 
 const loadData = ({ params: { username } }, dispatch) => {
-  return dispatch(fetchUser(username));
+  return dispatch(fetchUser(username)).then(action =>
+    dispatch(fetchUpcoming(action.payload.result))
+  );
   // TODO: re-enable when the user feed is fixed:
   // .then(action =>
   //   dispatch(fetchUserFeed(action.payload.result))
@@ -27,6 +31,7 @@ const mapStateToProps = (state, props) => {
   const user = selectUserWithGroups(state, { username });
   let feed;
   let feedItems;
+  let upcomingEvents = selectUpcomingEvents(state);
   if (user) {
     feed = { type: 'user', activities: [] };
     feedItems = [];
@@ -46,6 +51,7 @@ const mapStateToProps = (state, props) => {
     auth: state.auth,
     loggedIn: props.loggedIn,
     user,
+    upcomingEvents,
     feed,
     feedItems,
     showSettings,
@@ -53,7 +59,7 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-const mapDispatchToProps = { fetchUser, fetchUserFeed };
+const mapDispatchToProps = { fetchUser, fetchUpcoming, fetchUserFeed };
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),

--- a/app/routes/users/UserProfileRoute.js
+++ b/app/routes/users/UserProfileRoute.js
@@ -55,7 +55,8 @@ const mapStateToProps = (state, props) => {
     feed,
     feedItems,
     showSettings,
-    isMe
+    isMe,
+    loading: state.events.fetching
   };
 };
 

--- a/app/routes/users/components/UserProfile.css
+++ b/app/routes/users/components/UserProfile.css
@@ -13,6 +13,13 @@
   }
 }
 
+.emptyState {
+  color: var(--color-gray-1);
+  font-size: 20px;
+  font-weight: lighter;
+  font-style: italic;
+}
+
 .picture {
   display: flex;
   justify-content: center;

--- a/app/routes/users/components/UserProfile.css
+++ b/app/routes/users/components/UserProfile.css
@@ -56,3 +56,7 @@
   margin-top: 10px;
   margin-bottom: 20px;
 }
+
+.bottomMargin {
+  margin-bottom: 30px;
+}

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -19,6 +19,7 @@ import type { Group } from 'app/models';
 import cx from 'classnames';
 import { EventItem } from 'app/routes/events/components/EventList';
 import EmptyState from 'app/components/EmptyState';
+import { Event } from 'app/models';
 
 const fieldTranslations = {
   username: 'brukernavn',
@@ -30,8 +31,11 @@ type Props = {
   showSettings: boolean,
   feedItems: Array<any>,
   feed: Object,
-  isMe: Boolean,
-  upcomingEvents: Array<any>
+  isMe: boolean
+};
+
+type UpcomingEventsProps = {
+  upcomingEvents: Array<Event>
 };
 
 const GroupPill = ({ group }: { group: Group }) => (
@@ -62,9 +66,9 @@ const GroupBadge = ({ group }: { group: Group }) => {
   );
 };
 
-const UpcomingEvents = ({ upcomingEvents }: Props) => (
+const UpcomingEvents = ({ upcomingEvents }: UpcomingEventsProps) => (
   <div>
-    {upcomingEvents.length ? (
+    {upcomingEvents && upcomingEvents.length ? (
       <Flex column wrap>
         {upcomingEvents.map((event, i) => (
           <EventItem key={i} event={event} showTags={false} />
@@ -190,12 +194,10 @@ export default class UserProfile extends Component<Props> {
           </div>
           <div className={styles.rightContent}>
             {isMe && (
-              <div>
+              <div className={styles.bottomMargin}>
                 <h3>Dine kommende arrangementer</h3>
-                {upcomingEvents ? (
-                  <UpcomingEvents events={upcomingEvents} />
-                ) : (
-                  <LoadingIndicator loading />
+                {upcomingEvents && (
+                  <UpcomingEvents upcomingEvents={upcomingEvents} />
                 )}
               </div>
             )}

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -19,7 +19,7 @@ import type { Group } from 'app/models';
 import cx from 'classnames';
 import { EventItem } from 'app/routes/events/components/EventList';
 import EmptyState from 'app/components/EmptyState';
-import { Event } from 'app/models';
+import type { Event } from 'app/models';
 
 const fieldTranslations = {
   username: 'brukernavn',
@@ -84,7 +84,7 @@ const UpcomingEvents = ({ upcomingEvents }: UpcomingEventsProps) => (
   </div>
 );
 
-export default class UserProfile extends Component<Props> {
+export default class UserProfile extends Component<Props, UpcomingEventsProps> {
   sumPenalties() {
     return sumBy(this.props.user.penalties, 'weight');
   }
@@ -105,14 +105,9 @@ export default class UserProfile extends Component<Props> {
   }
 
   render() {
-    const {
-      user,
-      isMe,
-      showSettings,
-      feedItems,
-      feed,
-      upcomingEvents
-    } = this.props;
+    const { user, isMe, showSettings, feedItems, feed } = this.props;
+    const upcomingEvents = this.state.upcomingEvents;
+
     const { groupsAsBadges = [], groupsAsPills = [] } = groupBy(
       user.abakusGroups,
       group => (group.logo ? 'groupsAsBadges' : 'groupsAsPills')

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -32,7 +32,8 @@ type Props = {
   feedItems: Array<any>,
   feed: Object,
   isMe: boolean,
-  loading: boolean
+  loading: boolean,
+  upcomingEvents: Array<Event>
 };
 
 type UpcomingEventsProps = {

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -107,8 +107,15 @@ export default class UserProfile extends Component<Props, UpcomingEventsProps> {
   }
 
   render() {
-    const { user, isMe, showSettings, feedItems, feed, loading } = this.props;
-    const { upcomingEvents } = this.props;
+    const {
+      user,
+      isMe,
+      showSettings,
+      feedItems,
+      feed,
+      loading,
+      upcomingEvents
+    } = this.props;
 
     const { groupsAsBadges = [], groupsAsPills = [] } = groupBy(
       user.abakusGroups,

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -62,11 +62,11 @@ const GroupBadge = ({ group }: { group: Group }) => {
   );
 };
 
-const UpcomingEvents = ({ events }: Props) => (
+const UpcomingEvents = ({ upcomingEvents }: Props) => (
   <div>
-    {events.length ? (
+    {upcomingEvents.length ? (
       <Flex column wrap>
-        {events.map((event, i) => (
+        {upcomingEvents.map((event, i) => (
           <EventItem key={i} event={event} showTags={false} />
         ))}
       </Flex>

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -17,6 +17,8 @@ import { groupBy } from 'lodash';
 import { resolveGroupLink } from 'app/reducers/groups';
 import type { Group } from 'app/models';
 import cx from 'classnames';
+import { EventItem } from 'app/routes/events/components/EventList';
+import EmptyState from 'app/components/EmptyState';
 
 const fieldTranslations = {
   username: 'brukernavn',
@@ -28,7 +30,8 @@ type Props = {
   showSettings: boolean,
   feedItems: Array<any>,
   feed: Object,
-  isMe: Boolean
+  isMe: Boolean,
+  upcomingEvents: Array<any>
 };
 
 const GroupPill = ({ group }: { group: Group }) => (
@@ -59,6 +62,24 @@ const GroupBadge = ({ group }: { group: Group }) => {
   );
 };
 
+const UpcomingEvents = ({ events }: Props) => (
+  <div>
+    {events.length ? (
+      <Flex column wrap>
+        {events.map((event, i) => (
+          <EventItem key={i} event={event} showTags={false} />
+        ))}
+      </Flex>
+    ) : (
+      <EmptyState>
+        <h2 className={styles.emptyState}>
+          Du har ingen kommende arrangementer
+        </h2>
+      </EmptyState>
+    )}
+  </div>
+);
+
 export default class UserProfile extends Component<Props> {
   sumPenalties() {
     return sumBy(this.props.user.penalties, 'weight');
@@ -80,7 +101,14 @@ export default class UserProfile extends Component<Props> {
   }
 
   render() {
-    const { user, isMe, showSettings, feedItems, feed } = this.props;
+    const {
+      user,
+      isMe,
+      showSettings,
+      feedItems,
+      feed,
+      upcomingEvents
+    } = this.props;
     const { groupsAsBadges = [], groupsAsPills = [] } = groupBy(
       user.abakusGroups,
       group => (group.logo ? 'groupsAsBadges' : 'groupsAsPills')
@@ -160,8 +188,17 @@ export default class UserProfile extends Component<Props> {
                 </div>
               )}
           </div>
-
           <div className={styles.rightContent}>
+            {isMe && (
+              <div>
+                <h3>Dine kommende arrangementer</h3>
+                {upcomingEvents ? (
+                  <UpcomingEvents events={upcomingEvents} />
+                ) : (
+                  <LoadingIndicator loading />
+                )}
+              </div>
+            )}
             <h3>Nylig Aktivitet</h3>
             {feed ? (
               <Feed items={feedItems} feed={feed} />

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -31,7 +31,8 @@ type Props = {
   showSettings: boolean,
   feedItems: Array<any>,
   feed: Object,
-  isMe: boolean
+  isMe: boolean,
+  loading: boolean
 };
 
 type UpcomingEventsProps = {
@@ -105,8 +106,8 @@ export default class UserProfile extends Component<Props, UpcomingEventsProps> {
   }
 
   render() {
-    const { user, isMe, showSettings, feedItems, feed } = this.props;
-    const upcomingEvents = this.state.upcomingEvents;
+    const { user, isMe, showSettings, feedItems, feed, loading } = this.props;
+    const { upcomingEvents } = this.props;
 
     const { groupsAsBadges = [], groupsAsPills = [] } = groupBy(
       user.abakusGroups,
@@ -191,7 +192,10 @@ export default class UserProfile extends Component<Props, UpcomingEventsProps> {
             {isMe && (
               <div className={styles.bottomMargin}>
                 <h3>Dine kommende arrangementer</h3>
-                {upcomingEvents && (
+
+                {loading ? (
+                  <LoadingIndicator margin={'20px auto'} loading />
+                ) : (
                   <UpcomingEvents upcomingEvents={upcomingEvents} />
                 )}
               </div>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "lodash": "^4.17.2",
     "medium-draft": "beta",
     "minireset.css": "^0.0.3",
-    "moment": "^2.20.1",
     "moment-timezone": "^0.5.13",
     "morgan": "^1.8.2",
     "normalizr": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5446,10 +5446,6 @@ moment-timezone@^0.5.13:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-moment@^2.20.1:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
-
 morgan@^1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.8.2.tgz#784ac7734e4a453a9c6e6e8680a9329275c8b687"


### PR DESCRIPTION
Fixes #1074.

Now shows the events you're registered for in your own user profile for easy access. Modified the existing EventItem to be able to not show the tags of an event. Also an style update for the message shown in the feed section when there is no feed to show. Extended the existing events endpoint. 

Note: If you have registered for 1000 events, it will show all 1000 events and the page will get quite long. In reality the length won't be able to get unreasonably long though.

With registered events:
![screenshot from 2018-02-26 22-48-39](https://user-images.githubusercontent.com/25204035/36718070-c6714e06-1ba0-11e8-9b10-e03c5d05c4db.png)

Without registered events:
![screenshot from 2018-02-26 22-19-36](https://user-images.githubusercontent.com/25204035/36718112-e6936d68-1ba0-11e8-9a53-e73aaefd9956.png)

Won't show your registered events when viewing others profile.
![screenshot from 2018-02-26 22-37-29](https://user-images.githubusercontent.com/25204035/36718211-444c107c-1ba1-11e8-88d0-bd092e8da65a.png)

