### PR TITLE
Various style fixes and quote deleting

### DIFF
--- a/app/components/Editor/Editor.css
+++ b/app/components/Editor/Editor.css
@@ -26,4 +26,8 @@
     margin: 0;
     padding: 0;
   }
+
+  .public-DraftEditorPlaceholder-root {
+    z-index: 0;
+  }
 }

--- a/app/components/Form/CheckBox.css
+++ b/app/components/Form/CheckBox.css
@@ -10,7 +10,7 @@
 
 .box input:disabled + label::before {
   background: var(--color-mono-gray-4);
-  border: var(--color-mono-gray-4);
+  border: 1px solid var(--color-mono-gray-2);
 }
 
 .box input:disabled + label::after {

--- a/app/components/Form/RadioButton.css
+++ b/app/components/Form/RadioButton.css
@@ -15,11 +15,19 @@
   margin-top: 4px;
   margin-left: 5px;
   opacity: 0;
+
+  &:disabled:hover {
+    cursor: default;
+  }
 }
 
 .label {
   position: relative;
   cursor: pointer;
+
+  &:disabled:hover {
+    cursor: default;
+  }
 }
 
 /* radio aspect */
@@ -65,18 +73,28 @@
   background-color: #ddd;
 }
 
+.input:disabled:not(:checked):hover + .label::before,
+.input:disabled:checked:hover + .label::before {
+  cursor: default;
+}
+
 .input:disabled:checked + .label::after {
   color: #999;
 }
 
 .input:disabled + .label {
   color: #aaa;
+  cursor: default;
+}
+
+.input:disabled:hover + .label {
+  cursor: default;
 }
 
 /* accessibility */
 .input:checked:focus + .label::before,
 .input:not(:checked):focus + .label::before {
-  cursor: pointer;
+  cursor: default;
 }
 
 /* hover style just for information */

--- a/app/components/Form/RadioButton.css
+++ b/app/components/Form/RadioButton.css
@@ -15,19 +15,16 @@
   margin-top: 4px;
   margin-left: 5px;
   opacity: 0;
+}
 
-  &:disabled:hover {
-    cursor: default;
-  }
+.input:disabled,
+.input:disabled + .label {
+  cursor: default;
 }
 
 .label {
   position: relative;
   cursor: pointer;
-
-  &:disabled:hover {
-    cursor: default;
-  }
 }
 
 /* radio aspect */
@@ -73,28 +70,12 @@
   background-color: #ddd;
 }
 
-.input:disabled:not(:checked):hover + .label::before,
-.input:disabled:checked:hover + .label::before {
-  cursor: default;
-}
-
 .input:disabled:checked + .label::after {
   color: #999;
 }
 
 .input:disabled + .label {
   color: #aaa;
-  cursor: default;
-}
-
-.input:disabled:hover + .label {
-  cursor: default;
-}
-
-/* accessibility */
-.input:checked:focus + .label::before,
-.input:not(:checked):focus + .label::before {
-  cursor: default;
 }
 
 /* hover style just for information */

--- a/app/components/Toast/ToastContainer.js
+++ b/app/components/Toast/ToastContainer.js
@@ -47,7 +47,8 @@ function toastStyleFactory(index, style) {
   }
   return {
     ...style,
-    bottom: `${2 + index * 4}rem`
+    bottom: `${2 + index * 4}rem`,
+    zIndex: 2
   };
 }
 

--- a/app/components/Toast/ToastContainer.js
+++ b/app/components/Toast/ToastContainer.js
@@ -42,7 +42,8 @@ function toastStyleFactory(index, style) {
       padding: '14px 24px',
       lineHeight: '20px',
       fontSize: '14px',
-      boxShadow: 0
+      boxShadow: 0,
+      zIndex: 2
     };
   }
   return {

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -83,12 +83,13 @@ const OverviewItem = ({ item }: { item: Event | Article }) => {
                 {item.startTime && (
                   <Time time={item.startTime} format="DD.MM HH:mm" />
                 )}
-                {item.location !== '-' && (
-                  <span>
-                    <span className={styles.dot}> · </span>
-                    <span>{item.location}</span>
-                  </span>
-                )}
+                {item.location &&
+                  item.location !== '-' && (
+                    <span>
+                      <span className={styles.dot}> · </span>
+                      <span>{item.location}</span>
+                    </span>
+                  )}
                 {item.eventType && (
                   <span>
                     <span className={styles.dot}> · </span>

--- a/app/routes/quotes/components/Quote.js
+++ b/app/routes/quotes/components/Quote.js
@@ -125,7 +125,11 @@ export default class Quote extends Component<Props, State> {
                           <Dropdown.ListItem>
                             <a
                               className={styles.deleteQuote}
-                              onClick={() => this.setState({ deleting: true })}
+                              onClick={e => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                this.setState({ deleting: true });
+                              }}
                             >
                               Slett
                             </a>

--- a/app/routes/quotes/components/Quote.js
+++ b/app/routes/quotes/components/Quote.js
@@ -126,8 +126,10 @@ export default class Quote extends Component<Props, State> {
                             <a
                               className={styles.deleteQuote}
                               onClick={e => {
-                                e.preventDefault();
-                                e.stopPropagation();
+                                if (e) {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                }
                                 this.setState({ deleting: true });
                               }}
                             >


### PR DESCRIPTION
- Fixes the z-index of the editor so that it's not visible over modals
- Adds border to the disabled Checkbox
- Removes `cursor: pointer` from disabled radio buttons
- Fixes #1131 
- Removes the dot on the frontpage (meant to separate event info) from articles
- Fixes the z-index of the Toast so that it appears above anything with z-index 1 (radio buttons and checkboxes, for instance)