### PR TITLE
Make frontpage headers to links

### DIFF
--- a/app/routes/overview/components/CompactEvents.js
+++ b/app/routes/overview/components/CompactEvents.js
@@ -65,11 +65,15 @@ export default class CompactEvents extends Component<Props> {
       <Flex column>
         <Flex wrap className={styles.compactEvents}>
           <Flex column className={styles.compactLeft}>
-            <h3 className="u-ui-heading">Bedpres og Kurs</h3>
+            <Link to={'/events'}>
+              <h3 className="u-ui-heading">Bedpres og Kurs</h3>
+            </Link>
             <ul className={styles.innerList}>{leftEvents}</ul>
           </Flex>
           <Flex column className={styles.compactRight}>
-            <h3 className="u-ui-heading">Arrangementer</h3>
+            <Link to={'/events'}>
+              <h3 className="u-ui-heading">Arrangementer</h3>
+            </Link>
             <ul className={styles.innerList}>{rightEvents}</ul>
           </Flex>
         </Flex>

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -73,31 +73,31 @@ const OverviewItem = ({ item }: { item: Event | Article }) => {
           </Flex>
         )}
         <Flex column className={styles.innerRight}>
-          <div className={styles.heading}>
-            <h2 className={styles.itemTitle}>
-              <Link to={itemUrl(item)}>
+          <Link to={itemUrl(item)} style={{ color: 'rgba(0, 0, 0, 0.9)' }}>
+            <div className={styles.heading}>
+              <h2 className={styles.itemTitle}>
                 {truncateString(item.title, TITLE_MAX_LENGTH)}
-              </Link>
-            </h2>
+              </h2>
 
-            <span className={styles.itemInfo}>
-              {item.startTime && (
-                <Time time={item.startTime} format="DD.MM HH:mm" />
-              )}
-              {item.location !== '-' && (
-                <span>
-                  <span className={styles.dot}> · </span>
-                  <span>{item.location}</span>
-                </span>
-              )}
-              {item.eventType && (
-                <span>
-                  <span className={styles.dot}> · </span>
-                  <span>{EVENT_TYPE_TO_STRING(item.eventType)}</span>
-                </span>
-              )}
-            </span>
-          </div>
+              <span className={styles.itemInfo}>
+                {item.startTime && (
+                  <Time time={item.startTime} format="DD.MM HH:mm" />
+                )}
+                {item.location !== '-' && (
+                  <span>
+                    <span className={styles.dot}> · </span>
+                    <span>{item.location}</span>
+                  </span>
+                )}
+                {item.eventType && (
+                  <span>
+                    <span className={styles.dot}> · </span>
+                    <span>{EVENT_TYPE_TO_STRING(item.eventType)}</span>
+                  </span>
+                )}
+              </span>
+            </div>
+          </Link>
 
           <p
             className={styles.itemDescription}


### PR DESCRIPTION
MAJOR UPDATE. This always annoyed me, especially on mobile where pressing Events required the opening on the menu.

EDIT: Also added links to the Overview items. In the current form you can only press the image or the h3 title, with this change you press the whole headerspace