### PR TITLE
Fix user profile bug

### DIFF
--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -117,13 +117,15 @@ export default class UserProfile extends Component<Props, UpcomingEventsProps> {
       upcomingEvents
     } = this.props;
 
+    const { abakusGroups = [], firstName, lastName } = user;
+
     const { groupsAsBadges = [], groupsAsPills = [] } = groupBy(
-      user.abakusGroups,
+      abakusGroups.filter(Boolean),
       group => (group.logo ? 'groupsAsBadges' : 'groupsAsPills')
     );
     return (
       <div className={styles.root}>
-        <Helmet title={`${user.firstName} ${user.lastName}`} />
+        <Helmet title={`${firstName} ${lastName}`} />
 
         <Flex wrap className={styles.header}>
           <div className={cx(styles.sidebar, styles.picture)}>


### PR DESCRIPTION
This fixes the crash when navigating from the event administrate route
to a user profile. The bug occured because we send only the group ids
from the administrate endpoint. When mapping ids to the corresponding
elements, we then get a list full of 'undefined' values.

![screenshot from 2018-03-11 16-41-21](https://user-images.githubusercontent.com/1467188/37255589-af257e4a-254e-11e8-966f-f4bf54391d31.png)


Maybe we should fix this in the selectors? And if so, we should do it everywhere!