### PR TITLE
Fix prop typo in event interest/fav fetching

### DIFF
--- a/app/routes/events/EventDetailRoute.js
+++ b/app/routes/events/EventDetailRoute.js
@@ -113,13 +113,10 @@ const mapDispatchToProps = {
   updateUser
 };
 
-const loadData = (
-  { params: { eventId }, currentUser, isLoggedIn },
-  dispatch
-) => {
+const loadData = ({ params: { eventId }, currentUser, loggedIn }, dispatch) => {
   const userId = currentUser.id;
   return dispatch(fetchEvent(eventId)).then(
-    () => isLoggedIn && dispatch(isUserFollowing(eventId, userId))
+    () => loggedIn && dispatch(isUserFollowing(eventId, userId))
   );
 };
 


### PR DESCRIPTION
The prop is called 'loggedIn', not 'isLoggedIn'. The value `isLoggedIn`
was always undefined, and therefore the initial interest/fav request was
never executed.