### PR TITLE
Sort overview events by time and id

### DIFF
--- a/app/routes/overview/components/CompactEvents.js
+++ b/app/routes/overview/components/CompactEvents.js
@@ -20,7 +20,6 @@ export default class CompactEvents extends Component<Props> {
 
     const mapEvents = eventTypes => {
       return events
-        .sort((a, b) => a.startTime - b.startTime)
         .filter(
           event =>
             event.endTime.isAfter() && eventTypes.includes(event.eventType)


### PR DESCRIPTION
Depends on #1149 
This sorting did nothing, and with the new back-end sorting it works without any sorting in the front-end.