### PR TITLE
Launch(?) Survey adjustments

### DIFF
--- a/app/components/Search/utils.js
+++ b/app/components/Search/utils.js
@@ -104,6 +104,12 @@ const LINKS: Array<Link> = [
     key: 'email',
     title: 'E-post',
     url: '/admin/email'
+  },
+  {
+    admin: true,
+    key: 'surveys',
+    title: 'Spørreundersøkelser',
+    url: '/surveys'
   }
 ];
 

--- a/app/components/Search/utils.js
+++ b/app/components/Search/utils.js
@@ -72,15 +72,6 @@ const LINKS: Array<Link> = [
     title: 'Jobbannonser',
     url: '/joblistings'
   },
-  /*
-  TODO: Add surveys back in when the feature is done
-  {
-    admin: true,
-    key: 'surveys',
-    title: 'Undersøkelser',
-    url: '/surveys'
-  },
-  */
   {
     admin: true,
     key: 'announcements',

--- a/app/reducers/allowed.js
+++ b/app/reducers/allowed.js
@@ -12,7 +12,8 @@ const initialState = {
   groups: false,
   email: false,
   users: false,
-  bdb: false
+  bdb: false,
+  surveys: false
 };
 
 // export type Allowed = {

--- a/app/routes/events/components/Admin.js
+++ b/app/routes/events/components/Admin.js
@@ -52,6 +52,11 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
               event={event.id}
             />
           </li>
+          <li>
+            <Link to={`/surveys/add/?event=${event.id}`}>
+              Lag spørreundersøkelse
+            </Link>
+          </li>
           {canEdit && (
             <li>
               <Link to={`/events/${event.id}/edit`}>Rediger</Link>

--- a/app/routes/surveys/AddSurveyRoute.js
+++ b/app/routes/surveys/AddSurveyRoute.js
@@ -45,12 +45,14 @@ const mapStateToProps = (state, props) => {
       }
     : '';
   const activeFrom = event ? fullEvent.endTime : defaultActiveFrom(12, 0);
+  const title = event ? `Spørreundersøkelse for ${fullEvent.title}` : '';
 
   let initialValues = null;
   if (notFetching) {
     if (template) {
       initialValues = {
         ...template,
+        title,
         event: initialEvent,
         activeFrom
       };
@@ -58,7 +60,7 @@ const mapStateToProps = (state, props) => {
       initialValues = {
         activeFrom,
         event: initialEvent,
-        title: '',
+        title,
         questions: [initialQuestion]
       };
     }

--- a/app/routes/surveys/components/SurveyEditor/Option.js
+++ b/app/routes/surveys/components/SurveyEditor/Option.js
@@ -5,6 +5,7 @@ import { RadioButton, TextInput, CheckBox } from 'app/components/Form';
 import { Field } from 'redux-form';
 import styles from '../surveys.css';
 import { QuestionTypes } from '../../utils';
+import Icon from 'app/components/Icon';
 
 type Props = {
   questionType: string,
@@ -25,6 +26,7 @@ const MultipleChoice = (props: Props) => {
   return (
     <li>
       <RadioButton value={false} className={styles.option} />
+
       <Field
         onChange={props.onChange}
         name={`${props.option}.optionText`}

--- a/app/routes/surveys/components/SurveyEditor/Option.js
+++ b/app/routes/surveys/components/SurveyEditor/Option.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { RadioButton, TextInput, CheckBox } from 'app/components/Form';
 import { Field } from 'redux-form';
 import styles from '../surveys.css';
-import { QuestionTypes } from '../../utils';
+import { QuestionTypes } from 'app/routes/surveys/utils';
 
 type Props = {
   questionType: string,
@@ -14,15 +14,12 @@ type Props = {
   remove?: () => void
 };
 
-const removeOption = (remove?) => {
-  return remove ? (
+const RemoveButton = ({ remove }: { remove?: () => void }) =>
+  remove ? (
     <a onClick={remove} className={styles.removeOption}>
       <span>x</span>
     </a>
-  ) : (
-    ''
-  );
-};
+  ) : null;
 
 const Option = (props: Props) => {
   return props.questionType === QuestionTypes('single') ? (
@@ -44,7 +41,7 @@ const MultipleChoice = (props: Props) => {
         placeholder="Alternativ"
         fieldClassName={styles.optionField}
       />
-      {removeOption(props.remove)}
+      <RemoveButton remove={props.remove} />
     </li>
   );
 };
@@ -61,7 +58,7 @@ const Checkbox = (props: Props) => {
         placeholder="Alternativ"
         fieldClassName={styles.optionField}
       />
-      {removeOption(props.remove)}
+      <RemoveButton remove={props.remove} />
     </li>
   );
 };

--- a/app/routes/surveys/components/SurveyEditor/Option.js
+++ b/app/routes/surveys/components/SurveyEditor/Option.js
@@ -5,13 +5,23 @@ import { RadioButton, TextInput, CheckBox } from 'app/components/Form';
 import { Field } from 'redux-form';
 import styles from '../surveys.css';
 import { QuestionTypes } from '../../utils';
-import Icon from 'app/components/Icon';
 
 type Props = {
   questionType: string,
   option: string,
   onChange?: any => void,
-  index: number
+  index: number,
+  remove?: () => void
+};
+
+const removeOption = (remove?) => {
+  return remove ? (
+    <a onClick={remove} className={styles.removeOption}>
+      <span>x</span>
+    </a>
+  ) : (
+    ''
+  );
 };
 
 const Option = (props: Props) => {
@@ -26,7 +36,6 @@ const MultipleChoice = (props: Props) => {
   return (
     <li>
       <RadioButton value={false} className={styles.option} />
-
       <Field
         onChange={props.onChange}
         name={`${props.option}.optionText`}
@@ -35,6 +44,7 @@ const MultipleChoice = (props: Props) => {
         placeholder="Alternativ"
         fieldClassName={styles.optionField}
       />
+      {removeOption(props.remove)}
     </li>
   );
 };
@@ -51,6 +61,7 @@ const Checkbox = (props: Props) => {
         placeholder="Alternativ"
         fieldClassName={styles.optionField}
       />
+      {removeOption(props.remove)}
     </li>
   );
 };

--- a/app/routes/surveys/components/SurveyEditor/Question.js
+++ b/app/routes/surveys/components/SurveyEditor/Question.js
@@ -90,7 +90,7 @@ const Question = ({ index, question, questionData, deleteQuestion }: Props) => {
             className={styles.freeText}
             placeholder="Fritekst - sånn vil den se ut :smile:"
             value=""
-            disabled={true}
+            disabled
           />
         ) : (
           <FieldArray

--- a/app/routes/surveys/components/SurveyEditor/Question.js
+++ b/app/routes/surveys/components/SurveyEditor/Question.js
@@ -151,6 +151,7 @@ const renderOptions = ({
   <ul className={styles.options}>
     {fields.map((option, index) => {
       const isLast = fields.length - 1 === index;
+      const removeFunction = () => fields.remove(index);
       return (
         <Option
           index={index}
@@ -164,6 +165,7 @@ const renderOptions = ({
           key={index}
           questionType={questionType}
           option={option}
+          remove={isLast ? undefined : removeFunction}
         />
       );
     })}

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
@@ -156,7 +156,7 @@ class SurveyEditor extends Component<Props, State> {
           ) : (
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
               <Field
-                placeholder="Bekk Miniseminar"
+                placeholder="Velg arrangement"
                 label="Arrangement"
                 autoFocus={autoFocus}
                 name="event"

--- a/app/routes/surveys/components/SurveyList/SurveyItem.js
+++ b/app/routes/surveys/components/SurveyList/SurveyItem.js
@@ -49,9 +49,11 @@ const SurveyItem = (props: Props) => {
         )}
       </div>
 
-      <div className={styles.companyLogo}>
-        <Image src={survey.event.cover} />
-      </div>
+      {!survey.templateType && (
+        <div className={styles.companyLogo}>
+          <Image src={survey.event.cover} />
+        </div>
+      )}
     </div>
   );
 };

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -259,8 +259,14 @@
   margin-bottom: 15px;
 }
 
-.navTab {
-  font-size: inherit;
-  text-transform: inherit;
-  font-weight: inherit;
+.navTab > div > div {
+  font-size: 16px;
+  text-transform: none;
+  font-weight: normal;
+}
+
+.removeOption {
+  color: #999;
+  font-size: 20px;
+  margin-left: -5px;
 }

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -258,3 +258,9 @@
 .summary > li {
   margin-bottom: 15px;
 }
+
+.navTab {
+  font-size: inherit;
+  text-transform: inherit;
+  font-weight: inherit;
+}

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -4,6 +4,7 @@ import React, { type Node } from 'react';
 import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import moment from 'moment-timezone';
+import styles from './components/surveys.css';
 
 const questionStrings = {
   single: 'single_choice',
@@ -29,7 +30,7 @@ export const mappings = Object.keys(questionStrings).map(key => ({
 }));
 
 export const ListNavigation = ({ title }: { title: Node }) => (
-  <NavigationTab title={title}>
+  <NavigationTab title={title} headerClassName={styles.navTab}>
     <NavigationLink to="/surveys">Liste</NavigationLink>
     <NavigationLink to="/surveys/add">Ny undersøkelse</NavigationLink>
     <NavigationLink to="/surveys/templates">Maler</NavigationLink>
@@ -45,7 +46,7 @@ export const DetailNavigation = ({
   surveyId: number,
   deleteFunction: number => Promise<*>
 }) => (
-  <NavigationTab title={title}>
+  <NavigationTab title={title} headerClassName={styles.navTab}>
     <NavigationLink to="/surveys">Liste</NavigationLink>
     <NavigationLink to={`/surveys/${surveyId}`}>Undersøkelsen</NavigationLink>
     <NavigationLink to={`/surveys/${surveyId}/submissions/summary`}>


### PR DESCRIPTION
- Adds surveys to navigation menu
- Adds "Lag spørreundersøkelse" to event detail
- Adds functionality for removing options when creating or editing an event
- Fixes various other small issues outlined in #1165

Deleting options:
<img width="1043" alt="skjermbilde 2018-03-12 kl 23 39 03" src="https://user-images.githubusercontent.com/14221386/37313233-9409d29a-264e-11e8-8f6b-a36802dfbe1c.png">

With this PR and #1163, I believe Surveys could potentially be launched. Doing so would only involve giving sudo survey permissions to fagkom and bedkom, plus loading the template fixtures in the prod database (@odinuge knows which ones). 

The last four issues in #1165 remain unsolved and will likely stay that way until I return in april (except disabled forms heh @SmithPeder), so you'll have to consider whether they are necessary for launching the feature. In particular, I think #1164 might actually warrant delaying the launch. #1170 and #1171 are also worth considering.

Just to be clear, surveys doesn't need to be launched for this to be merged.