### PR TITLE
Compress the mobile feed

### DIFF
--- a/app/routes/overview/components/Feed.css
+++ b/app/routes/overview/components/Feed.css
@@ -24,6 +24,11 @@
   height: 459px;
   flex: 1;
   background-color: rgba(255, 255, 255, 0.4);
+
+  @media (--mobile-device) {
+    height: auto;
+    max-height: 495px;
+  }
 }
 
 @-moz-document url-prefix() {
@@ -31,11 +36,6 @@
     height: 490px;
     flex: none;
   }
-}
-
-.heading {
-  margin: 0;
-  padding: 0 20px;
 }
 
 .icon {
@@ -63,7 +63,8 @@
   }
 }
 
-.noActivities {
+.noActivities,
+.noActivities p {
   font-weight: bold;
   padding-top: 20px;
 }

--- a/app/routes/overview/components/Feed.js
+++ b/app/routes/overview/components/Feed.js
@@ -44,7 +44,7 @@ const Feed = (props: Props) => {
   return (
     <div className={styles.root}>
       <div className={styles.header}>
-        <h2 className="u-ui-heading" style={{ padding: '0' }}>
+        <h2 className="u-ui-heading" style={{ padding: '0', margin: '0' }}>
           Oppdateringer
         </h2>
         <Link to="/timeline">Tidslinje →</Link>
@@ -64,7 +64,7 @@ const Feed = (props: Props) => {
             icon="book-outline"
             size={40}
           >
-            <p className={styles.noActivities}>Ingen aktiviteter i feeden</p>
+            <p>Ingen aktiviteter i feeden</p>
           </EmptyState>
         )}
       </div>


### PR DESCRIPTION
When the feed is empty / only contains a few elements it takes a lot of space when on mobile.
I get that it should have a set height on desktop for the design, but on mobile screen real estate is precious.


![screenshot from 2018-04-03 22-38-41](https://user-images.githubusercontent.com/23152018/38274850-47521432-3790-11e8-86da-0ad789808224.png)

This also removes a margin which pushed the feed out of alignment on reactive screen sizes.  
So this no longer happens.
![screenshot from 2018-04-03 22-47-41](https://user-images.githubusercontent.com/23152018/38275095-0bb3037c-3791-11e8-84e5-e3ddaec14eff.png)

