### PR TITLE
Fix albums timezone

### DIFF
--- a/app/routes/photos/components/GalleryDetailsRow.js
+++ b/app/routes/photos/components/GalleryDetailsRow.js
@@ -29,9 +29,7 @@ const GalleryDetailsRow = ({
 
       {gallery.takenAt && (
         <span className={styles.detail}>
-          {moment(gallery.takenAt)
-            .utc()
-            .format('ll')}
+          {moment(gallery.takenAt).format('ll')}
         </span>
       )}
 


### PR DESCRIPTION
Fix timezone error.  When the album was taken at was 17.mai, the moment would convert it to 16.mai when viewing the details of the album