### PR TITLE
Disallow event registration when user has unanswered surveys

### DIFF
--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -21,3 +21,12 @@
 .paymentInfo {
   margin-top: 10px;
 }
+
+.unansweredSurveys {
+  max-width: 625px;
+  margin-top: 15px;
+}
+
+.unansweredSurveys h3 {
+  color: var(--color-red-3);
+}

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -275,25 +275,55 @@ export default class EventDetail extends Component<Props> {
               </Flex>
             </ContentSidebar>
           </ContentSection>
-          <div className={styles.joinHeader}>
-            Bli med på dette arrangementet
-          </div>
-          <Link to="/pages/info/26-arrangementsregler" style={{ marginTop: 0 }}>
-            <Flex alignItems="center">
-              <Icon name="document" style={{ marginRight: '4px' }} />
-              <span>Regler for Abakus&#39; arrangementer</span>
-            </Flex>
-          </Link>
+          {2 > 1 ||
+          (loggedIn &&
+            currentUser.unansweredSurveys &&
+            currentUser.unansweredSurveys.length > 0) ? (
+            <div className={styles.unansweredSurveys}>
+              <h3>
+                Du kan ikke melde deg på dette arrangementet fordi du har
+                ubesvarte spørreundersøkelser.
+              </h3>
+              <p>
+                Man må svare på alle spørreundersøkelser for tidligere
+                arrangementer før man kan melde seg på nye arrangementer. Du kan
+                svare på undersøkelsene dine ved å trykke på følgende linker:
+              </p>
+              <ul>
+                {currentUser.unansweredSurveys &&
+                  currentUser.unansweredSurveys.map((surveyId, i) => (
+                    <li key={surveyId}>
+                      <Link to={`/surveys/${surveyId}`}>
+                        Undersøkelse {i + 1}
+                      </Link>
+                    </li>
+                  ))}
+              </ul>
+            </div>
+          ) : (
+            <div>
+              <div className={styles.joinHeader}>
+                Bli med på dette arrangementet
+              </div>
+              <Link
+                to="/pages/info/26-arrangementsregler"
+                style={{ marginTop: 0 }}
+              >
+                <Flex alignItems="center">
+                  <Icon name="document" style={{ marginRight: '4px' }} />
+                  <span>Regler for Abakus&#39; arrangementer</span>
+                </Flex>
+              </Link>
 
-          {loggedIn && (
-            <JoinEventForm
-              event={event}
-              registration={currentRegistration}
-              currentUser={currentUser}
-              updateUser={updateUser}
-              onToken={this.handleToken}
-              onSubmit={this.handleRegistration}
-            />
+              <JoinEventForm
+                event={event}
+                registration={currentRegistration}
+                currentUser={currentUser}
+                updateUser={updateUser}
+                onToken={this.handleToken}
+                onSubmit={this.handleRegistration}
+              />
+            </div>
           )}
 
           {event.commentTarget && (

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -275,10 +275,10 @@ export default class EventDetail extends Component<Props> {
               </Flex>
             </ContentSidebar>
           </ContentSection>
-          {2 > 1 ||
-          (loggedIn &&
-            currentUser.unansweredSurveys &&
-            currentUser.unansweredSurveys.length > 0) ? (
+
+          {loggedIn &&
+          event.unansweredSurveys &&
+          event.unansweredSurveys.length > 0 ? (
             <div className={styles.unansweredSurveys}>
               <h3>
                 Du kan ikke melde deg på dette arrangementet fordi du har
@@ -290,14 +290,13 @@ export default class EventDetail extends Component<Props> {
                 svare på undersøkelsene dine ved å trykke på følgende linker:
               </p>
               <ul>
-                {currentUser.unansweredSurveys &&
-                  currentUser.unansweredSurveys.map((surveyId, i) => (
-                    <li key={surveyId}>
-                      <Link to={`/surveys/${surveyId}`}>
-                        Undersøkelse {i + 1}
-                      </Link>
-                    </li>
-                  ))}
+                {event.unansweredSurveys.map((surveyId, i) => (
+                  <li key={surveyId}>
+                    <Link to={`/surveys/${surveyId}`}>
+                      Undersøkelse {i + 1}
+                    </Link>
+                  </li>
+                ))}
               </ul>
             </div>
           ) : (


### PR DESCRIPTION
Requires https://github.com/webkom/lego/pull/1183

Replaces the event signup form with an error message with links to surveys when user has unanswered surveys.

<img width="898" alt="skjermbilde 2018-04-10 kl 16 02 48" src="https://user-images.githubusercontent.com/14221386/38561648-d6c8b8b2-3cd8-11e8-9d40-fb12bb97e3ea.png">

Feel free to comment on the wording or styling, this is mostly a quick and dirty version.
