### PR TITLE
Survey token

### DIFF
--- a/app/actions/SurveyActions.js
+++ b/app/actions/SurveyActions.js
@@ -7,13 +7,16 @@ import type { Thunk } from 'app/types';
 import moment from 'moment-timezone';
 import type { SurveyEntity } from 'app/reducers/surveys';
 
-export function fetch(surveyId: number): Thunk<*> {
+export function fetch(surveyId: number, token?: string): Thunk<*> {
   return dispatch =>
     dispatch(
       callAPI({
         types: Survey.FETCH,
         endpoint: `/surveys/${surveyId}/`,
         schema: surveySchema,
+        query: {
+          token
+        },
         meta: {
           errorMessage: 'Henting av spørreundersøkelse feilet'
         },

--- a/app/actions/SurveyActions.js
+++ b/app/actions/SurveyActions.js
@@ -7,15 +7,30 @@ import type { Thunk } from 'app/types';
 import moment from 'moment-timezone';
 import type { SurveyEntity } from 'app/reducers/surveys';
 
-export function fetch(surveyId: number, token?: string): Thunk<*> {
+export function fetch(surveyId: number): Thunk<*> {
   return dispatch =>
     dispatch(
       callAPI({
         types: Survey.FETCH,
         endpoint: `/surveys/${surveyId}/`,
         schema: surveySchema,
-        query: {
-          token
+        meta: {
+          errorMessage: 'Henting av spørreundersøkelse feilet'
+        },
+        propagateError: true
+      })
+    );
+}
+
+export function fetchWithToken(surveyId: number, token: string): Thunk<*> {
+  return dispatch =>
+    dispatch(
+      callAPI({
+        types: Survey.FETCH,
+        endpoint: `/survey-results/${surveyId}/`,
+        schema: surveySchema,
+        headers: {
+          Authorization: `Token ${token}`
         },
         meta: {
           errorMessage: 'Henting av spørreundersøkelse feilet'

--- a/app/actions/SurveySubmissionActions.js
+++ b/app/actions/SurveySubmissionActions.js
@@ -5,14 +5,11 @@ import callAPI from 'app/actions/callAPI';
 import { surveySubmissionSchema } from 'app/reducers';
 import type { Thunk } from 'app/types';
 
-export function fetchSubmissions(surveyId: number, token?: string): Thunk<*> {
+export function fetchSubmissions(surveyId: number): Thunk<*> {
   return callAPI({
     types: SurveySubmission.FETCH_ALL,
     endpoint: `/surveys/${surveyId}/submissions`,
     schema: [surveySubmissionSchema],
-    query: {
-      token
-    },
     meta: {
       errorMessage: 'Henting av svar på spørreundersøkelse feilet'
     },

--- a/app/actions/SurveySubmissionActions.js
+++ b/app/actions/SurveySubmissionActions.js
@@ -5,11 +5,14 @@ import callAPI from 'app/actions/callAPI';
 import { surveySubmissionSchema } from 'app/reducers';
 import type { Thunk } from 'app/types';
 
-export function fetchSubmissions(surveyId: number): Thunk<*> {
+export function fetchSubmissions(surveyId: number, token?: string): Thunk<*> {
   return callAPI({
     types: SurveySubmission.FETCH_ALL,
     endpoint: `/surveys/${surveyId}/submissions`,
     schema: [surveySubmissionSchema],
+    query: {
+      token
+    },
     meta: {
       errorMessage: 'Henting av svar på spørreundersøkelse feilet'
     },

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -13,7 +13,8 @@ export type SurveyEntity = {
   event: any,
   activeFrom?: string,
   questions: Array<QuestionEntity>,
-  templateType?: EventType
+  templateType?: EventType,
+  token?: string
 };
 
 export type QuestionEntity = {

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -14,7 +14,9 @@ export type SurveyEntity = {
   activeFrom?: string,
   questions: Array<QuestionEntity>,
   templateType?: EventType,
-  token?: string
+  token?: string,
+  results?: Object,
+  submissionCount?: number
 };
 
 export type QuestionEntity = {

--- a/app/routes/surveys/SubmissionsPublicResultsRoute.js
+++ b/app/routes/surveys/SubmissionsPublicResultsRoute.js
@@ -1,0 +1,35 @@
+import { connect } from 'react-redux';
+import prepare from 'app/utils/prepare';
+import { fetchWithToken } from 'app/actions/SurveyActions';
+import SubmissionPublicResults from './components/Submissions/SubmissionPublicResults';
+import { compose } from 'redux';
+import { selectSurveyById } from 'app/reducers/surveys';
+import { push } from 'react-router-redux';
+import loadingIndicator from 'app/utils/loadingIndicator';
+
+const loadData = (props, dispatch) => {
+  const { surveyId } = props.params;
+  const { token } = props.location.query;
+  return dispatch(fetchWithToken(surveyId, token));
+};
+
+const mapStateToProps = (state, props) => {
+  const surveyId = Number(props.params.surveyId);
+  const survey = selectSurveyById(state, { surveyId });
+  return {
+    survey,
+    notFetching: !state.surveys.fetching && !state.surveySubmissions.fetching,
+    actionGrant: survey.actionGrant,
+    token: props.location.query.token
+  };
+};
+
+const mapDispatchToProps = {
+  push
+};
+
+export default compose(
+  prepare(loadData),
+  connect(mapStateToProps, mapDispatchToProps),
+  loadingIndicator(['notFetching', 'survey.event', 'survey.questions'])
+)(SubmissionPublicResults);

--- a/app/routes/surveys/SubmissionsRoute.js
+++ b/app/routes/surveys/SubmissionsRoute.js
@@ -12,20 +12,21 @@ import { selectSurveySubmissions } from 'app/reducers/surveySubmissions';
 import { selectSurveyById } from 'app/reducers/surveys';
 import { push } from 'react-router-redux';
 import loadingIndicator from 'app/utils/loadingIndicator';
+import { LoginPage } from 'app/components/LoginForm';
+import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 
 const loadData = (props, dispatch) => {
   const { surveyId } = props.params;
-  const { token } = props.location.query;
   return Promise.all([
-    dispatch(fetch(surveyId, token)),
-    dispatch(fetchSubmissions(surveyId, token))
+    dispatch(fetch(surveyId)),
+    dispatch(fetchSubmissions(surveyId))
   ]);
 };
 
 const mapStateToProps = (state, props) => {
   const surveyId = Number(props.params.surveyId);
   const locationStrings = props.location.pathname.split('/');
-  const isIndividual =
+  const isSummary =
     locationStrings[locationStrings.length - 1] === 'individual';
   const survey = selectSurveyById(state, { surveyId });
   return {
@@ -33,7 +34,7 @@ const mapStateToProps = (state, props) => {
     submissions: selectSurveySubmissions(state, { surveyId }),
     notFetching: !state.surveys.fetching && !state.surveySubmissions.fetching,
     actionGrant: survey.actionGrant,
-    isIndividual
+    isSummary
   };
 };
 
@@ -45,6 +46,7 @@ const mapDispatchToProps = {
 };
 
 export default compose(
+  replaceUnlessLoggedIn(LoginPage),
   prepare(loadData),
   connect(mapStateToProps, mapDispatchToProps),
   loadingIndicator(['notFetching', 'survey.event', 'survey.questions'])

--- a/app/routes/surveys/SubmissionsRoute.js
+++ b/app/routes/surveys/SubmissionsRoute.js
@@ -10,16 +10,15 @@ import SubmissionPage from './components/Submissions/SubmissionPage';
 import { compose } from 'redux';
 import { selectSurveySubmissions } from 'app/reducers/surveySubmissions';
 import { selectSurveyById } from 'app/reducers/surveys';
-import { LoginPage } from 'app/components/LoginForm';
-import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { push } from 'react-router-redux';
 import loadingIndicator from 'app/utils/loadingIndicator';
 
 const loadData = (props, dispatch) => {
   const { surveyId } = props.params;
+  const { token } = props.location.query;
   return Promise.all([
-    dispatch(fetch(surveyId)),
-    dispatch(fetchSubmissions(surveyId))
+    dispatch(fetch(surveyId, token)),
+    dispatch(fetchSubmissions(surveyId, token))
   ]);
 };
 
@@ -45,7 +44,6 @@ const mapDispatchToProps = {
 };
 
 export default compose(
-  replaceUnlessLoggedIn(LoginPage),
   prepare(loadData),
   connect(mapStateToProps, mapDispatchToProps),
   loadingIndicator(['notFetching', 'survey.event', 'survey.questions'])

--- a/app/routes/surveys/SubmissionsRoute.js
+++ b/app/routes/surveys/SubmissionsRoute.js
@@ -25,14 +25,15 @@ const loadData = (props, dispatch) => {
 const mapStateToProps = (state, props) => {
   const surveyId = Number(props.params.surveyId);
   const locationStrings = props.location.pathname.split('/');
-  const isSummary = locationStrings[locationStrings.length - 1] === 'summary';
+  const isIndividual =
+    locationStrings[locationStrings.length - 1] === 'individual';
   const survey = selectSurveyById(state, { surveyId });
   return {
     survey,
     submissions: selectSurveySubmissions(state, { surveyId }),
     notFetching: !state.surveys.fetching && !state.surveySubmissions.fetching,
     actionGrant: survey.actionGrant,
-    isSummary
+    isIndividual
   };
 };
 

--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -40,7 +40,7 @@ const AdminSideBar = ({
   const shareLink = !token
     ? ''
     : `https://www.abakus.no/surveys/${surveyId}/submissions/summary/?token=${token}`;
-
+  console.log('admin side bar', canEdit, 'token:', token);
   return (
     canEdit && (
       <ContentSidebar className={styles.adminSideBar}>
@@ -63,11 +63,7 @@ const AdminSideBar = ({
               </li>
             </ConfirmModalWithParent>
           )}
-          {token && (
-            <li>
-              Delbar link: <a href={shareLink}>{shareLink}</a>
-            </li>
-          )}
+          {token && <Link to={shareLink}>Delbar link</Link>}
         </ul>
       </ContentSidebar>
     )

--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -75,7 +75,10 @@ export class AdminSideBar extends React.Component<Props, State> {
               <li>
                 <CopyToClipboard
                   text={shareLink}
-                  onCopy={() => this.setState({ copied: true })}
+                  onCopy={() => {
+                    this.setState({ copied: true });
+                    setTimeout(() => this.setState({ copied: false }), 2000);
+                  }}
                   style={{ marginTop: '5px' }}
                 >
                   <Button>

--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -11,14 +11,16 @@ type Props = {
   surveyId: number,
   deleteFunction?: number => Promise<*>,
   push?: string => void,
-  actionGrant: ActionGrant
+  actionGrant: ActionGrant,
+  token?: string
 };
 
 const AdminSideBar = ({
   surveyId,
   deleteFunction,
   actionGrant,
-  push
+  push,
+  token
 }: Props) => {
   const canEdit = actionGrant.includes('edit');
 
@@ -34,6 +36,10 @@ const AdminSideBar = ({
     }
     return Promise.resolve();
   };
+
+  const shareLink = !token
+    ? ''
+    : `https://www.abakus.no/surveys/${surveyId}/submissions/summary/?token=${token}`;
 
   return (
     canEdit && (
@@ -56,6 +62,11 @@ const AdminSideBar = ({
                 <Link to="">Slett undersøkelsen</Link>
               </li>
             </ConfirmModalWithParent>
+          )}
+          {token && (
+            <li>
+              Delbar link: <a href={shareLink}>{shareLink}</a>
+            </li>
           )}
         </ul>
       </ContentSidebar>

--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -40,7 +40,7 @@ const AdminSideBar = ({
   const shareLink = !token
     ? ''
     : `https://www.abakus.no/surveys/${surveyId}/submissions/summary/?token=${token}`;
-  console.log('admin side bar', canEdit, 'token:', token);
+
   return (
     canEdit && (
       <ContentSidebar className={styles.adminSideBar}>

--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -6,6 +6,9 @@ import { Link } from 'react-router';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import type { ActionGrant } from 'app/models';
 import { ContentSidebar } from 'app/components/Content';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import Button from 'app/components/Button';
+import config from 'app/config';
 
 type Props = {
   surveyId: number,
@@ -15,59 +18,77 @@ type Props = {
   token?: string
 };
 
-const AdminSideBar = ({
-  surveyId,
-  deleteFunction,
-  actionGrant,
-  push,
-  token
-}: Props) => {
-  const canEdit = actionGrant.includes('edit');
+type State = {
+  copied: boolean
+};
 
-  const onConfirm = () => {
-    if (deleteFunction && push) {
-      return (
-        deleteFunction &&
-        deleteFunction(surveyId).then(() => push && push('/surveys'))
-      );
-    }
-    if (deleteFunction) {
-      return deleteFunction && deleteFunction(surveyId);
-    }
-    return Promise.resolve();
+export class AdminSideBar extends React.Component<Props, State> {
+  state: State = {
+    copied: false
   };
 
-  const shareLink = !token
-    ? ''
-    : `https://www.abakus.no/surveys/${surveyId}/submissions/summary/?token=${token}`;
+  render() {
+    const { surveyId, deleteFunction, actionGrant, push, token } = this.props;
 
-  return (
-    canEdit && (
-      <ContentSidebar className={styles.adminSideBar}>
-        <strong>Admin</strong>
-        <ul>
-          <li>
-            <Link to="/surveys/add">Ny undersøkelse</Link>
-          </li>
-          <li>
-            <Link to={`/surveys/${surveyId}/edit`}>Endre undersøkelsen</Link>
-          </li>
-          {deleteFunction && (
-            <ConfirmModalWithParent
-              title="Slett undersøkelse"
-              message="Er du sikker på at du vil slette denne undersøkelseen?"
-              onConfirm={onConfirm}
-            >
+    const canEdit = actionGrant.includes('edit');
+
+    const onConfirm = () => {
+      if (deleteFunction && push) {
+        return (
+          deleteFunction &&
+          deleteFunction(surveyId).then(() => push && push('/surveys'))
+        );
+      }
+      if (deleteFunction) {
+        return deleteFunction && deleteFunction(surveyId);
+      }
+      return Promise.resolve();
+    };
+
+    const shareLink = !token
+      ? ''
+      : `${config.webUrl}/surveys/${surveyId}/results/?token=${token}`;
+
+    return (
+      canEdit && (
+        <ContentSidebar className={styles.adminSideBar}>
+          <strong>Admin</strong>
+          <ul>
+            <li>
+              <Link to="/surveys/add">Ny undersøkelse</Link>
+            </li>
+            <li>
+              <Link to={`/surveys/${surveyId}/edit`}>Endre undersøkelsen</Link>
+            </li>
+            {deleteFunction && (
+              <ConfirmModalWithParent
+                title="Slett undersøkelse"
+                message="Er du sikker på at du vil slette denne undersøkelseen?"
+                onConfirm={onConfirm}
+              >
+                <li>
+                  <Link to="">Slett undersøkelsen</Link>
+                </li>
+              </ConfirmModalWithParent>
+            )}
+            {token && (
               <li>
-                <Link to="">Slett undersøkelsen</Link>
+                <CopyToClipboard
+                  text={shareLink}
+                  onCopy={() => this.setState({ copied: true })}
+                  style={{ marginTop: '5px' }}
+                >
+                  <Button>
+                    {this.state.copied ? 'Kopiert!' : 'Kopier delbar link'}
+                  </Button>
+                </CopyToClipboard>
               </li>
-            </ConfirmModalWithParent>
-          )}
-          {token && <Link to={shareLink}>Delbar link</Link>}
-        </ul>
-      </ContentSidebar>
-    )
-  );
-};
+            )}
+          </ul>
+        </ContentSidebar>
+      )
+    );
+  }
+}
 
 export default AdminSideBar;

--- a/app/routes/surveys/components/Submissions/Results.js
+++ b/app/routes/surveys/components/Submissions/Results.js
@@ -14,41 +14,63 @@ type Props = {
   generateTextAnswers: QuestionEntity => any
 };
 
+type InfoBubblesProps = {
+  info: Array<Info>
+};
+
+type Info = {
+  icon: string,
+  data: number,
+  meta: string
+};
+
+const InfoBubbles = ({ info }: InfoBubblesProps) => {
+  return info.map((dataPoint, i) => (
+    <InfoBubble
+      key={i}
+      icon={dataPoint.icon}
+      data={String(dataPoint.data)}
+      meta={dataPoint.meta}
+      style={{ order: i }}
+    />
+  ));
+};
+
 const Results = ({
   graphData,
   generateTextAnswers,
   survey,
   numberOfSubmissions
 }: Props) => {
+  const info = [
+    {
+      icon: 'person',
+      data: survey.event.registrationCount,
+      meta: 'Påmeldte'
+    },
+    {
+      icon: 'checkmark',
+      data: survey.event.attendedCount,
+      meta: 'Møtte opp'
+    },
+    {
+      icon: 'list',
+      data: survey.event.waitingRegistrationCount,
+      meta: 'På venteliste'
+    },
+    {
+      icon: 'chatboxes',
+      data: numberOfSubmissions,
+      meta: 'Har svart'
+    }
+  ];
+
   return (
     <div>
       <div className={styles.eventSummary}>
         <h3>Arrangementet</h3>
         <div className={styles.infoBubbles}>
-          <InfoBubble
-            icon="person"
-            data={String(survey.event.registrationCount)}
-            meta="Påmeldte"
-            style={{ order: 0 }}
-          />
-          <InfoBubble
-            icon="checkmark"
-            data={String(survey.event.attendedCount)}
-            meta="Møtte opp"
-            style={{ order: 1 }}
-          />
-          <InfoBubble
-            icon="list"
-            data={String(survey.event.waitingRegistrationCount)}
-            meta="På venteliste"
-            style={{ order: 2 }}
-          />
-          <InfoBubble
-            icon="chatboxes"
-            data={String(numberOfSubmissions)}
-            meta="Har svart"
-            style={{ order: 3 }}
-          />
+          <InfoBubbles info={info} />
         </div>
       </div>
 
@@ -79,7 +101,7 @@ const Results = ({
                 <div className={styles.questionResults}>
                   <div style={{ width: '300px' }}>
                     <VictoryPie
-                      data={pieColors}
+                      data={pieData}
                       x="option"
                       y="selections"
                       theme={VictoryTheme.material}

--- a/app/routes/surveys/components/Submissions/Results.js
+++ b/app/routes/surveys/components/Submissions/Results.js
@@ -1,0 +1,121 @@
+// @flow
+
+import React from 'react';
+import styles from '../surveys.css';
+import type { SurveyEntity, QuestionEntity } from 'app/reducers/surveys';
+import { QuestionTypes, CHART_COLORS } from '../../utils';
+import InfoBubble from 'app/components/InfoBubble';
+import { VictoryPie, VictoryTheme } from 'victory';
+
+type Props = {
+  survey: SurveyEntity,
+  graphData: Object,
+  numberOfSubmissions: number,
+  generateTextAnswers: QuestionEntity => any
+};
+
+const Results = ({
+  graphData,
+  generateTextAnswers,
+  survey,
+  numberOfSubmissions
+}: Props) => {
+  return (
+    <div>
+      <div className={styles.eventSummary}>
+        <h3>Arrangementet</h3>
+        <div className={styles.infoBubbles}>
+          <InfoBubble
+            icon="person"
+            data={String(survey.event.registrationCount)}
+            meta="Påmeldte"
+            style={{ order: 0 }}
+          />
+          <InfoBubble
+            icon="checkmark"
+            data={String(survey.event.attendedCount)}
+            meta="Møtte opp"
+            style={{ order: 1 }}
+          />
+          <InfoBubble
+            icon="list"
+            data={String(survey.event.waitingRegistrationCount)}
+            meta="På venteliste"
+            style={{ order: 2 }}
+          />
+          <InfoBubble
+            icon="chatboxes"
+            data={String(numberOfSubmissions)}
+            meta="Har svart"
+            style={{ order: 3 }}
+          />
+        </div>
+      </div>
+
+      <ul className={styles.summary}>
+        {survey.questions.map(question => {
+          const colorsToRemove = [];
+          const pieData = graphData[question.id].filter((dataPoint, i) => {
+            if (dataPoint.selections === 0) {
+              colorsToRemove.push(i);
+              return false;
+            }
+            return true;
+          });
+          const pieColors = CHART_COLORS.filter(
+            (color, i) => !colorsToRemove.includes(i)
+          );
+          const labelRadius = pieData.length === 1 ? -10 : 60;
+
+          return (
+            <li key={question.id}>
+              <h3>{question.questionText}</h3>
+
+              {question.questionType === QuestionTypes('text') ? (
+                <ul className={styles.textAnswers}>
+                  {generateTextAnswers(question)}
+                </ul>
+              ) : (
+                <div className={styles.questionResults}>
+                  <div style={{ width: '300px' }}>
+                    <VictoryPie
+                      data={pieColors}
+                      x="option"
+                      y="selections"
+                      theme={VictoryTheme.material}
+                      colorScale={pieColors}
+                      labels={d => d.y}
+                      labelRadius={labelRadius}
+                      padding={{ left: 0, top: 40, right: 30, bottom: 30 }}
+                      style={{
+                        labels: { fill: 'white', fontSize: 20 }
+                      }}
+                    />
+                  </div>
+
+                  <ul className={styles.graphData}>
+                    {graphData[question.id].map((dataPoint, i) => (
+                      <li key={i}>
+                        <span
+                          className={styles.colorBox}
+                          style={{ backgroundColor: CHART_COLORS[i] }}
+                        >
+                          &nbsp;
+                        </span>
+                        <span style={{ marginTop: '-5px' }}>
+                          {dataPoint.option}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default Results;

--- a/app/routes/surveys/components/Submissions/Results.js
+++ b/app/routes/surveys/components/Submissions/Results.js
@@ -14,7 +14,7 @@ type Props = {
   generateTextAnswers: QuestionEntity => any
 };
 
-type InfoBubblesProps = {
+type EventDataProps = {
   info: Array<Info>
 };
 
@@ -24,7 +24,7 @@ type Info = {
   meta: string
 };
 
-const InfoBubbles = ({ info }: InfoBubblesProps) => {
+const EventData = ({ info }: EventDataProps) => {
   return info.map((dataPoint, i) => (
     <InfoBubble
       key={i}
@@ -70,7 +70,7 @@ const Results = ({
       <div className={styles.eventSummary}>
         <h3>Arrangementet</h3>
         <div className={styles.infoBubbles}>
-          <InfoBubbles info={info} />
+          <EventData info={info} />
         </div>
       </div>
 

--- a/app/routes/surveys/components/Submissions/SubmissionPage.js
+++ b/app/routes/surveys/components/Submissions/SubmissionPage.js
@@ -17,11 +17,11 @@ type Props = {
   survey: SurveyEntity,
   children: React.Element<*>,
   actionGrant: ActionGrant,
-  isSummary: boolean
+  isIndividual: boolean
 };
 
 const SubmissionPage = (props: Props) => {
-  const { deleteSurvey, survey, actionGrant, isSummary } = props;
+  const { deleteSurvey, survey, actionGrant, isIndividual } = props;
 
   return (
     <Content className={styles.surveyDetail} banner={survey.event.cover}>
@@ -36,14 +36,18 @@ const SubmissionPage = (props: Props) => {
           <div className={styles.submissionNav}>
             <Link
               to={`/surveys/${survey.id}/submissions/summary`}
-              className={isSummary ? styles.activeRoute : styles.inactiveRoute}
+              className={
+                !isIndividual ? styles.activeRoute : styles.inactiveRoute
+              }
             >
               Oppsummering
             </Link>
             {' | '}
             <Link
               to={`/surveys/${survey.id}/submissions/individual`}
-              className={!isSummary ? styles.activeRoute : styles.inactiveRoute}
+              className={
+                isIndividual ? styles.activeRoute : styles.inactiveRoute
+              }
             >
               Individuell
             </Link>

--- a/app/routes/surveys/components/Submissions/SubmissionPage.js
+++ b/app/routes/surveys/components/Submissions/SubmissionPage.js
@@ -52,7 +52,11 @@ const SubmissionPage = (props: Props) => {
           {React.cloneElement(props.children, props)}
         </ContentMain>
 
-        <AdminSideBar surveyId={survey.id} actionGrant={actionGrant} />
+        <AdminSideBar
+          surveyId={survey.id}
+          actionGrant={actionGrant}
+          token={survey.token}
+        />
       </ContentSection>
     </Content>
   );

--- a/app/routes/surveys/components/Submissions/SubmissionPage.js
+++ b/app/routes/surveys/components/Submissions/SubmissionPage.js
@@ -17,11 +17,11 @@ type Props = {
   survey: SurveyEntity,
   children: React.Element<*>,
   actionGrant: ActionGrant,
-  isIndividual: boolean
+  isSummary: boolean
 };
 
 const SubmissionPage = (props: Props) => {
-  const { deleteSurvey, survey, actionGrant, isIndividual } = props;
+  const { deleteSurvey, survey, actionGrant, isSummary } = props;
 
   return (
     <Content className={styles.surveyDetail} banner={survey.event.cover}>
@@ -36,18 +36,14 @@ const SubmissionPage = (props: Props) => {
           <div className={styles.submissionNav}>
             <Link
               to={`/surveys/${survey.id}/submissions/summary`}
-              className={
-                !isIndividual ? styles.activeRoute : styles.inactiveRoute
-              }
+              className={isSummary ? styles.activeRoute : styles.inactiveRoute}
             >
               Oppsummering
             </Link>
             {' | '}
             <Link
               to={`/surveys/${survey.id}/submissions/individual`}
-              className={
-                isIndividual ? styles.activeRoute : styles.inactiveRoute
-              }
+              className={!isSummary ? styles.activeRoute : styles.inactiveRoute}
             >
               Individuell
             </Link>

--- a/app/routes/surveys/components/Submissions/SubmissionPublicResults.js
+++ b/app/routes/surveys/components/Submissions/SubmissionPublicResults.js
@@ -1,0 +1,86 @@
+// @flow
+
+import * as React from 'react';
+import styles from '../surveys.css';
+import type { SurveyEntity } from 'app/reducers/surveys';
+import { Content, ContentSection, ContentMain } from 'app/components/Content';
+import type { ActionGrant } from 'app/models';
+import Results from './Results';
+import { QuestionTypes, TokenNavigation } from '../../utils';
+
+type Props = {
+  survey: SurveyEntity,
+  actionGrant: ActionGrant,
+  results: Object
+};
+
+const SubmissionPublicResultsPage = ({ survey, actionGrant }: Props) => {
+  const results = survey.results || {};
+
+  const generateTextAnswers = question => {
+    let texts = [];
+    Object.keys(results[String(question.id)])
+      .map(name => {
+        if (name !== 'questionType') {
+          texts = results[String(question.id)][name].map((answer, i) => (
+            <li key={i}>{answer}</li>
+          ));
+        }
+      })
+      .filter(Boolean);
+
+    return texts.length === 0 ? <i>Ingen svar.</i> : texts;
+  };
+
+  const generateQuestionData = questionId => {
+    const questionData = [];
+    const question =
+      survey.questions.find(q => q.id === Number(questionId)) || {};
+
+    Object.keys(results[questionId]).map(optionId => {
+      const optionText = (
+        question.options.find(o => o.id === Number(optionId)) || {}
+      ).optionText;
+      if (optionText) {
+        questionData.push({
+          option: (question.options.find(o => o.id === Number(optionId)) || {})
+            .optionText,
+          selections: Number(results[questionId][optionId])
+        });
+      }
+    });
+    return questionData;
+  };
+
+  const graphData = {};
+  Object.keys(results)
+    .filter(
+      questionId => results[questionId].questionType !== QuestionTypes('text')
+    )
+    .map(questionId => {
+      graphData[Number(questionId)] = generateQuestionData(questionId);
+    });
+
+  return (
+    <Content className={styles.surveyDetail} banner={survey.event.cover}>
+      <TokenNavigation
+        title={survey.title}
+        actionGrant={actionGrant}
+        surveyId={survey.id}
+      />
+
+      <ContentSection>
+        <ContentMain>
+          <Results
+            survey={survey}
+            graphData={graphData}
+            numberOfSubmissions={survey.submissionCount || 0}
+            generateTextAnswers={generateTextAnswers}
+          />
+        </ContentMain>
+      </ContentSection>
+    </Content>
+  );
+};
+
+export default SubmissionPublicResultsPage;

--- a/app/routes/surveys/components/Submissions/SubmissionPublicResults.js
+++ b/app/routes/surveys/components/Submissions/SubmissionPublicResults.js
@@ -6,7 +6,7 @@ import type { SurveyEntity } from 'app/reducers/surveys';
 import { Content, ContentSection, ContentMain } from 'app/components/Content';
 import type { ActionGrant } from 'app/models';
 import Results from './Results';
-import { QuestionTypes, TokenNavigation } from '../../utils';
+import { TokenNavigation } from '../../utils';
 
 type Props = {
   survey: SurveyEntity,
@@ -53,13 +53,9 @@ const SubmissionPublicResultsPage = ({ survey, actionGrant }: Props) => {
   };
 
   const graphData = {};
-  Object.keys(results)
-    .filter(
-      questionId => results[questionId].questionType !== QuestionTypes('text')
-    )
-    .map(questionId => {
-      graphData[Number(questionId)] = generateQuestionData(questionId);
-    });
+  Object.keys(results).map(questionId => {
+    graphData[Number(questionId)] = generateQuestionData(questionId);
+  });
 
   return (
     <Content className={styles.surveyDetail} banner={survey.event.cover}>

--- a/app/routes/surveys/components/Submissions/SubmissionPublicResults.js
+++ b/app/routes/surveys/components/Submissions/SubmissionPublicResults.js
@@ -15,14 +15,14 @@ type Props = {
 };
 
 const SubmissionPublicResultsPage = ({ survey, actionGrant }: Props) => {
-  const results = survey.results || {};
+  const { results = {} } = survey;
 
   const generateTextAnswers = question => {
     let texts = [];
-    Object.keys(results[String(question.id)])
+    Object.keys(results[question.id])
       .map(name => {
         if (name !== 'questionType') {
-          texts = results[String(question.id)][name].map((answer, i) => (
+          texts = results[question.id][name].map((answer, i) => (
             <li key={i}>{answer}</li>
           ));
         }

--- a/app/routes/surveys/components/Submissions/SubmissionSummary.js
+++ b/app/routes/surveys/components/Submissions/SubmissionSummary.js
@@ -1,13 +1,10 @@
 // @flow
 
 import React from 'react';
-import styles from '../surveys.css';
 import type { SubmissionEntity } from 'app/reducers/surveySubmissions';
 import type { SurveyEntity } from 'app/reducers/surveys';
-import { QuestionTypes, CHART_COLORS } from '../../utils';
-import InfoBubble from 'app/components/InfoBubble';
-import { VictoryPie, VictoryTheme } from 'victory';
 import type { QuestionEntity } from 'app/reducers/surveys';
+import Results from './Results';
 
 type Props = {
   submissions: Array<SubmissionEntity>,
@@ -17,7 +14,7 @@ type Props = {
 };
 
 const SubmissionSummary = ({ submissions, deleteSurvey, survey }: Props) => {
-  const textAnswers = (submissions, question) => {
+  const generateTextAnswers = question => {
     const texts = submissions
       .map(submission => {
         const answer = submission.answers.find(
@@ -59,108 +56,12 @@ const SubmissionSummary = ({ submissions, deleteSurvey, survey }: Props) => {
   });
 
   return (
-    <div>
-      <div className={styles.eventSummary}>
-        <h3>Arrangementet</h3>
-        <div className={styles.infoBubbles}>
-          <InfoBubble
-            icon="person"
-            data={String(survey.event.registrationCount)}
-            meta="Påmeldte"
-            style={{ order: 0 }}
-          />
-          <InfoBubble
-            icon="checkmark"
-            data={String(survey.event.attendedCount)}
-            meta="Møtte opp"
-            style={{ order: 1 }}
-          />
-          <InfoBubble
-            icon="list"
-            data={String(survey.event.waitingRegistrationCount)}
-            meta="På venteliste"
-            style={{ order: 2 }}
-          />
-          <InfoBubble
-            icon="chatboxes"
-            data={String(submissions.length)}
-            meta="Har svart"
-            style={{ order: 3 }}
-          />
-        </div>
-      </div>
-
-      <ul className={styles.summary}>
-        {survey.questions
-          .sort(
-            // Shuffle text answers to the end, otherwise keep ordering
-            (a, b) =>
-              a.questionType === QuestionTypes('text')
-                ? 1
-                : a.relativeIndex - b.relativeIndex
-          )
-          .map(question => {
-            const colorsToRemove = [];
-            const pieData = graphData[question.id].filter((dataPoint, i) => {
-              if (dataPoint.selections === 0) {
-                colorsToRemove.push(i);
-                return false;
-              }
-              return true;
-            });
-            const pieColors = CHART_COLORS.filter(
-              (color, i) => !colorsToRemove.includes(i)
-            );
-            const labelRadius = pieData.length === 1 ? -10 : 60;
-
-            return (
-              <li key={question.id}>
-                <h3>{question.questionText}</h3>
-
-                {question.questionType === QuestionTypes('text') ? (
-                  <ul className={styles.textAnswers}>
-                    {textAnswers(submissions, question)}
-                  </ul>
-                ) : (
-                  <div className={styles.questionResults}>
-                    <div style={{ width: '300px' }}>
-                      <VictoryPie
-                        data={pieData}
-                        x="option"
-                        y="selections"
-                        theme={VictoryTheme.material}
-                        colorScale={pieColors}
-                        labels={d => d.y}
-                        labelRadius={labelRadius}
-                        padding={{ left: 0, top: 40, right: 30, bottom: 30 }}
-                        style={{
-                          labels: { fill: 'white', fontSize: 20 }
-                        }}
-                      />
-                    </div>
-
-                    <ul className={styles.graphData}>
-                      {graphData[question.id].map((dataPoint, i) => (
-                        <li key={i}>
-                          <span
-                            className={styles.colorBox}
-                            style={{ backgroundColor: CHART_COLORS[i] }}
-                          >
-                            &nbsp;
-                          </span>
-                          <span style={{ marginTop: '-5px' }}>
-                            {dataPoint.option}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-              </li>
-            );
-          })}
-      </ul>
-    </div>
+    <Results
+      survey={survey}
+      graphData={graphData}
+      generateTextAnswers={generateTextAnswers}
+      numberOfSubmissions={submissions.length}
+    />
   );
 };
 

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -305,6 +305,10 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+
+  @media (--mobile-device) {
+    flex-direction: column;
+  }
 }
 
 .graphData li {

--- a/app/routes/surveys/index.js
+++ b/app/routes/surveys/index.js
@@ -29,18 +29,22 @@ export default {
       ...resolveAsyncRoute(() => import('./SubmissionsRoute')),
       childRoutes: [
         {
-          path: 'summary', // admin/groups/123/settings
+          path: 'summary',
           ...resolveAsyncRoute(() =>
             import('./components/Submissions/SubmissionSummary')
           )
         },
         {
-          path: 'individual', // admin/groups/123/members
+          path: 'individual',
           ...resolveAsyncRoute(() =>
             import('./components/Submissions/SubmissionIndividual')
           )
         }
       ]
+    },
+    {
+      path: ':surveyId/results',
+      ...resolveAsyncRoute(() => import('./SubmissionsPublicResultsRoute'))
     }
   ]
 };

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -5,6 +5,7 @@ import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import moment from 'moment-timezone';
 import styles from './components/surveys.css';
+import { type ActionGrant } from 'app/models';
 
 const questionStrings = {
   single: 'single_choice',
@@ -40,11 +41,13 @@ export const ListNavigation = ({ title }: { title: Node }) => (
 export const DetailNavigation = ({
   title,
   surveyId,
-  deleteFunction
+  deleteFunction,
+  actionGrant
 }: {
   title: Node,
   surveyId: number,
-  deleteFunction: number => Promise<*>
+  deleteFunction: number => Promise<*>,
+  actionGrant?: ActionGrant
 }) => (
   <NavigationTab title={title} headerClassName={styles.navTab}>
     <NavigationLink to="/surveys">Liste</NavigationLink>
@@ -52,6 +55,25 @@ export const DetailNavigation = ({
     <NavigationLink to={`/surveys/${surveyId}/submissions/summary`}>
       Resultater
     </NavigationLink>
+  </NavigationTab>
+);
+
+export const TokenNavigation = ({
+  title,
+  surveyId,
+  actionGrant
+}: {
+  title: Node,
+  surveyId: number,
+  actionGrant?: ActionGrant
+}) => (
+  <NavigationTab title={title} headerClassName={styles.navTab}>
+    {actionGrant &&
+      actionGrant.includes('EDIT') && (
+        <NavigationLink to={`/surveys/${surveyId}/submissions/summary`}>
+          Adminversjon
+        </NavigationLink>
+      )}
   </NavigationTab>
 );
 

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -61,19 +61,18 @@ export const DetailNavigation = ({
 export const TokenNavigation = ({
   title,
   surveyId,
-  actionGrant
+  actionGrant = []
 }: {
   title: Node,
   surveyId: number,
   actionGrant?: ActionGrant
 }) => (
   <NavigationTab title={title} headerClassName={styles.navTab}>
-    {actionGrant &&
-      actionGrant.includes('EDIT') && (
-        <NavigationLink to={`/surveys/${surveyId}/submissions/summary`}>
-          Adminversjon
-        </NavigationLink>
-      )}
+    {actionGrant.includes('EDIT') && (
+      <NavigationLink to={`/surveys/${surveyId}/submissions/summary`}>
+        Adminversjon
+      </NavigationLink>
+    )}
   </NavigationTab>
 );
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react": "^16.2.0",
     "react-async-script": "^0.9.1",
     "react-collapse": "^4.0.3",
+    "react-copy-to-clipboard": "^5.0.1",
     "react-cropper": "^0.12.0",
     "react-dom": "^16.2.0",
     "react-dropzone": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,6 +1992,12 @@ copy-concurrently@^1.0.0:
     rimraf "^2.5.4"
     run-queue "^1.0.0"
 
+copy-to-clipboard@^3:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
+
 copy-webpack-plugin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz#9728e383b94316050d0c7463958f2b85c0aa8200"
@@ -7010,6 +7016,13 @@ react-collapse@^4.0.3:
   dependencies:
     prop-types "^15.5.8"
 
+react-copy-to-clipboard@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
+
 react-cropper@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/react-cropper/-/react-cropper-0.12.0.tgz#4b1e7f947e476d72d60ef9b228d9a308fe5be8b5"
@@ -8669,6 +8682,10 @@ to-fast-properties@^1.0.3:
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 toposort@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
Requires https://github.com/webkom/lego/pull/1193/files. 

Adds a button that lets admin users get a shareable link that makes survey results publicly available, mainly for the purpose of allowing companies to see the result of their own events.

<img width="1124" alt="skjermbilde 2018-04-24 kl 18 36 45" src="https://user-images.githubusercontent.com/14221386/39201658-f9b53694-47ef-11e8-8a59-8055c9334906.png">

<img width="245" alt="skjermbilde 2018-04-24 kl 18 36 51" src="https://user-images.githubusercontent.com/14221386/39201660-fcfa8eb2-47ef-11e8-83f8-160d75483dcc.png">

Also adds an entirely separate page to view those public results. This looks basically the same as the admin version, except all navigation and other admin-only stuff is gone.

<img width="1280" alt="skjermbilde 2018-04-24 kl 18 37 35" src="https://user-images.githubusercontent.com/14221386/39201671-02ab3186-47f0-11e8-97aa-a59b08064b70.png">
