### PR TITLE
Use object permissions in surveys

### DIFF
--- a/app/routes/surveys/AddSubmissionRoute.js
+++ b/app/routes/surveys/AddSubmissionRoute.js
@@ -35,7 +35,7 @@ const mapStateToProps = (state, props) => {
     submission,
     currentUser,
     notFetching,
-    actionGrant: state.surveys.actionGrant,
+    actionGrant: survey.actionGrant,
     initialValues: {
       answers: []
     }

--- a/app/routes/surveys/SubmissionsRoute.js
+++ b/app/routes/surveys/SubmissionsRoute.js
@@ -27,11 +27,12 @@ const mapStateToProps = (state, props) => {
   const surveyId = Number(props.params.surveyId);
   const locationStrings = props.location.pathname.split('/');
   const isSummary = locationStrings[locationStrings.length - 1] === 'summary';
+  const survey = selectSurveyById(state, { surveyId });
   return {
-    survey: selectSurveyById(state, { surveyId }),
+    survey,
     submissions: selectSurveySubmissions(state, { surveyId }),
     notFetching: !state.surveys.fetching && !state.surveySubmissions.fetching,
-    actionGrant: state.surveys.actionGrant,
+    actionGrant: survey.actionGrant,
     isSummary
   };
 };

--- a/app/routes/surveys/SurveyDetailRoute.js
+++ b/app/routes/surveys/SurveyDetailRoute.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, props) => {
   return {
     survey,
     surveyId,
-    actionGrant: state.surveys.actionGrant
+    actionGrant: survey.actionGrant
   };
 };
 


### PR DESCRIPTION
Ever since ActionGrant changed, permissions functionality in surveys has been broken unless you navigate from the list view first every time. This fixes that by using object permissions.