### PR TITLE
Adjust survey result page

### DIFF
--- a/app/components/NavigationTab/NavigationTab.css
+++ b/app/components/NavigationTab/NavigationTab.css
@@ -14,6 +14,7 @@
   margin: 0;
   padding-top: 15px;
   padding-bottom: 15px;
+  padding-right: 20px;
   text-transform: uppercase;
   flex-shrink: 99999;
 }

--- a/app/routes/surveys/components/Submissions/SubmissionSummary.js
+++ b/app/routes/surveys/components/Submissions/SubmissionSummary.js
@@ -99,51 +99,66 @@ const SubmissionSummary = ({ submissions, deleteSurvey, survey }: Props) => {
                 ? 1
                 : a.relativeIndex - b.relativeIndex
           )
-          .map(question => (
-            <li key={question.id}>
-              <h3>{question.questionText}</h3>
+          .map(question => {
+            const colorsToRemove = [];
+            const pieData = graphData[question.id].filter((dataPoint, i) => {
+              if (dataPoint.selections === 0) {
+                colorsToRemove.push(i);
+                return false;
+              }
+              return true;
+            });
+            const pieColors = CHART_COLORS.filter(
+              (color, i) => !colorsToRemove.includes(i)
+            );
+            const labelRadius = pieData.length === 1 ? -10 : 60;
 
-              {question.questionType === QuestionTypes('text') ? (
-                <ul className={styles.textAnswers}>
-                  {textAnswers(submissions, question)}
-                </ul>
-              ) : (
-                <div className={styles.questionResults}>
-                  <div style={{ width: '300px' }}>
-                    <VictoryPie
-                      data={graphData[question.id]}
-                      x="option"
-                      y="selections"
-                      theme={VictoryTheme.material}
-                      colorScale={CHART_COLORS}
-                      labels={d => d.y}
-                      labelRadius={60}
-                      padding={{ left: 0, top: 40, right: 30, bottom: 30 }}
-                      style={{
-                        labels: { fill: 'white', fontSize: 20 }
-                      }}
-                    />
-                  </div>
+            return (
+              <li key={question.id}>
+                <h3>{question.questionText}</h3>
 
-                  <ul className={styles.graphData}>
-                    {graphData[question.id].map((dataPoint, i) => (
-                      <li key={i}>
-                        <span
-                          className={styles.colorBox}
-                          style={{ backgroundColor: CHART_COLORS[i] }}
-                        >
-                          &nbsp;
-                        </span>
-                        <span style={{ marginTop: '-5px' }}>
-                          {dataPoint.option}
-                        </span>
-                      </li>
-                    ))}
+                {question.questionType === QuestionTypes('text') ? (
+                  <ul className={styles.textAnswers}>
+                    {textAnswers(submissions, question)}
                   </ul>
-                </div>
-              )}
-            </li>
-          ))}
+                ) : (
+                  <div className={styles.questionResults}>
+                    <div style={{ width: '300px' }}>
+                      <VictoryPie
+                        data={pieData}
+                        x="option"
+                        y="selections"
+                        theme={VictoryTheme.material}
+                        colorScale={pieColors}
+                        labels={d => d.y}
+                        labelRadius={labelRadius}
+                        padding={{ left: 0, top: 40, right: 30, bottom: 30 }}
+                        style={{
+                          labels: { fill: 'white', fontSize: 20 }
+                        }}
+                      />
+                    </div>
+
+                    <ul className={styles.graphData}>
+                      {graphData[question.id].map((dataPoint, i) => (
+                        <li key={i}>
+                          <span
+                            className={styles.colorBox}
+                            style={{ backgroundColor: CHART_COLORS[i] }}
+                          >
+                            &nbsp;
+                          </span>
+                          <span style={{ marginTop: '-5px' }}>
+                            {dataPoint.option}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </li>
+            );
+          })}
       </ul>
     </div>
   );

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -312,6 +312,11 @@
   align-items: center;
 }
 
+.textAnswers li {
+  line-height: 19px;
+  margin-bottom: 10px;
+}
+
 .colorBox {
   width: 10px;
   height: 10px;

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -66,6 +66,6 @@ export const CHART_COLORS = [
   '#2b95d6',
   '#d9822b',
   '#3dcc91',
-  '#48aff0',
-  '#f55656'
+  '#c73aea',
+  '#f4ee42'
 ];


### PR DESCRIPTION
Removes options with 0 selections from the pie charts and updates colors:

<img width="558" alt="skjermbilde 2018-04-24 kl 15 46 42" src="https://user-images.githubusercontent.com/14221386/39191249-d7bf45de-47d6-11e8-97c8-2cdae9dee6ae.png">

<img width="548" alt="skjermbilde 2018-04-24 kl 15 46 50" src="https://user-images.githubusercontent.com/14221386/39191257-daf7683a-47d6-11e8-83f4-4ceccb85b092.png">

Makes text answers more distinct:

<img width="772" alt="skjermbilde 2018-04-24 kl 15 46 55" src="https://user-images.githubusercontent.com/14221386/39191302-f13aac38-47d6-11e8-89d5-a1a890ad3487.png">

Adds some room between title and menu in NavigationTab (the green on the right):
<img width="1071" alt="skjermbilde 2018-04-24 kl 15 49 40" src="https://user-images.githubusercontent.com/14221386/39191393-283786f2-47d7-11e8-8fda-823dba7376e3.png">
