### PR TITLE
Disable deleting surveys

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -285,7 +285,6 @@ export const Survey = {
   FETCH: generateStatuses('Survey.FETCH'),
   ADD: generateStatuses('Survey.ADD'),
   EDIT: generateStatuses('Survey.EDIT'),
-  DELETE: generateStatuses('Survey.DELETE'),
   SHARE: generateStatuses('Survey.SHARE'),
   HIDE: generateStatuses('Survey.HIDE')
 };

--- a/app/actions/SurveyActions.js
+++ b/app/actions/SurveyActions.js
@@ -87,19 +87,6 @@ export function editSurvey({ surveyId, ...data }: Object): Thunk<*> {
   });
 }
 
-export function deleteSurvey(surveyId: number): Thunk<*> {
-  return callAPI({
-    types: Survey.DELETE,
-    endpoint: `/surveys/${surveyId}/`,
-    method: 'DELETE',
-    meta: {
-      id: Number(surveyId),
-      errorMessage: 'Sletting av spørreundersøkelse feilet',
-      successMessage: 'Spørreundersøkelse slettet.'
-    }
-  });
-}
-
 export function fetchTemplates(): Thunk<*> {
   return callAPI({
     types: Survey.FETCH,

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -33,27 +33,12 @@ export type OptionEntity = {
   optionText: string
 };
 
-function mutateSurveys(state, action) {
-  switch (action.type) {
-    case Survey.DELETE.SUCCESS: {
-      return {
-        ...state,
-        items: state.items.filter(id => id !== action.meta.id)
-      };
-    }
-
-    default:
-      return state;
-  }
-}
-
 export default createEntityReducer({
   key: 'surveys',
   types: {
     fetch: Survey.FETCH,
     mutate: Survey.ADD
-  },
-  mutate: mutateSurveys
+  }
 });
 
 export const selectSurveys = createSelector(

--- a/app/routes/surveys/AddSurveyRoute.js
+++ b/app/routes/surveys/AddSurveyRoute.js
@@ -1,10 +1,6 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import {
-  addSurvey,
-  deleteSurvey,
-  fetchTemplate
-} from '../../actions/SurveyActions';
+import { addSurvey, fetchTemplate } from '../../actions/SurveyActions';
 import { formValueSelector } from 'redux-form';
 import SurveyEditor from './components/SurveyEditor/SurveyEditor';
 import { LoginPage } from 'app/components/LoginForm';
@@ -82,8 +78,7 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = {
   submitFunction: addSurvey,
-  push,
-  deleteSurvey
+  push
 };
 
 export default compose(

--- a/app/routes/surveys/EditSurveyRoute.js
+++ b/app/routes/surveys/EditSurveyRoute.js
@@ -1,12 +1,7 @@
 import { connect } from 'react-redux';
 import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
-import {
-  editSurvey,
-  fetch,
-  deleteSurvey,
-  fetchTemplate
-} from '../../actions/SurveyActions';
+import { editSurvey, fetch, fetchTemplate } from '../../actions/SurveyActions';
 import SurveyEditor from './components/SurveyEditor/SurveyEditor';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
@@ -86,7 +81,6 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = {
   submitFunction: editSurvey,
-  deleteSurvey,
   push
 };
 

--- a/app/routes/surveys/SubmissionsRoute.js
+++ b/app/routes/surveys/SubmissionsRoute.js
@@ -7,12 +7,7 @@ import {
   hideAnswer,
   showAnswer
 } from 'app/actions/SurveySubmissionActions';
-import {
-  fetch,
-  deleteSurvey,
-  shareSurvey,
-  hideSurvey
-} from 'app/actions/SurveyActions';
+import { fetch, shareSurvey, hideSurvey } from 'app/actions/SurveyActions';
 import SubmissionPage from './components/Submissions/SubmissionPage';
 import { compose } from 'redux';
 import { selectSurveySubmissions } from 'app/reducers/surveySubmissions';
@@ -48,7 +43,6 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   addSubmission,
   deleteSubmission,
-  deleteSurvey,
   push,
   shareSurvey,
   hideSurvey,

--- a/app/routes/surveys/SurveyDetailRoute.js
+++ b/app/routes/surveys/SurveyDetailRoute.js
@@ -1,11 +1,6 @@
 import { connect } from 'react-redux';
 import prepare from 'app/utils/prepare';
-import {
-  fetch,
-  deleteSurvey,
-  shareSurvey,
-  hideSurvey
-} from 'app/actions/SurveyActions';
+import { fetch, shareSurvey, hideSurvey } from 'app/actions/SurveyActions';
 import SurveyDetail from './components/SurveyDetail';
 import { compose } from 'redux';
 import { selectSurveyById } from 'app/reducers/surveys';
@@ -28,7 +23,6 @@ const mapStateToProps = (state, props) => {
 };
 
 const mapDispatchToProps = {
-  deleteSurvey,
   push,
   shareSurvey,
   hideSurvey

--- a/app/routes/surveys/TemplatesRoute.js
+++ b/app/routes/surveys/TemplatesRoute.js
@@ -1,10 +1,6 @@
 import { connect } from 'react-redux';
 import prepare from 'app/utils/prepare';
-import {
-  addSurvey,
-  deleteSurvey,
-  fetchTemplates
-} from '../../actions/SurveyActions';
+import { addSurvey, fetchTemplates } from '../../actions/SurveyActions';
 import SurveyPage from './components/SurveyList/SurveyPage';
 import { compose } from 'redux';
 import { selectSurveyTemplates } from 'app/reducers/surveys';
@@ -22,7 +18,6 @@ const mapStateToProps = (state, props) => ({
 
 const mapDispatchToProps = {
   addSurvey,
-  deleteSurvey,
   push
 };
 

--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import styles from './surveys.css';
 import { Link } from 'react-router';
-import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import type { ActionGrant } from 'app/models';
 import { ContentSidebar } from 'app/components/Content';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
@@ -13,8 +12,6 @@ import { CheckBox } from 'app/components/Form';
 
 type Props = {
   surveyId: number,
-  deleteFunction?: number => Promise<*>,
-  push?: string => void,
   actionGrant: ActionGrant,
   token?: string,
   shareSurvey: number => Promise<*>,
@@ -33,28 +30,13 @@ export class AdminSideBar extends React.Component<Props, State> {
   render() {
     const {
       surveyId,
-      deleteFunction,
       actionGrant = [],
-      push,
       token,
       shareSurvey,
       hideSurvey
     } = this.props;
 
     const canEdit = actionGrant.includes('edit');
-
-    const onConfirm = () => {
-      if (deleteFunction && push) {
-        return (
-          deleteFunction &&
-          deleteFunction(surveyId).then(() => push && push('/surveys'))
-        );
-      }
-      if (deleteFunction) {
-        return deleteFunction && deleteFunction(surveyId);
-      }
-      return Promise.resolve();
-    };
 
     const shareLink = !token
       ? ''
@@ -71,17 +53,6 @@ export class AdminSideBar extends React.Component<Props, State> {
             <li>
               <Link to={`/surveys/${surveyId}/edit`}>Endre undersøkelsen</Link>
             </li>
-            {deleteFunction && (
-              <ConfirmModalWithParent
-                title="Slett undersøkelse"
-                message="Er du sikker på at du vil slette denne undersøkelseen?"
-                onConfirm={onConfirm}
-              >
-                <li>
-                  <Link to="">Slett undersøkelsen</Link>
-                </li>
-              </ConfirmModalWithParent>
-            )}
             {actionGrant &&
               actionGrant.includes('edit') &&
               shareSurvey && (

--- a/app/routes/surveys/components/Submissions/SubmissionIndividual.js
+++ b/app/routes/surveys/components/Submissions/SubmissionIndividual.js
@@ -10,11 +10,10 @@ import cx from 'classnames';
 type Props = {
   submissions: Array<SubmissionEntity>,
   addSubmission: SubmissionEntity => Promise<*>,
-  deleteSurvey: number => Promise<*>,
   survey: SurveyEntity
 };
 
-const SubmissionPage = ({ submissions, deleteSurvey, survey }: Props) => {
+const SubmissionPage = ({ submissions, survey }: Props) => {
   return (
     <ul className={styles.submissions}>
       {submissions.map((submission, i) => (

--- a/app/routes/surveys/components/Submissions/SubmissionPage.js
+++ b/app/routes/surveys/components/Submissions/SubmissionPage.js
@@ -13,7 +13,6 @@ import type { ActionGrant } from 'app/models';
 type Props = {
   submissions: Array<SubmissionEntity>,
   addSubmission: SubmissionEntity => Promise<*>,
-  deleteSurvey: number => Promise<*>,
   survey: SurveyEntity,
   children: React.Element<*>,
   actionGrant: ActionGrant,
@@ -23,22 +22,11 @@ type Props = {
 };
 
 const SubmissionPage = (props: Props) => {
-  const {
-    deleteSurvey,
-    survey,
-    actionGrant,
-    isSummary,
-    hideSurvey,
-    shareSurvey
-  } = props;
+  const { survey, actionGrant, isSummary, hideSurvey, shareSurvey } = props;
 
   return (
     <Content className={styles.surveyDetail} banner={survey.event.cover}>
-      <DetailNavigation
-        title={survey.title}
-        surveyId={Number(survey.id)}
-        deleteFunction={deleteSurvey}
-      />
+      <DetailNavigation title={survey.title} surveyId={Number(survey.id)} />
 
       <ContentSection>
         <ContentMain>

--- a/app/routes/surveys/components/Submissions/SubmissionSummary.js
+++ b/app/routes/surveys/components/Submissions/SubmissionSummary.js
@@ -10,7 +10,6 @@ import styles from '../surveys.css';
 type Props = {
   submissions: Array<SubmissionEntity>,
   addSubmission: SubmissionEntity => Promise<*>,
-  deleteSurvey: number => Promise<*>,
   survey: SurveyEntity,
   hideAnswer: (number, number, number) => Promise<*>,
   showAnswer: (number, number, number) => Promise<*>
@@ -18,7 +17,6 @@ type Props = {
 
 const SubmissionSummary = ({
   submissions,
-  deleteSurvey,
   survey,
   hideAnswer,
   showAnswer

--- a/app/routes/surveys/components/SurveyDetail.js
+++ b/app/routes/surveys/components/SurveyDetail.js
@@ -15,7 +15,6 @@ import { eventTypes } from 'app/routes/events/utils';
 
 type Props = {
   survey: SurveyEntity,
-  deleteSurvey: number => Promise<*>,
   actionGrant: ActionGrant,
   push: string => void,
   shareSurvey: number => Promise<*>,
@@ -33,25 +32,14 @@ class SurveyDetail extends Component<Props> {
   }
 
   render() {
-    const {
-      survey,
-      deleteSurvey,
-      actionGrant = [],
-      push,
-      shareSurvey,
-      hideSurvey
-    } = this.props;
+    const { survey, actionGrant = [], shareSurvey, hideSurvey } = this.props;
 
     return (
       <Content
         className={styles.surveyDetail}
         banner={!survey.templateType && survey.event.cover}
       >
-        <DetailNavigation
-          title={survey.title}
-          surveyId={Number(survey.id)}
-          deleteFunction={deleteSurvey}
-        />
+        <DetailNavigation title={survey.title} surveyId={Number(survey.id)} />
 
         <ContentSection>
           <ContentMain>
@@ -86,8 +74,6 @@ class SurveyDetail extends Component<Props> {
           <AdminSideBar
             surveyId={survey.id}
             actionGrant={actionGrant}
-            push={push}
-            deleteFunction={deleteSurvey}
             token={survey.token}
             shareSurvey={shareSurvey}
             hideSurvey={hideSurvey}

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
@@ -27,7 +27,6 @@ type Props = FieldProps & {
   autoFocus: Object,
   surveyData: Array<Object>,
   submitFunction: (SurveyEntity, ?number) => Promise<*>,
-  deleteSurvey: number => Promise<*>,
   push: string => void,
   template?: Object,
   destroy: () => void,
@@ -95,7 +94,6 @@ class SurveyEditor extends Component<Props, State> {
       submitting,
       autoFocus,
       handleSubmit,
-      deleteSurvey,
       template,
       push,
       destroy,
@@ -117,11 +115,7 @@ class SurveyEditor extends Component<Props, State> {
       <Content className={styles.detail}>
         <form onSubmit={handleSubmit}>
           {survey && survey.id ? (
-            <DetailNavigation
-              title={titleField}
-              surveyId={Number(survey.id)}
-              deleteFunction={deleteSurvey}
-            />
+            <DetailNavigation title={titleField} surveyId={Number(survey.id)} />
           ) : (
             <ListNavigation title={titleField} />
           )}

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -41,12 +41,10 @@ export const ListNavigation = ({ title }: { title: Node }) => (
 export const DetailNavigation = ({
   title,
   surveyId,
-  deleteFunction,
   actionGrant
 }: {
   title: Node,
   surveyId: number,
-  deleteFunction: number => Promise<*>,
   actionGrant?: ActionGrant
 }) => (
   <NavigationTab title={title} headerClassName={styles.navTab}>


### PR DESCRIPTION
There's a problem when deleting surveys. They are both Persistent and part of a one-to-one relation, which means that when you delete a survey for a particular event, you can never create a new survey for that event again.

There are several solutions to this. One is to remove "PersistentModel" from Surveys, and I strongly considered that option. However, that would mean deleting a survey also deletes all submissions for that survey, which makes a small fuckup pretty devastating. 

Another is to remove the OneToOne aspect of the event-survey relationship, but that's a pretty major change as I've assumed that relationship for several features both backend and frontend.

So while the core problem has yet to be solved, I decided to instead just remove the `delete` functionality from the front end for now. It's still available in the API and of course the shell, but regular users should very rarely need to delete a survey. I struggle to think of a use case. So for now, this should be an acceptable solution while we decide how to solve the underlying one.