### PR TITLE
Add more colors to the survey results pie charts

### DIFF
--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -86,5 +86,8 @@ export const CHART_COLORS = [
   '#d9822b',
   '#3dcc91',
   '#c73aea',
-  '#f4ee42'
+  '#f4ee42',
+  '#98f442',
+  '#ff87eb',
+  '#000000'
 ];


### PR DESCRIPTION
I thought 6 options would be enough, but already in the first 3 surveys, several questions have used more. So we need more available colors for the pie charts.