### PR TITLE
Fix filename too long 'issue'

### DIFF
--- a/app/routes/bdb/components/bdb.css
+++ b/app/routes/bdb/components/bdb.css
@@ -149,6 +149,10 @@
   & div {
     display: inline;
   }
+
+  & span {
+    max-width: 200px;
+  }
 }
 
 .deleteIcon {


### PR DESCRIPTION
The issue of a filenames begin to long in the bdb detail is already fixed by  `{truncateString(name, FILE_NAME_LENGTH)}`, so on refresh Jonathan Eriksen issue would have disappeared. This just limits the width of the span, so on upload the filename will line-break.