### PR TITLE
Make event sorting stable and deterministic (sort of, atleast)

### DIFF
--- a/app/reducers/frontpage.js
+++ b/app/reducers/frontpage.js
@@ -17,6 +17,7 @@ export const selectFrontpage = createSelector(
       documentType: 'article'
     }));
     events = events.map(event => ({ ...event, documentType: 'event' }));
+    const now = moment();
     return sortBy(articles.concat(events), [
       // Always sort pinned items first:
       item => !item.pinned,
@@ -24,7 +25,7 @@ export const selectFrontpage = createSelector(
         // For events we care about when the event starts, whereas for articles
         // we look at when it was written:
         const timeField = item.eventType ? item.startTime : item.createdAt;
-        return Math.abs(moment().diff(timeField));
+        return Math.abs(now.diff(timeField));
       },
       item => item.id
     ]);


### PR DESCRIPTION
Since our sorting algorithm isn't `O(0)`, we need this. :100: This fixes the flashing on the frontpage when two events have the same date, and the SSR and client sorts with a different pace.


This is the output of `moment().format("x")` (unix-time) inside the sorting algorithm. We cannot give varying constants as input to our sorting algorithm, resulting in strange non-deterministic input. 

Client:
![screenshot from 2018-09-23 14-32-55](https://user-images.githubusercontent.com/1467188/45928054-98aa2d80-bf3d-11e8-9444-c4d760745c30.png)


Server side renderer
![screenshot from 2018-09-23 14-31-50](https://user-images.githubusercontent.com/1467188/45928048-787a6e80-bf3d-11e8-9b56-4f91d22f0704.png)

Result: `node>chrome`

