### PR TITLE
Remove fixed width value for readmes on frontpage

### DIFF
--- a/app/routes/overview/components/LatestReadme.css
+++ b/app/routes/overview/components/LatestReadme.css
@@ -5,6 +5,10 @@
   composes: withShadow from 'app/styles/utilities.css';
   background: var(--lego-card-color);
   padding: 10px 20px;
+
+  @media (--mobile-device) {
+    padding: 10px 5px;
+  }
 }
 
 .heading {
@@ -18,6 +22,11 @@
   transition: transform 0.2s;
   display: block;
   object-fit: contain;
+
+  @media (--mobile-device) {
+    width: 48%;
+    height: auto;
+  }
 
   &:hover {
     transform: scale(1.1);

--- a/app/routes/overview/components/LatestReadme.js
+++ b/app/routes/overview/components/LatestReadme.js
@@ -45,7 +45,7 @@ class LatestReadme extends Component<Props, State> {
         </button>
 
         {expanded && (
-          <Flex wrap justifyContent="space-between" style={{ paddingTop: 20 }}>
+          <Flex wrap justifyContent="space-around" style={{ paddingTop: 20 }}>
             {readmes.slice(0, 6).map(({ image, pdf, title }) => (
               <a key={title} href={pdf} className={styles.thumb}>
                 <Image src={image} />


### PR DESCRIPTION
The frontpage readmes had a set `150px` width, which for many smaller viewports would mean that only one readme could fit on each row. Setting the width to a `percentage` fixes this.

**::before**
![screenshot from 2018-10-14 15-49-45](https://user-images.githubusercontent.com/23152018/46917709-31c2e600-cfca-11e8-9de3-ca75ed1c0e78.png)

**::after**
![screenshot from 2018-10-14 15-58-52](https://user-images.githubusercontent.com/23152018/46917726-63d44800-cfca-11e8-9e7b-bbd3b61477f8.png)

