### PR TITLE
Summary and individual are inverted

### DIFF
--- a/app/routes/surveys/components/Submissions/SubmissionPage.js
+++ b/app/routes/surveys/components/Submissions/SubmissionPage.js
@@ -33,14 +33,14 @@ const SubmissionPage = (props: Props) => {
           <div className={styles.submissionNav}>
             <Link
               to={`/surveys/${survey.id}/submissions/summary`}
-              className={isSummary ? styles.activeRoute : styles.inactiveRoute}
+              className={!isSummary ? styles.activeRoute : styles.inactiveRoute}
             >
               Oppsummering
             </Link>
             {' | '}
             <Link
               to={`/surveys/${survey.id}/submissions/individual`}
-              className={!isSummary ? styles.activeRoute : styles.inactiveRoute}
+              className={isSummary ? styles.activeRoute : styles.inactiveRoute}
             >
               Individuell
             </Link>


### PR DESCRIPTION
When you are at "Summary" then "Individual" is bold, and vice versa. This fixes that.
![screenshot from 2018-10-15 19-22-41](https://user-images.githubusercontent.com/23152018/46967139-f13d9800-d0af-11e8-9cb2-a2e52233a545.png)
