### PR TITLE
Add/delete/edit podcasts

### DIFF
--- a/app/actions/PodcastAction.js
+++ b/app/actions/PodcastAction.js
@@ -4,6 +4,7 @@ import { Podcast } from './ActionTypes';
 import { podcastSchema } from 'app/reducers';
 import callAPI from 'app/actions/callAPI';
 import type { Thunk } from 'app/types';
+import { push } from 'react-router-redux';
 
 export function fetchPodcasts() {
   return callAPI({
@@ -50,15 +51,43 @@ export function addPodcast(data: {
   description: string,
   authors: Array<number>
 }): Thunk<*> {
-  return callAPI({
-    types: Podcast.CREATE,
-    endpoint: '/podcasts/',
-    method: 'POST',
-    body: data,
-    schema: podcastSchema,
-    meta: {
-      errorMessage: 'Legg til podcast feilet',
-      successMessage: 'Podcast lagt til'
-    }
-  });
+  return dispatch =>
+    dispatch(
+      callAPI({
+        types: Podcast.CREATE,
+        endpoint: '/podcasts/',
+        method: 'POST',
+        body: data,
+        schema: podcastSchema,
+        meta: {
+          errorMessage: 'Legg til podcast feilet',
+          successMessage: 'Podcast lagt til'
+        }
+      })
+    ).then(() => dispatch(push(`podcasts/`)));
+}
+
+export function editPodcast({
+  id,
+  ...data
+}: {
+  id: number,
+  title: string,
+  source: string,
+  description: string,
+  authors: Array<number>
+}): Thunk<*> {
+  return dispatch =>
+    dispatch(
+      callAPI({
+        types: Podcast.UPDATE,
+        endpoint: `/podcasts/${id}/`,
+        method: 'PUT',
+        schema: podcastSchema,
+        body: data,
+        meta: {
+          errorMessage: 'Endring av podcast feilet'
+        }
+      })
+    ).then(() => dispatch(push(`/podcasts/`)));
 }

--- a/app/reducers/podcasts.js
+++ b/app/reducers/podcasts.js
@@ -12,7 +12,7 @@ export type PodcastEntity = {
   discription: string
 };
 
-const deleteQuote = (state: any, action: any) => {
+const deletePodcast = (state: any, action: any) => {
   switch (action.type) {
     case Podcast.DELETE.SUCCESS:
       return {
@@ -30,7 +30,7 @@ export default createEntityReducer({
     fetch: Podcast.FETCH,
     mutate: Podcast.CREATE
   },
-  mutate: deleteQuote
+  mutate: deletePodcast
 });
 
 export const selectPodcasts = createSelector(

--- a/app/routes/podcasts/PodcastEditRoute.js
+++ b/app/routes/podcasts/PodcastEditRoute.js
@@ -5,7 +5,7 @@ import { selectPodcastById } from 'app/reducers/podcasts';
 import {
   fetchPodcasts,
   deletePodcast,
-  addPodcast
+  editPodcast
 } from 'app/actions/PodcastAction';
 import prepare from 'app/utils/prepare';
 import PodcastEditor from './components/PodcastEditor';
@@ -15,7 +15,7 @@ import loadingIndicator from 'app/utils/loadingIndicator';
 const mapDispachToProps = {
   deletePodcast,
   push,
-  handleSubmitCallback: addPodcast
+  handleSubmitCallback: editPodcast
 };
 
 const mapStateToProps = (state, props) => {

--- a/app/routes/podcasts/components/Podcast.css
+++ b/app/routes/podcasts/components/Podcast.css
@@ -128,6 +128,11 @@
   padding: 20px;
 }
 
+.extra {
+  margin-top: 10px;
+  justify-content: space-evenly;
+}
+
 .showMore {
   display: flex;
   justify-content: center;

--- a/app/routes/podcasts/components/Podcast.js
+++ b/app/routes/podcasts/components/Podcast.js
@@ -6,7 +6,6 @@ import LegoSoundCloudPlayer from './PodcastPlayer.js';
 import { Link } from 'react-router';
 import Icon from 'app/components/Icon';
 import { ProfilePicture } from 'app/components/Image';
-import moment from 'moment-timezone';
 
 type Props = {
   id: number,
@@ -39,7 +38,6 @@ class Podcast extends Component<Props, State> {
     const {
       id,
       source,
-      createdAt,
       description,
       authors,
       thanks,
@@ -95,13 +93,7 @@ class Podcast extends Component<Props, State> {
             <div className={styles.talking}>
               <span className={styles.init}>Snakker</span> {authorsSpan}
             </div>
-            <p>
-              <span className={styles.init}>Publisert</span>
-              <span className={styles.published}>
-                {moment(createdAt).format('Do MMM YY')}
-              </span>
-            </p>
-            <p style={{ textAlign: 'justify' }}>
+            <p style={{ textAlign: 'justify', marginBottom: '0' }}>
               <span className={styles.init}>Om </span>
               {description}
             </p>

--- a/app/routes/podcasts/components/PodcastEditor.js
+++ b/app/routes/podcasts/components/PodcastEditor.js
@@ -31,7 +31,7 @@ class PodcastEditor extends Component<Props, *> {
   render() {
     const handleDeletePodcast = () => {
       const { deletePodcast, initialValues: { id }, push } = this.props;
-      deletePodcast(id).then(() => {
+      return deletePodcast(id).then(() => {
         push('/podcasts/');
       });
     };

--- a/app/routes/podcasts/components/PodcastEditor.js
+++ b/app/routes/podcasts/components/PodcastEditor.js
@@ -11,6 +11,7 @@ import {
   legoForm
 } from 'app/components/Form';
 import { Form, Field } from 'redux-form';
+import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 
 type Props = {
   id: number,
@@ -47,11 +48,13 @@ class PodcastEditor extends Component<Props, *> {
           <Field
             name="source"
             label="SoundCloud lenke"
+            placeholder="https://soundcloud.com/user-279926342/24-du-vil-aldri-tro-hva-disse-guttene-sa-pa-lufta"
             component={TextInput.Field}
           />
           <Field
             name="description"
             label="Beskrivelse"
+            placeholder="I ukas podcast snakker vi om..."
             component={TextArea.Field}
           />
           <Field
@@ -72,7 +75,13 @@ class PodcastEditor extends Component<Props, *> {
             {this.props.new ? 'Lag podcast' : 'Lagre podcast'}
           </Button>
           {this.props.initialValues.id && (
-            <Button onClick={handleDeletePodcast}>Delete</Button>
+            <ConfirmModalWithParent
+              title="Slett podcast"
+              message="Er du sikker på at du vil slette denne podcasten"
+              onConfirm={handleDeletePodcast}
+            >
+              <Button>Delete</Button>
+            </ConfirmModalWithParent>
           )}
         </Form>
       </Content>
@@ -82,10 +91,9 @@ class PodcastEditor extends Component<Props, *> {
 
 const onSubmit = (
   {
-    source,
-    description,
     authors,
-    thanks
+    thanks,
+    ...rest
   }: {
     source: string,
     description: string,
@@ -94,13 +102,13 @@ const onSubmit = (
   },
   dispach,
   props
-) =>
-  props.handleSubmitCallback({
-    source,
-    description,
+) => {
+  return props.handleSubmitCallback({
     authors: authors.map(user => user.value),
-    thanks: thanks.map(user => user.value)
+    thanks: thanks.map(user => user.value),
+    ...rest
   });
+};
 
 export default legoForm({
   form: 'podcastEditor',

--- a/app/routes/podcasts/components/PodcastPlayer.js
+++ b/app/routes/podcasts/components/PodcastPlayer.js
@@ -18,6 +18,7 @@ import styles from './Podcast.css';
 import { Flex } from 'app/components/Layout';
 import Icon from 'app/components/Icon';
 import { Link } from 'react-router';
+import moment from 'moment-timezone';
 
 type Props = {
   id: number,
@@ -32,6 +33,23 @@ type Props = {
 class LegoSoundCloudPlayer extends Component<Props, *> {
   render() {
     const { id, track, currentTime, duration, actionGrant } = this.props;
+    if (!track) {
+      return (
+        <p style={{ textAlign: 'center' }}>
+          {actionGrant.includes('edit') && (
+            <Link
+              to={`/podcasts/${id}/edit`}
+              style={{ marginRight: '10px', whiteSpace: 'nowrap' }}
+            >
+              <Icon size={17} name="options" style={{ marginRight: '5px' }} />
+              Det er noe feil med linken til denne podcasten, trykk her for å
+              endre den
+            </Link>
+          )}
+        </p>
+      );
+    }
+    const [date] = track.created_at.split(' ');
     return (
       <section>
         <div className={styles.header}>
@@ -73,6 +91,17 @@ class LegoSoundCloudPlayer extends Component<Props, *> {
             duration={track ? track.duration / 1000 : 0}
             {...this.props}
           />
+          <Flex className={styles.extra}>
+            <span>
+              <Icon size={15} name="time" style={{ margin: '0 5px' }} />
+              {moment(date, 'YYYY/MM/DD').format('Do MMM YYYY')}
+            </span>
+            <span>
+              Lyttere
+              <Icon size={15} name="podium" style={{ margin: '0 5px' }} />
+              {track.playback_count}
+            </span>
+          </Flex>
         </Flex>
       </section>
     );


### PR DESCRIPTION
A general improvement to the podcast.

- Permissions work as intended

- The ability to add/delete/edit podcasts work as intended

- Add extra info from the SoundCloud API

- Add delete modal

- Add the ability for admins to change the podcast if the resolveURL is wrong

![screenshot 2018-10-26 at 23 19 40](https://user-images.githubusercontent.com/23152018/47594526-0225bd80-d97c-11e8-819b-2a6540e5bb4c.png)

