### PR TITLE
Temporary frontpage fix - remove feeds, insert weekly

### DIFF
--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -68,6 +68,35 @@
   flex-wrap: wrap;
 }
 
+.weeklyArticles {
+  border: 1px solid rgba(0, 0, 0, 0.09);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+  border-radius: 3px;
+  overflow-y: auto;
+  height: 480px;
+  flex: 1;
+  background: var(--lego-card-color);
+
+  @media (--mobile-device) {
+    height: auto;
+    max-height: 495px;
+  }
+}
+
+@media only screen and (max-width: 855px) {
+  .weeklyArticles {
+    height: auto;
+    max-height: 615px;
+  }
+}
+
+@-moz-document url-prefix() {
+  .content {
+    height: 490px;
+    flex: none;
+  }
+}
+
 .showMore {
   display: flex;
   justify-content: center;

--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -73,8 +73,7 @@
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
   border-radius: 3px;
   overflow-y: auto;
-  height: 480px;
-  flex: 1;
+  height: 489px;
   background: var(--lego-card-color);
 
   @media (--mobile-device) {
@@ -86,7 +85,7 @@
 @media only screen and (max-width: 855px) {
   .weeklyArticles {
     height: auto;
-    max-height: 615px;
+    max-height: 659px;
   }
 }
 

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -7,7 +7,7 @@ import Time from 'app/components/Time';
 import { Container, Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import LatestReadme from './LatestReadme';
-import Feed from './Feed';
+// import Feed from './Feed';
 import CompactEvents from './CompactEvents';
 import { EVENT_TYPE_TO_STRING } from 'app/routes/events/utils';
 import type { Event, Article } from 'app/models';
@@ -21,8 +21,8 @@ import truncateString from 'app/utils/truncateString';
 
 type Props = {
   frontpage: Array<Object>,
-  feed: Object,
-  feedItems: Array<Object>,
+  // feed: Object,
+  // feedItems: Array<Object>,
   readmes: Array<Object>,
   loadingFrontpage: boolean
 };
@@ -90,8 +90,8 @@ class Overview extends Component<Props, State> {
     const isEvent = o => typeof o['startTime'] !== 'undefined';
     const {
       frontpage,
-      feed,
-      feedItems,
+      // feed,
+      // feedItems,
       loadingFrontpage,
       readmes
     } = this.props;
@@ -113,7 +113,29 @@ class Overview extends Component<Props, State> {
               )}
             </LoadingIndicator>
           </Flex>
-          <Feed style={{ flex: 2 }} feed={feed} feedItems={feedItems} />
+          {/* <Feed style={{ flex: 2 }} feed={feed} feedItems={feedItems} /> */}
+          <Flex column style={{ flex: '0.8', margin: 'auto' }}>
+            <p
+              className="u-ui-heading"
+              style={{ paddingTop: 0, paddingBottom: 0 }}
+            >
+              Weekly
+            </p>
+            <Flex column className={styles.weeklyArticles}>
+              {frontpage
+                .filter(item => item.documentType === 'article')
+                .filter(article => article.tags.includes('weekly'))
+                .slice(0, this.state.articlesToShow)
+                .map(article => (
+                  <ArticleItem
+                    key={article.id}
+                    item={article}
+                    url={this.itemUrl(article)}
+                    meta={this.renderMeta(article)}
+                  />
+                ))}
+            </Flex>
+          </Flex>
         </Flex>
         <Flex />
 
@@ -145,6 +167,7 @@ class Overview extends Component<Props, State> {
             <Flex className={styles.articles}>
               {frontpage
                 .filter(item => item.documentType === 'article')
+                .filter(article => !article.tags.includes('weekly'))
                 .slice(0, this.state.articlesToShow)
                 .map(article => (
                   <ArticleItem

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -114,7 +114,10 @@ class Overview extends Component<Props, State> {
             </LoadingIndicator>
           </Flex>
           {/* <Feed style={{ flex: 2 }} feed={feed} feedItems={feedItems} /> */}
-          <Flex column style={{ flex: '0.8', margin: 'auto' }}>
+          <Flex
+            column
+            style={{ flex: '1', padding: '0 10px', margin: '0 auto' }}
+          >
             <p
               className="u-ui-heading"
               style={{ paddingTop: 0, paddingBottom: 0 }}
@@ -125,7 +128,6 @@ class Overview extends Component<Props, State> {
               {frontpage
                 .filter(item => item.documentType === 'article')
                 .filter(article => article.tags.includes('weekly'))
-                .slice(0, this.state.articlesToShow)
                 .map(article => (
                   <ArticleItem
                     key={article.id}
@@ -138,7 +140,6 @@ class Overview extends Component<Props, State> {
           </Flex>
         </Flex>
         <Flex />
-
         <Flex padding={10}>
           <LatestReadme readmes={readmes} expanded={frontpage.length === 0} />
         </Flex>


### PR DESCRIPTION
In light of the wishes of Abakom (and personal agreement to remove it before its useful) to remove "kunngjøringer" from the frontpage (feeds basically, but only announcements as is), I've removed it and replaced it with the prettier Weekly articles section. 

This is not meant as a permanent fix, rather a quick fix to improve upon the existing before we can work more on the structure (which we know it will change in the future).

Announcements can still be viewed from your notifications.

Please approve of this change <3 

![screenshot from 2018-11-01 12-35-26](https://user-images.githubusercontent.com/25204035/47850230-df106900-ddd4-11e8-84ed-308ed2855025.png)

![screenshot from 2018-11-01 12-35-54](https://user-images.githubusercontent.com/25204035/47850237-e33c8680-ddd4-11e8-8de2-b9be16088b82.png)

![screenshot from 2018-11-01 12-36-11](https://user-images.githubusercontent.com/25204035/47850248-e768a400-ddd4-11e8-9c26-42e7d6f5bdfc.png)
