### PR TITLE
Display position of registration in waiting registration list

### DIFF
--- a/app/routes/events/EventDetailRoute.js
+++ b/app/routes/events/EventDetailRoute.js
@@ -96,6 +96,7 @@ const mapStateToProps = (state, props) => {
     );
     currentRegistration = currentPool.registrations[currentRegistrationIndex];
   }
+  const hasSimpleWaitingList = poolsWithRegistrations.length <= 1;
 
   return {
     comments,
@@ -106,7 +107,8 @@ const mapStateToProps = (state, props) => {
     pools,
     registrations,
     currentRegistration,
-    currentRegistrationIndex
+    currentRegistrationIndex,
+    hasSimpleWaitingList
   };
 };
 

--- a/app/routes/events/EventDetailRoute.js
+++ b/app/routes/events/EventDetailRoute.js
@@ -27,9 +27,6 @@ import {
 import loadingIndicator from 'app/utils/loadingIndicator';
 import helmet from 'app/utils/helmet';
 
-const findCurrentRegistration = (registrations, currentUser) =>
-  registrations.find(registration => registration.user.id === currentUser.id);
-
 const mapStateToProps = (state, props) => {
   const {
     params: { eventId },
@@ -86,10 +83,19 @@ const mapStateToProps = (state, props) => {
           permissionGroups: []
         })
       : poolsWithRegistrations;
-  const currentRegistration = findCurrentRegistration(
-    registrations.concat(waitingRegistrations),
-    currentUser
+  const currentPool = pools.find(pool =>
+    pool.registrations.some(
+      registration => registration.user.id === currentUser.id
+    )
   );
+  let currentRegistration;
+  let currentRegistrationIndex;
+  if (currentPool) {
+    currentRegistrationIndex = currentPool.registrations.findIndex(
+      registration => registration.user.id === currentUser.id
+    );
+    currentRegistration = currentPool.registrations[currentRegistrationIndex];
+  }
 
   return {
     comments,
@@ -99,7 +105,8 @@ const mapStateToProps = (state, props) => {
     eventId,
     pools,
     registrations,
-    currentRegistration
+    currentRegistration,
+    currentRegistrationIndex
   };
 };
 

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -52,6 +52,7 @@ type Props = {
   pools: Array<Object>,
   registrations: Array<Object>,
   currentRegistration: Object,
+  currentRegistrationIndex: number,
   waitingRegistrations: Array<Object>,
   register: ({
     eventId: string,

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -53,6 +53,7 @@ type Props = {
   registrations: Array<Object>,
   currentRegistration: Object,
   currentRegistrationIndex: number,
+  hasSimpleWaitingList: boolean,
   waitingRegistrations: Array<Object>,
   register: ({
     eventId: string,
@@ -131,6 +132,7 @@ export default class EventDetail extends Component<Props> {
       registrations,
       currentRegistration,
       currentRegistrationIndex,
+      hasSimpleWaitingList,
       deleteEvent,
       follow,
       unfollow
@@ -264,6 +266,7 @@ export default class EventDetail extends Component<Props> {
                     registration={currentRegistration}
                     isPriced={event.isPriced}
                     registrationIndex={currentRegistrationIndex}
+                    hasSimpleWaitingList={hasSimpleWaitingList}
                   />
                 )}
                 <Admin

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -129,6 +129,7 @@ export default class EventDetail extends Component<Props> {
       pools,
       registrations,
       currentRegistration,
+      currentRegistrationIndex,
       deleteEvent,
       follow,
       unfollow
@@ -261,6 +262,7 @@ export default class EventDetail extends Component<Props> {
                   <RegistrationMeta
                     registration={currentRegistration}
                     isPriced={event.isPriced}
+                    registrationIndex={currentRegistrationIndex}
                   />
                 )}
                 <Admin

--- a/app/routes/events/components/RegistrationMeta.js
+++ b/app/routes/events/components/RegistrationMeta.js
@@ -6,7 +6,7 @@ import { hasPaid } from '../utils';
 type Props = {
   registration: Object,
   isPriced: boolean,
-  registrationIndex?: Number
+  registrationIndex?: number
 };
 
 const RegistrationMeta = ({

--- a/app/routes/events/components/RegistrationMeta.js
+++ b/app/routes/events/components/RegistrationMeta.js
@@ -6,13 +6,15 @@ import { hasPaid } from '../utils';
 type Props = {
   registration: Object,
   isPriced: boolean,
-  registrationIndex?: number
+  registrationIndex: number,
+  hasSimpleWaitingList: boolean
 };
 
 const RegistrationMeta = ({
   registration,
   isPriced,
-  registrationIndex
+  registrationIndex,
+  hasSimpleWaitingList
 }: Props) => (
   <div>
     {!registration && (
@@ -26,7 +28,7 @@ const RegistrationMeta = ({
           <div>
             <i className="fa fa-check-circle" /> Du er registrert
           </div>
-        ) : registrationIndex !== undefined ? (
+        ) : hasSimpleWaitingList ? (
           <div>
             <i className="fa fa-pause-circle" /> Din plass i venteliste{' '}
             <strong>{registrationIndex + 1}</strong>

--- a/app/routes/events/components/RegistrationMeta.js
+++ b/app/routes/events/components/RegistrationMeta.js
@@ -5,10 +5,15 @@ import { hasPaid } from '../utils';
 
 type Props = {
   registration: Object,
-  isPriced: boolean
+  isPriced: boolean,
+  registrationIndex?: Number
 };
 
-const RegistrationMeta = ({ registration, isPriced }: Props) => (
+const RegistrationMeta = ({
+  registration,
+  isPriced,
+  registrationIndex
+}: Props) => (
   <div>
     {!registration && (
       <div>
@@ -20,6 +25,11 @@ const RegistrationMeta = ({ registration, isPriced }: Props) => (
         {registration.pool ? (
           <div>
             <i className="fa fa-check-circle" /> Du er registrert
+          </div>
+        ) : registrationIndex !== undefined ? (
+          <div>
+            <i className="fa fa-pause-circle" /> Din plass i venteliste{' '}
+            <strong>{registrationIndex + 1}</strong>
           </div>
         ) : (
           <div>


### PR DESCRIPTION
I'd like to get a spot on the Julebord, but I don't know where I am in the waiting registration list! Here's something to make waiting to get moved out of the waiting registration list a little more exciting.

![bilde](https://user-images.githubusercontent.com/5446387/47875370-a7c2ac00-de16-11e8-92ac-f09bd2bd5b2d.png)

I have implemented a prop for EventDetail that specifies the position of the current registration in its registration pool. This value is displayed accordingly if the pool is "Venteliste".