### PR TITLE
Use id instead of htmlId

### DIFF
--- a/app/components/DisplayContent/index.js
+++ b/app/components/DisplayContent/index.js
@@ -19,7 +19,7 @@ type Props = {
  */
 function DisplayContent({ content, id, style, className }: Props) {
   return (
-    <div key={content} htmlId={id} style={style} className={className}>
+    <div key={content} id={id} style={style} className={className}>
       <Editor
         onChange={() => {}}
         onBlur={() => {}}


### PR DESCRIPTION
This warning seems to have gone by unnoticed. Looks like a bug introduced in #1130, maybe started showing up with a ReactDOM update?

As far as I know, the ID is only being used for testing the Comment component. For whatever reason, `htmlId` still passes as `id` and the test passes!

```
PASS app/components/Comments/__tests__/Comment.spec.js
  ● Console

    console.error node_modules/fbjs/lib/warning.js:33
      Warning: React does not recognize the `htmlId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `htmlid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          in div
          in DisplayContent
```