### PR TITLE
Add registration close time

### DIFF
--- a/app/models.js
+++ b/app/models.js
@@ -53,7 +53,6 @@ type EventBase = {
   useCaptcha: boolean,
   tags: Array<Tags>,
   registrationDeadlineHours: number,
-  registrationCloseTime: Dateish,
   unregistrationDeadline: Dateish,
   pinned: boolean,
   youtubeUrl: string

--- a/app/models.js
+++ b/app/models.js
@@ -52,6 +52,8 @@ type EventBase = {
   mergeTime: ?Dateish,
   useCaptcha: boolean,
   tags: Array<Tags>,
+  registrationDeadlineHours: number,
+  registrationCloseTime: Dateish,
   unregistrationDeadline: Dateish,
   pinned: boolean,
   youtubeUrl: string

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -16,6 +16,7 @@ import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { isEmpty } from 'lodash';
 import { fetchEvent } from 'app/actions/EventActions';
 import loadingIndicator from 'app/utils/loadingIndicator';
+import moment from 'moment-timezone';
 
 const mapStateToProps = (state, props) => {
   const actionGrant = state.events.actionGrant;
@@ -65,7 +66,8 @@ const mapStateToProps = (state, props) => {
       useConsent: false,
       feedbackDescription: '',
       pools: [],
-      unregistrationDeadline: time({ hours: 12 })
+      unregistrationDeadline: time({ hours: 12 }),
+      registrationDeadlineHours: 2
     },
     actionGrant,
     ...selectedValues
@@ -109,6 +111,18 @@ const mapStateToProps = (state, props) => {
       responsibleGroup: eventTemplate.responsibleGroup && {
         label: eventTemplate.responsibleGroup.name,
         value: eventTemplate.responsibleGroup.id
+      },
+      event: {
+        addFee: valueSelector(state, 'addFee'),
+        isPriced: valueSelector(state, 'isPriced'),
+        eventType: valueSelector(state, 'eventType'),
+        priceMember: valueSelector(state, 'priceMember'),
+        registrationDeadline:
+          valueSelector(state, 'startTime') &&
+          moment(valueSelector(state, 'startTime')).subtract(
+            valueSelector(state, 'registrationDeadlineHours'),
+            'hours'
+          )
       }
     },
     actionGrant,

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -38,7 +38,13 @@ const mapStateToProps = (state, props) => {
       eventType: valueSelector(state, 'eventType'),
       priceMember: valueSelector(state, 'priceMember'),
       startTime: valueSelector(state, 'startTime'),
-      eventStatusType: valueSelector(state, 'eventStatusType')
+      eventStatusType: valueSelector(state, 'eventStatusType'),
+      registrationDeadline:
+        valueSelector(state, 'startTime') &&
+        moment(valueSelector(state, 'startTime')).subtract(
+          valueSelector(state, 'registrationDeadlineHours'),
+          'hours'
+        )
     },
     pools: valueSelector(state, 'pools')
   };
@@ -111,18 +117,6 @@ const mapStateToProps = (state, props) => {
       responsibleGroup: eventTemplate.responsibleGroup && {
         label: eventTemplate.responsibleGroup.name,
         value: eventTemplate.responsibleGroup.id
-      },
-      event: {
-        addFee: valueSelector(state, 'addFee'),
-        isPriced: valueSelector(state, 'isPriced'),
-        eventType: valueSelector(state, 'eventType'),
-        priceMember: valueSelector(state, 'priceMember'),
-        registrationDeadline:
-          valueSelector(state, 'startTime') &&
-          moment(valueSelector(state, 'startTime')).subtract(
-            valueSelector(state, 'registrationDeadlineHours'),
-            'hours'
-          )
       }
     },
     actionGrant,

--- a/app/routes/events/EventEditRoute.js
+++ b/app/routes/events/EventEditRoute.js
@@ -21,6 +21,7 @@ import { LoginPage } from 'app/components/LoginForm';
 import { transformEvent } from './utils';
 import time from 'app/utils/time';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
+import moment from 'moment-timezone';
 
 const mapStateToProps = (state, props) => {
   const eventId = props.params.eventId;
@@ -64,7 +65,13 @@ const mapStateToProps = (state, props) => {
       heedPenalties: valueSelector(state, 'heedPenalties'),
       feedbackRequired: valueSelector(state, 'feedbackRequired'),
       useStripe: valueSelector(state, 'useStripe'),
-      priceMember: valueSelector(state, 'priceMember')
+      priceMember: valueSelector(state, 'priceMember'),
+      registrationDeadline:
+        valueSelector(state, 'startTime') &&
+        moment(valueSelector(state, 'startTime')).subtract(
+          valueSelector(state, 'registrationDeadlineHours'),
+          'hours'
+        )
     },
     eventId,
     pools: valueSelector(state, 'pools'),

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -16,7 +16,11 @@ import { FormatTime, FromToTime } from 'app/components/Time';
 import InfoList from 'app/components/InfoList';
 import { Flex } from 'app/components/Layout';
 import Tooltip from 'app/components/Tooltip';
-import { eventTypeToString, colorForEvent } from '../../utils';
+import {
+  eventTypeToString,
+  colorForEvent,
+  registrationCloseTime
+} from '../../utils';
 import Admin from '../Admin';
 import RegistrationMeta from '../RegistrationMeta';
 import DisplayContent from 'app/components/DisplayContent';
@@ -212,18 +216,18 @@ export default class EventDetail extends Component<Props> {
             value: <FormatTime time={event.activationTime} />
           }
         : null,
+      event.registrationDeadlineHours &&
+      !['OPEN', 'TBA'].includes(event.eventStatusType)
+        ? {
+            value: <FormatTime time={registrationCloseTime(event)} />,
+            key: 'Påmelding stenger'
+          }
+        : null,
       event.unregistrationDeadline &&
       !['OPEN', 'TBA'].includes(event.eventStatusType)
         ? {
             key: 'Avregistreringsfrist',
             value: <FormatTime time={event.unregistrationDeadline} />
-          }
-        : null,
-      event.registrationDeadlineHours &&
-      !['OPEN', 'TBA'].includes(event.eventStatusType)
-        ? {
-            key: 'Påmelding stenger',
-            value: <FormatTime time={event.registrationCloseTime} />
           }
         : null
     ];

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -218,6 +218,13 @@ export default class EventDetail extends Component<Props> {
             key: 'Avregistreringsfrist',
             value: <FormatTime time={event.unregistrationDeadline} />
           }
+        : null,
+      event.registrationDeadlineHours &&
+      !['OPEN', 'TBA'].includes(event.eventStatusType)
+        ? {
+            key: 'Påmelding stenger',
+            value: <FormatTime time={event.registrationCloseTime} />
+          }
         : null
     ];
 

--- a/app/routes/events/components/EventEditor/EventEditor.css
+++ b/app/routes/events/components/EventEditor/EventEditor.css
@@ -26,6 +26,10 @@
   padding-left: 5px;
 }
 
+.registrationDeadlineHours {
+  font-size: 100%;
+}
+
 .metaField {
   margin-bottom: 0;
 }

--- a/app/routes/events/components/EventEditor/EventEditor.css
+++ b/app/routes/events/components/EventEditor/EventEditor.css
@@ -28,6 +28,8 @@
 
 .registrationDeadlineHours {
   font-size: 100%;
+  margin: 0;
+  font-style: italic;
 }
 
 .metaField {

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -229,7 +229,6 @@ function EventEditor({
               fieldClassName={styles.metaField}
               className={styles.formField}
             />
-
             <Tooltip content="Kun la medlemmer i Abakom se arrangement">
               <Field
                 label="Kun for Abakom"
@@ -240,7 +239,6 @@ function EventEditor({
                 normalize={v => !!v}
               />
             </Tooltip>
-
             <Field
               label="Påmeldingstype"
               name="eventStatusType"
@@ -249,7 +247,6 @@ function EventEditor({
               options={eventStatusType}
               simpleValue
             />
-
             {['NORMAL', 'OPEN', 'INFINITE'].includes(event.eventStatusType) && (
               <Field
                 label="Sted"
@@ -261,7 +258,6 @@ function EventEditor({
                 warn={isTBA}
               />
             )}
-
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Field
                 label="Betalt arrangement"
@@ -272,7 +268,6 @@ function EventEditor({
                 normalize={v => !!v}
               />
             )}
-
             {event.isPriced && (
               <div className={styles.subSection}>
                 <Tooltip content="Manuell betaling kan også av i etterkant">
@@ -329,7 +324,6 @@ function EventEditor({
                 />
               </div>
             )}
-
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Field
                 label="Bruk prikker"
@@ -340,27 +334,6 @@ function EventEditor({
                 normalize={v => !!v}
               />
             )}
-
-            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) &&
-              event.heedPenalties && (
-                <div className={styles.subSection}>
-                  <Tooltip content="Frist for påmelding - antall timer før arrangementet">
-                    <Field
-                      key="registrationDeadlineHours"
-                      label="Påmeldingsfrist"
-                      name="registrationDeadlineHours"
-                      type="number"
-                      component={TextInput.Field}
-                      fieldClassName={styles.metaField}
-                      className={styles.formField}
-                    />
-                  </Tooltip>
-                  <p className={styles.registrationDeadlineHours}>
-                    <FormatTime time={moment(event.registrationDeadline)} />
-                  </p>
-                </div>
-              )}
-
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) &&
               event.heedPenalties && (
                 <div className={styles.subSection}>
@@ -376,7 +349,23 @@ function EventEditor({
                   </Tooltip>
                 </div>
               )}
-
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
+              <Tooltip content="Frist for påmelding - antall timer før arrangementet">
+                <Field
+                  key="registrationDeadlineHours"
+                  label="Påmelding stenger (standard 2 timer)"
+                  name="registrationDeadlineHours"
+                  type="number"
+                  component={TextInput.Field}
+                  fieldClassName={styles.metaField}
+                  className={styles.formField}
+                />
+                <p className={styles.registrationDeadlineHours}>
+                  Stenger:{' '}
+                  <FormatTime time={moment(event.registrationDeadline)} />
+                </p>
+              </Tooltip>
+            )}
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Tooltip content="Bruk samtykke til bilder">
                 <Field
@@ -389,7 +378,6 @@ function EventEditor({
                 />
               </Tooltip>
             )}
-
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Tooltip content="Et spørsmål alle må svare på før de melder seg på">
                 <Field
@@ -414,7 +402,6 @@ function EventEditor({
                   />
                 </div>
               )}
-
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Flex column>
                 <h3>Pools</h3>
@@ -474,7 +461,7 @@ function EventEditor({
 
 const validate = data => {
   const errors = {};
-
+  const isPositiveNumeric = value => /^\d+$/.test(value);
   const [isValidYoutubeUrl, errorMessage = ''] = validYoutubeUrl()(
     data.youtubeUrl
   );
@@ -510,6 +497,9 @@ const validate = data => {
   }
   if (data.feedbackRequired && !data.feedbackDescription) {
     errors.feedbackDescription = 'Kan ikke være tomt';
+  }
+  if (!isPositiveNumeric(data.registrationDeadlineHours)) {
+    errors.registrationDeadlineHours = 'Kun hele timer';
   }
   return errors;
 };

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -350,10 +350,10 @@ function EventEditor({
                 </div>
               )}
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
-              <Tooltip content="Frist for påmelding - antall timer før arrangementet">
+              <Tooltip content="Frist for påmelding/avmelding - antall timer før arrangementet. Det er ikke mulig å melde seg hverken på eller av etter denne fristen">
                 <Field
                   key="registrationDeadlineHours"
-                  label="Påmelding stenger (standard 2 timer)"
+                  label="Antall timer før"
                   name="registrationDeadlineHours"
                   type="number"
                   component={TextInput.Field}

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -36,6 +36,8 @@ import Tooltip from 'app/components/Tooltip';
 import Icon from 'app/components/Icon';
 import type { ID } from 'app/models';
 import { validYoutubeUrl } from 'app/utils/validation';
+import { FormatTime } from 'app/components/Time';
+import moment from 'moment-timezone';
 
 type Props = {
   eventId: number,
@@ -338,6 +340,26 @@ function EventEditor({
                 normalize={v => !!v}
               />
             )}
+
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) &&
+              event.heedPenalties && (
+                <div className={styles.subSection}>
+                  <Tooltip content="Frist for påmelding - antall timer før arrangementet">
+                    <Field
+                      key="registrationDeadlineHours"
+                      label="Påmeldingsfrist"
+                      name="registrationDeadlineHours"
+                      type="number"
+                      component={TextInput.Field}
+                      fieldClassName={styles.metaField}
+                      className={styles.formField}
+                    />
+                  </Tooltip>
+                  <p className={styles.registrationDeadlineHours}>
+                    <FormatTime time={moment(event.registrationDeadline)} />
+                  </p>
+                </div>
+              )}
 
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) &&
               event.heedPenalties && (

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -16,6 +16,7 @@ import withCountdown from './JoinEventFormCountdownProvider';
 import formStyles from 'app/components/Form/Field.css';
 import moment from 'moment-timezone';
 import { paymentSuccess, paymentManual } from '../utils';
+import { registrationIsClosed } from '../utils';
 
 type Event = Object;
 
@@ -173,11 +174,8 @@ class JoinEventForm extends Component<Props> {
       registration &&
       registration.pool &&
       ![paymentManual, paymentSuccess].includes(registration.chargeStatus);
-    const registrationIsOver = moment().isAfter(
-      moment(event.registrationCloseTime)
-    );
 
-    if (registrationIsOver) {
+    if (registrationIsClosed(event)) {
       return (
         <>
           {!formOpen && registration && showStripe && (

--- a/app/routes/events/components/JoinEventFormCountdownProvider.js
+++ b/app/routes/events/components/JoinEventFormCountdownProvider.js
@@ -3,6 +3,7 @@
 import React, { Component, type Node, type ComponentType } from 'react';
 import moment from 'moment-timezone';
 import type { Dateish, Event, EventRegistration } from 'app/models';
+import { registrationIsClosed } from '../utils';
 
 type Action =
   | 'REGISTRATION_AVAILABLE'
@@ -132,19 +133,15 @@ function withCountdown(WrappedComponent: ComponentType<Props>) {
     }
 
     setupEventCountdown = (event: Event, registration: ?EventRegistration) => {
-      const { activationTime, startTime, registrationDeadlineHours } = event;
+      const { activationTime } = event;
       const poolActivationTime = moment(activationTime);
-      const currentTime = moment();
 
-      const registrationIsClosed = currentTime.isAfter(
-        moment(startTime).subtract(registrationDeadlineHours, 'hours')
-      );
-      if ((!registration && !activationTime) || registrationIsClosed) {
+      if ((!registration && !activationTime) || registrationIsClosed(event)) {
         this.dispatch('REGISTRATION_NOT_AVAILABLE');
         return;
       }
 
-      if (registration || poolActivationTime.isBefore(currentTime)) {
+      if (registration || poolActivationTime.isBefore(moment())) {
         this.dispatch('REGISTERED_OR_REGISTRATION_ALREADY_OPENED');
         return;
       }

--- a/app/routes/events/components/JoinEventFormCountdownProvider.js
+++ b/app/routes/events/components/JoinEventFormCountdownProvider.js
@@ -132,13 +132,12 @@ function withCountdown(WrappedComponent: ComponentType<Props>) {
     }
 
     setupEventCountdown = (event: Event, registration: ?EventRegistration) => {
-      const { activationTime, startTime } = event;
+      const { activationTime, startTime, registrationDeadlineHours } = event;
       const poolActivationTime = moment(activationTime);
       const currentTime = moment();
 
-      // TODO: the 2 hour subtract is a hardcoded close time and should be improved
       const registrationIsClosed = currentTime.isAfter(
-        moment(startTime).subtract(2, 'hours')
+        moment(startTime).subtract(registrationDeadlineHours, 'hours')
       );
       if ((!registration && !activationTime) || registrationIsClosed) {
         this.dispatch('REGISTRATION_NOT_AVAILABLE');

--- a/app/routes/events/components/__tests__/JoinEventFormCountdownProvider.spec.js
+++ b/app/routes/events/components/__tests__/JoinEventFormCountdownProvider.spec.js
@@ -30,6 +30,8 @@ const EVENT = {
   mergeTime: null,
   useCaptcha: true,
   tags: [],
+  registrationDeadlineHours: 2,
+  registrationCloseTime: moment().add(2, 'hours'),
   unregistrationDeadline: moment().add(10, 'days'),
   pinned: false,
   actionGrant: [],

--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -1,7 +1,7 @@
 // @flow
 import { pick } from 'lodash';
 import moment from 'moment-timezone';
-import type { TransformEvent } from 'app/models';
+import type { TransformEvent, Event } from 'app/models';
 
 // Value type based on the EVENT_CONSTANTS
 export type eventTypes = $Values<typeof EVENT_CONSTANTS>;
@@ -64,7 +64,6 @@ const eventCreateAndUpdateFields = [
   'tags',
   'pools',
   'registrationDeadlineHours',
-  'registrationCloseTime',
   'unregistrationDeadline',
   'pinned',
   'heedPenalties',
@@ -186,3 +185,10 @@ export const hasPaid = (chargeStatus: string) =>
   paymentSuccessMappings[chargeStatus];
 
 export const addStripeFee = (price: number) => Math.ceil(price * 1.012 + 1.8);
+
+export const registrationCloseTime = (event: Event) =>
+  moment(event.startTime).subtract(event.registrationDeadlineHours, 'hours');
+
+export const registrationIsClosed = (event: Event) => {
+  return moment().isAfter(registrationCloseTime(event));
+};

--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -63,6 +63,8 @@ const eventCreateAndUpdateFields = [
   'useCaptcha',
   'tags',
   'pools',
+  'registrationDeadlineHours',
+  'registrationCloseTime',
   'unregistrationDeadline',
   'pinned',
   'heedPenalties',


### PR DESCRIPTION
Event should have a dynamic registration close time.

Now it needs instant change of `registration_close_time` when user types hours in field and perhaps some styling.

Event:
![image](https://user-images.githubusercontent.com/31897129/48174029-7e1def00-e306-11e8-8ce3-736453cb6fe4.png)


Edit event:
![image](https://user-images.githubusercontent.com/31897129/48173957-35fecc80-e306-11e8-8815-13bfb06a7a92.png)
