### PR TITLE
Don't show 0/0 attendance pills for events

### DIFF
--- a/app/routes/events/components/CalendarCell.js
+++ b/app/routes/events/components/CalendarCell.js
@@ -46,9 +46,11 @@ const renderEvent = ({
     <div>
       <h3 className={styles.eventItemTitle}>
         {title}
-        <Pill style={{ marginLeft: 10 }}>
-          {`${registrationCount} / ${totalCapacity}`}
-        </Pill>
+        {totalCapacity > 0 && (
+          <Pill style={{ marginLeft: 10 }}>
+            {`${registrationCount} / ${totalCapacity}`}
+          </Pill>
+        )}
       </h3>
 
       {description}

--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -75,11 +75,13 @@ export function EventItem({ event, showTags = true }: EventItemProps) {
       <div>
         <Link to={`/events/${event.id}`}>
           <h3 className={styles.eventItemTitle}>{event.title}</h3>
-          <Attendance
-            registrationCount={event.registrationCount}
-            totalCapacity={event.totalCapacity}
-            style={{ marginLeft: '5px', color: 'black' }}
-          />
+          {event.totalCapacity > 0 && (
+            <Attendance
+              registrationCount={event.registrationCount}
+              totalCapacity={event.totalCapacity}
+              style={{ marginLeft: '5px', color: 'black' }}
+            />
+          )}
         </Link>
 
         <div className={styles.eventTime}>


### PR DESCRIPTION
Pills showing "0/0" look slightly ugly in my opinion, so here I have simply removed the pills when the total capacity of the event is zero (which I assume is what qualifies as some event not requiring registration). Showing something else is an alternative - let me know if you would prefer that.

![bilde](https://user-images.githubusercontent.com/5446387/48231038-37cf9b00-e3ad-11e8-95a3-e66b6375029e.png)

Note that this also applies to the tooltips in the event calendar.

Speaking of events that do not require registration - When researching how to approach this, I stumbled upon similar logic elsewhere in the application from #1293 which does not appear to be correct:

https://github.com/webkom/lego-webapp/blob/be4a72a10df25a9f489e2a86c842909eef271a6d/app/routes/overview/components/EventItem.js#L32-L38

I believe this would result in "Ingen påmelding" when the event has nonzero capacity but no participants. That does not look like the intended behavior. If it is, it should be applied in this PR too. If not, I'll probably make a separate PR to fix that as well.