### PR TITLE
Do not show penalty warning if in waiting list

### DIFF
--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -163,7 +163,9 @@ class JoinEventForm extends Component<Props> {
       : false;
     const disabledForUser = !formOpen && !event.activationTime;
     const showPenaltyNotice =
-      event.heedPenalties && moment().isAfter(event.unregistrationDeadline);
+      event.heedPenalties &&
+      moment().isAfter(event.unregistrationDeadline) &&
+      registration.pool;
     const showCaptcha =
       !submitting && !registration && captchaOpen && event.useCaptcha;
     const showStripe =


### PR DESCRIPTION
Should take care of issue #1280 if I've understood how the data flow works correctly, which is that your registration is only put in a pool once you've actually got a spot on the event. 

If that is not the case, that the registration has no pools, you are in the waiting list and should therefore be allowed to unregister without getting a penalty (which is also the case when actually unregistering) 