### PR TITLE
Remove global css

### DIFF
--- a/app/routes/brand/components/BrandPage.css
+++ b/app/routes/brand/components/BrandPage.css
@@ -15,7 +15,7 @@
   padding-top: 10px;
 }
 
-ul {
+.colLeft ul {
   list-style: outside;
   padding-left: 1.5em;
 }

--- a/app/routes/brand/components/BrandPage.js
+++ b/app/routes/brand/components/BrandPage.js
@@ -46,7 +46,7 @@ const BrandPage = () => (
             </p>
           </Flex>
           <Flex column className={styles.colRight}>
-            <img src={logosDos} width={200} />
+            <img src={logosDos} alt="Allowed examples" width={200} />
           </Flex>
         </Flex>
 
@@ -74,7 +74,7 @@ const BrandPage = () => (
             </ul>
           </Flex>
           <Flex column className={styles.colRight}>
-            <img src={logosDonts} width={200} />
+            <img src={logosDonts} alt="Not allowed examples" width={200} />
           </Flex>
         </Flex>
         <div>


### PR DESCRIPTION
All ul list elements in the webapp got this new ul styling. CSS-modules only hash/scope the custom classNames