### PR TITLE
Fix Ingen påmelding tag

### DIFF
--- a/app/routes/overview/components/EventItem.css
+++ b/app/routes/overview/components/EventItem.css
@@ -65,7 +65,7 @@
   }
 }
 
-.count {
+.info {
   background: white;
   text-align: center;
   border-radius: 0 0 5px 5px;

--- a/app/routes/overview/components/EventItem.js
+++ b/app/routes/overview/components/EventItem.js
@@ -9,6 +9,7 @@ import { Link } from 'react-router';
 import { Flex } from 'app/components/Layout';
 import { colorForEvent } from 'app/routes/events/utils';
 import styles from './EventItem.css';
+import moment from 'moment-timezone';
 
 type Props = {
   item: Event | Article,
@@ -20,7 +21,16 @@ class EventItem extends Component<Props, *> {
   render() {
     const { item, url, meta } = this.props;
     const TITLE_MAX_LENGTH = 50;
-    const { registrationCount, totalCapacity } = item;
+    const { registrationCount, totalCapacity, activationTime } = item;
+
+    // This value will less then 0 if activationTime has yet to come
+    const future = moment().diff(activationTime) < 0;
+    const info = future
+      ? `Åpner ${moment(activationTime).format('dddd D MMM HH:mm')}`
+      : totalCapacity == 0
+      ? 'Åpent arrangement'
+      : `${registrationCount}/${totalCapacity}`;
+
     return (
       <div className={styles.body}>
         <Link to={url} className={styles.link}>
@@ -29,13 +39,7 @@ class EventItem extends Component<Props, *> {
               {item.cover && (
                 <Image className={styles.image} src={item.cover} />
               )}
-              {registrationCount && totalCapacity ? (
-                <span className={styles.count}>
-                  {registrationCount}/{totalCapacity}
-                </span>
-              ) : (
-                <span className={styles.count}>Ingen påmelding</span>
-              )}
+              <span className={styles.info}>{info}</span>
             </Flex>
             <div
               className={styles.right}


### PR DESCRIPTION
Long ago I wrote some bad code that made all events 0/0 or 0/x say Ingen påmelding. This was wrong as all events that were yet to open got this message. Long ago we fixed the serializer so activation time is sent with the event.

This will(should) add a better tooltip under the event. I think I've thought of all scenarios that can happen to an event.

![screenshot 2019-01-15 at 21 57 20](https://user-images.githubusercontent.com/23152018/51209557-c8c47480-1910-11e9-81a8-48eee27ad185.png)
