### PR TITLE
Send announcement from a group

### DIFF
--- a/app/actions/AnnouncementsActions.js
+++ b/app/actions/AnnouncementsActions.js
@@ -25,6 +25,7 @@ export function createAnnouncement(
     groups,
     events,
     meetings,
+    fromGroup,
     send
   }: Object /*AnnouncementModel*/
 ): Thunk<*> {
@@ -39,7 +40,8 @@ export function createAnnouncement(
           users,
           groups,
           events,
-          meetings
+          meetings,
+          fromGroup
         },
         schema: announcementsSchema,
         meta: {

--- a/app/components/Feed/renders/announcement.js
+++ b/app/components/Feed/renders/announcement.js
@@ -3,6 +3,7 @@ import React, { type Element } from 'react';
 import Icon from 'app/components/Icon';
 import { lookupContext, contextRender } from '../context';
 import type { AggregatedActivity, TagInfo } from '../types';
+import styles from '../context.css';
 
 /**
  * Group by object
@@ -17,7 +18,11 @@ export function activityHeader(
 
   return (
     <b>
-      {htmlTag(contextRender[actor.contentType](actor))}
+      {object.fromGroup ? (
+        <span className={styles.highlight}>{object.fromGroup.name}</span>
+      ) : (
+        htmlTag(contextRender[actor.contentType](actor))
+      )}
       {' sendte ut en kunngjøring:'}
       <br />
       {htmlTag(contextRender[object.contentType](object))}

--- a/app/models.js
+++ b/app/models.js
@@ -183,6 +183,11 @@ export type Announcement = {
   groups: Array<Object>,
   events: Array<Object>,
   meetings: Array<Object>,
+  fromGroup: {
+    id: number,
+    name: string,
+    type: string
+  },
   sent?: boolean
 };
 

--- a/app/models.js
+++ b/app/models.js
@@ -183,11 +183,7 @@ export type Announcement = {
   groups: Array<Object>,
   events: Array<Object>,
   meetings: Array<Object>,
-  fromGroup: {
-    id: number,
-    name: string,
-    type: string
-  },
+  fromGroup: Group,
   sent?: boolean
 };
 

--- a/app/routes/announcements/components/AnnouncementItem.js
+++ b/app/routes/announcements/components/AnnouncementItem.js
@@ -32,6 +32,15 @@ const AnnouncementItem = ({
           )}
         </Flex>
         <Flex className={styles.msg}>{announcement.message}</Flex>
+        <Flex wrap>
+          {announcement.fromGroup && 'Sendt fra: '}
+          <Link
+            className={styles.recipients}
+            to={`/admin/groups/${announcement.fromGroup.id}/`}
+          >
+            {announcement.fromGroup.name}
+          </Link>
+        </Flex>
         <Flex column>
           <span className={styles.recHeader}>Mottakere:</span>
           <Flex wrap>
@@ -64,7 +73,7 @@ const AnnouncementItem = ({
               <Link
                 key={i}
                 className={styles.recipients}
-                to={`/groups/${group.id}/`}
+                to={`/admin/groups/${group.id}/`}
               >
                 {group.name}
               </Link>

--- a/app/routes/announcements/components/AnnouncementItem.js
+++ b/app/routes/announcements/components/AnnouncementItem.js
@@ -32,15 +32,17 @@ const AnnouncementItem = ({
           )}
         </Flex>
         <Flex className={styles.msg}>{announcement.message}</Flex>
-        <Flex wrap>
-          {announcement.fromGroup && 'Sendt fra: '}
-          <Link
-            className={styles.recipients}
-            to={`/admin/groups/${announcement.fromGroup.id}/`}
-          >
-            {announcement.fromGroup.name}
-          </Link>
-        </Flex>
+        {announcement.fromGroup && (
+          <Flex wrap>
+            {'Sendt fra: '}
+            <Link
+              className={styles.recipients}
+              to={`/admin/groups/${announcement.fromGroup.id}/`}
+            >
+              {announcement.fromGroup.name}
+            </Link>
+          </Flex>
+        )}
         <Flex column>
           <span className={styles.recHeader}>Mottakere:</span>
           <Flex wrap>

--- a/app/routes/announcements/components/AnnouncementsCreate.js
+++ b/app/routes/announcements/components/AnnouncementsCreate.js
@@ -35,6 +35,7 @@ const AnnouncementsCreate = ({
       groups: announcement.groups.map(group => group.value),
       meetings: announcement.meetings.map(meeting => meeting.value),
       events: announcement.events.map(event => event.value),
+      fromGroup: announcement.fromGroup ? announcement.fromGroup.value : null,
       send
     });
   };
@@ -86,6 +87,13 @@ const AnnouncementsCreate = ({
                 component={SelectInput.AutocompleteField}
               />
             </Flex>
+            <span className={styles.formHeaders}>Sendt fra:</span>
+            <Field
+              name="fromGroup"
+              placeholder="Fra gruppe"
+              filter={['users.abakusgroup']}
+              component={SelectInput.AutocompleteField}
+            />
             <Flex>
               <Button
                 onClick={handleSubmit(values => onSubmit(values, false))}

--- a/app/routes/announcements/components/AnnouncementsCreate.js
+++ b/app/routes/announcements/components/AnnouncementsCreate.js
@@ -35,7 +35,7 @@ const AnnouncementsCreate = ({
       groups: announcement.groups.map(group => group.value),
       meetings: announcement.meetings.map(meeting => meeting.value),
       events: announcement.events.map(event => event.value),
-      fromGroup: announcement.fromGroup.value,
+      fromGroup: announcement.fromGroup && announcement.fromGroup.value,
       send
     });
   };
@@ -87,7 +87,7 @@ const AnnouncementsCreate = ({
                 component={SelectInput.AutocompleteField}
               />
             </Flex>
-            <span className={styles.formHeaders}>Sendt fra:</span>
+            <span className={styles.formHeaders}>Send på vegne av:</span>
             <Field
               name="fromGroup"
               placeholder="Fra gruppe"

--- a/app/routes/announcements/components/AnnouncementsCreate.js
+++ b/app/routes/announcements/components/AnnouncementsCreate.js
@@ -35,7 +35,7 @@ const AnnouncementsCreate = ({
       groups: announcement.groups.map(group => group.value),
       meetings: announcement.meetings.map(meeting => meeting.value),
       events: announcement.events.map(event => event.value),
-      fromGroup: announcement.fromGroup ? announcement.fromGroup.value : null,
+      fromGroup: announcement.fromGroup,
       send
     });
   };

--- a/app/routes/announcements/components/AnnouncementsCreate.js
+++ b/app/routes/announcements/components/AnnouncementsCreate.js
@@ -35,7 +35,7 @@ const AnnouncementsCreate = ({
       groups: announcement.groups.map(group => group.value),
       meetings: announcement.meetings.map(meeting => meeting.value),
       events: announcement.events.map(event => event.value),
-      fromGroup: announcement.fromGroup,
+      fromGroup: announcement.fromGroup.value,
       send
     });
   };


### PR DESCRIPTION
Adds the option to send an announcement from a group. If specified, the selected group replaces the user as the sender. The user who creates the announcements is still shown in the timeline.
Resolve https://github.com/webkom/lego/issues/1389