### PR TITLE
Fix tooltip for events

### DIFF
--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -38,9 +38,6 @@ const InterestedButton = ({ isInterested }: InterestedButtonProps) => {
   return <Icon className={styles.star} name={icon} />;
 };
 
-/**
- *
- */
 type Props = {
   eventId: string,
   event: Object,
@@ -78,9 +75,6 @@ type Props = {
   updateUser: Object => void
 };
 
-/**
- *
- */
 export default class EventDetail extends Component<Props> {
   handleRegistration = ({ captchaResponse, feedback, type }: Object) => {
     const {

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -185,13 +185,15 @@ function EventEditor({
               fieldClassName={styles.metaField}
               className={styles.formField}
             />
-            <Field
-              label="Sted"
-              name="location"
-              component={TextInput.Field}
-              fieldClassName={styles.metaField}
-              className={styles.formField}
-            />
+            <Tooltip content="Events som settes som TBA og ikke har noen pool vil vises som TBA på forsiden.">
+              <Field
+                label="Sted"
+                name="location"
+                component={TextInput.Field}
+                fieldClassName={styles.metaField}
+                className={styles.formField}
+              />
+            </Tooltip>
             <Field
               label="Betalt arrangement"
               name="isPriced"

--- a/app/routes/overview/components/EventItem.js
+++ b/app/routes/overview/components/EventItem.js
@@ -23,13 +23,41 @@ class EventItem extends Component<Props, *> {
     const TITLE_MAX_LENGTH = 50;
     const { registrationCount, totalCapacity, activationTime } = item;
 
-    // This value will less then 0 if activationTime has yet to come
-    const future = moment().diff(activationTime) < 0;
-    const info = future
+    /* The event tooltip is calculated based on different factors.
+     *
+     * 1) The event is yet to announced, meaning nobody has created
+     * a pool for the event and the location is set to TBA.
+     *
+     * 2) The event has no pool because no pool is needed for this
+     * event. These events will show up as 'Åpent arrangement' if
+     * they have their location set to something else then 'TBA'
+     *
+     * 3) The event is yet to open. This event will have the
+     * activationTime set to something else then 'null'
+     *
+     * 4) The event is open. Here activation time will be 'null' again
+     * and we show how many has signed up for the event.
+     *
+     * 5) The user has signed up for the event. This should also
+     * show how many users have signed up for the event.
+     *
+     */
+
+    const tba =
+      activationTime == null &&
+      !totalCapacity &&
+      !registrationCount &&
+      item.location.toLowerCase() == 'tba';
+
+    const future = moment().isBefore(activationTime);
+
+    const info = tba
+      ? 'TBA'
+      : future
       ? `Åpner ${moment(activationTime).format('dddd D MMM HH:mm')}`
       : totalCapacity == 0
       ? 'Åpent arrangement'
-      : `${registrationCount}/${totalCapacity}`;
+      : `${registrationCount}/${totalCapacity} påmeldte`;
 
     return (
       <div className={styles.body}>


### PR DESCRIPTION
This should cover all the cases for events. Checking the `TBA` is a big hack, but it works quite well since `TBA` is the default value for the event, and 99% of `TBA` events say `TBA` as the location.

The TBA check is also the last check. So if you have an open event and write TBA you will get TBA as a tooltip. I think this is fair because if the user writes TBA on the location they can't complain when they get TBA.

<img width="607" alt="screenshot 2019-01-21 at 19 38 56" src="https://user-images.githubusercontent.com/23152018/51493041-37437f80-1db4-11e9-8b89-d6837a6f9934.png">
