### PR TITLE
Event filtering

### DIFF
--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -41,6 +41,7 @@ type TimeStampProps = {
 
 const TimeStamp = ({ event, field }: TimeStampProps) => {
   const future = moment().isBefore(event.activationTime);
+
   const registration = future
     ? `Åpner ${moment(event.activationTime).format('ll HH:mm')}`
     : `Åpent`;

--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -1,0 +1,69 @@
+// @flow
+
+import React from 'react';
+import styles from './styles.css';
+import Pill from 'app/components/Pill';
+import { colorForEvent } from 'app/routes/events/utils';
+import { Link } from 'react-router';
+import { Image } from 'app/components/Image';
+import Time from 'app/components/Time';
+import Tag from 'app/components/Tags/Tag';
+import { Flex } from 'app/components/Layout';
+import type { Event } from 'app/models';
+
+type AttendanceProps = {
+  registrationCount: number,
+  totalCapacity: number
+};
+
+const Attendance = ({ registrationCount, totalCapacity }: AttendanceProps) => {
+  return (
+    <Pill style={{ marginLeft: '5px', color: 'black', whiteSpace: 'nowrap' }}>
+      {`${registrationCount} / ${totalCapacity}`}
+    </Pill>
+  );
+};
+
+type EventItemProps = {
+  event: Event,
+  showTags?: boolean
+};
+
+const EventItem = ({ event, showTags = true }: EventItemProps) => {
+  return (
+    <div
+      style={{ borderColor: colorForEvent(event.eventType) }}
+      className={styles.eventItem}
+    >
+      <div>
+        <Link to={`/events/${event.id}`}>
+          <h3 className={styles.eventItemTitle}>{event.title}</h3>
+          {event.totalCapacity > 0 && (
+            <Attendance
+              registrationCount={event.registrationCount}
+              totalCapacity={event.totalCapacity}
+            />
+          )}
+        </Link>
+
+        <div className={styles.eventTime}>
+          <Time time={event.startTime} format="ll HH:mm" />
+          {` • ${event.location}`}
+        </div>
+        {showTags && (
+          <Flex wrap>
+            {event.tags.map((tag, index) => (
+              <Tag key={index} tag={tag} small />
+            ))}
+          </Flex>
+        )}
+      </div>
+
+      <div className={styles.companyLogo}>
+        {event.cover && <Image src={event.cover} />}
+      </div>
+    </div>
+  );
+};
+
+export default EventItem;

--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -9,7 +9,7 @@ import { Image } from 'app/components/Image';
 import Time from 'app/components/Time';
 import Tag from 'app/components/Tags/Tag';
 import { Flex } from 'app/components/Layout';
-import type { Event } from 'app/models';
+import type { Event, EventTimeType } from 'app/models';
 import moment from 'moment-timezone';
 import { EVENTFIELDS } from 'app/utils/constants';
 
@@ -24,10 +24,10 @@ const Attendance = ({
   totalCapacity,
   event
 }: AttendanceProps) => {
-  const future = moment().isBefore(event.activationTime);
+  const isFuture = moment().isBefore(event.activationTime);
   return (
     <Pill style={{ marginLeft: '5px', color: 'black', whiteSpace: 'nowrap' }}>
-      {future
+      {isFuture
         ? `${totalCapacity} plasser`
         : `${registrationCount} / ${totalCapacity}`}
     </Pill>
@@ -36,13 +36,13 @@ const Attendance = ({
 
 type TimeStampProps = {
   event: Event,
-  field: string
+  field: EventTimeType
 };
 
 const TimeStamp = ({ event, field }: TimeStampProps) => {
-  const future = moment().isBefore(event.activationTime);
+  const isFuture = moment().isBefore(event.activationTime);
 
-  const registration = future
+  const registration = isFuture
     ? `Åpner ${moment(event.activationTime).format('ll HH:mm')}`
     : `Åpent`;
 
@@ -57,7 +57,7 @@ const TimeStamp = ({ event, field }: TimeStampProps) => {
 
 type EventItemProps = {
   event: Event,
-  field?: 'activationTime' | 'startTime',
+  field?: EventTimeType,
   showTags?: boolean
 };
 

--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -11,6 +11,7 @@ import Tag from 'app/components/Tags/Tag';
 import { Flex } from 'app/components/Layout';
 import type { Event } from 'app/models';
 import moment from 'moment-timezone';
+import { EVENTFIELDS } from 'app/utils/constants';
 
 type AttendanceProps = {
   registrationCount: number,
@@ -23,7 +24,7 @@ const Attendance = ({
   totalCapacity,
   event
 }: AttendanceProps) => {
-  const future = moment().isAfter(event.activationTime);
+  const future = moment().isBefore(event.activationTime);
   return (
     <Pill style={{ marginLeft: '5px', color: 'black', whiteSpace: 'nowrap' }}>
       {future
@@ -39,7 +40,7 @@ type TimeStampProps = {
 };
 
 const TimeStamp = ({ event, field }: TimeStampProps) => {
-  const future = moment().isAfter(event.activationTime);
+  const future = moment().isBefore(event.activationTime);
   const registration = future
     ? `Åpner ${moment(event.activationTime).format('ll HH:mm')}`
     : `Åpent`;
@@ -55,42 +56,44 @@ const TimeStamp = ({ event, field }: TimeStampProps) => {
 
 type EventItemProps = {
   event: Event,
-  field: string,
+  field?: 'activationTime' | 'startTime',
   showTags?: boolean
 };
 
-const EventItem = ({ event, field, showTags = true }: EventItemProps) => {
-  return (
-    <div
-      style={{ borderColor: colorForEvent(event.eventType) }}
-      className={styles.eventItem}
-    >
-      <div>
-        <Link to={`/events/${event.id}`}>
-          <h3 className={styles.eventItemTitle}>{event.title}</h3>
-          {event.totalCapacity > 0 && (
-            <Attendance
-              registrationCount={event.registrationCount}
-              totalCapacity={event.totalCapacity}
-              event={event}
-            />
-          )}
-        </Link>
-        <TimeStamp event={event} field={field} />
-        {showTags && (
-          <Flex wrap>
-            {event.tags.map((tag, index) => (
-              <Tag key={index} tag={tag} small />
-            ))}
-          </Flex>
+const EventItem = ({
+  event,
+  field = EVENTFIELDS.start,
+  showTags = true
+}: EventItemProps) => (
+  <div
+    style={{ borderColor: colorForEvent(event.eventType) }}
+    className={styles.eventItem}
+  >
+    <div>
+      <Link to={`/events/${event.id}`}>
+        <h3 className={styles.eventItemTitle}>{event.title}</h3>
+        {event.totalCapacity > 0 && (
+          <Attendance
+            registrationCount={event.registrationCount}
+            totalCapacity={event.totalCapacity}
+            event={event}
+          />
         )}
-      </div>
-
-      <div className={styles.companyLogo}>
-        {event.cover && <Image src={event.cover} />}
-      </div>
+      </Link>
+      <TimeStamp event={event} field={field} />
+      {showTags && (
+        <Flex wrap>
+          {event.tags.map((tag, index) => (
+            <Tag key={index} tag={tag} small />
+          ))}
+        </Flex>
+      )}
     </div>
-  );
-};
+
+    <div className={styles.companyLogo}>
+      {event.cover && <Image src={event.cover} />}
+    </div>
+  </div>
+);
 
 export default EventItem;

--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -10,26 +10,56 @@ import Time from 'app/components/Time';
 import Tag from 'app/components/Tags/Tag';
 import { Flex } from 'app/components/Layout';
 import type { Event } from 'app/models';
+import moment from 'moment-timezone';
 
 type AttendanceProps = {
   registrationCount: number,
-  totalCapacity: number
+  totalCapacity: number,
+  event: Event
 };
 
-const Attendance = ({ registrationCount, totalCapacity }: AttendanceProps) => {
+const Attendance = ({
+  registrationCount,
+  totalCapacity,
+  event
+}: AttendanceProps) => {
+  const future = moment().isAfter(event.activationTime);
   return (
     <Pill style={{ marginLeft: '5px', color: 'black', whiteSpace: 'nowrap' }}>
-      {`${registrationCount} / ${totalCapacity}`}
+      {future
+        ? `${totalCapacity} plasser`
+        : `${registrationCount} / ${totalCapacity}`}
     </Pill>
+  );
+};
+
+type TimeStampProps = {
+  event: Event,
+  field: string
+};
+
+const TimeStamp = ({ event, field }: TimeStampProps) => {
+  const future = moment().isAfter(event.activationTime);
+  const registration = future
+    ? `Åpner ${moment(event.activationTime).format('ll HH:mm')}`
+    : `Åpent`;
+
+  return (
+    <div className={styles.eventTime}>
+      {registration}
+      <br />
+      Starter kl: <Time time={event.startTime} format="ll HH:mm" />
+    </div>
   );
 };
 
 type EventItemProps = {
   event: Event,
+  field: string,
   showTags?: boolean
 };
 
-const EventItem = ({ event, showTags = true }: EventItemProps) => {
+const EventItem = ({ event, field, showTags = true }: EventItemProps) => {
   return (
     <div
       style={{ borderColor: colorForEvent(event.eventType) }}
@@ -42,14 +72,11 @@ const EventItem = ({ event, showTags = true }: EventItemProps) => {
             <Attendance
               registrationCount={event.registrationCount}
               totalCapacity={event.totalCapacity}
+              event={event}
             />
           )}
         </Link>
-
-        <div className={styles.eventTime}>
-          <Time time={event.startTime} format="ll HH:mm" />
-          {` • ${event.location}`}
-        </div>
+        <TimeStamp event={event} field={field} />
         {showTags && (
           <Flex wrap>
             {event.tags.map((tag, index) => (

--- a/app/components/EventItem/styles.css
+++ b/app/components/EventItem/styles.css
@@ -1,0 +1,32 @@
+.eventItem {
+  padding-left: 20px;
+  border-left: 4px solid transparent;
+  margin-bottom: 15px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.eventItemTitle {
+  color: #333;
+  font-weight: 700;
+  margin: 0;
+  word-break: break-word;
+}
+
+.eventTime {
+  color: #777;
+}
+
+.companyLogo {
+  width: 120px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+}
+
+.companyLogo img {
+  min-width: 120px;
+  height: 80px;
+  object-fit: contain;
+}

--- a/app/models.js
+++ b/app/models.js
@@ -11,6 +11,8 @@ export type ActionGrant = Array<string>;
 
 export type IcalToken = string;
 
+export type EventTimeType = 'activationTime' | 'startTime';
+
 export type EventType =
   | 'company_presentation'
   | 'lunch_presentation'

--- a/app/models.js
+++ b/app/models.js
@@ -9,6 +9,8 @@ export type Dateish = Moment | Date | string;
 
 export type ActionGrant = Array<string>;
 
+export type IcalToken = string;
+
 export type EventType =
   | 'company_presentation'
   | 'lunch_presentation'

--- a/app/reducers/events.js
+++ b/app/reducers/events.js
@@ -228,6 +228,8 @@ function transformEvent(event) {
     ...event,
     startTime: moment(event.startTime),
     endTime: moment(event.endTime),
+    activationTime:
+      event.activationTime !== null ? moment(event.activationTime) : null,
     mergeTime: event.mergeTime && moment(event.mergeTime)
   };
 }

--- a/app/routes/events/components/Calendar.js
+++ b/app/routes/events/components/Calendar.js
@@ -9,14 +9,14 @@ import createMonthlyCalendar from 'app/utils/createMonthlyCalendar';
 import CalendarCell from './CalendarCell';
 import Toolbar from './Toolbar';
 import EventFooter from './EventFooter';
-import type { ActionGrant } from 'app/models';
+import type { ActionGrant, IcalToken } from 'app/models';
 
 const WEEKDAYS = ['Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør', 'Søn'];
 
 type Props = {
   weekOffset: number,
   date: moment,
-  icalToken: string,
+  icalToken: IcalToken,
   actionGrant: ActionGrant
 };
 

--- a/app/routes/events/components/Calendar.js
+++ b/app/routes/events/components/Calendar.js
@@ -9,6 +9,7 @@ import createMonthlyCalendar from 'app/utils/createMonthlyCalendar';
 import CalendarCell from './CalendarCell';
 import Toolbar from './Toolbar';
 import EventFooter from './EventFooter';
+import type { ActionGrant } from 'app/models';
 
 const WEEKDAYS = ['Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør', 'Søn'];
 
@@ -16,7 +17,7 @@ type Props = {
   weekOffset: number,
   date: moment,
   icalToken: string,
-  actionGrant: Object
+  actionGrant: ActionGrant
 };
 
 function pathForPrevMonth(date: moment) {

--- a/app/routes/events/components/EventList.css
+++ b/app/routes/events/components/EventList.css
@@ -22,44 +22,27 @@
   font-size: 20px;
 }
 
-.eventItem {
-  padding-left: 20px;
-  border-left: 4px solid transparent;
-  margin-bottom: 15px;
-  display: flex;
-  justify-content: space-between;
-}
-
-.eventItemTitle {
-  color: #333;
-  font-weight: 700;
-  margin: 0;
-  word-break: break-word;
-}
-
 .eventGroup {
   margin-bottom: 40px;
-}
-
-.eventTime {
-  color: #777;
-}
-
-.companyLogo {
-  width: 120px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: row;
-}
-
-.companyLogo img {
-  min-width: 120px;
-  height: 80px;
-  object-fit: contain;
 }
 
 .bottomBorder {
   margin-top: 40px;
   border-top: 1px solid #ddd;
+}
+
+.filter {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: -36px;
+  margin-right: -2px;
+}
+
+.select {
+  width: 200px;
+
+  @media (--mobile-device) {
+    width: 100px;
+  }
 }

--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -10,7 +10,7 @@ import styles from './EventList.css';
 import EventFooter from './EventFooter';
 import EmptyState from 'app/components/EmptyState';
 import { isEmpty } from 'lodash';
-import type { Event, ActionGrant, IcalToken } from 'app/models';
+import type { Event, ActionGrant, IcalToken, EventTimeType } from 'app/models';
 import Select from 'react-select';
 import { orderBy } from 'lodash';
 import Icon from 'app/components/Icon';
@@ -21,7 +21,7 @@ const groupEvents = ({
   field = 'startTime'
 }: {
   events: Array<Event>,
-  field: 'activationTime' | 'startTime'
+  field?: EventTimeType
 }) => {
   const nextWeek = moment().add(1, 'week');
   const groups = {
@@ -48,8 +48,8 @@ const EventListGroup = ({
   events = []
 }: {
   name: string,
-  field: 'activationTime' | 'startTime',
-  events: Array<Event>
+  field?: EventTimeType,
+  events?: Array<Event>
 }) => {
   return isEmpty(events) ? null : (
     <div className={styles.eventGroup}>
@@ -72,7 +72,7 @@ type EventListProps = {
 type Option = {
   filterFunc: Event => boolean,
   label: string,
-  field: 'activationTime' | 'startTime'
+  field: EventTimeType
 };
 
 type State = {

--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -1,40 +1,37 @@
 // @flow
 
-import React from 'react';
-import { Link } from 'react-router';
+import React, { Component } from 'react';
 import Helmet from 'react-helmet';
 import moment from 'moment-timezone';
-import Time from 'app/components/Time';
-import Pill from 'app/components/Pill';
-import { Image } from 'app/components/Image';
-import Tag from 'app/components/Tags/Tag';
 import Button from 'app/components/Button';
+import EventItem from 'app/components/EventItem';
 import Toolbar from './Toolbar';
-import { colorForEvent } from '../utils';
 import styles from './EventList.css';
 import EventFooter from './EventFooter';
-import { Flex } from 'app/components/Layout';
 import EmptyState from 'app/components/EmptyState';
 import { isEmpty } from 'lodash';
+import type { Event, ActionGrant } from 'app/models';
+import Select from 'react-select';
+import { orderBy } from 'lodash';
+import Icon from 'app/components/Icon';
 
-// Kinda works
-function groupEvents(events) {
-  const now = moment();
-  const nextWeek = now.clone().add(1, 'week');
-
-  const groupers = {
-    currentWeek: event =>
-      event.startTime.isBetween(
-        now.clone().startOf('day'),
-        now.clone().endOf('week')
-      ),
-    nextWeek: event => event.startTime.isSame(nextWeek, 'week'),
-    later: event => event.startTime.isAfter(nextWeek)
+const groupEvents = ({
+  events,
+  field = 'startTime'
+}: {
+  events: Array<Event>,
+  field: string
+}) => {
+  const nextWeek = moment().add(1, 'week');
+  const groups = {
+    currentWeek: event => event[field].isSame(moment(), 'week'),
+    nextWeek: event => event[field].isSame(nextWeek, 'week'),
+    later: event => event[field].isAfter(nextWeek)
   };
 
   return events.reduce((result, event) => {
-    for (const groupName in groupers) {
-      if (groupers[groupName](event)) {
+    for (const groupName in groups) {
+      if (groups[groupName](event)) {
         result[groupName] = (result[groupName] || []).concat(event);
         return result;
       }
@@ -42,116 +39,130 @@ function groupEvents(events) {
 
     return result;
   }, {});
-}
-
-type AttendanceProps = {
-  registrationCount: number,
-  totalCapacity: number,
-  style: any
 };
 
-function Attendance({
-  registrationCount,
-  totalCapacity,
-  style
-}: AttendanceProps) {
-  // @todo choose pill color based on capacity
-  return (
-    <Pill style={{ ...style, whiteSpace: 'nowrap' }}>
-      {`${registrationCount} / ${totalCapacity}`}
-    </Pill>
-  );
-}
-type EventItemProps = {
-  event: any,
-  showTags?: boolean
-};
-export function EventItem({ event, showTags = true }: EventItemProps) {
-  return (
-    <div
-      style={{ borderColor: colorForEvent(event.eventType) }}
-      className={styles.eventItem}
-    >
-      <div>
-        <Link to={`/events/${event.id}`}>
-          <h3 className={styles.eventItemTitle}>{event.title}</h3>
-          {event.totalCapacity > 0 && (
-            <Attendance
-              registrationCount={event.registrationCount}
-              totalCapacity={event.totalCapacity}
-              style={{ marginLeft: '5px', color: 'black' }}
-            />
-          )}
-        </Link>
-
-        <div className={styles.eventTime}>
-          <Time time={event.startTime} format="ll HH:mm" />
-          {` • ${event.location}`}
-        </div>
-        {showTags && (
-          <Flex wrap className={styles.tagList}>
-            {event.tags.map((tag, index) => (
-              <Tag key={index} tag={tag} small />
-            ))}
-          </Flex>
-        )}
-      </div>
-
-      <div className={styles.companyLogo}>
-        {event.cover && <Image src={event.cover} />}
-      </div>
-    </div>
-  );
-}
-
-type EventListGroupProps = {
+const EventListGroup = ({
+  name,
+  field = 'startTime',
+  events = []
+}: {
   name: string,
-  events: Array</*TODO: Event */ any>
-};
-
-function EventListGroup({ name, events = [] }: EventListGroupProps) {
+  field: string,
+  events: Array<Event>
+}) => {
   return isEmpty(events) ? null : (
     <div className={styles.eventGroup}>
       <h2 className={styles.heading}>{name}</h2>
       {events.map((event, i) => (
-        <EventItem key={i} event={event} />
+        <EventItem key={i} event={event} field={field} />
       ))}
     </div>
   );
-}
+};
 
 type EventListProps = {
-  events: Array<any>,
-  actionGrant: /* TODO: ActionGrant */ any,
-  icalToken: /* TODO: IcalToken */ string,
+  events: Array<Event>,
+  actionGrant: ActionGrant,
+  icalToken: string,
   showFetchMore: boolean,
   fetchMore: () => Promise<*>
 };
 
-// $FlowFixMe
-const EventList = (props: EventListProps) => {
-  const events = groupEvents(props.events);
-  const { icalToken, showFetchMore, fetchMore } = props;
-  return (
-    <div className={styles.root}>
-      <Helmet title="Arrangementer" />
-      <Toolbar actionGrant={props.actionGrant} />
-      <EventListGroup name="Denne uken" events={events.currentWeek} />
-
-      <EventListGroup name="Neste uke" events={events.nextWeek} />
-
-      <EventListGroup name="Senere" events={events.later} />
-
-      {isEmpty(props.events) && (
-        <EmptyState icon="book-outline" size={40}>
-          <h2 className={styles.noEvents}>Ingen kommende arrangementer</h2>
-        </EmptyState>
-      )}
-      {showFetchMore && <Button onClick={fetchMore}>Last inn mer</Button>}
-      <div className={styles.bottomBorder} />
-      <EventFooter icalToken={icalToken} />
-    </div>
-  );
+type Option = {
+  value: Event => Event,
+  label: string,
+  field: string
 };
+
+type State = {
+  selectedOption: Option
+};
+
+// $FlowFixMe
+class EventList extends Component<EventListProps, State> {
+  state = {
+    selectedOption: {
+      // $FlowFixMe
+      value: event => event,
+      label: 'Alle',
+      field: 'startTime'
+    }
+  };
+
+  handleChange = (selectedOption: Option): void => {
+    this.setState({ selectedOption });
+  };
+
+  render() {
+    const { icalToken, showFetchMore, fetchMore, events } = this.props;
+    const { field, value } = this.state.selectedOption;
+
+    const groupedEvents = groupEvents({
+      events: orderBy(events.filter(value), field),
+      field: field
+    });
+
+    return (
+      <div className={styles.root}>
+        <Helmet title="Arrangementer" />
+        <Toolbar actionGrant={this.props.actionGrant} />
+        <div className={styles.filter}>
+          <Icon
+            size={25}
+            name="funnel-outline"
+            style={{ marginRight: '5px' }}
+          />
+          <Select
+            name="form-field-name"
+            value={this.state.selectedOption}
+            onChange={this.handleChange}
+            className={styles.select}
+            options={[
+              {
+                value: event => event,
+                label: 'Vis alle',
+                field: 'startTime'
+              },
+              {
+                value: event => event.activationTime == null,
+                label: 'Påmelding åpnet',
+                field: 'startTime'
+              },
+              {
+                value: event => event.activationTime !== null,
+                label: 'Åpner i fremtiden',
+                field: 'activationTime'
+              }
+            ]}
+          />
+        </div>
+        <EventListGroup
+          name="Denne uken"
+          events={groupedEvents.currentWeek}
+          field={field}
+        />
+        <EventListGroup
+          name="Neste uke"
+          events={groupedEvents.nextWeek}
+          field={field}
+        />
+        <EventListGroup
+          name="Senere"
+          events={groupedEvents.later}
+          field={field}
+        />
+
+        {isEmpty(this.props.events) && (
+          <EmptyState icon="book-outline" size={40}>
+            <h2 className={styles.noEvents}>Ingen kommende arrangementer</h2>
+          </EmptyState>
+        )}
+        {showFetchMore && <Button onClick={fetchMore}>Last inn mer</Button>}
+        <div className={styles.bottomBorder} />
+        <EventFooter icalToken={icalToken} />
+      </div>
+    );
+  }
+}
 
 export default EventList;

--- a/app/routes/events/components/Toolbar.css
+++ b/app/routes/events/components/Toolbar.css
@@ -1,32 +1,42 @@
+@import 'app/styles/variables.css';
+
 .root {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  margin-bottom: 30px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-rows: 1fr;
+  grid-template-areas: 'time list calender create';
   white-space: nowrap;
+  margin-bottom: 20px;
+
+  @media (--mobile-device) {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    grid-template-areas:
+      'time create'
+      'list calender';
+  }
 }
 
-.section {
-  flex: 1;
+.time {
+  grid-area: time;
   display: flex;
+  justify-content: flex-start;
   align-items: center;
-  margin-bottom: 10px;
-
-  &:last-of-type {
-    margin-left: 20px;
-    justify-content: flex-end;
-  }
-
-  &:first-of-type {
-    margin-right: 20px;
-    justify-content: flex-start;
-  }
 }
 
-.buttons {
-  composes: section;
-  flex: 2;
-  justify-content: center;
+.create {
+  grid-area: create;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.list {
+  grid-area: list;
+}
+
+.calender {
+  grid-area: calender;
 }
 
 .pickerItem {

--- a/app/routes/events/components/Toolbar.js
+++ b/app/routes/events/components/Toolbar.js
@@ -4,13 +4,13 @@ import React, { Component } from 'react';
 import { Link, IndexLink } from 'react-router';
 import Modal from 'app/components/Modal';
 import Time from 'app/components/Time';
-import Button from 'app/components/Button';
 import EventEditor from './EventEditor';
-import { Flex } from 'app/components/Layout';
 import styles from './Toolbar.css';
+import type { ActionGrant } from 'app/models';
+import cx from 'classnames';
 
 type Props = {
-  actionGrant: /*TODO: ActionGrant */ any
+  actionGrant: ActionGrant
 };
 
 type State = {
@@ -25,34 +25,30 @@ class Toolbar extends Component<Props, State> {
   render() {
     const { actionGrant } = this.props;
     return (
-      <Flex wrap className={styles.root}>
-        <div className={styles.section}>
+      <div className={styles.root}>
+        <div className={cx(styles.section, styles.time)}>
           <Time format="ll" className={styles.timeNow} />
         </div>
 
-        <div className={styles.buttons}>
-          <IndexLink
-            to="/events"
-            activeClassName={styles.active}
-            className={styles.pickerItem}
-          >
-            Liste
-          </IndexLink>
+        <IndexLink
+          to="/events"
+          activeClassName={styles.active}
+          className={cx(styles.pickerItem, styles.list)}
+        >
+          Liste
+        </IndexLink>
 
-          <Link
-            to="/events/calendar"
-            activeClassName={styles.active}
-            className={styles.pickerItem}
-          >
-            Kalender
-          </Link>
-        </div>
+        <Link
+          to="/events/calendar"
+          activeClassName={styles.active}
+          className={cx(styles.pickerItem, styles.calender)}
+        >
+          Kalender
+        </Link>
 
-        <div className={styles.section}>
+        <div className={cx(styles.section, styles.create)}>
           {actionGrant && actionGrant.includes('create') && (
-            <Link to="/events/create">
-              <Button>Lag nytt arrangement</Button>
-            </Link>
+            <Link to="/events/create">Lag nytt</Link>
           )}
         </div>
 
@@ -64,7 +60,7 @@ class Toolbar extends Component<Props, State> {
         >
           <EventEditor />
         </Modal>
-      </Flex>
+      </div>
     );
   }
 }

--- a/app/routes/events/components/Toolbar.js
+++ b/app/routes/events/components/Toolbar.js
@@ -26,7 +26,7 @@ class Toolbar extends Component<Props, State> {
     const { actionGrant } = this.props;
     return (
       <div className={styles.root}>
-        <div className={cx(styles.section, styles.time)}>
+        <div className={styles.time}>
           <Time format="ll" className={styles.timeNow} />
         </div>
 
@@ -46,7 +46,7 @@ class Toolbar extends Component<Props, State> {
           Kalender
         </Link>
 
-        <div className={cx(styles.section, styles.create)}>
+        <div className={styles.create}>
           {actionGrant && actionGrant.includes('create') && (
             <Link to="/events/create">Lag nytt</Link>
           )}

--- a/app/routes/overview/components/NextEvent.js
+++ b/app/routes/overview/components/NextEvent.js
@@ -96,7 +96,7 @@ const Filler = () => (
 );
 
 // Filter for activation
-const hasActivation = event => typeof event['activationTime'] !== 'object';
+const hasActivation = event => event.activationTime !== null;
 
 // Filter for range
 const inRange = event => {

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -192,7 +192,7 @@ class Overview extends Component<Props, State> {
 
     const nextEvent = (
       <Flex column>
-        <Link to={'/articles'}>
+        <Link to={'/events'}>
           <h3 className="u-ui-heading">Påmeldinger</h3>
         </Link>
         <NextEvent

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -125,7 +125,7 @@ class Overview extends Component<Props, State> {
 
     const events = (
       <Flex column className={styles.eventsWrapper}>
-        <Link to={'/events'}>
+        <Link to="/events">
           <h3 className="u-ui-heading">Arrangementer</h3>
         </Link>
         <Flex className={styles.events}>
@@ -170,7 +170,7 @@ class Overview extends Component<Props, State> {
 
     const articles = (
       <Flex column className={styles.articlesWrapper}>
-        <Link to={'/articles'}>
+        <Link to="/articles">
           <h3 className="u-ui-heading">Artikler</h3>
         </Link>
         <Flex className={styles.articles}>
@@ -192,7 +192,7 @@ class Overview extends Component<Props, State> {
 
     const nextEvent = (
       <Flex column>
-        <Link to={'/events'}>
+        <Link to="/events">
           <h3 className="u-ui-heading">Påmeldinger</h3>
         </Link>
         <NextEvent

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -18,7 +18,7 @@ import { groupBy } from 'lodash';
 import { resolveGroupLink } from 'app/reducers/groups';
 import type { Group, AddPenalty, Event, ID } from 'app/models';
 import cx from 'classnames';
-import { EventItem } from 'app/routes/events/components/EventList';
+import EventItem from 'app/components/EventItem';
 import EmptyState from 'app/components/EmptyState';
 import moment from 'moment-timezone';
 import type { Dateish } from 'app/models';

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -115,12 +115,7 @@ const UpcomingEvents = ({ upcomingEvents }: UpcomingEventsProps) => (
     {upcomingEvents && upcomingEvents.length ? (
       <Flex column wrap>
         {upcomingEvents.map((event, i) => (
-          <EventItem
-            key={i}
-            event={event}
-            showTags={false}
-            field={'startTime'}
-          />
+          <EventItem key={i} event={event} showTags={false} />
         ))}
       </Flex>
     ) : (

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -115,7 +115,12 @@ const UpcomingEvents = ({ upcomingEvents }: UpcomingEventsProps) => (
     {upcomingEvents && upcomingEvents.length ? (
       <Flex column wrap>
         {upcomingEvents.map((event, i) => (
-          <EventItem key={i} event={event} showTags={false} />
+          <EventItem
+            key={i}
+            event={event}
+            showTags={false}
+            field={'startTime'}
+          />
         ))}
       </Flex>
     ) : (

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -40,3 +40,8 @@ export const roleOptions = (Object.keys(ROLES)
     value: role,
     label: ROLES[role] || startCase(role)
   })): Array<{ value: string, label: string }>);
+
+export const EVENTFIELDS = {
+  start: 'startTime',
+  activate: 'activationTime'
+};


### PR DESCRIPTION
Closes #1334

This will allow events to be filtered on the `/events` route. I've pulled out the `EventItem` component and made it a lot more responsive to props and time differences. I've also fixed a lot of flow, bad code, old js and so forth in many on the files. This includes some bad css when it comes to the mobile view of this page.

It uses the `react-select` component and will choose a filter based on the user selected. I've put in the three most obvious filters:
- Show all
- Available for registration
- Will open soon
It will also sort on the best attribute available. This means that when the user sorts on all events, the events are sorted by they `StartTime`, but when the user sorts on admission opening the events are sorted by their `ActivationTime`.

**Filter selection**
![screenshot 2019-01-22 at 22 44 27](https://user-images.githubusercontent.com/23152018/51567643-02105d80-1e98-11e9-9c81-3985706240d5.png)

**After and before on desktop**
![screenshot 2019-01-22 at 22 42 52](https://user-images.githubusercontent.com/23152018/51567583-d8efcd00-1e97-11e9-948b-8c2dbdce93c6.png)

**After and before on mobile**
![screenshot 2019-01-22 at 22 43 59](https://user-images.githubusercontent.com/23152018/51567610-eb6a0680-1e97-11e9-8afe-7042f1a2b915.png)

