### PR TITLE
Add function for creating event from template

### DIFF
--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -26,6 +26,49 @@ const mapStateToProps = (state, props) => {
     eventId
   });
 
+  const selectedValues = {
+    event: {
+      addFee: valueSelector(state, 'addFee'),
+      isPriced: valueSelector(state, 'isPriced'),
+      eventType: valueSelector(state, 'eventType'),
+      priceMember: valueSelector(state, 'priceMember'),
+      startTime: valueSelector(state, 'startTime')
+    },
+    pools: valueSelector(state, 'pools')
+  };
+
+  const initialCreateValues = {
+    initialValues: {
+      title: '',
+      startTime: time({ hours: 17, minutes: 15 }),
+      endTime: time({ hours: 20, minutes: 15 }),
+      description: '',
+      text: '',
+      eventType: '',
+      company: null,
+      responsibleGroup: null,
+      location: 'TBA',
+      isPriced: false,
+      useStripe: true,
+      priceMember: 0,
+      paymentDueDate: time({ days: 7, hours: 17, minutes: 15 }),
+      mergeTime: time({ hours: 12 }),
+      useCaptcha: true,
+      heedPenalties: true,
+      isAbakomOnly: false,
+      feedbackDescription: 'Melding til arrangører',
+      pools: [],
+      unregistrationDeadline: time({ hours: 12 })
+    },
+    actionGrant,
+    ...selectedValues
+  };
+
+  /* If there is no eventId in the params then we use the
+   * normal initalValues for a new event
+   */
+  if (!eventId) return initialCreateValues;
+
   /* This will set the initalvalues as NULL if there is an
    * eventID but the template is empty. This means the template
    * is yet to be loaded. We return NULL to prevent the initial
@@ -62,14 +105,7 @@ const mapStateToProps = (state, props) => {
       }
     },
     actionGrant,
-    event: {
-      addFee: valueSelector(state, 'addFee'),
-      isPriced: valueSelector(state, 'isPriced'),
-      eventType: valueSelector(state, 'eventType'),
-      priceMember: valueSelector(state, 'priceMember'),
-      startTime: valueSelector(state, 'startTime')
-    },
-    pools: valueSelector(state, 'pools')
+    ...selectedValues
   };
 };
 

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -26,61 +26,41 @@ const mapStateToProps = (state, props) => {
     eventId
   });
 
-  const initialValues = {
-    title: '',
-    startTime: time({ hours: 17, minutes: 15 }),
-    endTime: time({ hours: 20, minutes: 15 }),
-    description: '',
-    text: '',
-    eventType: '',
-    company: null,
-    responsibleGroup: null,
-    location: 'TBA',
-    isPriced: false,
-    useStripe: true,
-    priceMember: 0,
-    paymentDueDate: time({ days: 7, hours: 17, minutes: 15 }),
-    mergeTime: time({ hours: 12 }),
-    useCaptcha: true,
-    heedPenalties: true,
-    isAbakomOnly: false,
-    feedbackDescription: 'Melding til arrangører',
-    pools: [],
-    unregistrationDeadline: time({ hours: 12 })
-  };
-
+  /* This will set the initalvalues as NULL if there is an
+   * eventID but the template is empty. This means the template
+   * is yet to be loaded. We return NULL to prevent the initial
+   * values to be set to default
+   */
   if (isEmpty(eventTemplate) && eventId) {
     return { initialValues: null };
   }
 
   return {
-    initialValues: isEmpty(eventTemplate)
-      ? initialValues
-      : {
-          ...eventTemplate,
-          mergeTime: eventTemplate.mergeTime
-            ? eventTemplate.mergeTime
-            : time({ hours: 12 }),
-          priceMember: eventTemplate.priceMember / 100,
-          pools: poolsTemplate.map(pool => ({
-            activationDate: pool.activationDate,
-            capacity: pool.capacity,
-            name: pool.name,
-            registrations: [],
-            permissionGroups: (pool.permissionGroups || []).map(group => ({
-              label: group.name,
-              value: group.id
-            }))
-          })),
-          company: eventTemplate.company && {
-            label: eventTemplate.company.name,
-            value: eventTemplate.company.id
-          },
-          responsibleGroup: eventTemplate.responsibleGroup && {
-            label: eventTemplate.responsibleGroup.name,
-            value: eventTemplate.responsibleGroup.id
-          }
-        },
+    initialValues: {
+      ...eventTemplate,
+      mergeTime: eventTemplate.mergeTime
+        ? eventTemplate.mergeTime
+        : time({ hours: 12 }),
+      priceMember: eventTemplate.priceMember / 100,
+      pools: poolsTemplate.map(pool => ({
+        activationDate: pool.activationDate,
+        capacity: pool.capacity,
+        name: pool.name,
+        registrations: [],
+        permissionGroups: (pool.permissionGroups || []).map(group => ({
+          label: group.name,
+          value: group.id
+        }))
+      })),
+      company: eventTemplate.company && {
+        label: eventTemplate.company.name,
+        value: eventTemplate.company.id
+      },
+      responsibleGroup: eventTemplate.responsibleGroup && {
+        label: eventTemplate.responsibleGroup.name,
+        value: eventTemplate.responsibleGroup.id
+      }
+    },
     actionGrant,
     event: {
       addFee: valueSelector(state, 'addFee'),
@@ -100,7 +80,10 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  prepare(({ location }, dispatch) => dispatch(fetchEvent(location.query.id))),
+  prepare(
+    ({ location }, dispatch) =>
+      location.query.id && dispatch(fetchEvent(location.query.id))
+  ),
   connect(
     mapStateToProps,
     mapDispatchToProps

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -1,42 +1,86 @@
-// @flow
-
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { formValueSelector } from 'redux-form';
 import { createEvent } from 'app/actions/EventActions';
 import { uploadFile } from 'app/actions/FileActions';
 import EventEditor from './components/EventEditor';
+import {
+  selectEventById,
+  selectPoolsWithRegistrationsForEvent
+} from 'app/reducers/events';
 import { LoginPage } from 'app/components/LoginForm';
-import { transformEvent } from './utils';
-import { time } from 'app/utils/time.js';
+import { transformEvent, time } from './utils';
+import prepare from 'app/utils/prepare';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
+import { isEmpty } from 'lodash';
+import { fetchEvent } from 'app/actions/EventActions';
+import loadingIndicator from 'app/utils/loadingIndicator';
 
 const mapStateToProps = (state, props) => {
   const actionGrant = state.events.actionGrant;
   const valueSelector = formValueSelector('eventEditor');
+  const eventId = props.location.query.id;
+
+  const eventTemplate = selectEventById(state, { eventId });
+  const poolsTemplate = selectPoolsWithRegistrationsForEvent(state, {
+    eventId
+  });
+
+  const initialValues = {
+    title: '',
+    startTime: time({ hours: 17, minutes: 15 }),
+    endTime: time({ hours: 20, minutes: 15 }),
+    description: '',
+    text: '',
+    eventType: '',
+    company: null,
+    responsibleGroup: null,
+    location: 'TBA',
+    isPriced: false,
+    useStripe: true,
+    priceMember: 0,
+    paymentDueDate: time({ days: 7, hours: 17, minutes: 15 }),
+    mergeTime: time({ hours: 12 }),
+    useCaptcha: true,
+    heedPenalties: true,
+    isAbakomOnly: false,
+    feedbackDescription: 'Melding til arrangører',
+    pools: [],
+    unregistrationDeadline: time({ hours: 12 })
+  };
+
+  if (isEmpty(eventTemplate) && eventId) {
+    return { initialValues: null };
+  }
+
   return {
-    initialValues: {
-      title: '',
-      startTime: time({ hours: 17, minutes: 15 }),
-      endTime: time({ hours: 20, minutes: 15 }),
-      description: '',
-      text: '',
-      eventType: '',
-      company: null,
-      responsibleGroup: null,
-      location: 'TBA',
-      isPriced: false,
-      useStripe: true,
-      priceMember: 0,
-      paymentDueDate: time({ days: 7, hours: 17, minutes: 15 }),
-      mergeTime: time({ hours: 12 }),
-      useCaptcha: true,
-      heedPenalties: true,
-      isAbakomOnly: false,
-      feedbackDescription: 'Melding til arrangører',
-      pools: [],
-      unregistrationDeadline: time({ hours: 12 })
-    },
+    initialValues: isEmpty(eventTemplate)
+      ? initialValues
+      : {
+          ...eventTemplate,
+          mergeTime: eventTemplate.mergeTime
+            ? eventTemplate.mergeTime
+            : time({ hours: 12 }),
+          priceMember: eventTemplate.priceMember / 100,
+          pools: poolsTemplate.map(pool => ({
+            activationDate: pool.activationDate,
+            capacity: pool.capacity,
+            name: pool.name,
+            registrations: [],
+            permissionGroups: (pool.permissionGroups || []).map(group => ({
+              label: group.name,
+              value: group.id
+            }))
+          })),
+          company: eventTemplate.company && {
+            label: eventTemplate.company.name,
+            value: eventTemplate.company.id
+          },
+          responsibleGroup: eventTemplate.responsibleGroup && {
+            label: eventTemplate.responsibleGroup.name,
+            value: eventTemplate.responsibleGroup.id
+          }
+        },
     actionGrant,
     event: {
       addFee: valueSelector(state, 'addFee'),
@@ -56,8 +100,10 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
+  prepare(({ location }, dispatch) => dispatch(fetchEvent(location.query.id))),
   connect(
     mapStateToProps,
     mapDispatchToProps
-  )
+  ),
+  loadingIndicator(['initialValues'])
 )(EventEditor);

--- a/app/routes/events/components/Admin.js
+++ b/app/routes/events/components/Admin.js
@@ -107,6 +107,16 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
               </Link>
             )}
           </li>
+          <li>
+            <Link
+              to={{
+                pathname: `/events/create`,
+                query: { id: event.id }
+              }}
+            >
+              Lag kopi av arrangement
+            </Link>
+          </li>
           {canEdit && (
             <li>
               <Link to={`/events/${event.id}/edit`}>Rediger</Link>


### PR DESCRIPTION
Solves https://github.com/webkom/lego/issues/1355

This allows the user to create a new event based on another event (use an old event as template)
![screenshot 2019-01-28 at 21 36 30](https://user-images.githubusercontent.com/23152018/51864739-d7654f80-2344-11e9-93ea-94fd6adba8d3.png)

This is done via query params.
![screenshot 2019-01-28 at 21 36 42](https://user-images.githubusercontent.com/23152018/51864746-da604000-2344-11e9-8555-6954b23e274e.png)
