### PR TITLE
Change time for captcha to show from 1 minute before event opens to 90 seconds

### DIFF
--- a/app/routes/events/components/JoinEventFormCountdownProvider.js
+++ b/app/routes/events/components/JoinEventFormCountdownProvider.js
@@ -30,7 +30,7 @@ const COUNTDOWN_INTERVAL = 1000;
 // Must be sorted lo->hi
 const TICK_ACTIONS: Array<[number, Action]> = [
   [0, 'REGISTRATION_AVAILABLE'],
-  [3 * 60 * 1000, '90_SECONDS_LEFT'],
+  [1.5 * 60 * 1000, '90_SECONDS_LEFT'],
   [60 * 10000, '10_MINUTE_LEFT'],
   [Infinity, 'STILL_WAITING']
 ];

--- a/app/routes/events/components/JoinEventFormCountdownProvider.js
+++ b/app/routes/events/components/JoinEventFormCountdownProvider.js
@@ -6,7 +6,7 @@ import type { Dateish, Event, EventRegistration } from 'app/models';
 
 type Action =
   | 'REGISTRATION_AVAILABLE'
-  | '3_MINUTE_LEFT'
+  | '90_SECONDS_LEFT'
   | '10_MINUTE_LEFT'
   | 'STILL_WAITING'
   | 'REGISTERED_OR_REGISTRATION_ALREADY_OPENED'
@@ -30,7 +30,7 @@ const COUNTDOWN_INTERVAL = 1000;
 // Must be sorted lo->hi
 const TICK_ACTIONS: Array<[number, Action]> = [
   [0, 'REGISTRATION_AVAILABLE'],
-  [3 * 60 * 1000, '3_MINUTE_LEFT'],
+  [3 * 60 * 1000, '90_SECONDS_LEFT'],
   [60 * 10000, '10_MINUTE_LEFT'],
   [Infinity, 'STILL_WAITING']
 ];
@@ -56,7 +56,7 @@ const countdownReducer = (
         registrationOpensIn: null
       };
 
-    case '3_MINUTE_LEFT':
+    case '90_SECONDS_LEFT':
       return {
         captchaOpen: true,
         formOpen: true,

--- a/app/routes/events/components/JoinEventFormCountdownProvider.js
+++ b/app/routes/events/components/JoinEventFormCountdownProvider.js
@@ -30,7 +30,7 @@ const COUNTDOWN_INTERVAL = 1000;
 // Must be sorted lo->hi
 const TICK_ACTIONS: Array<[number, Action]> = [
   [0, 'REGISTRATION_AVAILABLE'],
-  [180 * 1000, '3_MINUTE_LEFT'],
+  [3 * 60 * 1000, '3_MINUTE_LEFT'],
   [60 * 10000, '10_MINUTE_LEFT'],
   [Infinity, 'STILL_WAITING']
 ];

--- a/app/routes/events/components/JoinEventFormCountdownProvider.js
+++ b/app/routes/events/components/JoinEventFormCountdownProvider.js
@@ -30,7 +30,7 @@ const COUNTDOWN_INTERVAL = 1000;
 // Must be sorted lo->hi
 const TICK_ACTIONS: Array<[number, Action]> = [
   [0, 'REGISTRATION_AVAILABLE'],
-  [1.5 * 60 * 1000, '90_SECONDS_LEFT'],
+  [90 * 1000, '90_SECONDS_LEFT'],
   [60 * 10000, '10_MINUTE_LEFT'],
   [Infinity, 'STILL_WAITING']
 ];

--- a/app/routes/events/components/JoinEventFormCountdownProvider.js
+++ b/app/routes/events/components/JoinEventFormCountdownProvider.js
@@ -56,7 +56,7 @@ const countdownReducer = (
         registrationOpensIn: null
       };
 
-    case '1_MINUTE_LEFT':
+    case '3_MINUTE_LEFT':
       return {
         captchaOpen: true,
         formOpen: true,

--- a/app/routes/events/components/JoinEventFormCountdownProvider.js
+++ b/app/routes/events/components/JoinEventFormCountdownProvider.js
@@ -6,7 +6,7 @@ import type { Dateish, Event, EventRegistration } from 'app/models';
 
 type Action =
   | 'REGISTRATION_AVAILABLE'
-  | '1_MINUTE_LEFT'
+  | '3_MINUTE_LEFT'
   | '10_MINUTE_LEFT'
   | 'STILL_WAITING'
   | 'REGISTERED_OR_REGISTRATION_ALREADY_OPENED'
@@ -30,7 +30,7 @@ const COUNTDOWN_INTERVAL = 1000;
 // Must be sorted lo->hi
 const TICK_ACTIONS: Array<[number, Action]> = [
   [0, 'REGISTRATION_AVAILABLE'],
-  [60 * 1000, '1_MINUTE_LEFT'],
+  [180 * 1000, '3_MINUTE_LEFT'],
   [60 * 10000, '10_MINUTE_LEFT'],
   [Infinity, 'STILL_WAITING']
 ];


### PR DESCRIPTION
Fikser dette captcha timeren?? Hvis ja, det er litt kjipt når captchaen tar over ett minutt å løse og den først vises ett minutt før påmelding. Hvis feil, please send help