### PR TITLE
Add internal email to profile & membership list

### DIFF
--- a/app/routes/admin/groups/components/GroupMembersList.js
+++ b/app/routes/admin/groups/components/GroupMembersList.js
@@ -62,8 +62,8 @@ const GroupMembersList = ({
       title: 'E-post',
       dataIndex: 'user.internalEmailAddress',
       search: false,
-      render: (email: string) =>
-        email && <a href={`mailto ${email}`}>{email}</a>
+      render: (internalEmail: string) =>
+        internalEmail && <a href={`mailto:${internalEmail}`}>{internalEmail}</a>
     }
   ];
   return (

--- a/app/routes/admin/groups/components/GroupMembersList.js
+++ b/app/routes/admin/groups/components/GroupMembersList.js
@@ -57,6 +57,13 @@ const GroupMembersList = ({
         role === 'member' || !ROLES[role] ? '' : ROLES[role],
       render: (role: string) =>
         role !== 'member' && <span>{ROLES[role] || role} </span>
+    },
+    {
+      title: 'E-post',
+      dataIndex: 'user.emailAddress',
+      search: false,
+      render: (email: string) =>
+        email && <a href={`mailto ${email}`}>{email}</a>
     }
   ];
   return (

--- a/app/routes/admin/groups/components/GroupMembersList.js
+++ b/app/routes/admin/groups/components/GroupMembersList.js
@@ -60,7 +60,7 @@ const GroupMembersList = ({
     },
     {
       title: 'E-post',
-      dataIndex: 'user.emailAddress',
+      dataIndex: 'user.internalEmailAddress',
       search: false,
       render: (email: string) =>
         email && <a href={`mailto ${email}`}>{email}</a>

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -28,7 +28,7 @@ import frame from 'app/assets/frame.png';
 const fieldTranslations = {
   username: 'brukernavn',
   email: 'e-post',
-  emailAddress: 'abakus e-post'
+  internalEmailAddress: 'abakus e-post'
 };
 
 type Props = {
@@ -137,12 +137,6 @@ export default class UserProfile extends Component<Props, UpcomingEventsProps> {
   renderFields() {
     const { user } = this.props;
     let fields = Object.keys(fieldTranslations).filter(field => user[field]);
-    if (
-      ['email', 'emailAddress'].every(x => fields.includes(x)) &&
-      user['email'] == user['emailAddress']
-    ) {
-      fields.splice(fields.indexOf('emailAddress'));
-    }
     const tags = fields.map(field => {
       const translation = capitalize(fieldTranslations[field]);
       return (

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -27,7 +27,8 @@ import frame from 'app/assets/frame.png';
 
 const fieldTranslations = {
   username: 'brukernavn',
-  email: 'e-post'
+  email: 'e-post',
+  emailAddress: 'abakus e-post'
 };
 
 type Props = {
@@ -135,12 +136,27 @@ export default class UserProfile extends Component<Props, UpcomingEventsProps> {
 
   renderFields() {
     const { user } = this.props;
-    const fields = Object.keys(fieldTranslations).filter(field => user[field]);
+    let fields = Object.keys(fieldTranslations).filter(field => user[field]);
+    if (
+      ['email', 'emailAddress'].every(x => fields.includes(x)) &&
+      user['email'] == user['emailAddress']
+    ) {
+      fields.splice(fields.indexOf('emailAddress'));
+    }
     const tags = fields.map(field => {
       const translation = capitalize(fieldTranslations[field]);
       return (
         <li key={field}>
-          <strong>{translation}:</strong> {user[field]}
+          {field.toLowerCase().includes('email') ? (
+            <span>
+              <strong>{translation}:</strong>
+              <a href={`mailto: ${user[field]}`}> {user[field]}</a>
+            </span>
+          ) : (
+            <span>
+              <strong>{translation}:</strong> {user[field]}
+            </span>
+          )}
         </li>
       );
     });

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 import Helmet from 'react-helmet';
-import { capitalize, sumBy } from 'lodash';
+import { sumBy } from 'lodash';
 import { ProfilePicture, CircularPicture } from 'app/components/Image';
 import Card from 'app/components/Card';
 import Pill from 'app/components/Pill';
@@ -26,9 +26,28 @@ import { Image } from 'app/components/Image';
 import frame from 'app/assets/frame.png';
 
 const fieldTranslations = {
-  username: 'brukernavn',
-  email: 'e-post',
-  internalEmailAddress: 'abakus e-post'
+  username: 'Brukernavn',
+  email: 'E-post',
+  internalEmailAddress: 'Abakus e-post'
+};
+
+const defaultFieldRender = (field, value) => (
+  <span>
+    <strong>{field}:</strong> {value}
+  </span>
+);
+
+const emailFieldRender = (field, value) => (
+  <span>
+    <strong>{field}:</strong>
+    <a href={`mailto:${value}`}> {value}</a>
+  </span>
+);
+
+const fieldRenders = {
+  username: defaultFieldRender,
+  email: emailFieldRender,
+  internalEmailAddress: emailFieldRender
 };
 
 type Props = {
@@ -136,24 +155,10 @@ export default class UserProfile extends Component<Props, UpcomingEventsProps> {
 
   renderFields() {
     const { user } = this.props;
-    let fields = Object.keys(fieldTranslations).filter(field => user[field]);
-    const tags = fields.map(field => {
-      const translation = capitalize(fieldTranslations[field]);
-      return (
-        <li key={field}>
-          {field.toLowerCase().includes('email') ? (
-            <span>
-              <strong>{translation}:</strong>
-              <a href={`mailto: ${user[field]}`}> {user[field]}</a>
-            </span>
-          ) : (
-            <span>
-              <strong>{translation}:</strong> {user[field]}
-            </span>
-          )}
-        </li>
-      );
-    });
+    const fields = Object.keys(fieldTranslations).filter(field => user[field]);
+    const tags = fields.map(field => (
+      <li key={field}>{fieldRenders[field](field, user[field])}</li>
+    ));
 
     return <ul>{tags}</ul>;
   }


### PR DESCRIPTION
Adds internal email, if it exists, to profile page and group membership list. Also changes email text to links.

Fix https://github.com/webkom/lego/issues/1374