### PR TITLE
Fix global field placeholder style

### DIFF
--- a/app/components/Form/TextInput.css
+++ b/app/components/Form/TextInput.css
@@ -16,6 +16,10 @@
   border-color: #aaa;
 }
 
+.input::placeholder {
+  color: #aaa;
+}
+
 span.suffix {
   padding: 0 4px;
   color: rgba(0, 0, 0, 0.65);


### PR DESCRIPTION
The redux-form placeholder text has different color than react-select form placeholders