### PR TITLE
Fix CompanyDetail events display

### DIFF
--- a/app/actions/CompanyActions.js
+++ b/app/actions/CompanyActions.js
@@ -84,7 +84,7 @@ export function fetchEventsForCompany(companyId: string) {
     dispatch(
       callAPI({
         types: Event.FETCH,
-        endpoint: `/events/?company=${companyId}`,
+        endpoint: `/events/?company=${companyId}&ordering=-start_time`,
         schema: [eventSchema],
         meta: {
           errorMessage: 'Henting av tilknyttede arrangementer feilet'

--- a/app/routes/company/components/CompanyDetail.js
+++ b/app/routes/company/components/CompanyDetail.js
@@ -59,7 +59,7 @@ const CompanyDetail = (props: Props) => {
       .map((event, i) => (
         <tr key={i}>
           <td>
-            <Link to={`events/${event.id}`}>{event.title}</Link>
+            <Link to={`/events/${event.id}`}>{event.title}</Link>
           </td>
           <td>{eventTypes[event.eventType]}</td>
           <td>


### PR DESCRIPTION
- Fix URLs to events from CompanyDetail
- Load newest events rather than oldest event for the company

See https://abakus.no/companies/4621 to see both these issues, it has non-working event links and is missing the two newest events.