### PR TITLE
Fix editor image upload in safari

### DIFF
--- a/app/components/Editor/Sides/Buttons.js
+++ b/app/components/Editor/Sides/Buttons.js
@@ -22,8 +22,9 @@ export class ImageButton extends Component<Props, State> {
     showUpload: false
   };
 
-  onClick = () => {
+  onClick = (e: SyntheticMouseEvent<*>) => {
     this.setState({ showUpload: true });
+    e.preventDefault();
   };
 
   onSubmit = (image: File | Array<DropFile>) => {

--- a/app/components/Modal/index.js
+++ b/app/components/Modal/index.js
@@ -40,6 +40,7 @@ class Modal extends Component<Props> {
       closeOnBackdropClick,
       backdrop,
       show,
+      contentClassName,
       ...props
     } = this.props;
     return (
@@ -56,7 +57,7 @@ class Modal extends Component<Props> {
       >
         <div>
           {!closeOnBackdropClick && this.modal && this.modal.renderBackdrop()}
-          <div className={cx(styles.content, props.contentClassName)}>
+          <div className={cx(styles.content, contentClassName)}>
             <button onClick={onHide} className={styles.closeButton}>
               <Icon name="close" />
             </button>


### PR DESCRIPTION
- Prevent default on sidebutton click to prevent safari from re-focusing input field and therefore closing modal. 
- Move a prop in Modal to remove warning.

Fixes https://github.com/webkom/lego/issues/1469