### PR TITLE
Enable sourcemaps in prod (aka. ship them in prod)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,4 @@ COPY --from=builder /app/package.json .
 COPY --from=builder /app/styleguide styleguide
 COPY --from=builder /app/node_modules node_modules
 
-RUN yarn delete-sourcemaps
-
 ENTRYPOINT ["node", "dist/server.js"]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "build:client": "webpack --config config/webpack.client.js --mode=production",
     "build:server": "webpack --config config/webpack.server.js --mode=production",
     "build:dll": "BUILDING_DLL=true webpack --display-chunks --color --config config/webpack.dll.js",
-    "delete-sourcemaps": "find ./dist-client -name '*.map' -delete",
     "postinstall": "yarn run build:dll",
     "test": "NODE_ENV=test jest",
     "test:coverage": "yarn run test -- --coverage",


### PR DESCRIPTION
This makes it a lot funnier for external contributors to debug code when running on abakus.no.

Would make stack traces like seen here https://github.com/webkom/lego/issues/1481 way more human readable.