### PR TITLE
Change wait-list icon color and add a separate icon for admin registrations in the attendance list

### DIFF
--- a/app/models.js
+++ b/app/models.js
@@ -102,6 +102,7 @@ export type EventRegistrationChargeStatus = 'manual' | 'succeeded' | 'failed';
 export type EventRegistration = {
   id: number,
   user: User,
+  adminRegistrationReason: string,
   registrationDate: Dateish,
   unregistrationDate: Dateish,
   pool: number,

--- a/app/routes/events/components/EventAdministrate/Abacard.css
+++ b/app/routes/events/components/EventAdministrate/Abacard.css
@@ -12,3 +12,10 @@
   color: var(--lego-text-gray);
   float: right;
 }
+
+.adminRegistrations {
+  font-size: 16px;
+  color: var(--lego-text-gray);
+  float: right;
+  padding-right: 15px;
+}

--- a/app/routes/events/components/EventAdministrate/Administrate.css
+++ b/app/routes/events/components/EventAdministrate/Administrate.css
@@ -29,6 +29,11 @@
   color: green;
 }
 
+.orangeIcon {
+  font-size: 1.5em;
+  color: orange;
+}
+
 .questionIcon {
   font-size: 1.5em;
   color: blue;

--- a/app/routes/events/components/EventAdministrate/Attendees.js
+++ b/app/routes/events/components/EventAdministrate/Attendees.js
@@ -90,6 +90,10 @@ export default class Attendees extends Component<Props, State> {
       reg => reg.presence === 'PRESENT' && reg.pool
     ).length;
 
+    const adminRegisterCount = registered.filter(
+      reg => reg.adminRegistrationReason !== '' && reg.pool
+    ).length;
+
     if (loading) {
       return <LoadingIndicator loading />;
     }
@@ -111,6 +115,9 @@ export default class Attendees extends Component<Props, State> {
             <strong>Påmeldte:</strong>
             <div className={styles.attendees}>
               {`${registerCount}/${event.totalCapacity} har møtt opp`}
+            </div>
+            <div className={styles.adminRegistrations}>
+              {`${adminRegisterCount}/${event.totalCapacity} er adminpåmeldt`}
             </div>
           </div>
           {registered.length === 0 && <li>Ingen påmeldte</li>}

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -67,7 +67,7 @@ export class RegisteredTable extends Component<Props> {
             iconClass={
               pool
                 ? cx('fa fa-check-circle', styles.greenIcon)
-                : cx('fa fa-clock-o fa-2x', styles.greenIcon)
+                : cx('fa fa-clock-o fa-2x', styles.orangeIcon)
             }
           />
         )

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -61,11 +61,19 @@ export class RegisteredTable extends Component<Props> {
       {
         title: 'Status',
         dataIndex: 'pool',
-        render: pool => (
+        render: (pool, registration) => (
           <TooltipIcon
-            content={pool ? 'Påmeldt' : 'Venteliste'}
+            content={
+              registration.adminRegistrationReason !== ''
+                ? 'Adminpåmeldt: ' + registration.adminRegistrationReason
+                : pool
+                ? 'Påmeldt'
+                : 'Venteliste'
+            }
             iconClass={
-              pool
+              registration.adminRegistrationReason !== ''
+                ? cx('fa fa-user-secret', styles.greenIcon)
+                : pool
                 ? cx('fa fa-check-circle', styles.greenIcon)
                 : cx('fa fa-clock-o fa-2x', styles.orangeIcon)
             }


### PR DESCRIPTION
- Add the admin registration count to the attendance list header, as seen below.
<img src="https://user-images.githubusercontent.com/14221489/54455961-4237e200-475d-11e9-934a-0a63c746f66e.png" width="500">

- Add orange color to the registrations in the waiting list, and also add a seperate icon for admin registrations (with message if you hover over the icon), as seen below.
<img src="https://user-images.githubusercontent.com/14221489/54456352-3bf63580-475e-11e9-8ad9-8655e00331f7.png" height="300">

<img src="https://user-images.githubusercontent.com/14221489/54456108-a5297900-475d-11e9-9da6-9ebc6493fb26.png" width="300">
