### PR TITLE
Event status type

### DIFF
--- a/app/models.js
+++ b/app/models.js
@@ -25,6 +25,8 @@ export type EventType =
 
 type SelectInput = { label: string, value: string };
 
+export type EventStatusType = 'NORMAL' | 'OPEN' | 'TBA' | 'INFINITE';
+
 type EventBase = {
   id: ID,
   title: string,
@@ -35,6 +37,7 @@ type EventBase = {
   feedbackDescription: string,
   feedbackRequired: boolean,
   eventType: EventType,
+  eventStatusType: EventStatusType,
   location: string,
   isPriced: boolean,
   isAbakomOnly: boolean,

--- a/app/reducers/forms.js
+++ b/app/reducers/forms.js
@@ -8,38 +8,58 @@ export default formReducer.plugin({
   eventEditor: (state, action) => {
     switch (action.type) {
       case '@@redux-form/CHANGE':
-        if (action.meta.field == 'eventStatusType') {
-          switch (action.payload) {
-            case 'INFINITE':
-              return {
-                ...state,
-                values: {
-                  ...state.values,
-                  pools: [
-                    {
-                      name: 'Uendelig Plasser',
-                      registrations: [],
-                      activationDate: moment(state.values.startTime)
-                        .subtract(7, 'd')
-                        .hour(12)
-                        .minute(0)
-                        .toISOString(),
-                      permissionGroups: []
-                    }
-                  ]
-                }
-              };
-            default:
-              return {
-                ...state,
-                values: {
-                  ...state.values,
-                  pools: []
-                }
-              };
-          }
+        if (action.meta.field !== 'eventStatusType') {
+          return state;
         }
-        return state;
+
+        switch (action.payload) {
+          case 'INFINITE':
+            return {
+              ...state,
+              values: {
+                ...state.values,
+                pools: [
+                  {
+                    name: 'Alle',
+                    registrations: [],
+                    activationDate: moment(state.values.startTime)
+                      .subtract(7, 'd')
+                      .hour(12)
+                      .minute(0)
+                      .toISOString(),
+                    permissionGroups: []
+                  }
+                ]
+              }
+            };
+          case 'NORMAL':
+            return {
+              ...state,
+              values: {
+                ...state.values,
+                pools: [
+                  {
+                    name: 'Pool #1',
+                    registrations: [],
+                    activationDate: moment(state.values.startTime)
+                      .subtract(7, 'd')
+                      .hour(12)
+                      .minute(0)
+                      .toISOString(),
+                    permissionGroups: []
+                  }
+                ]
+              }
+            };
+          default:
+            return {
+              ...state,
+              values: {
+                ...state.values,
+                pools: []
+              }
+            };
+        }
       default:
         return state;
     }

--- a/app/reducers/forms.js
+++ b/app/reducers/forms.js
@@ -10,7 +10,7 @@ export default formReducer.plugin({
       case '@@redux-form/CHANGE':
         if (action.meta.field == 'eventStatusType') {
           switch (action.payload) {
-            case 'INFINITY':
+            case 'INFINITE':
               return {
                 ...state,
                 values: {
@@ -19,7 +19,7 @@ export default formReducer.plugin({
                     {
                       name: 'Uendelig Plasser',
                       registrations: [],
-                      activationDate: moment(event.startTime)
+                      activationDate: moment(state.values.startTime)
                         .subtract(7, 'd')
                         .hour(12)
                         .minute(0)

--- a/app/reducers/forms.js
+++ b/app/reducers/forms.js
@@ -2,8 +2,49 @@
 
 import { reducer as formReducer } from 'redux-form';
 import { Event } from '../actions/ActionTypes';
+import moment from 'moment-timezone';
 
 export default formReducer.plugin({
+  eventEditor: (state, action) => {
+    switch (action.type) {
+      case '@@redux-form/CHANGE':
+        if (action.meta.field == 'eventStatusType') {
+          switch (action.payload) {
+            case 'INFINITY':
+              return {
+                ...state,
+                values: {
+                  ...state.values,
+                  pools: [
+                    {
+                      name: 'Uendelig Plasser',
+                      registrations: [],
+                      activationDate: moment(event.startTime)
+                        .subtract(7, 'd')
+                        .hour(12)
+                        .minute(0)
+                        .toISOString(),
+                      permissionGroups: []
+                    }
+                  ]
+                }
+              };
+            default:
+              return {
+                ...state,
+                values: {
+                  ...state.values,
+                  pools: []
+                }
+              };
+          }
+        }
+        return state;
+      default:
+        return state;
+    }
+  },
+
   joinEvent: (state, action) => {
     switch (action.type) {
       case Event.REQUEST_REGISTER.BEGIN:

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -31,6 +31,8 @@ const mapStateToProps = (state, props) => {
     event: {
       addFee: valueSelector(state, 'addFee'),
       isPriced: valueSelector(state, 'isPriced'),
+      heedPenalties: valueSelector(state, 'heedPenalties'),
+      useStripe: valueSelector(state, 'useStripe'),
       eventType: valueSelector(state, 'eventType'),
       priceMember: valueSelector(state, 'priceMember'),
       startTime: valueSelector(state, 'startTime'),

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -31,6 +31,7 @@ const mapStateToProps = (state, props) => {
     event: {
       addFee: valueSelector(state, 'addFee'),
       isPriced: valueSelector(state, 'isPriced'),
+      feedbackRequired: valueSelector(state, 'feedbackRequired'),
       heedPenalties: valueSelector(state, 'heedPenalties'),
       useStripe: valueSelector(state, 'useStripe'),
       eventType: valueSelector(state, 'eventType'),
@@ -62,7 +63,7 @@ const mapStateToProps = (state, props) => {
       heedPenalties: true,
       isAbakomOnly: false,
       useConsent: false,
-      feedbackDescription: 'Melding til arrangører',
+      feedbackDescription: '',
       pools: [],
       unregistrationDeadline: time({ hours: 12 })
     },

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -33,7 +33,8 @@ const mapStateToProps = (state, props) => {
       isPriced: valueSelector(state, 'isPriced'),
       eventType: valueSelector(state, 'eventType'),
       priceMember: valueSelector(state, 'priceMember'),
-      startTime: valueSelector(state, 'startTime')
+      startTime: valueSelector(state, 'startTime'),
+      eventStatusType: valueSelector(state, 'eventStatusType')
     },
     pools: valueSelector(state, 'pools')
   };
@@ -46,9 +47,10 @@ const mapStateToProps = (state, props) => {
       description: '',
       text: '',
       eventType: '',
+      eventStatusType: 'TBA',
       company: null,
       responsibleGroup: null,
-      location: 'TBA',
+      location: '',
       isPriced: false,
       useStripe: true,
       priceMember: 0,

--- a/app/routes/events/EventEditRoute.js
+++ b/app/routes/events/EventEditRoute.js
@@ -60,6 +60,7 @@ const mapStateToProps = (state, props) => {
       addFee: valueSelector(state, 'addFee'),
       isPriced: valueSelector(state, 'isPriced'),
       eventType: valueSelector(state, 'eventType'),
+      eventStatusType: valueSelector(state, 'eventStatusType'),
       priceMember: valueSelector(state, 'priceMember')
     },
     eventId,

--- a/app/routes/events/EventEditRoute.js
+++ b/app/routes/events/EventEditRoute.js
@@ -61,6 +61,9 @@ const mapStateToProps = (state, props) => {
       isPriced: valueSelector(state, 'isPriced'),
       eventType: valueSelector(state, 'eventType'),
       eventStatusType: valueSelector(state, 'eventStatusType'),
+      heedPenalties: valueSelector(state, 'heedPenalties'),
+      feedbackRequired: valueSelector(state, 'feedbackRequired'),
+      useStripe: valueSelector(state, 'useStripe'),
       priceMember: valueSelector(state, 'priceMember')
     },
     eventId,

--- a/app/routes/events/components/EventEditor/EventEditor.css
+++ b/app/routes/events/components/EventEditor/EventEditor.css
@@ -43,3 +43,19 @@
 .metaList > span {
   display: flex;
 }
+
+.poolHeader {
+  text-align: center;
+}
+
+.poolBox {
+  background: rgba(200, 200, 200, 0.5);
+  padding: 10px;
+  margin-top: 10px;
+}
+
+.centeredButton {
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+}

--- a/app/routes/events/components/EventEditor/EventEditor.css
+++ b/app/routes/events/components/EventEditor/EventEditor.css
@@ -59,3 +59,9 @@
   justify-content: center;
   margin-top: 10px;
 }
+
+.subSection {
+  margin-left: 10px;
+  border-left: 4px solid var(--lego-red);
+  padding: 0 0 10px 10px;
+}

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -5,7 +5,6 @@ import React from 'react';
 import { Link } from 'react-router';
 import renderPools, { validatePools } from './renderPools';
 import RegisteredSummary from '../RegisteredSummary';
-import UserGrid from 'app/components/UserGrid';
 import {
   AttendanceStatus,
   ModalParentComponent
@@ -330,15 +329,6 @@ function EventEditor({
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Flex column>
                 <h3>Påmeldte:</h3>
-                <UserGrid
-                  minRows={2}
-                  maxRows={2}
-                  users={
-                    registrations
-                      ? registrations.slice(0, 14).map(reg => reg.user)
-                      : []
-                  }
-                />
                 <ModalParentComponent
                   key="modal"
                   pools={pools || []}

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -221,6 +221,7 @@ function EventEditor({
               <Field
                 label="Sted"
                 name="location"
+                placeholder="Den gode nabo, R5, ..."
                 component={TextInput.Field}
                 fieldClassName={styles.metaField}
                 className={styles.formField}
@@ -240,7 +241,7 @@ function EventEditor({
             )}
 
             {event.isPriced && (
-              <div>
+              <div className={styles.subSection}>
                 <Tooltip content="Manuell betaling kan også av i etterkant">
                   <Field
                     label="Betaling igjennom Abakus.no"
@@ -259,14 +260,18 @@ function EventEditor({
                   fieldClassName={styles.metaField}
                   className={styles.formField}
                 />
-                <Field
-                  label="Legg til gebyr"
-                  name="addFee"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={v => !!v}
-                />
+                {event.useStripe && (
+                  <Tooltip content="Legger automatisk til transaksjonskostnaden til prisen">
+                    <Field
+                      label="Legg til systemgebyr"
+                      name="addFee"
+                      component={CheckBox.Field}
+                      fieldClassName={styles.metaField}
+                      className={styles.formField}
+                      normalize={v => !!v}
+                    />
+                  </Tooltip>
+                )}
                 {event.priceMember > 0 && (
                   <i>
                     Totalt:{' '}
@@ -289,30 +294,31 @@ function EventEditor({
             )}
 
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
-              <Tooltip content="Utsetter registrering og deler ut prikker">
-                <Field
-                  label="Bruk prikker"
-                  name="heedPenalties"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={v => !!v}
-                />
-              </Tooltip>
+              <Field
+                label="Bruk prikker"
+                name="heedPenalties"
+                component={CheckBox.Field}
+                fieldClassName={styles.metaField}
+                className={styles.formField}
+                normalize={v => !!v}
+              />
             )}
 
-            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
-              <Tooltip content="Frist for avmelding – fører til prikk etterpå">
-                <Field
-                  key="unregistrationDeadline"
-                  label="Avregistreringsfrist"
-                  name="unregistrationDeadline"
-                  component={DatePicker.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                />
-              </Tooltip>
-            )}
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) &&
+              event.heedPenalties && (
+                <div className={styles.subSection}>
+                  <Tooltip content="Frist for avmelding – fører til prikk etterpå">
+                    <Field
+                      key="unregistrationDeadline"
+                      label="Avregistreringsfrist"
+                      name="unregistrationDeadline"
+                      component={DatePicker.Field}
+                      fieldClassName={styles.metaField}
+                      className={styles.formField}
+                    />
+                  </Tooltip>
+                </div>
+              )}
 
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Tooltip content="Bruk samtykke til bilder">
@@ -320,6 +326,8 @@ function EventEditor({
                   label="Samtykke til bilder"
                   name="useConsent"
                   component={CheckBox.Field}
+                  fieldClassName={styles.metaField}
+                  className={styles.formField}
                   normalize={v => !!v}
                 />
               </Tooltip>

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -87,6 +87,9 @@ function EventEditor({
     return <div>{error.message}</div>;
   }
 
+  const isTBA = value =>
+    value && value == 'TBA' ? `Velg påmeldingstype TBA` : undefined;
+
   const eventStatusType = [
     { value: 'TBA', label: 'Ikke bestemt (TBA)' },
     { value: 'NORMAL', label: 'Vanlig påmelding (med pools)' },
@@ -223,6 +226,7 @@ function EventEditor({
                 component={TextInput.Field}
                 fieldClassName={styles.metaField}
                 className={styles.formField}
+                warn={isTBA}
               />
             )}
 

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -88,10 +88,10 @@ function EventEditor({
   }
 
   const eventStatusType = [
-    { value: 'TBA', label: 'TBA' },
-    { value: 'NORMAL', label: 'Vanlig' },
-    { value: 'OPEN', label: 'Åpent' },
-    { value: 'INFINITY', label: 'Uendelig' }
+    { value: 'TBA', label: 'Ikke bestemt (TBA)' },
+    { value: 'NORMAL', label: 'Vanlig påmelding (med pools)' },
+    { value: 'OPEN', label: 'Åpen (uten påmelding)' },
+    { value: 'INFINITE', label: 'Åpen (med påmelding)' }
   ];
 
   const color = colorForEvent(event.eventType);
@@ -143,7 +143,7 @@ function EventEditor({
             <Field
               name="text"
               component={EditorField.Field}
-              label="Hovedtext"
+              label="Hovedbeskrivelse"
               placeholder="Dette blir tidenes fest..."
               className={styles.descriptionEditor}
               uploadFile={uploadFile}
@@ -208,7 +208,7 @@ function EventEditor({
               />
             </Tooltip>
             <Field
-              label="Status"
+              label="Påmeldingstype"
               name="eventStatusType"
               component={SelectInput.Field}
               fieldClassName={styles.metaField}
@@ -216,7 +216,7 @@ function EventEditor({
               simpleValue
             />
 
-            {['NORMAL', 'OPEN', 'INFINITY'].includes(event.eventStatusType) && (
+            {['NORMAL', 'OPEN', 'INFINITE'].includes(event.eventStatusType) && (
               <Field
                 label="Sted"
                 name="location"
@@ -226,7 +226,7 @@ function EventEditor({
               />
             )}
 
-            {['NORMAL', 'INFINITY'].includes(event.eventStatusType) && (
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Field
                 label="Betalt arrangement"
                 name="isPriced"
@@ -286,7 +286,7 @@ function EventEditor({
               </div>
             )}
 
-            {['NORMAL', 'INFINITY'].includes(event.eventStatusType) && (
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Tooltip content="Utsetter registrering og deler ut prikker">
                 <Field
                   label="Bruk prikker"
@@ -299,7 +299,7 @@ function EventEditor({
               </Tooltip>
             )}
 
-            {['NORMAL', 'INFINITY'].includes(event.eventStatusType) && (
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Tooltip content="Frist for avmelding – fører til prikk etterpå">
                 <Field
                   key="unregistrationDeadline"
@@ -312,7 +312,7 @@ function EventEditor({
               </Tooltip>
             )}
 
-            {['NORMAL', 'INFINITY'].includes(event.eventStatusType) && (
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Tooltip content="Bruk samtykke til bilder">
                 <Field
                   label="Samtykke til bilder"
@@ -323,7 +323,7 @@ function EventEditor({
               </Tooltip>
             )}
 
-            {['NORMAL', 'INFINITY'].includes(event.eventStatusType) && (
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Flex column>
                 <h3>Påmeldte:</h3>
                 <UserGrid
@@ -436,6 +436,9 @@ const validate = data => {
   }
   if (!data.id && !data.cover) {
     errors.cover = 'Cover er påkrevet';
+  }
+  if (!data.eventStatusType) {
+    errors.eventStatusType = 'Påmeldingstype er påkrevd';
   }
   if (data.pools) {
     errors.pools = validatePools(data.pools);

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -4,7 +4,6 @@ import styles from './EventEditor.css';
 import React from 'react';
 import { Link } from 'react-router';
 import renderPools, { validatePools } from './renderPools';
-import RegisteredSummary from '../RegisteredSummary';
 import {
   AttendanceStatus,
   ModalParentComponent
@@ -328,14 +327,13 @@ function EventEditor({
 
             {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Flex column>
-                <h3>Påmeldte:</h3>
+                <h3>Pools</h3>
                 <ModalParentComponent
                   key="modal"
                   pools={pools || []}
                   registrations={registrations || []}
                   title="Påmeldte"
                 >
-                  <RegisteredSummary registrations={registrations} />
                   <AttendanceStatus />
                 </ModalParentComponent>
                 <div className={styles.metaList}>

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -87,6 +87,13 @@ function EventEditor({
     return <div>{error.message}</div>;
   }
 
+  const eventStatusType = [
+    { value: 'TBA', label: 'TBA' },
+    { value: 'NORMAL', label: 'Vanlig' },
+    { value: 'OPEN', label: 'Åpent' },
+    { value: 'INFINITY', label: 'Uendelig' }
+  ];
+
   const color = colorForEvent(event.eventType);
   return (
     <Content>
@@ -188,91 +195,14 @@ function EventEditor({
               fieldClassName={styles.metaField}
               className={styles.formField}
             />
-            <Tooltip content="Events som settes som TBA og ikke har noen pool vil vises som TBA på forsiden.">
-              <Field
-                label="Sted"
-                name="location"
-                component={TextInput.Field}
-                fieldClassName={styles.metaField}
-                className={styles.formField}
-              />
-            </Tooltip>
             <Field
-              label="Betalt arrangement"
-              name="isPriced"
-              component={CheckBox.Field}
+              label="Status"
+              name="eventStatusType"
+              component={SelectInput.Field}
               fieldClassName={styles.metaField}
-              className={styles.formField}
-              normalize={v => !!v}
+              options={eventStatusType}
+              simpleValue
             />
-            {event.isPriced && (
-              <div>
-                <Tooltip content="Manuell betaling kan også av i etterkant">
-                  <Field
-                    label="Betaling igjennom Abakus.no"
-                    name="useStripe"
-                    component={CheckBox.Field}
-                    fieldClassName={styles.metaField}
-                    className={styles.formField}
-                    normalize={v => !!v}
-                  />
-                </Tooltip>
-                <Field
-                  label="Pris medlem"
-                  name="priceMember"
-                  type="number"
-                  component={TextInput.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                />
-                <Field
-                  label="Legg til gebyr"
-                  name="addFee"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={v => !!v}
-                />
-                {event.priceMember > 0 && (
-                  <i>
-                    Totalt:{' '}
-                    <strong>
-                      {event.addFee
-                        ? addStripeFee(Number(event.priceMember))
-                        : event.priceMember}
-                      ,-
-                    </strong>
-                  </i>
-                )}
-                <Field
-                  label="Betalingsfrist"
-                  name="paymentDueDate"
-                  component={DatePicker.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                />
-              </div>
-            )}
-            <Tooltip content="Utsetter registrering og deler ut prikker">
-              <Field
-                label="Bruk prikker"
-                name="heedPenalties"
-                component={CheckBox.Field}
-                fieldClassName={styles.metaField}
-                className={styles.formField}
-                normalize={v => !!v}
-              />
-            </Tooltip>
-            <Tooltip content="Frist for avmelding – fører til prikk etterpå">
-              <Field
-                key="unregistrationDeadline"
-                label="Avregistreringsfrist"
-                name="unregistrationDeadline"
-                component={DatePicker.Field}
-                fieldClassName={styles.metaField}
-                className={styles.formField}
-              />
-            </Tooltip>
             <Tooltip content="Kun la medlemmer i Abakom se arrangement">
               <Field
                 label="Kun for Abakom"
@@ -283,60 +213,147 @@ function EventEditor({
                 normalize={v => !!v}
               />
             </Tooltip>
-            <Tooltip content="Bruk samtykke til bilder">
-              <Field
-                label="Samtykke til bilder"
-                name="useConsent"
-                component={CheckBox.Field}
-                normalize={v => !!v}
-              />
-            </Tooltip>
-            <Flex column>
-              <h3>Påmeldte:</h3>
-              <UserGrid
-                minRows={2}
-                maxRows={2}
-                users={
-                  registrations
-                    ? registrations.slice(0, 14).map(reg => reg.user)
-                    : []
-                }
-              />
-              <ModalParentComponent
-                key="modal"
-                pools={pools || []}
-                registrations={registrations || []}
-                title="Påmeldte"
-              >
-                <RegisteredSummary registrations={registrations} />
-                <AttendanceStatus />
-              </ModalParentComponent>
-              <div className={styles.metaList}>
-                <FieldArray
-                  name="pools"
-                  component={renderPools}
-                  startTime={event.startTime}
+            {event.eventStatusType != 'TBA' && (
+              <>
+                <Field
+                  label="Sted"
+                  name="location"
+                  component={TextInput.Field}
+                  fieldClassName={styles.metaField}
+                  className={styles.formField}
                 />
-              </div>
-              {pools && pools.length > 1 && (
-                <Tooltip content="Tidspunkt for å slå sammen poolene">
+                <Field
+                  label="Betalt arrangement"
+                  name="isPriced"
+                  component={CheckBox.Field}
+                  fieldClassName={styles.metaField}
+                  className={styles.formField}
+                  normalize={v => !!v}
+                />
+                {event.isPriced && (
+                  <div>
+                    <Tooltip content="Manuell betaling kan også av i etterkant">
+                      <Field
+                        label="Betaling igjennom Abakus.no"
+                        name="useStripe"
+                        component={CheckBox.Field}
+                        fieldClassName={styles.metaField}
+                        className={styles.formField}
+                        normalize={v => !!v}
+                      />
+                    </Tooltip>
+                    <Field
+                      label="Pris medlem"
+                      name="priceMember"
+                      type="number"
+                      component={TextInput.Field}
+                      fieldClassName={styles.metaField}
+                      className={styles.formField}
+                    />
+                    <Field
+                      label="Legg til gebyr"
+                      name="addFee"
+                      component={CheckBox.Field}
+                      fieldClassName={styles.metaField}
+                      className={styles.formField}
+                      normalize={v => !!v}
+                    />
+                    {event.priceMember > 0 && (
+                      <i>
+                        Totalt:{' '}
+                        <strong>
+                          {event.addFee
+                            ? addStripeFee(Number(event.priceMember))
+                            : event.priceMember}
+                          ,-
+                        </strong>
+                      </i>
+                    )}
+                    <Field
+                      label="Betalingsfrist"
+                      name="paymentDueDate"
+                      component={DatePicker.Field}
+                      fieldClassName={styles.metaField}
+                      className={styles.formField}
+                    />
+                  </div>
+                )}
+                <Tooltip content="Utsetter registrering og deler ut prikker">
                   <Field
-                    label="Sammenslåingstidspunkt"
-                    name="mergeTime"
+                    label="Bruk prikker"
+                    name="heedPenalties"
+                    component={CheckBox.Field}
+                    fieldClassName={styles.metaField}
+                    className={styles.formField}
+                    normalize={v => !!v}
+                  />
+                </Tooltip>
+                <Tooltip content="Frist for avmelding – fører til prikk etterpå">
+                  <Field
+                    key="unregistrationDeadline"
+                    label="Avregistreringsfrist"
+                    name="unregistrationDeadline"
                     component={DatePicker.Field}
                     fieldClassName={styles.metaField}
                     className={styles.formField}
                   />
                 </Tooltip>
-              )}
-              {isEditPage && (
-                <Admin
-                  actionGrant={actionGrant}
-                  event={event}
-                  deleteEvent={deleteEvent}
-                />
-              )}
-            </Flex>
+                <Tooltip content="Bruk samtykke til bilder">
+                  <Field
+                    label="Samtykke til bilder"
+                    name="useConsent"
+                    component={CheckBox.Field}
+                    normalize={v => !!v}
+                  />
+                </Tooltip>
+                <Flex column>
+                  <h3>Påmeldte:</h3>
+                  <UserGrid
+                    minRows={2}
+                    maxRows={2}
+                    users={
+                      registrations
+                        ? registrations.slice(0, 14).map(reg => reg.user)
+                        : []
+                    }
+                  />
+                  <ModalParentComponent
+                    key="modal"
+                    pools={pools || []}
+                    registrations={registrations || []}
+                    title="Påmeldte"
+                  >
+                    <RegisteredSummary registrations={registrations} />
+                    <AttendanceStatus />
+                  </ModalParentComponent>
+                  <div className={styles.metaList}>
+                    <FieldArray
+                      name="pools"
+                      component={renderPools}
+                      startTime={event.startTime}
+                    />
+                  </div>
+                  {pools && pools.length > 1 && (
+                    <Tooltip content="Tidspunkt for å slå sammen poolene">
+                      <Field
+                        label="Sammenslåingstidspunkt"
+                        name="mergeTime"
+                        component={DatePicker.Field}
+                        fieldClassName={styles.metaField}
+                        className={styles.formField}
+                      />
+                    </Tooltip>
+                  )}
+                  {isEditPage && (
+                    <Admin
+                      actionGrant={actionGrant}
+                      event={event}
+                      deleteEvent={deleteEvent}
+                    />
+                  )}
+                </Flex>
+              </>
+            )}
           </ContentSidebar>
         </ContentSection>
 

--- a/app/routes/events/components/EventEditor/renderPools.js
+++ b/app/routes/events/components/EventEditor/renderPools.js
@@ -8,20 +8,21 @@ import {
   SelectInput,
   Button
 } from 'app/components/Form';
+import type { Dateish, EventStatusType } from 'app/models';
 
 import moment from 'moment-timezone';
 
 type poolProps = {
   fields: Object,
-  startTime: Object,
-  eventStatusType: string
+  startTime: Dateish,
+  eventStatusType: EventStatusType
 };
 
 const minimumOne = value =>
   value && value < 1 ? `Pools må ha minst 1 plass` : undefined;
 
 const highWarning = value =>
-  value && value >= 500 ? 'Uendlig plasser? Velg åpent event :)' : undefined;
+  value && value >= 500 ? 'Åpent event gir uendelig plasser 😁' : undefined;
 
 const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
   <ul style={{ flex: 1 }}>
@@ -64,7 +65,9 @@ const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
         />
         {['NORMAL'].includes(eventStatusType) && (
           <Button
-            disabled={fields.get(index).registrations.length > 0}
+            disabled={
+              fields.get(index).registrations.length > 0 || fields.length == 1
+            }
             onClick={() => fields.remove(index)}
           >
             Fjern pool

--- a/app/routes/events/components/EventEditor/renderPools.js
+++ b/app/routes/events/components/EventEditor/renderPools.js
@@ -27,9 +27,10 @@ const highWarning = value =>
 const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
   <ul style={{ flex: 1 }}>
     {fields.map((pool, index) => (
-      <li key={index}>
-        <h4>Pool #{index + 1}</h4>
+      <li key={index} className={styles.poolBox}>
+        <h3 className={styles.poolHeader}>Pool #{index + 1}</h3>
         <Field
+          label="Navn"
           name={`pools[${index}].name`}
           fieldClassName={styles.metaField}
           className={styles.formField}
@@ -64,19 +65,22 @@ const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
           multi
         />
         {['NORMAL'].includes(eventStatusType) && (
-          <Button
-            disabled={
-              fields.get(index).registrations.length > 0 || fields.length == 1
-            }
-            onClick={() => fields.remove(index)}
-          >
-            Fjern pool
-          </Button>
+          <div className={styles.centeredButton}>
+            <Button
+              disabled={
+                fields.get(index).registrations.length > 0 || fields.length == 1
+              }
+              onClick={() => fields.remove(index)}
+            >
+              Fjern pool
+            </Button>
+          </div>
         )}
       </li>
     ))}
     {['NORMAL'].includes(eventStatusType) && (
       <li>
+          <div className={styles.centeredButton}>
         <Button
           onClick={() =>
             fields.push({
@@ -93,6 +97,7 @@ const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
         >
           Legg til ny pool
         </Button>
+          </div>
       </li>
     )}
   </ul>

--- a/app/routes/events/components/EventEditor/renderPools.js
+++ b/app/routes/events/components/EventEditor/renderPools.js
@@ -13,10 +13,11 @@ import moment from 'moment-timezone';
 
 type poolProps = {
   fields: Object,
-  startTime: Object
+  startTime: Object,
+  eventStatusType: string
 };
 
-const renderPools = ({ fields, startTime }: poolProps) => (
+const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
   <ul style={{ flex: 1 }}>
     {fields.map((pool, index) => (
       <li key={index}>
@@ -27,15 +28,17 @@ const renderPools = ({ fields, startTime }: poolProps) => (
           className={styles.formField}
           component={TextInput.Field}
         />
-        <Field
-          label="Kapasitet"
-          name={`pools[${index}].capacity`}
-          type="number"
-          placeholder="0 er ubegrenset"
-          fieldClassName={styles.metaField}
-          className={styles.formField}
-          component={TextInput.Field}
-        />
+        {['NORMAL'].includes(eventStatusType) && (
+          <Field
+            label="Kapasitet"
+            name={`pools[${index}].capacity`}
+            type="number"
+            placeholder="0 er ubegrenset"
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+            component={TextInput.Field}
+          />
+        )}
         <Field
           label="Aktiveringstidspunkt"
           name={`pools[${index}].activationDate`}
@@ -51,32 +54,36 @@ const renderPools = ({ fields, startTime }: poolProps) => (
           component={SelectInput.AutocompleteField}
           multi
         />
-        <Button
-          disabled={fields.get(index).registrations.length > 0}
-          onClick={() => fields.remove(index)}
-        >
-          Fjern pool
-        </Button>
+        {['NORMAL'].includes(eventStatusType) && (
+          <Button
+            disabled={fields.get(index).registrations.length > 0}
+            onClick={() => fields.remove(index)}
+          >
+            Fjern pool
+          </Button>
+        )}
       </li>
     ))}
-    <li>
-      <Button
-        onClick={() =>
-          fields.push({
-            name: `Pool #${fields.length + 1}`,
-            registrations: [],
-            activationDate: moment(startTime)
-              .subtract(7, 'd')
-              .hour(12)
-              .minute(0)
-              .toISOString(),
-            permissionGroups: []
-          })
-        }
-      >
-        Legg til ny pool
-      </Button>
-    </li>
+    {['NORMAL'].includes(eventStatusType) && (
+      <li>
+        <Button
+          onClick={() =>
+            fields.push({
+              name: `Pool #${fields.length + 1}`,
+              registrations: [],
+              activationDate: moment(startTime)
+                .subtract(7, 'd')
+                .hour(12)
+                .minute(0)
+                .toISOString(),
+              permissionGroups: []
+            })
+          }
+        >
+          Legg til ny pool
+        </Button>
+      </li>
+    )}
   </ul>
 );
 

--- a/app/routes/events/components/EventEditor/renderPools.js
+++ b/app/routes/events/components/EventEditor/renderPools.js
@@ -80,24 +80,24 @@ const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
     ))}
     {['NORMAL'].includes(eventStatusType) && (
       <li>
-          <div className={styles.centeredButton}>
-        <Button
-          onClick={() =>
-            fields.push({
-              name: `Pool #${fields.length + 1}`,
-              registrations: [],
-              activationDate: moment(startTime)
-                .subtract(7, 'd')
-                .hour(12)
-                .minute(0)
-                .toISOString(),
-              permissionGroups: []
-            })
-          }
-        >
-          Legg til ny pool
-        </Button>
-          </div>
+        <div className={styles.centeredButton}>
+          <Button
+            onClick={() =>
+              fields.push({
+                name: `Pool #${fields.length + 1}`,
+                registrations: [],
+                activationDate: moment(startTime)
+                  .subtract(7, 'd')
+                  .hour(12)
+                  .minute(0)
+                  .toISOString(),
+                permissionGroups: []
+              })
+            }
+          >
+            Legg til ny pool
+          </Button>
+        </div>
       </li>
     )}
   </ul>

--- a/app/routes/events/components/EventEditor/renderPools.js
+++ b/app/routes/events/components/EventEditor/renderPools.js
@@ -17,6 +17,12 @@ type poolProps = {
   eventStatusType: string
 };
 
+const minimumOne = value =>
+  value && value < 1 ? `Pools må ha minst 1 plass` : undefined;
+
+const highWarning = value =>
+  value && value >= 500 ? 'Uendlig plasser? Velg åpent event :)' : undefined;
+
 const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
   <ul style={{ flex: 1 }}>
     {fields.map((pool, index) => (
@@ -33,7 +39,9 @@ const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
             label="Kapasitet"
             name={`pools[${index}].capacity`}
             type="number"
-            placeholder="0 er ubegrenset"
+            placeholder="20,30,50"
+            validate={minimumOne}
+            warn={highWarning}
             fieldClassName={styles.metaField}
             className={styles.formField}
             component={TextInput.Field}

--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -22,11 +22,11 @@ const TYPE_COLORS = {
   company_presentation: '#A1C34A',
   lunch_presentation: '#A1C34A',
   course: '#52B0EC',
-  kid_event: '#111',
+  kid_event: '#111111',
   party: '#FCD748',
   social: '#B11C11',
   event: '#B11C11',
-  other: '#111'
+  other: '#111111'
 };
 
 export const colorForEvent = (eventType: EventType) => {
@@ -44,15 +44,13 @@ const eventCreateAndUpdateFields = [
   'feedbackDescription',
   'feedbackRequired',
   'eventType',
+  'eventStatusType',
   'location',
   'isPriced',
   'priceMember',
   'priceGuest',
   'useStripe',
   'paymentDueDate',
-  'startTime',
-  'endTime',
-  'mergeTime',
   'useCaptcha',
   'tags',
   'pools',
@@ -63,6 +61,7 @@ const eventCreateAndUpdateFields = [
   'useConsent'
 ];
 
+// Pool fields that should be created or updated based on the API
 const poolCreateAndUpdateFields = [
   'id',
   'name',
@@ -71,35 +70,86 @@ const poolCreateAndUpdateFields = [
   'permissionGroups'
 ];
 
-export const transformEvent = (data: TransformEvent, edit: boolean = false) => {
-  let priceMember = 0;
-  if (data.isPriced) {
-    priceMember =
-      (data.addFee ? addStripeFee(data.priceMember) : data.priceMember) * 100;
-  }
+/* Calculate the event price
+ * @param isPriced: If the event is priced
+ * @param addFee: If the event uses Stipe and needs a fee
+ */
+const calculatePrice = data => {
+  let price = 0;
+  price = data.isPriced ? data.priceMember : price;
+  price = data.addFee ? addStripeFee(data.priceMember) * 100 : price;
+  return price;
+};
 
-  return {
-    ...pick(data, eventCreateAndUpdateFields),
-    startTime: moment(data.startTime).toISOString(),
-    endTime: moment(data.endTime).toISOString(),
-    mergeTime:
-      data.pools.length >= 2 ? moment(data.mergeTime).toISOString() : null,
-    company: data.company && data.company.value,
-    responsibleGroup: data.responsibleGroup && data.responsibleGroup.value,
-    priceMember,
-    paymentDueDate: data.isPriced
-      ? moment(data.paymentDueDate).toISOString()
-      : null,
-    unregistrationDeadline: data.unregistrationDeadline
-      ? moment(data.unregistrationDeadline).toISOString()
-      : null,
-    pools: data.pools.map(pool => ({
+/* Calculate the event location
+ * @param eventStatusType: what kind of registrationmode this event has
+ */
+const calculateLocation = data =>
+  data.eventStatusType == 'TBA' ? 'TBA' : data.location;
+
+/* Calculate the event pools
+ * @param eventStatusType: what kind of registrationmode this event has
+ * @param pools: the event groups as specified by the CreateEvent forms
+ */
+const calcualtePools = data => {
+  let pools = [];
+  if (data.eventStatusType == 'TBA' || data.eventStatusType == 'OPEN') {
+    pools = [];
+  } else if (data.eventStatusType == 'INFINITE') {
+    pools = [
+      {
+        ...pick(data.pools[0], poolCreateAndUpdateFields),
+        activationDate: moment(data.pools[0].activationDate).toISOString(),
+        permissionGroups: data.pools[0].permissionGroups.map(
+          group => group.value
+        )
+      }
+    ];
+  } else if (data.eventStatusType == 'NORMAL') {
+    pools = data.pools.map(pool => ({
       ...pick(pool, poolCreateAndUpdateFields),
       activationDate: moment(pool.activationDate).toISOString(),
       permissionGroups: pool.permissionGroups.map(group => group.value)
-    }))
-  };
+    }));
+  }
+  return pools;
 };
+
+/* Calculte and convert to payment due date
+ * @param paymentDueDate: date from form
+ */
+const calcualtePaymentDueDate = data =>
+  data.isPriced ? moment(data.paymentDueDate).toISOString() : null;
+
+/* Calcualte and convert the registation deadline
+ * @param unregistationDeadline: data from form
+ */
+const calculateUnregistrationDeadline = data =>
+  data.unregistrationDeadline
+    ? moment(data.unregistrationDeadline).toISOString()
+    : null;
+
+/* Calculate the merge time for the pools. Only set if there are more then one pool
+ * @param mergeTime: date from form
+ */
+const calculateMergeTime = data =>
+  data.pools.length > 1 ? moment(data.mergeTime).toISOString() : null;
+
+// Takes the full data-object and input and transforms the event to the API format.
+export const transformEvent = (data: TransformEvent) => ({
+  ...pick(data, eventCreateAndUpdateFields),
+  startTime: moment(data.startTime).toISOString(),
+  endTime: moment(data.endTime).toISOString(),
+  mergeTime: calculateMergeTime(data),
+  company: data.company && data.company.value,
+  eventStatusType: data.eventStatusType,
+  responsibleGroup: data.responsibleGroup && data.responsibleGroup.value,
+  priceMember: calculatePrice(data),
+  location: calculateLocation(data),
+  paymentDueDate: calcualtePaymentDueDate(data),
+  unregistrationDeadline: calculateUnregistrationDeadline(data),
+  pools: calcualtePools(data)
+});
 
 export const paymentPending = 'pending';
 export const paymentSuccess = 'succeeded';

--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -92,27 +92,29 @@ const calculateLocation = data =>
  * @param pools: the event groups as specified by the CreateEvent forms
  */
 const calcualtePools = data => {
-  let pools = [];
-  if (data.eventStatusType == 'TBA' || data.eventStatusType == 'OPEN') {
-    pools = [];
-  } else if (data.eventStatusType == 'INFINITE') {
-    pools = [
-      {
-        ...pick(data.pools[0], poolCreateAndUpdateFields),
-        activationDate: moment(data.pools[0].activationDate).toISOString(),
-        permissionGroups: data.pools[0].permissionGroups.map(
-          group => group.value
-        )
-      }
-    ];
-  } else if (data.eventStatusType == 'NORMAL') {
-    pools = data.pools.map(pool => ({
-      ...pick(pool, poolCreateAndUpdateFields),
-      activationDate: moment(pool.activationDate).toISOString(),
-      permissionGroups: pool.permissionGroups.map(group => group.value)
-    }));
+  switch (data.eventStatusType) {
+    case 'TBA':
+    case 'OPEN':
+      return [];
+    case 'INFINITE':
+      return [
+        {
+          ...pick(data.pools[0], poolCreateAndUpdateFields),
+          activationDate: moment(data.pools[0].activationDate).toISOString(),
+          permissionGroups: data.pools[0].permissionGroups.map(
+            group => group.value
+          )
+        }
+      ];
+    case 'NORMAL':
+      return data.pools.map(pool => ({
+        ...pick(pool, poolCreateAndUpdateFields),
+        activationDate: moment(pool.activationDate).toISOString(),
+        permissionGroups: pool.permissionGroups.map(group => group.value)
+      }));
+    default:
+      break;
   }
-  return pools;
 };
 
 /* Calculte and convert to payment due date

--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -75,12 +75,14 @@ const poolCreateAndUpdateFields = [
  * @param addFee: If the event uses Stipe and needs a fee
  */
 const calculatePrice = data => {
-  let price = 0;
-  price = data.isPriced ? data.priceMember : price;
-  price = data.addFee ? addStripeFee(data.priceMember) * 100 : price;
-  return price;
+  if (data.isPriced) {
+    if (data.addFee) {
+      return addStripeFee(data.priceMember) * 100;
+    }
+    return data.priceMember * 100;
+  }
+  return 0;
 };
-
 /* Calculate the event location
  * @param eventStatusType: what kind of registrationmode this event has
  */
@@ -91,7 +93,7 @@ const calculateLocation = data =>
  * @param eventStatusType: what kind of registrationmode this event has
  * @param pools: the event groups as specified by the CreateEvent forms
  */
-const calcualtePools = data => {
+const calculatePools = data => {
   switch (data.eventStatusType) {
     case 'TBA':
     case 'OPEN':
@@ -120,7 +122,7 @@ const calcualtePools = data => {
 /* Calculte and convert to payment due date
  * @param paymentDueDate: date from form
  */
-const calcualtePaymentDueDate = data =>
+const calculatePaymentDueDate = data =>
   data.isPriced ? moment(data.paymentDueDate).toISOString() : null;
 
 /* Calcualte and convert the registation deadline
@@ -148,9 +150,10 @@ export const transformEvent = (data: TransformEvent) => ({
   responsibleGroup: data.responsibleGroup && data.responsibleGroup.value,
   priceMember: calculatePrice(data),
   location: calculateLocation(data),
-  paymentDueDate: calcualtePaymentDueDate(data),
+  paymentDueDate: calculatePaymentDueDate(data),
   unregistrationDeadline: calculateUnregistrationDeadline(data),
-  pools: calcualtePools(data)
+  pools: calculatePools(data),
+  useCaptcha: true // always use Captcha, this blocks the use of CLI
 });
 
 export const paymentPending = 'pending';


### PR DESCRIPTION
## Implement EventStatusType for events
> Dependent on https://github.com/webkom/lego/pull/1488

- Each event has a field named `eventStatusType` that sets specific criteria for that event.
- Types [`TBA`, `NORMAL`, `OPEN`, `INFINITE`]
![image](https://user-images.githubusercontent.com/23152018/54565760-66025e80-49cf-11e9-81a1-8c23483afbf5.png)

### TBA
When selecting **TBA** the event will automatically be set to `pools = []` and `location: 'TBA'`.
This is to be used when only the time and date of an event is known, but not any specifics about pool sizes and locations.
![image](https://user-images.githubusercontent.com/23152018/54565937-cd201300-49cf-11e9-9330-d7ad75a928be.png)

### NORMAL
When selecting **NORMAL** the event will act like a normal event, and all the normal fields will appear.
![image](https://user-images.githubusercontent.com/23152018/54566115-3f90f300-49d0-11e9-8c50-b2e488c29507.png)

### OPEN
When selecting **OPEN** the event will set `pools = []`, but it will allow the user to set location. This is to be used for events like _LaBamba Fest_ and other events that require no registration.
![image](https://user-images.githubusercontent.com/23152018/54566132-4d467880-49d0-11e9-8e1f-b0f1a5e9618c.png)

### INFINITE
When selection **INFINITE** the event will set `pools = [...one-pool]` and allow the user to set the settings of that pool. They cannot create more/fewer pools and can not change the number of users.
This is to be used for events like _Workshop_ and other events with infinite space, but registration is required.
![image](https://user-images.githubusercontent.com/23152018/54566274-ab735b80-49d0-11e9-9b52-2b49eb9c9416.png)


## Improve from styling
- When checking off different boxes in the form more fields will appear, and it's hard to keep track of what is connected to what. By implementing sub-section styling and rendering this will be more clear.
![image](https://user-images.githubusercontent.com/23152018/54598443-d1344b00-4a38-11e9-9ce3-3090ea3d50f3.png)
![image](https://user-images.githubusercontent.com/23152018/54598415-c1b50200-4a38-11e9-9d8a-440faa3affda.png)

- When adding many pools the form gets very disorganized. By removing the `Påmeldte` section and adding a background its a lot easier to see what is connected

*After - Before*
![image](https://user-images.githubusercontent.com/23152018/54592331-6aa93000-4a2c-11e9-8811-6be23bf80c47.png)

- Move the Feedback field into the dynamic form and validate its input. Remove the Captcha checkbox and always send in true for captcha.
![image](https://user-images.githubusercontent.com/23152018/54629595-32c7da00-4a78-11e9-83ab-e7f839e2e3a9.png)


