### PR TITLE
Event detail changes

### DIFF
--- a/app/models.js
+++ b/app/models.js
@@ -110,7 +110,12 @@ export type User = {
 
 export type EventRegistrationPresence = 'PRESENT' | 'NOT_PRESENT' | 'UNKNOWN';
 
-export type EventRegistrationChargeStatus = 'manual' | 'succeeded' | 'failed';
+export type EventRegistrationChargeStatus =
+  | 'pending'
+  | 'manual'
+  | 'succeeded'
+  | 'failed'
+  | 'card_declined';
 
 export type EventRegistration = {
   id: number,

--- a/app/models.js
+++ b/app/models.js
@@ -67,7 +67,7 @@ export type Event = EventBase & {
   pools: Array<EventPool>,
   survey: ?ID,
   userReg: EventRegistration,
-  useConsent: ?boolean,
+  useConsent: boolean,
   isUserFollowing: UserFollowing,
   unansweredSurveys: Array<ID>,
   responsibleGroup: Group,
@@ -109,6 +109,10 @@ export type User = {
 };
 
 export type EventRegistrationPresence = 'PRESENT' | 'NOT_PRESENT' | 'UNKNOWN';
+export type EventRegistrationPhotoConsent =
+  | 'PHOTO_NOT_CONSENT'
+  | 'PHOTO_CONSENT'
+  | 'UNKNOWN';
 
 export type EventRegistrationChargeStatus =
   | 'pending'
@@ -127,7 +131,8 @@ export type EventRegistration = {
   presence: EventRegistrationPresence,
   chargeStatus: EventRegistrationChargeStatus,
   feedback: string,
-  sharedMemberships?: number
+  sharedMemberships?: number,
+  consent: EventRegistrationPhotoConsent
 };
 
 type EventPoolBase = {

--- a/app/routes/events/EventDetailRoute.js
+++ b/app/routes/events/EventDetailRoute.js
@@ -12,7 +12,6 @@ import {
   unfollow,
   isUserFollowing
 } from 'app/actions/EventActions';
-import { updateUser } from 'app/actions/UserActions';
 import EventDetail from './components/EventDetail';
 import {
   selectEventById,
@@ -123,7 +122,6 @@ const mapDispatchToProps = {
   follow,
   unfollow,
   isUserFollowing,
-  updateUser,
   deleteComment
 };
 

--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -67,6 +67,7 @@
 }
 
 .joinHeader {
+  margin-top: 20px;
   font-size: 20px;
   color: var(--lego-color-gray);
   text-transform: uppercase;

--- a/app/routes/events/components/EventAdministrate/Abacard.js
+++ b/app/routes/events/components/EventAdministrate/Abacard.js
@@ -9,7 +9,11 @@ import Modal from 'app/components/Modal';
 import Validator from 'app/components/UserValidator';
 
 // $FlowFixMe
-import type { EventRegistration, Event } from 'app/models';
+import type {
+  EventRegistration,
+  EventRegistrationPhotoConsent,
+  Event
+} from 'app/models';
 type State = {
   // Skra
   resolve: ?() => Promise<*>,
@@ -20,7 +24,11 @@ type Props = {
   event: Event,
   clearSearch: () => void,
   markUsernamePresent: (string, string) => Promise<*>,
-  markUsernameConsent: (string, string, string) => Promise<*>,
+  markUsernameConsent: (
+    string,
+    string,
+    EventRegistrationPhotoConsent
+  ) => Promise<*>,
   location: Object,
   onQueryChanged: string => void,
   results: Array<SearchResult>,

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -337,7 +337,7 @@ export default class EventDetail extends Component<Props> {
           </Link>
           {loggedIn && (
             <p>
-              Du kan oppdatere dine allergier og preferanser{' '}
+              Du kan oppdatere dine allergier og preferanser
               <Link to="/users/me"> her</Link>.
             </p>
           )}

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -11,6 +11,7 @@ import {
   ModalParentComponent
 } from 'app/components/UserAttendance';
 import Tag from 'app/components/Tags/Tag';
+import moment from 'moment-timezone';
 import { FormatTime, FromToTime } from 'app/components/Time';
 import InfoList from 'app/components/InfoList';
 import { Flex } from 'app/components/Layout';
@@ -261,7 +262,10 @@ export default class EventDetail extends Component<Props> {
                       registrations={registrations}
                       title="Påmeldte"
                     >
-                      <RegisteredSummary registrations={registrations} />
+                      <RegisteredSummary
+                        registrations={registrations}
+                        currentRegistration={currentRegistration}
+                      />
                       <AttendanceStatus />
                     </ModalParentComponent>
                   </Fragment>
@@ -271,6 +275,8 @@ export default class EventDetail extends Component<Props> {
 
                 {loggedIn && (
                   <RegistrationMeta
+                    useConsent={event.useConsent}
+                    hasEnded={moment(event.endTime).isBefore(moment())}
                     registration={currentRegistration}
                     isPriced={event.isPriced}
                     registrationIndex={currentRegistrationIndex}

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -80,7 +80,6 @@ type Props = {
     feedback: string
   ) => Promise<*>,
   deleteEvent: (eventId: ID) => Promise<*>,
-  updateUser: UserEntity => void,
   deleteComment: (id: ID, commentTarget: string) => Promise<*>
 };
 
@@ -127,7 +126,6 @@ export default class EventDetail extends Component<Props> {
       event,
       loggedIn,
       currentUser,
-      updateUser,
       actionGrant,
       comments,
       error,
@@ -279,6 +277,41 @@ export default class EventDetail extends Component<Props> {
                     hasSimpleWaitingList={hasSimpleWaitingList}
                   />
                 )}
+
+                {event.unansweredSurveys &&
+                event.unansweredSurveys.length > 0 ? (
+                  <div className={styles.unansweredSurveys}>
+                    <h3>
+                      Du kan ikke melde deg på dette arrangementet fordi du har
+                      ubesvarte spørreundersøkelser.
+                    </h3>
+                    <p>
+                      Man må svare på alle spørreundersøkelser for tidligere
+                      arrangementer før man kan melde seg på nye arrangementer.
+                      Du kan svare på undersøkelsene dine ved å trykke på
+                      følgende linker:
+                    </p>
+                    <ul>
+                      {event.unansweredSurveys.map((surveyId, i) => (
+                        <li key={surveyId}>
+                          <Link to={`/surveys/${surveyId}`}>
+                            Undersøkelse {i + 1}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : (
+                  <div>
+                    <JoinEventForm
+                      event={event}
+                      registration={currentRegistration}
+                      currentUser={currentUser}
+                      onToken={this.handleToken}
+                      onSubmit={this.handleRegistration}
+                    />
+                  </div>
+                )}
                 <Admin
                   actionGrant={actionGrant}
                   event={event}
@@ -287,54 +320,20 @@ export default class EventDetail extends Component<Props> {
               </Flex>
             </ContentSidebar>
           </ContentSection>
-
-          {loggedIn &&
-          event.unansweredSurveys &&
-          event.unansweredSurveys.length > 0 ? (
-            <div className={styles.unansweredSurveys}>
-              <h3>
-                Du kan ikke melde deg på dette arrangementet fordi du har
-                ubesvarte spørreundersøkelser.
-              </h3>
-              <p>
-                Man må svare på alle spørreundersøkelser for tidligere
-                arrangementer før man kan melde seg på nye arrangementer. Du kan
-                svare på undersøkelsene dine ved å trykke på følgende linker:
-              </p>
-              <ul>
-                {event.unansweredSurveys.map((surveyId, i) => (
-                  <li key={surveyId}>
-                    <Link to={`/surveys/${surveyId}`}>
-                      Undersøkelse {i + 1}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : (
-            <div>
-              <div className={styles.joinHeader}>
-                Bli med på dette arrangementet
-              </div>
-              <Link
-                to="/pages/arrangementer/26-arrangementsregler"
-                style={{ marginTop: 0 }}
-              >
-                <Flex alignItems="center">
-                  <Icon name="document" style={{ marginRight: '4px' }} />
-                  <span>Regler for Abakus&#39; arrangementer</span>
-                </Flex>
-              </Link>
-
-              <JoinEventForm
-                event={event}
-                registration={currentRegistration}
-                currentUser={currentUser}
-                updateUser={updateUser}
-                onToken={this.handleToken}
-                onSubmit={this.handleRegistration}
-              />
-            </div>
+          <Link
+            to="/pages/arrangementer/26-arrangementsregler"
+            style={{ marginTop: 0 }}
+          >
+            <Flex alignItems="center">
+              <Icon name="document" style={{ marginRight: '4px' }} />
+              <span>Regler for Abakus&#39; arrangementer</span>
+            </Flex>
+          </Link>
+          {loggedIn && (
+            <p>
+              Du kan oppdatere dine allergier og preferanser{' '}
+              <Link to="/users/me"> her</Link>.
+            </p>
           )}
 
           {event.commentTarget && (

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -282,6 +282,14 @@ class JoinEventForm extends Component<Props> {
             </Form>
           </Flex>
         )}
+        {!formOpen && registration && showStripe && (
+          <PaymentRequestForm
+            onToken={onToken}
+            event={event}
+            currentUser={currentUser}
+            chargeStatus={registration.chargeStatus}
+          />
+        )}
       </Flex>
     );
   }

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -16,7 +16,7 @@ import { Flex } from 'app/components/Layout';
 import withCountdown from './JoinEventFormCountdownProvider';
 import formStyles from 'app/components/Form/Field.css';
 import moment from 'moment-timezone';
-import { paymentPending, paymentSuccess, paymentManual } from '../utils';
+import { paymentSuccess, paymentManual } from '../utils';
 
 type Event = Object;
 
@@ -159,7 +159,7 @@ class JoinEventForm extends Component<Props> {
     const disabledButton = !registration
       ? isInvalid || isPristine || submitting
       : false;
-    const disabledForUser = !formOpen && !event.activationTime;
+    const disabledForUser = !formOpen && !event.activationTime && !registration;
     const showPenaltyNotice = Boolean(
       event.heedPenalties &&
         moment().isAfter(event.unregistrationDeadline) &&
@@ -173,9 +173,7 @@ class JoinEventForm extends Component<Props> {
       event.price > 0 &&
       registration &&
       registration.pool &&
-      ![paymentPending, paymentManual, paymentSuccess].includes(
-        registration.chargeStatus
-      );
+      ![paymentManual, paymentSuccess].includes(registration.chargeStatus);
 
     return (
       <Flex column className={styles.join}>
@@ -265,11 +263,12 @@ class JoinEventForm extends Component<Props> {
                       spotsLeft={event.spotsLeft}
                     />
                   )}
-                  {showStripe && (
+                  {registration && showStripe && (
                     <PaymentRequestForm
                       onToken={onToken}
                       event={event}
                       currentUser={currentUser}
+                      chargeStatus={registration.chargeStatus}
                     />
                   )}
                 </Flex>

--- a/app/routes/events/components/RegisteredSummary.js
+++ b/app/routes/events/components/RegisteredSummary.js
@@ -8,16 +8,22 @@ import { Flex } from 'app/components/Layout';
 import type { EventRegistration } from 'app/models';
 
 type RegistrationProps = {
-  registration: EventRegistration
+  registration: EventRegistration,
+  currentRegistration?: ?EventRegistration
 };
 
-const Registration = ({ registration }: RegistrationProps) => (
+const Registration = ({
+  registration,
+  currentRegistration
+}: RegistrationProps) => (
   <Tooltip content={registration.user.fullName}>
     <Link
       to={`/users/${registration.user.username}`}
       style={{ color: 'inherit' }}
     >
-      {registration.user.firstName.split(' ')[0]}
+      {registration.id === (currentRegistration && currentRegistration.id)
+        ? 'Du'
+        : registration.user.firstName.split(' ')[0]}
     </Link>
   </Tooltip>
 );
@@ -59,22 +65,32 @@ const RegistrationList = ({
 
 type RegisteredSummaryProps = {
   registrations: Array<EventRegistration>,
+  currentRegistration?: ?EventRegistration,
   toggleModal?: number => void
 };
 
 const RegisteredSentence = ({
   registrations,
-  toggleModal
+  toggleModal,
+  currentRegistration
 }: RegisteredSummaryProps) => {
   switch (registrations.length) {
     case 0:
       return 'Ingen';
     case 1:
-      return <Registration registration={registrations[0]} />;
+      return (
+        <Registration
+          currentRegistration={currentRegistration}
+          registration={registrations[0]}
+        />
+      );
     case 2:
       return (
         <Flex>
-          <Registration registration={registrations[0]} />
+          <Registration
+            currentRegistration={currentRegistration}
+            registration={registrations[0]}
+          />
           {' og '}
           <Registration registration={registrations[1]} />
         </Flex>
@@ -83,7 +99,10 @@ const RegisteredSentence = ({
       // For more than 2 registrations we add a clickable `more` link:
       return (
         <Flex>
-          <Registration registration={registrations[0]} />
+          <Registration
+            currentRegistration={currentRegistration}
+            registration={registrations[0]}
+          />
           {', '}
           <Registration registration={registrations[1]} />
           {' og '}

--- a/app/routes/events/components/RegistrationMeta.js
+++ b/app/routes/events/components/RegistrationMeta.js
@@ -1,7 +1,11 @@
 // @flow
 
 import React from 'react';
-import type { EventRegistrationChargeStatus } from 'app/models';
+import type {
+  EventRegistrationPresence,
+  EventRegistrationChargeStatus,
+  EventRegistrationPhotoConsent
+} from 'app/models';
 import {
   paymentPending,
   paymentCardDeclined,
@@ -9,31 +13,106 @@ import {
   paymentManual,
   paymentCardExpired
 } from '../utils';
+import Tooltip from 'app/components/Tooltip';
 
 type Props = {
   registration: Object,
   isPriced: boolean,
   registrationIndex: number,
-  hasSimpleWaitingList: boolean
+  hasSimpleWaitingList: boolean,
+  useConsent: boolean,
+  hasEnded: boolean
 };
-const PaymentStatus = ({
-  chargeStatus
+
+const ConsentStatus = ({
+  useConsent,
+  photoConsent,
+  hasEnded
 }: {
-  chargeStatus: EventRegistrationChargeStatus
+  useConsent: boolean,
+  photoConsent: EventRegistrationPhotoConsent,
+  hasEnded: boolean
 }) => {
+  if (!useConsent) return null;
+  switch (photoConsent) {
+    case 'PHOTO_NOT_CONSENT':
+      return (
+        <div>
+          <i className="fa fa-check-circle" /> Du har valgt <i>NEI</i> på
+          samtykke om bilder
+        </div>
+      );
+    case 'PHOTO_CONSENT':
+      return (
+        <div>
+          <i className="fa fa-check-circle" /> Du har valgt <i>ja</i> på
+          samtykke om bilder
+        </div>
+      );
+    case 'UNKNOWN':
+      if (!hasEnded) return null;
+      return (
+        <div>
+          <i className="fa fa-exclamation-circle" /> Du har enda ikke tatt
+          stilling til samtykke om bilder
+        </div>
+      );
+    default:
+      return null;
+  }
+};
+const PresenceStatus = ({
+  presence,
+  hasEnded
+}: {
+  hasEnded: boolean,
+  presence: EventRegistrationPresence
+}) => {
+  switch (presence) {
+    case 'NOT_PRESENT':
+      return (
+        <>
+          <i className="fa fa-exclamation-circle" /> Du møtte ikke opp på
+          arrangementet
+        </>
+      );
+    case 'PRESENT':
+      return (
+        <>
+          <i className="fa fa-check-circle" /> Du møtte opp på arrangementet
+        </>
+      );
+    case 'UNKNOWN':
+      if (!hasEnded) return null;
+      return (
+        <>
+          <i className="fa fa-check-circle" /> Oppmøte ble ikke sjekktet
+        </>
+      );
+  }
+};
+
+const PaymentStatus = ({
+  chargeStatus,
+  isPriced
+}: {
+  chargeStatus: EventRegistrationChargeStatus,
+  isPriced: boolean
+}) => {
+  if (!isPriced) return null;
   switch (chargeStatus) {
     case paymentPending:
       return (
-        <>
+        <div>
           <i className="fa fa-exclamation-circle" /> Betaling pågår
-        </>
+        </div>
       );
     case paymentManual:
     case paymentSuccess:
       return (
-        <>
+        <div>
           <i className="fa fa-check-circle" /> Du har betalt
-        </>
+        </div>
       );
     case paymentCardDeclined:
       return (
@@ -44,22 +123,24 @@ const PaymentStatus = ({
       );
     case paymentCardExpired:
       return (
-        <>
+        <div>
           <i className="fa fa-exclamation-circle" /> Du har ikke betalt. Kortet
           du prøvde å betale med har gått ut på dato.
-        </>
+        </div>
       );
     default:
       return (
-        <>
+        <div>
           <i className="fa fa-exclamation-circle" /> Du har ikke betalt
-        </>
+        </div>
       );
   }
 };
 
 const RegistrationMeta = ({
   registration,
+  hasEnded,
+  useConsent,
   isPriced,
   registrationIndex,
   hasSimpleWaitingList
@@ -86,11 +167,18 @@ const RegistrationMeta = ({
             <i className="fa fa-pause-circle" /> Du er i venteliste
           </div>
         )}
-        {isPriced && (
-          <div>
-            <PaymentStatus chargeStatus={registration.chargeStatus} />
-          </div>
-        )}
+        <PresenceStatus presence={registration.presence} hasEnded={hasEnded} />
+        <Tooltip content="Du kan når som helst endre samtykket ved å kontakte oss på abakus@abakus.no">
+          <ConsentStatus
+            useConsent={useConsent}
+            hasEnded={hasEnded}
+            photoConsent={registration.photoConsent}
+          />
+        </Tooltip>
+        <PaymentStatus
+          isPriced={isPriced}
+          chargeStatus={registration.chargeStatus}
+        />
       </div>
     )}
   </div>

--- a/app/routes/events/components/RegistrationMeta.js
+++ b/app/routes/events/components/RegistrationMeta.js
@@ -1,13 +1,61 @@
 // @flow
 
 import React from 'react';
-import { hasPaid } from '../utils';
+import type { EventRegistrationChargeStatus } from 'app/models';
+import {
+  paymentPending,
+  paymentCardDeclined,
+  paymentSuccess,
+  paymentManual,
+  paymentCardExpired
+} from '../utils';
 
 type Props = {
   registration: Object,
   isPriced: boolean,
   registrationIndex: number,
   hasSimpleWaitingList: boolean
+};
+const PaymentStatus = ({
+  chargeStatus
+}: {
+  chargeStatus: EventRegistrationChargeStatus
+}) => {
+  switch (chargeStatus) {
+    case paymentPending:
+      return (
+        <>
+          <i className="fa fa-exclamation-circle" /> Betaling pågår
+        </>
+      );
+    case paymentManual:
+    case paymentSuccess:
+      return (
+        <>
+          <i className="fa fa-check-circle" /> Du har betalt
+        </>
+      );
+    case paymentCardDeclined:
+      return (
+        <>
+          <i className="fa fa-exclamation-circle" /> Du har ikke betalt. Kortet
+          du prøvde å betale med ble ikke godtatt.
+        </>
+      );
+    case paymentCardExpired:
+      return (
+        <>
+          <i className="fa fa-exclamation-circle" /> Du har ikke betalt. Kortet
+          du prøvde å betale med har gått ut på dato.
+        </>
+      );
+    default:
+      return (
+        <>
+          <i className="fa fa-exclamation-circle" /> Du har ikke betalt
+        </>
+      );
+  }
 };
 
 const RegistrationMeta = ({
@@ -38,16 +86,11 @@ const RegistrationMeta = ({
             <i className="fa fa-pause-circle" /> Du er i venteliste
           </div>
         )}
-        {isPriced &&
-          (hasPaid(registration.chargeStatus) ? (
-            <div>
-              <i className="fa fa-check-circle" /> Du har betalt
-            </div>
-          ) : (
-            <div>
-              <i className="fa fa-exclamation-circle" /> Du har ikke betalt
-            </div>
-          ))}
+        {isPriced && (
+          <div>
+            <PaymentStatus chargeStatus={registration.chargeStatus} />
+          </div>
+        )}
       </div>
     )}
   </div>

--- a/app/routes/events/components/RegistrationMeta.js
+++ b/app/routes/events/components/RegistrationMeta.js
@@ -67,14 +67,14 @@ const RegistrationMeta = ({
   <div>
     {!registration && (
       <div>
-        <i className="fa fa-exclamation-circle" /> Du er ikke registrert
+        <i className="fa fa-exclamation-circle" /> Du er ikke påmeldt
       </div>
     )}
     {registration && (
       <div>
         {registration.pool ? (
           <div>
-            <i className="fa fa-check-circle" /> Du er registrert
+            <i className="fa fa-check-circle" /> Du er påmeldt
           </div>
         ) : hasSimpleWaitingList ? (
           <div>

--- a/app/routes/events/components/StripeElement.css
+++ b/app/routes/events/components/StripeElement.css
@@ -8,6 +8,5 @@
 }
 
 .overlayParent {
-  width: 100%;
   position: relative;
 }

--- a/app/routes/events/components/StripeElement.css
+++ b/app/routes/events/components/StripeElement.css
@@ -1,0 +1,13 @@
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.4);
+  z-index: 2;
+}
+
+.overlayParent {
+  width: 100%;
+  position: relative;
+}

--- a/app/routes/events/components/StripeElement.js
+++ b/app/routes/events/components/StripeElement.js
@@ -26,7 +26,7 @@ type FormProps = Props & { stripe: { paymentRequest: Object => Object } };
 
 type State = {
   paymentRequest: Object,
-  canMakePayment: boolean
+  canMakePayment?: boolean
 };
 
 const paymentButtonWidth = 130;
@@ -59,7 +59,7 @@ class PaymentRequestForm extends React.Component<FormProps, State> {
     });
 
     this.state = {
-      canMakePayment: false,
+      canMakePayment: undefined,
       paymentRequest
     };
   }
@@ -77,7 +77,7 @@ class PaymentRequestForm extends React.Component<FormProps, State> {
             }}
           />
         )}
-        {this.state.canMakePayment ? (
+        {this.state.canMakePayment && (
           <div style={{ width: 130 }}>
             <PaymentRequestButtonElement
               paymentRequest={this.state.paymentRequest}
@@ -89,7 +89,9 @@ class PaymentRequestForm extends React.Component<FormProps, State> {
               }}
             />
           </div>
-        ) : (
+        )}
+
+        {this.state.canMakePayment === false && (
           <StripeCheckout
             name="Abakus Linjeforening"
             description={event.title}

--- a/app/routes/events/components/StripeElement.js
+++ b/app/routes/events/components/StripeElement.js
@@ -93,7 +93,7 @@ class PaymentRequestForm extends React.Component<FormProps, State> {
 
         {this.state.canMakePayment === false && (
           <StripeCheckout
-            name="Abakus Linjeforening"
+            name="Abakus"
             description={event.title}
             image={logoImage}
             currency="NOK"

--- a/app/routes/events/components/StripeElement.js
+++ b/app/routes/events/components/StripeElement.js
@@ -9,13 +9,17 @@ import {
 import config from 'app/config';
 import StripeCheckout from 'react-stripe-checkout';
 import Button from 'app/components/Button';
+import styles from './StripeElement.css';
 import logoImage from 'app/assets/kule.png';
-import type { User, Event } from 'app/models';
+import type { EventRegistrationChargeStatus, User, Event } from 'app/models';
+
+import { paymentPending } from '../utils';
 
 type Props = {
   event: Event,
   currentUser: User,
-  onToken: (token: string) => Promise<*>
+  onToken: (token: string) => Promise<*>,
+  chargeStatus: EventRegistrationChargeStatus
 };
 
 type FormProps = Props & { stripe: { paymentRequest: Object => Object } };
@@ -24,6 +28,8 @@ type State = {
   paymentRequest: Object,
   canMakePayment: boolean
 };
+
+const paymentButtonWidth = 130;
 
 class PaymentRequestForm extends React.Component<FormProps, State> {
   constructor(props) {
@@ -59,34 +65,47 @@ class PaymentRequestForm extends React.Component<FormProps, State> {
   }
 
   render() {
-    const { event, onToken, currentUser } = this.props;
-    return this.state.canMakePayment ? (
-      <div style={{ width: 130 }}>
-        <PaymentRequestButtonElement
-          paymentRequest={this.state.paymentRequest}
-          className="PaymentRequestButton"
-          style={{
-            paymentRequestButton: {
-              height: '41px'
-            }
-          }}
-        />
+    const { chargeStatus, event, onToken, currentUser } = this.props;
+    const showOverlay = chargeStatus === paymentPending;
+    return (
+      <div className={styles.overlayParent}>
+        {showOverlay && (
+          <div
+            className={styles.overlay}
+            style={{
+              width: paymentButtonWidth
+            }}
+          />
+        )}
+        {this.state.canMakePayment ? (
+          <div style={{ width: 130 }}>
+            <PaymentRequestButtonElement
+              paymentRequest={this.state.paymentRequest}
+              className="PaymentRequestButton"
+              style={{
+                paymentRequestButton: {
+                  height: '41px'
+                }
+              }}
+            />
+          </div>
+        ) : (
+          <StripeCheckout
+            name="Abakus Linjeforening"
+            description={event.title}
+            image={logoImage}
+            currency="NOK"
+            allowRememberMe
+            locale="no"
+            token={onToken}
+            stripeKey={config.stripeKey}
+            amount={event.price}
+            email={currentUser.email}
+          >
+            <Button style={{ width: 130 }}>Betal nå</Button>
+          </StripeCheckout>
+        )}
       </div>
-    ) : (
-      <StripeCheckout
-        name="Abakus Linjeforening"
-        description={event.title}
-        image={logoImage}
-        currency="NOK"
-        allowRememberMe
-        locale="no"
-        token={onToken}
-        stripeKey={config.stripeKey}
-        amount={event.price}
-        email={currentUser.email}
-      >
-        <Button>Betal nå</Button>
-      </StripeCheckout>
     );
   }
 }

--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -105,6 +105,8 @@ export const paymentPending = 'pending';
 export const paymentSuccess = 'succeeded';
 export const paymentFailure = 'failed';
 export const paymentManual = 'manual';
+export const paymentCardDeclined = 'card_declined';
+export const paymentCardExpired = 'expired_card';
 
 const paymentSuccessMappings = {
   [paymentManual]: true,


### PR DESCRIPTION
Depends on https://github.com/webkom/lego/pull/1512

- Add a few more payment statuses
- Disable payment button during payment
- Show stripe payment button after event has started
- Update payment status real time
- Simplify registration form
- Move registration form to right side of screen

![Screenshot from 2019-03-19 04-19-56](https://user-images.githubusercontent.com/1467188/54578350-c14c4500-49ff-11e9-8d34-61c761950a00.png)
![Screenshot from 2019-03-19 04-20-00](https://user-images.githubusercontent.com/1467188/54578351-c14c4500-49ff-11e9-8b7c-20106ceedcc5.png)
![Screenshot from 2019-03-19 04-20-20](https://user-images.githubusercontent.com/1467188/54578352-c14c4500-49ff-11e9-9476-f7996da03ea8.png)
![Screenshot from 2019-03-19 04-24-24](https://user-images.githubusercontent.com/1467188/54578353-c14c4500-49ff-11e9-97ae-7cc3379f2185.png)


![Screenshot from 2019-03-19 18-01-38](https://user-images.githubusercontent.com/1467188/54632013-6d804100-4a7d-11e9-97b3-fa4fd39c08d1.png)
![Screenshot from 2019-03-19 18-04-48](https://user-images.githubusercontent.com/1467188/54632014-6d804100-4a7d-11e9-8458-84c03e976e7f.png)
![Screenshot from 2019-03-19 18-05-03](https://user-images.githubusercontent.com/1467188/54632015-6d804100-4a7d-11e9-9c26-f88aca48f462.png)
![Screenshot from 2019-03-19 18-08-36](https://user-images.githubusercontent.com/1467188/54632017-6d804100-4a7d-11e9-93c7-c6bdbe32fd7b.png)
![Screenshot from 2019-03-19 19-20-59](https://user-images.githubusercontent.com/1467188/54632018-6e18d780-4a7d-11e9-8c5c-265fec475450.png)
![Screenshot from 2019-03-19 19-26-07](https://user-images.githubusercontent.com/1467188/54632020-6e18d780-4a7d-11e9-8426-88338cffd5b3.png)
