### PR TITLE
Add scroll-to-top/scroll restoration on route change.

### DIFF
--- a/app/Root.js
+++ b/app/Root.js
@@ -2,11 +2,12 @@
 
 import React from 'react';
 import { setStatusCode } from 'app/actions/RoutingActions';
-import { Router } from 'react-router';
+import { Router, applyRouterMiddleware } from 'react-router';
 import { Provider } from 'react-redux';
 import type { Store } from 'app/types';
 import { connect } from 'react-redux';
 import ErrorBoundary from 'app/components/ErrorBoundary';
+import { useScroll } from 'react-router-scroll';
 
 type Props = {
   store: Store
@@ -35,7 +36,11 @@ const RouteHandler = connect(
     setStatusCode: (statusCode: ?number) => void
   }) => (
     <ErrorBoundary openReportDialog>
-      <Router onError={err => setStatusCode(500)} {...restProps} />
+      <Router
+        onError={err => setStatusCode(500)}
+        {...restProps}
+        render={applyRouterMiddleware(useScroll())}
+      />
     </ErrorBoundary>
   )
 );

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -12,7 +12,6 @@
 
 html {
   font-size: 1rem;
-  scroll-behavior: smooth;
 }
 
 body {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-redux": "^5.0.1",
     "react-router": "^3.2.1",
     "react-router-redux": "^4.0.8",
+    "react-router-scroll": "^0.4.4",
     "react-select": "^1.0.0-rc.3",
     "react-soundplayer": "^1.0.4",
     "react-stickynode": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9873,6 +9873,15 @@ react-router-redux@^4.0.8:
   resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
   integrity sha1-InQDWWtRUeGCN32rg1tdRfD4BU4=
 
+react-router-scroll@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/react-router-scroll/-/react-router-scroll-0.4.4.tgz#4d7b71c75b45ff296e4adca1e029a86e898a155d"
+  integrity sha512-FR+kyNmRrNqhRbMHDFSgFPVrOy923AdJZE0Qqefub5u56+5d7EENLy4DOrCZVr2fTHsJjWJDE0X1vU063t4bOA==
+  dependencies:
+    prop-types "^15.6.0"
+    scroll-behavior "^0.9.5"
+    warning "^3.0.0"
+
 react-router@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.1.tgz#b9a3279962bdfbe684c8bd0482b81ef288f0f244"
@@ -10750,6 +10759,14 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+scroll-behavior@^0.9.5:
+  version "0.9.10"
+  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.10.tgz#c8953adeeb3586060b903328d860aa8346d62861"
+  integrity sha512-JVJQkBkqMLEM4ATtbHTKare97zhz/qlla9mNttFYY/bcpyOb4BuBGEQ/N9AQWXvshzf6zo9jP60TlphnJ4YPoQ==
+  dependencies:
+    dom-helpers "^3.2.1"
+    invariant "^2.2.2"
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
* Fixes https://github.com/webkom/lego/issues/1520

Quick fix for v3, but when upgrading to v4 this won't work anymore. But the people at React Router has provided an alternative so no biggie. 

This is the package used (plug and play): https://github.com/taion/react-router-scroll

Further reading for v4 solutions and reasoning for removing it (tldr: browsers are starting to implement it):
https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md
https://reacttraining.com/react-router/web/guides/scroll-restoration

Note: Removed global `scroll-behavior: smooth` css, since it makes the screen jump when navigating, and while this property is nice for admin pages like lego form and searching in those pages (groups, email etc), I think regular users should be prioritised. So I'm removing this, but in the future we might want to look into alternatives. `scrollIntoView` as used in legoForm has a property where you can specify smooth scrolling, but I did not change this as it does not seem to work on my pc at least. Hopefully we can find other solutions for smooth scrolling where it would be nice to have it. https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView