### PR TITLE
Tool tip fix

### DIFF
--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -78,7 +78,7 @@ class Poll extends React.Component<Props, State> {
             <Icon name="stats" />
             <span className={styles.pollHeader}>{title}</span>
           </Link>
-          <Tooltip content="Avstemningen er anonym." renderToThe="left">
+          <Tooltip content="Avstemningen er anonym." renderDirection="left">
             <Icon
               name="information-circle-outline"
               size={20}

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -78,14 +78,11 @@ class Poll extends React.Component<Props, State> {
             <Icon name="stats" />
             <span className={styles.pollHeader}>{title}</span>
           </Link>
-          <Tooltip
-            content="Avstemningen er anonym."
-            style={{ marginLeft: '-180px' }}
-          >
+          <Tooltip content="Avstemningen er anonym." renderToThe={'left'}>
             <Icon
               name="information-circle-outline"
               size={20}
-              style={{ marginLeft: '10px', cursor: 'pointer' }}
+              style={{ cursor: 'pointer' }}
             />
           </Tooltip>
         </Flex>

--- a/app/components/Tooltip/Tooltip.css
+++ b/app/components/Tooltip/Tooltip.css
@@ -19,13 +19,12 @@
   height: 0;
   border-width: 5px;
   border-style: solid;
-  left: 10%;
+  left: 50%;
 }
 
 .showTooltip {
-  margin-top: -45px;
+  transform: translate(-50%, -100%);
   position: absolute;
-  transform: translateX(-10%);
 }
 
 .showTooltip::after {

--- a/app/components/Tooltip/Tooltip.css
+++ b/app/components/Tooltip/Tooltip.css
@@ -19,12 +19,6 @@
   height: 0;
   border-width: 5px;
   border-style: solid;
-  left: 50%;
-}
-
-.showTooltip {
-  transform: translate(-50%, -100%);
-  position: absolute;
 }
 
 .showTooltip::after {
@@ -32,9 +26,34 @@
   border-color: #333 transparent transparent;
 }
 
+.renderToTheLeft {
+  transform: translate(-90%, -100%);
+}
+
+.renderToTheLeft::after {
+  left: 90%;
+}
+
+.renderToTheRight {
+  transform: translate(-10%, -100%);
+}
+
+.renderToTheRight::after {
+  left: 10%;
+}
+
+.renderFromCenter {
+  transform: translate(-50%, -100%);
+}
+
+.renderFromCenter::after {
+  left: 50%;
+}
+
 .listTooltip {
   flex-direction: column;
   margin-top: 30px;
+  transform: translateX(-50%);
 }
 
 .listTooltip::after {

--- a/app/components/Tooltip/Tooltip.css
+++ b/app/components/Tooltip/Tooltip.css
@@ -26,19 +26,19 @@
   border-color: #333 transparent transparent;
 }
 
-.renderToTheLeft {
+.renderDirectionLeft {
   transform: translate(-90%, -100%);
 }
 
-.renderToTheLeft::after {
+.renderDirectionLeft::after {
   left: 90%;
 }
 
-.renderToTheRight {
+.renderDirectionRight {
   transform: translate(-10%, -100%);
 }
 
-.renderToTheRight::after {
+.renderDirectionRight::after {
   left: 10%;
 }
 

--- a/app/components/Tooltip/index.js
+++ b/app/components/Tooltip/index.js
@@ -11,8 +11,8 @@ type Props = {
   onClick?: () => void,
   style?: Object,
   list?: boolean,
-  renderToThe?: string,
-  pointerToThe?: string
+  renderDirection?: string,
+  pointerPosition?: string
 };
 
 type State = {
@@ -22,10 +22,10 @@ type State = {
 
 /**
  * A tooltip that appears when you hover over the component placed within.
- * The tooltip will by default be centered, however it supports a 'renderToThe'
- * prop that will make it render either to the left. The pointer
+ * The tooltip will by default be centered, however it supports a 'renderDirection'
+ * prop that will make it render either to the left or the right from the postion of the pointer. The pointer
  * (the small arrow that points towards the component within the tooltip) will
- * also default to center, and it can be adjusted with the 'pointerToThe' prop.
+ * also default to center, and it can be adjusted with the 'pointerPosition' prop.
  * Both props can be set as either 'left' or 'right'.
  */
 
@@ -76,21 +76,21 @@ export default class Tooltip extends Component<Props, State> {
       list,
       style,
       onClick,
-      renderToThe,
-      pointerToThe
+      renderDirection,
+      pointerPosition
     } = this.props;
-    let renderToTheClass = styles.renderFromCenter;
+    let renderDirectionClass = styles.renderFromCenter;
     let startPointChildren = 2;
     if (!list) {
-      switch (renderToThe) {
+      switch (renderDirection) {
         case 'left':
-          renderToTheClass = styles.renderToTheLeft;
+          renderDirectionClass = styles.renderDirectionLeft;
           break;
         case 'right':
-          renderToTheClass = styles.renderToTheRight;
+          renderDirectionClass = styles.renderDirectionRight;
           break;
       }
-      switch (pointerToThe) {
+      switch (pointerPosition) {
         case 'left':
           startPointChildren = 9;
           break;
@@ -113,7 +113,7 @@ export default class Tooltip extends Component<Props, State> {
           onMouseLeave={this.onMouseLeave}
         >
           <div
-            className={cx(tooltipClass, tooltip, renderToTheClass)}
+            className={cx(tooltipClass, tooltip, renderDirectionClass)}
             style={{
               ...style,
               marginLeft:

--- a/app/components/Tooltip/index.js
+++ b/app/components/Tooltip/index.js
@@ -10,20 +10,34 @@ type Props = {
   className?: string,
   onClick?: () => void,
   style?: Object,
-  list: boolean
+  list: boolean,
+  childrenContainerRef: ?HTMLDivElement
 };
 
 type State = {
-  hovered: boolean
+  hovered: boolean,
+  childrenContainerWidth: number
 };
 
 export default class Tooltip extends Component<Props, State> {
   static defaultProps = {
-    list: false
+    list: false,
+    childrenContainerRef: React.createRef
   };
 
+  tooltip: ?HTMLDivElement;
+
+  measure() {
+    const width = this.tooltip.clientWidth;
+
+    this.setState({
+      childrenContainerWidth: width
+    });
+  }
+
   state = {
-    hovered: false
+    hovered: false,
+    childrenContainerWidth: 0
   };
 
   onMouseEnter = () => {
@@ -38,6 +52,10 @@ export default class Tooltip extends Component<Props, State> {
     });
   };
 
+  componentDidMount() {
+    this.measure();
+  }
+
   render() {
     const { content, children, className, list, style, onClick } = this.props;
     const tooltipClass = this.state.hovered
@@ -46,10 +64,22 @@ export default class Tooltip extends Component<Props, State> {
     const tooltip = list ? styles.listTooltip : styles.showTooltip;
     return (
       <div className={className} onClick={onClick}>
-        <div className={cx(tooltipClass, tooltip)} style={style}>
+        <div
+          className={cx(tooltipClass, tooltip)}
+          style={{
+            ...style,
+            marginLeft: this.state.childrenContainerWidth / 2
+          }}
+        >
           {content}
         </div>
-        <div onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+        <div
+          ref={ref => {
+            this.tooltip = ref;
+          }}
+          onMouseEnter={this.onMouseEnter}
+          onMouseLeave={this.onMouseLeave}
+        >
           {children}
         </div>
       </div>

--- a/app/components/Tooltip/index.js
+++ b/app/components/Tooltip/index.js
@@ -10,8 +10,9 @@ type Props = {
   className?: string,
   onClick?: () => void,
   style?: Object,
-  list: boolean,
-  childrenContainerRef: ?HTMLDivElement
+  list?: boolean,
+  renderToThe?: string,
+  pointerToThe?: string
 };
 
 type State = {
@@ -19,16 +20,27 @@ type State = {
   childrenContainerWidth: number
 };
 
+/**
+ * A tooltip that appears when you hover over the component placed within.
+ * The tooltip will by default be centered, however it supports a 'renderToThe'
+ * prop that will make it render either to the left. The pointer
+ * (the small arrow that points towards the component within the tooltip) will
+ * also default to center, and it can be adjusted with the 'pointerToThe' prop.
+ * Both props can be set as either 'left' or 'right'.
+ */
+
 export default class Tooltip extends Component<Props, State> {
   static defaultProps = {
-    list: false,
-    childrenContainerRef: React.createRef
+    list: false
   };
 
   tooltip: ?HTMLDivElement;
 
   measure() {
-    const width = this.tooltip.clientWidth;
+    if (!this.tooltip) {
+      return;
+    }
+    const width = this.tooltip.offsetWidth;
 
     this.setState({
       childrenContainerWidth: width
@@ -57,7 +69,38 @@ export default class Tooltip extends Component<Props, State> {
   }
 
   render() {
-    const { content, children, className, list, style, onClick } = this.props;
+    const {
+      content,
+      children,
+      className,
+      list,
+      style,
+      onClick,
+      renderToThe,
+      pointerToThe
+    } = this.props;
+    let renderToTheClass = styles.renderFromCenter;
+    if (!list) {
+      switch (renderToThe) {
+        case 'left':
+          renderToTheClass = styles.renderToTheLeft;
+          break;
+        case 'right':
+          renderToTheClass = styles.renderToTheRight;
+          break;
+      }
+    }
+    let startPointChildren = 2;
+    if (!list) {
+      switch (pointerToThe) {
+        case 'left':
+          startPointChildren = 9;
+          break;
+        case 'right':
+          startPointChildren = 10 / 9;
+          break;
+      }
+    }
     const tooltipClass = this.state.hovered
       ? styles.baseTooltipHover
       : styles.tooltip;
@@ -65,21 +108,22 @@ export default class Tooltip extends Component<Props, State> {
     return (
       <div className={className} onClick={onClick}>
         <div
-          className={cx(tooltipClass, tooltip)}
-          style={{
-            ...style,
-            marginLeft: this.state.childrenContainerWidth / 2
-          }}
-        >
-          {content}
-        </div>
-        <div
           ref={ref => {
             this.tooltip = ref;
           }}
           onMouseEnter={this.onMouseEnter}
           onMouseLeave={this.onMouseLeave}
         >
+          <div
+            className={cx(tooltipClass, tooltip, renderToTheClass)}
+            style={{
+              ...style,
+              marginLeft:
+                this.state.childrenContainerWidth / startPointChildren - 5
+            }}
+          >
+            {content}
+          </div>
           {children}
         </div>
       </div>

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -260,34 +260,35 @@ class JoinEventForm extends Component<Props> {
                   </Flex>
                 )}
                 {buttonOpen && !submitting && (
-                  <Flex alignItems="center" justifyContent="space-between">
-                    <SubmitButton
-                      disabled={disabledButton}
-                      onSubmit={this.submitWithType(
-                        handleSubmit,
-                        feedbackName,
-                        registrationType
-                      )}
-                      type={registrationType}
-                      title={title || joinTitle}
-                      showPenaltyNotice={showPenaltyNotice}
-                    />
-                    {registration && showStripe && (
-                      <PaymentRequestForm
-                        onToken={onToken}
-                        event={event}
-                        currentUser={currentUser}
-                        chargeStatus={registration.chargeStatus}
+                  <>
+                    <Flex alignItems="center" justifyContent="space-between">
+                      <SubmitButton
+                        disabled={disabledButton}
+                        onSubmit={this.submitWithType(
+                          handleSubmit,
+                          feedbackName,
+                          registrationType
+                        )}
+                        type={registrationType}
+                        title={title || joinTitle}
+                        showPenaltyNotice={showPenaltyNotice}
                       />
-                    )}
-
+                      {registration && showStripe && (
+                        <PaymentRequestForm
+                          onToken={onToken}
+                          event={event}
+                          currentUser={currentUser}
+                          chargeStatus={registration.chargeStatus}
+                        />
+                      )}
+                    </Flex>
                     {!registration && (
                       <SpotsLeft
                         activeCapacity={event.activeCapacity}
                         spotsLeft={event.spotsLeft}
                       />
                     )}
-                  </Flex>
+                  </>
                 )}
                 {submitting && (
                   <LoadingIndicator

--- a/app/routes/events/components/RegistrationMeta.js
+++ b/app/routes/events/components/RegistrationMeta.js
@@ -89,6 +89,8 @@ const PresenceStatus = ({
           <i className="fa fa-check-circle" /> Oppmøte ble ikke sjekktet
         </>
       );
+    default:
+      return null;
   }
 };
 


### PR DESCRIPTION
Modify tooltip compenent in order to make it look good regardless of where it is placed without the need for inline styling, as well as make it easier to customise how it is displayed.
Demonstration of being able to choose direction for the tooltip to render.
Before:
![Screenshot from 2019-03-25 21-30-28](https://user-images.githubusercontent.com/7977650/54952023-44602480-4f45-11e9-88a8-14d6663538d5.png)
After:
![Screenshot from 2019-03-25 21-28-18](https://user-images.githubusercontent.com/7977650/54951914-0c58e180-4f45-11e9-843b-795db731313e.png)
Tooltips are now centered by default:
![Screenshot from 2019-03-25 21-31-46](https://user-images.githubusercontent.com/7977650/54952082-6e194b80-4f45-11e9-8c69-a78d740767ee.png)
Able to specify the start of tooltips as well:
![Screenshot from 2019-03-25 22-18-00](https://user-images.githubusercontent.com/7977650/54954841-ef73dc80-4f4b-11e9-8ac9-e8223d41eb59.png)



