### PR TITLE
zxcvbn password validation

### DIFF
--- a/app/routes/users/UserConfirmationRoute.js
+++ b/app/routes/users/UserConfirmationRoute.js
@@ -21,8 +21,8 @@ const mapStateToProps = (state, props) => {
       username: valueSelector(state, 'username'),
       firstName: valueSelector(state, 'firstName'),
       lastName: valueSelector(state, 'lastName'),
-      allergies: valueSelector(state, 'allergies')
-    }
+      allergies: valueSelector(state, 'allergies'),
+    },
   };
 };
 

--- a/app/routes/users/UserConfirmationRoute.js
+++ b/app/routes/users/UserConfirmationRoute.js
@@ -1,6 +1,7 @@
 import prepare from 'app/utils/prepare';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import { formValueSelector } from 'redux-form';
 import UserConfirmation from './components/UserConfirmation';
 import { createUser, validateRegistrationToken } from 'app/actions/UserActions';
 import qs from 'qs';
@@ -13,7 +14,16 @@ const loadData = ({ location: { search } }, dispatch) => {
 };
 
 const mapStateToProps = (state, props) => {
-  return { token: state.auth.registrationToken };
+  const valueSelector = formValueSelector('ConfirmationForm');
+  return {
+    token: state.auth.registrationToken,
+    user: {
+      username: valueSelector(state, 'username'),
+      firstName: valueSelector(state, 'firstName'),
+      lastName: valueSelector(state, 'lastName'),
+      allergies: valueSelector(state, 'allergies')
+    }
+  };
 };
 
 const mapDispatchToProps = {

--- a/app/routes/users/components/ChangePassword.js
+++ b/app/routes/users/components/ChangePassword.js
@@ -11,10 +11,12 @@ import {
   validPassword,
   sameAs,
 } from 'app/utils/validation';
+import PasswordField from './PasswordField';
 
 type Props = FormProps & {
   push: (string) => void,
   changePassword: (Object) => Promise<void>,
+  user: Object,
 };
 
 const ChangePassword = ({
@@ -22,6 +24,7 @@ const ChangePassword = ({
   invalid,
   pristine,
   submitting,
+  user,
   ...props
 }: Props) => {
   const disabledButton = invalid || pristine || submitting;
@@ -34,12 +37,7 @@ const ChangePassword = ({
         type="password"
         component={TextInput.Field}
       />
-      <Field
-        label="Nytt passord"
-        name="newPassword"
-        type="password"
-        component={TextInput.Field}
-      />
+      <PasswordField user={user} label="Nytt passord" name="newPassword" />
       <Field
         label="Nytt passord (gjenta)"
         name="retypeNewPassword"

--- a/app/routes/users/components/ChangePassword.js
+++ b/app/routes/users/components/ChangePassword.js
@@ -12,11 +12,18 @@ import {
   sameAs,
 } from 'app/utils/validation';
 import PasswordField from './PasswordField';
+import { type UserEntity } from 'app/reducers/users';
+
+type PasswordPayload = {
+  newPassword: string,
+  password: string,
+  retype_new_password: string,
+};
 
 type Props = FormProps & {
   push: (string) => void,
-  changePassword: (Object) => Promise<void>,
-  user: Object,
+  changePassword: (PasswordPayload) => Promise<void>,
+  user: UserEntity,
 };
 
 const ChangePassword = ({

--- a/app/routes/users/components/PasswordField.js
+++ b/app/routes/users/components/PasswordField.js
@@ -5,11 +5,15 @@ import { TextInput } from 'app/components/Form';
 import { Field } from 'redux-form';
 import PasswordStrengthMeter from './PasswordStrengthMeter';
 
+type Props = {
+  user: Object
+};
+
 type State = {
   password: string
 };
 
-class PasswordField extends Component<State> {
+class PasswordField extends Component<Props, State> {
   state = {
     password: ''
   };
@@ -25,7 +29,10 @@ class PasswordField extends Component<State> {
           component={TextInput.Field}
           onChange={e => this.setState({ password: e.target.value })}
         />
-        <PasswordStrengthMeter password={this.state.password} />
+        <PasswordStrengthMeter
+          password={this.state.password}
+          user={this.props.user}
+        />
       </Fragment>
     );
   }

--- a/app/routes/users/components/PasswordField.js
+++ b/app/routes/users/components/PasswordField.js
@@ -6,7 +6,9 @@ import { Field } from 'redux-form';
 import PasswordStrengthMeter from './PasswordStrengthMeter';
 
 type Props = {
-  user: Object
+  user: Object,
+  label: string,
+  name: string
 };
 
 type State = {
@@ -18,21 +20,25 @@ class PasswordField extends Component<Props, State> {
     password: ''
   };
 
+  static defaultProps = {
+    user: {},
+    label: 'Password',
+    name: 'password'
+  };
+
   render() {
+    const { name, label, user } = this.props;
     return (
       <Fragment>
         <Field
-          name="password"
+          name={name}
           type="password"
-          placeholder="Passord"
-          label="Passord"
+          placeholder={label}
+          label={label}
           component={TextInput.Field}
           onChange={e => this.setState({ password: e.target.value })}
         />
-        <PasswordStrengthMeter
-          password={this.state.password}
-          user={this.props.user}
-        />
+        <PasswordStrengthMeter password={this.state.password} user={user} />
       </Fragment>
     );
   }

--- a/app/routes/users/components/PasswordField.js
+++ b/app/routes/users/components/PasswordField.js
@@ -1,0 +1,34 @@
+// @flow
+
+import React, { Component, Fragment } from 'react';
+import { TextInput } from 'app/components/Form';
+import { Field } from 'redux-form';
+import PasswordStrengthMeter from './PasswordStrengthMeter';
+
+type State = {
+  password: string
+};
+
+class PasswordField extends Component<State> {
+  state = {
+    password: ''
+  };
+
+  render() {
+    return (
+      <Fragment>
+        <Field
+          name="password"
+          type="password"
+          placeholder="Passord"
+          label="Passord"
+          component={TextInput.Field}
+          onChange={e => this.setState({ password: e.target.value })}
+        />
+        <PasswordStrengthMeter password={this.state.password} />
+      </Fragment>
+    );
+  }
+}
+
+export default PasswordField;

--- a/app/routes/users/components/PasswordField.js
+++ b/app/routes/users/components/PasswordField.js
@@ -4,26 +4,27 @@ import React, { Component, Fragment } from 'react';
 import { TextInput } from 'app/components/Form';
 import { Field } from 'redux-form';
 import PasswordStrengthMeter from './PasswordStrengthMeter';
+import { type UserEntity } from 'app/reducers/users';
 
 type Props = {
-  user: Object,
+  user: UserEntity,
   label: string,
-  name: string
+  name: string,
 };
 
 type State = {
-  password: string
+  password: string,
 };
 
 class PasswordField extends Component<Props, State> {
   state = {
-    password: ''
+    password: '',
   };
 
   static defaultProps = {
     user: {},
     label: 'Password',
-    name: 'password'
+    name: 'password',
   };
 
   render() {
@@ -36,7 +37,7 @@ class PasswordField extends Component<Props, State> {
           placeholder={label}
           label={label}
           component={TextInput.Field}
-          onChange={e => this.setState({ password: e.target.value })}
+          onChange={(e) => this.setState({ password: e.target.value })}
         />
         <PasswordStrengthMeter password={this.state.password} user={user} />
       </Fragment>

--- a/app/routes/users/components/PasswordStrengthMeter.css
+++ b/app/routes/users/components/PasswordStrengthMeter.css
@@ -1,28 +1,18 @@
 @import 'app/styles/variables.css';
 
-.passwordStrengthMeter {
-  width: 100%;
-  height: 8px;
-  border: 1px solid #ccc;
-  border-radius: 3px;
+.tipsList {
+  font-size: 12px;
+  margin-left: 10px;
+  margin-top: 0;
+  padding-inline-start: 40px;
+  list-style: disc;
 }
 
-.passwordStrengthMeter::-webkit-meter-bar {
-  background: none;
-  background-color: #eee;
+.tipsList li {
+  margin-left: 10px;
 }
 
-.passwordStrengthMeter::-webkit-meter-optimum-value {
-  background-image: linear-gradient(90deg, #336600, 100%);
-  background-size: 100% 100%;
-}
-
-.passwordStrengthMeter::-webkit-meter-suboptimum-value {
-  background-image: #e67300;
-  background-size: 100% 100%;
-}
-
-.passwordStrengthMeter::-webkit-meter-even-less-good-value {
-  background-image: #e62e00;
-  background-size: 100% 100%;
+/* Remove labels in react-meter-bar component */
+.removeLabels > div > div:first-child {
+  display: none !important;
 }

--- a/app/routes/users/components/PasswordStrengthMeter.css
+++ b/app/routes/users/components/PasswordStrengthMeter.css
@@ -1,0 +1,28 @@
+@import 'app/styles/variables.css';
+
+.passwordStrengthMeter {
+  width: 100%;
+  height: 8px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+
+.passwordStrengthMeter::-webkit-meter-bar {
+  background: none;
+  background-color: #eee;
+}
+
+.passwordStrengthMeter::-webkit-meter-optimum-value {
+  background-image: linear-gradient(90deg, #336600, 100%);
+  background-size: 100% 100%;
+}
+
+.passwordStrengthMeter::-webkit-meter-suboptimum-value {
+  background-image: #e67300;
+  background-size: 100% 100%;
+}
+
+.passwordStrengthMeter::-webkit-meter-even-less-good-value {
+  background-image: #e62e00;
+  background-size: 100% 100%;
+}

--- a/app/routes/users/components/PasswordStrengthMeter.css
+++ b/app/routes/users/components/PasswordStrengthMeter.css
@@ -1,5 +1,3 @@
-@import 'app/styles/variables.css';
-
 .tipsList {
   font-size: 12px;
   margin-left: 10px;

--- a/app/routes/users/components/PasswordStrengthMeter.js
+++ b/app/routes/users/components/PasswordStrengthMeter.js
@@ -2,6 +2,7 @@
 
 import React, { Component, Fragment } from 'react';
 import { pick } from 'lodash';
+import moment from 'moment-timezone';
 import zxcvbn from 'zxcvbn';
 import Bar from 'react-meter-bar';
 import styles from './PasswordStrengthMeter.css';
@@ -27,6 +28,12 @@ class PasswordStrengthMeter extends Component<Props> {
     tips.push(zxcvbnValue.feedback.warning);
     tips = tips.map(tip => passwordFeedbackMessages[tip]).filter(Boolean);
 
+    let crackTimeSec =
+      zxcvbnValue.crack_times_seconds.offline_slow_hashing_1e4_per_second;
+    let crackTimeDuration = moment.duration(crackTimeSec, 'seconds').humanize();
+    let crackTime =
+      crackTimeSec > 2 ? crackTimeDuration : crackTimeSec + ' sekunder';
+
     return (
       <Fragment>
         <div className={styles.removeLabels}>
@@ -39,9 +46,16 @@ class PasswordStrengthMeter extends Component<Props> {
           />
         </div>
         {password && (
-          <div>
-            <strong>Passordstyrke: </strong> {passwordLabel[zxcvbnValue.score]}{' '}
-          </div>
+          <Fragment>
+            <span>
+              <strong>Passordstyrke: </strong>{' '}
+              {passwordLabel[zxcvbnValue.score]}
+            </span>
+            <p>
+              Dette passordet hadde tatt en maskin {crackTime} å knekke @ 10^4
+              Hash/s.
+            </p>
+          </Fragment>
         )}
         {password && zxcvbnValue.score < 2 && (
           <ul className={styles.tipsList}>

--- a/app/routes/users/components/PasswordStrengthMeter.js
+++ b/app/routes/users/components/PasswordStrengthMeter.js
@@ -1,0 +1,45 @@
+// @flow
+
+import React, { Component, Fragment } from 'react';
+import zxcvbn from 'zxcvbn';
+import styles from './PasswordStrengthMeter.css';
+
+type Props = {
+  password: string
+};
+
+class PasswordStrengthMeter extends Component<Props> {
+  passwordLabel = {
+    0: 'Veldig svakt',
+    1: 'Svakt',
+    2: 'OK',
+    3: 'Bra',
+    4: 'Sterkt'
+  };
+
+  render() {
+    const { password } = this.props;
+    const zxcvbnValue = zxcvbn(password);
+    console.log(zxcvbnValue);
+    return (
+      <Fragment>
+        <meter
+          className={styles.passwordStrengthMeter}
+          value={zxcvbnValue.score}
+          max="4"
+          optimum="4"
+          high="3"
+          low="2"
+        />
+        {password && (
+          <div>
+            <strong>Passordstyrke: </strong>{' '}
+            {this.passwordLabel[zxcvbnValue.score]}{' '}
+          </div>
+        )}
+      </Fragment>
+    );
+  }
+}
+
+export default PasswordStrengthMeter;

--- a/app/routes/users/components/PasswordStrengthMeter.js
+++ b/app/routes/users/components/PasswordStrengthMeter.js
@@ -30,10 +30,12 @@ class PasswordStrengthMeter extends Component<Props> {
     tips.push(zxcvbnValue.feedback.warning);
     tips = tips.map((tip) => passwordFeedbackMessages[tip]).filter(Boolean);
 
-    let crackTimeSec =
+    const crackTimeSec =
       zxcvbnValue.crack_times_seconds.offline_slow_hashing_1e4_per_second;
-    let crackTimeDuration = moment.duration(crackTimeSec, 'seconds').humanize();
-    let crackTime =
+    const crackTimeDuration = moment
+      .duration(crackTimeSec, 'seconds')
+      .humanize();
+    const crackTime =
       crackTimeSec > 2 ? crackTimeDuration : crackTimeSec + ' sekunder';
 
     return (

--- a/app/routes/users/components/PasswordStrengthMeter.js
+++ b/app/routes/users/components/PasswordStrengthMeter.js
@@ -4,17 +4,19 @@ import React, { Component, Fragment } from 'react';
 import { pick } from 'lodash';
 import moment from 'moment-timezone';
 import zxcvbn from 'zxcvbn';
-import Bar from 'react-meter-bar';
+import Bar from '@webkom/react-meter-bar';
+import '@webkom/react-meter-bar/dist/Bar.css';
 import styles from './PasswordStrengthMeter.css';
 import {
   passwordLabel,
   barColor,
-  passwordFeedbackMessages
+  passwordFeedbackMessages,
 } from './passwordStrengthVariables';
+import { type UserEntity } from 'app/reducers/users';
 
 type Props = {
   password: string,
-  user: Object
+  user: UserEntity,
 };
 
 class PasswordStrengthMeter extends Component<Props> {
@@ -26,7 +28,7 @@ class PasswordStrengthMeter extends Component<Props> {
     );
     let tips = zxcvbnValue.feedback.suggestions;
     tips.push(zxcvbnValue.feedback.warning);
-    tips = tips.map(tip => passwordFeedbackMessages[tip]).filter(Boolean);
+    tips = tips.map((tip) => passwordFeedbackMessages[tip]).filter(Boolean);
 
     let crackTimeSec =
       zxcvbnValue.crack_times_seconds.offline_slow_hashing_1e4_per_second;
@@ -57,7 +59,7 @@ class PasswordStrengthMeter extends Component<Props> {
             </p>
           </Fragment>
         )}
-        {password && zxcvbnValue.score < 2 && (
+        {password && zxcvbnValue.score < 3 && (
           <ul className={styles.tipsList}>
             {tips.map((value, key) => {
               return <li key={key}>{value}</li>;

--- a/app/routes/users/components/UserConfirmation.js
+++ b/app/routes/users/components/UserConfirmation.js
@@ -14,6 +14,7 @@ import {
 import { Field } from 'redux-form';
 import { Link } from 'react-router-dom';
 import { createValidator, required, validPassword } from 'app/utils/validation';
+import PasswordField from './PasswordField';
 
 type Props = {
   token: string,
@@ -75,13 +76,7 @@ const UserConfirmation = ({
             label="Brukernavn"
             component={TextInput.Field}
           />
-          <Field
-            name="password"
-            type="password"
-            placeholder="Passord"
-            label="Passord"
-            component={TextInput.Field}
-          />
+          <PasswordField />
           <Field
             name="firstName"
             placeholder="Fornavn"

--- a/app/routes/users/components/UserConfirmation.js
+++ b/app/routes/users/components/UserConfirmation.js
@@ -18,6 +18,7 @@ import PasswordField from './PasswordField';
 
 type Props = {
   token: string,
+  user: Object,
   handleSubmit: (Function) => void,
   createUser: (token: string, data: Object) => void,
   router: any,
@@ -26,6 +27,7 @@ type Props = {
 
 const UserConfirmation = ({
   token,
+  user,
   handleSubmit,
   createUser,
   router,
@@ -76,7 +78,7 @@ const UserConfirmation = ({
             label="Brukernavn"
             component={TextInput.Field}
           />
-          <PasswordField />
+          <PasswordField user={user} />
           <Field
             name="firstName"
             placeholder="Fornavn"

--- a/app/routes/users/components/UserConfirmation.js
+++ b/app/routes/users/components/UserConfirmation.js
@@ -13,12 +13,18 @@ import {
 } from 'app/components/Form';
 import { Field } from 'redux-form';
 import { Link } from 'react-router-dom';
-import { createValidator, required, validPassword } from 'app/utils/validation';
+import {
+  createValidator,
+  required,
+  validPassword,
+  sameAs,
+} from 'app/utils/validation';
 import PasswordField from './PasswordField';
+import { type UserEntity } from 'app/reducers/users';
 
 type Props = {
   token: string,
-  user: Object,
+  user: UserEntity,
   handleSubmit: (Function) => void,
   createUser: (token: string, data: Object) => void,
   router: any,
@@ -80,6 +86,12 @@ const UserConfirmation = ({
           />
           <PasswordField user={user} />
           <Field
+            label="Passord (gjenta)"
+            name="retypePassword"
+            type="password"
+            component={TextInput.Field}
+          />
+          <Field
             name="firstName"
             placeholder="Fornavn"
             label="Fornavn"
@@ -129,6 +141,7 @@ const UserConfirmation = ({
 const validate = createValidator({
   username: [required()],
   password: [required(), validPassword()],
+  retypePassword: [required(), sameAs('password', 'Passordene er ikke like')],
   gender: [required()],
 });
 

--- a/app/routes/users/components/UserResetPassword.js
+++ b/app/routes/users/components/UserResetPassword.js
@@ -1,10 +1,15 @@
 // @flow
 import React from 'react';
-import { reduxForm, type FormProps } from 'redux-form';
+import { reduxForm, type FormProps, Field } from 'redux-form';
 import { Content } from 'app/components/Content';
-import { Form, Button } from 'app/components/Form';
-import { createValidator, required, validPassword } from 'app/utils/validation';
 import type { Action } from 'app/types';
+import { Form, Button, TextInput } from 'app/components/Form';
+import {
+  createValidator,
+  required,
+  validPassword,
+  sameAs,
+} from 'app/utils/validation';
 import PasswordField from './PasswordField';
 
 type Props = {
@@ -23,6 +28,16 @@ const UserResetPassword = ({
   push,
 }: Props) => {
   const disabledButton = invalid || pristine || submitting;
+  const dummyUser = {
+    id: 0,
+    username: '',
+    fullName: '',
+    firstName: '',
+    lastName: '',
+    gender: '',
+    profilePicture: '',
+    selectedTheme: '',
+  };
   return (
     <Content>
       <h1>Tilbakestill Passord</h1>
@@ -32,7 +47,13 @@ const UserResetPassword = ({
             resetPassword({ token, ...props }).then(() => push('/'))
           )}
         >
-          <PasswordField label="Nytt passord" />
+          <PasswordField label="Nytt passord" user={dummyUser} />
+          <Field
+            label="Nytt passord (gjenta)"
+            name="retypeNewPassword"
+            type="password"
+            component={TextInput.Field}
+          />
           <Button submit disabled={disabledButton}>
             Tilbakestill passord
           </Button>
@@ -46,6 +67,10 @@ const UserResetPassword = ({
 
 const validate = createValidator({
   password: [required(), validPassword()],
+  retypeNewPassword: [
+    required(),
+    sameAs('password', 'Passordene er ikke like'),
+  ],
 });
 
 export default reduxForm({

--- a/app/routes/users/components/UserResetPassword.js
+++ b/app/routes/users/components/UserResetPassword.js
@@ -1,10 +1,11 @@
 // @flow
 import React from 'react';
-import { reduxForm, type FormProps, Field } from 'redux-form';
+import { reduxForm, type FormProps } from 'redux-form';
 import { Content } from 'app/components/Content';
-import { Form, Button, TextInput } from 'app/components/Form';
+import { Form, Button } from 'app/components/Form';
 import { createValidator, required, validPassword } from 'app/utils/validation';
 import type { Action } from 'app/types';
+import PasswordField from './PasswordField';
 
 type Props = {
   token: string,
@@ -31,12 +32,7 @@ const UserResetPassword = ({
             resetPassword({ token, ...props }).then(() => push('/'))
           )}
         >
-          <Field
-            label="Nytt passord"
-            name="password"
-            type="password"
-            component={TextInput.Field}
-          />
+          <PasswordField label="Nytt passord" />
           <Button submit disabled={disabledButton}>
             Tilbakestill passord
           </Button>

--- a/app/routes/users/components/UserSettings.js
+++ b/app/routes/users/components/UserSettings.js
@@ -157,7 +157,11 @@ const UserSettings = (props: Props) => {
       {isMe && (
         <div className={styles.changePassword}>
           <h2>Endre passord</h2>
-          <ChangePassword push={push} changePassword={changePassword} />
+          <ChangePassword
+            push={push}
+            changePassword={changePassword}
+            user={user}
+          />
         </div>
       )}
     </div>

--- a/app/routes/users/components/passwordStrengthVariables.js
+++ b/app/routes/users/components/passwordStrengthVariables.js
@@ -1,0 +1,61 @@
+// @flow
+
+export const passwordLabel = {
+  0: 'Veldig svakt',
+  1: 'Svakt',
+  2: 'OK',
+  3: 'Bra',
+  4: 'Sterkt'
+};
+
+export const barColor = {
+  0: '#F25F5C',
+  1: '#F25F5C',
+  2: '#FFE066',
+  3: '#70C1B3',
+  4: '#006600'
+};
+
+export const passwordFeedbackMessages = {
+  'Add another word or two. Uncommon words are better.':
+    'Legg til ett ord eller to. Uvanlige ord er best.',
+  'Straight rows of keys are easy to guess':
+    'Rader fra tastaturet er enkle å gjette.',
+  'Short keyboard patterns are easy to guess':
+    'Korte keyboardmønstre er enkle å gjette',
+  'Use a longer keyboard pattern with more turns':
+    'Bruk et lengre keyboardmønster med større variasjon.',
+  'Repeats like "aaa" are easy to guess':
+    'Gjentakelser som "aaa" er enkle å gjette.',
+  'Repeats like "abcabcabc" are only slightly harder to guess than "abc"':
+    'Gjentakelser som "abcabcabc" er kun litt vanskeligere å gjette enn "abc".',
+  'Avoid repeated words and characters': 'Unngå gjentakende ord og tegn.',
+  'Sequences like abc or 6543 are easy to guess':
+    'Sekvenser som "abc" eller "6543" er enkle å gjette.',
+  'Recent years are easy to guess': 'Nylige år er enkle å gjette.',
+  'Avoid years that are associated with you':
+    'Unngå år som kan assosieres med deg.',
+  'Dates are often easy to guess': 'Datoer er ofte enkle å gjette.',
+  'Avoid dates and years that are associated with you':
+    'Unngå datoer og år som kan assosieres med deg.',
+  'This is a top-10 common password':
+    'Dette er et av de topp 10 vanligste passordene.',
+  'This is a top-100 common password':
+    'Dette er et av de topp 100 vanligste passordene.',
+  'This is a very common password': 'Dette er et veldig vanlig passord.',
+  'This is similar to a commonly used password':
+    'Dette likner på et veldig vanlig passord.',
+  'A word by itself is easy to guess': 'Ett enkelt ord er enkelt å gjette.',
+  'Names and surnames by themselves are easy to guess':
+    'Fornavn og etternavn er enkle å gjette.',
+  'Common names and surnames are easy to guess':
+    'Vanlige navn er enkle å gjette.',
+  "Capitalization doesn't help very much":
+    'Stor forbokstav gir ikke mye vanskeligere passord.',
+  'All-uppercase is almost as easy to guess as all-lowercase':
+    'Kun store bokstaver er nesten like lette å gjette som kun små bokstaver.',
+  "Reversed words aren't much harder to guess":
+    'Reverserte ord er nesten like enkle å gjette som originalordet.',
+  "Predictable substitutions like '@' instead of 'a' don't help very much":
+    "Forutsigbare erstatninger som '@' istedenfor 'a' gir ingen stor forbedring."
+};

--- a/app/routes/users/components/passwordStrengthVariables.js
+++ b/app/routes/users/components/passwordStrengthVariables.js
@@ -1,11 +1,9 @@
-// @flow
-
 export const passwordLabel = {
   0: 'Veldig svakt',
   1: 'Svakt',
   2: 'OK',
   3: 'Bra',
-  4: 'Sterkt'
+  4: 'Sterkt',
 };
 
 export const barColor = {
@@ -13,7 +11,7 @@ export const barColor = {
   1: '#F25F5C',
   2: '#FFE066',
   3: '#70C1B3',
-  4: '#006600'
+  4: '#006600',
 };
 
 export const passwordFeedbackMessages = {
@@ -57,5 +55,5 @@ export const passwordFeedbackMessages = {
   "Reversed words aren't much harder to guess":
     'Reverserte ord er nesten like enkle å gjette som originalordet.',
   "Predictable substitutions like '@' instead of 'a' don't help very much":
-    "Forutsigbare erstatninger som '@' istedenfor 'a' gir ingen stor forbedring."
+    "Forutsigbare erstatninger som '@' istedenfor 'a' gir ingen stor forbedring.",
 };

--- a/app/utils/validation.js
+++ b/app/utils/validation.js
@@ -2,7 +2,6 @@ import zxcvbn from 'zxcvbn';
 import { pick } from 'lodash';
 
 export const EMAIL_REGEX = /.+@.+\..+/;
-const PASSWORD_REGEX = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,72}$/;
 const YOUTUBE_URL_REGEX = /(?:https?:\/\/)?(?:www[.])?(?:youtube[.]com\/watch[?]v=|youtu[.]be\/)([^&]{11})/;
 
 export const required = (message = 'Feltet må fylles ut') => (value) => [
@@ -28,14 +27,9 @@ export const isEmail = (message = 'Ugyldig e-post') =>
 export const validYoutubeUrl = (message = 'Ikke gyldig YouTube URL.') =>
   matchesRegex(YOUTUBE_URL_REGEX, message);
 
-export const validPassword2 = (
-  message = 'Passordet må inneholde store og små bokstaver og tall, samt være minst 8 tegn langt.'
-) => matchesRegex(PASSWORD_REGEX, message);
-
-export const validPassword = (message = 'Passordet er for svakt.') => (
-  value,
-  data
-) => {
+export const validPassword = (
+  message = 'Passordet er for svakt. Minimum styrke er 3.'
+) => (value, data) => {
   if (value === undefined) {
     return [true];
   }
@@ -43,7 +37,7 @@ export const validPassword = (message = 'Passordet er for svakt.') => (
     pick(data, ['username', 'firstName', 'lastName'])
   );
   const evalPass = zxcvbn(value, userValues);
-  return [evalPass.score >= 2, message];
+  return [evalPass.score >= 3, message];
 };
 
 export const whenPresent = (validator) => (value, context) =>

--- a/app/utils/validation.js
+++ b/app/utils/validation.js
@@ -1,3 +1,5 @@
+import zxcvbn from 'zxcvbn';
+
 export const EMAIL_REGEX = /.+@.+\..+/;
 const PASSWORD_REGEX = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,72}$/;
 const YOUTUBE_URL_REGEX = /(?:https?:\/\/)?(?:www[.])?(?:youtube[.]com\/watch[?]v=|youtu[.]be\/)([^&]{11})/;
@@ -22,14 +24,18 @@ export const matchesRegex = (regex, message) => (value) => [
 export const isEmail = (message = 'Ugyldig e-post') =>
   matchesRegex(EMAIL_REGEX, message);
 
-export const validPassword = (
+export const validPassword2 = (
   message = 'Passordet må inneholde store og små bokstaver og tall, samt være minst 8 tegn langt.'
 ) => matchesRegex(PASSWORD_REGEX, message);
 
 export const validYoutubeUrl = (message = 'Ikke gyldig YouTube URL.') =>
   matchesRegex(YOUTUBE_URL_REGEX, message);
 
-export const whenPresent = (validator) => (value, context) =>
+export const validPassword = (
+  message = 'Passordet er for svakt. Minimumsverdien er grad 3.'
+) => value => [value === undefined ? false : zxcvbn(value).score >= 2, message];
+
+export const whenPresent = validator => (value, context) =>
   value ? validator(value, context) : [true];
 
 export const sameAs = (otherField, message) => (value, context) => [

--- a/app/utils/validation.js
+++ b/app/utils/validation.js
@@ -1,4 +1,5 @@
 import zxcvbn from 'zxcvbn';
+import { pick } from 'lodash';
 
 export const EMAIL_REGEX = /.+@.+\..+/;
 const PASSWORD_REGEX = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,72}$/;
@@ -24,18 +25,28 @@ export const matchesRegex = (regex, message) => (value) => [
 export const isEmail = (message = 'Ugyldig e-post') =>
   matchesRegex(EMAIL_REGEX, message);
 
+export const validYoutubeUrl = (message = 'Ikke gyldig YouTube URL.') =>
+  matchesRegex(YOUTUBE_URL_REGEX, message);
+
 export const validPassword2 = (
   message = 'Passordet må inneholde store og små bokstaver og tall, samt være minst 8 tegn langt.'
 ) => matchesRegex(PASSWORD_REGEX, message);
 
-export const validYoutubeUrl = (message = 'Ikke gyldig YouTube URL.') =>
-  matchesRegex(YOUTUBE_URL_REGEX, message);
+export const validPassword = (message = 'Passordet er for svakt.') => (
+  value,
+  data
+) => {
+  if (value === undefined) {
+    return [true];
+  }
+  const userValues = Object.values(
+    pick(data, ['username', 'firstName', 'lastName'])
+  );
+  const evalPass = zxcvbn(value, userValues);
+  return [evalPass.score >= 2, message];
+};
 
-export const validPassword = (
-  message = 'Passordet er for svakt. Minimumsverdien er grad 3.'
-) => value => [value === undefined ? false : zxcvbn(value).score >= 2, message];
-
-export const whenPresent = validator => (value, context) =>
+export const whenPresent = (validator) => (value, context) =>
   value ? validator(value, context) : [true];
 
 export const sameAs = (otherField, message) => (value, context) => [

--- a/cypress/integration/password_change_spec.js
+++ b/cypress/integration/password_change_spec.js
@@ -37,7 +37,7 @@ describe('Change password', () => {
     fieldError('newPassword').should('exist');
     cy.contains('Change Password').should('be.disabled');
 
-    field('newPassword').clear().type(weakServerPassword).blur();
+    field('newPassword').clear().type(newPassword).blur();
     field('retypeNewPassword').clear().type(weakPassword).blur();
     fieldError('newPassword').should('not.exist');
     fieldError('retypeNewPassword').should('contain', 'ikke like');

--- a/cypress/integration/password_change_spec.js
+++ b/cypress/integration/password_change_spec.js
@@ -8,8 +8,7 @@ describe('Change password', () => {
 
   const password = 'Webkom123';
   const newPassword = 'Abakus123';
-  const weakPassword = '123';
-  const weakServerPassword = 'Testing123';
+  const weakPassword = 'Testing123';
 
   it('Can change password', () => {
     cy.visit('/users/me/settings/profile');
@@ -39,14 +38,12 @@ describe('Change password', () => {
 
     field('newPassword').clear().type(newPassword).blur();
     field('retypeNewPassword').clear().type(weakPassword).blur();
-    fieldError('newPassword').should('not.exist');
     fieldError('retypeNewPassword').should('contain', 'ikke like');
     cy.contains('Change Password').should('be.disabled');
 
-    field('retypeNewPassword').clear().type(weakServerPassword).blur();
+    field('newPassword').clear().type(weakPassword).blur();
+    fieldError('newPassword').should('contain', 'for svakt');
     fieldError('retypeNewPassword').should('not.exist');
-    cy.contains('Change Password').should('not.be.disabled').click();
-    fieldError('newPassword').should('contain', 'too common');
     cy.contains('Change Password').should('be.disabled');
 
     field('password').clear().type('this is not my password').blur();

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "@sentry/browser": "^5.24.2",
     "@sentry/integrations": "^5.20.1",
     "@sentry/node": "^5.15.4",
-    "@webkom/lego-editor": "^1.2.1",
+    "@webkom/lego-editor": "^1.2.0",
+    "@webkom/react-meter-bar": "^1.0.3",
     "@webkom/react-prepare": "0.7.0",
     "animate.css": "^4.1.0",
     "bunyan": "^1.8.12",
@@ -69,7 +70,6 @@
     "react-google-recaptcha": "^2.0.1",
     "react-helmet": "^6.1.0",
     "react-infinite-scroller": "^1.0.15",
-    "react-meter-bar": "^1.0.2",
     "react-notification": "^6.8.5",
     "react-overlays": "0.8.3",
     "react-redux": "6.0.1",
@@ -213,7 +213,7 @@
       "@sentry/node",
       "source-map-support",
       "convert-source-map",
-      "react-meter-bar"
+      "@webkom/react-meter-bar"
     ]
   },
   "moduleRoots": [

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-google-recaptcha": "^2.0.1",
     "react-helmet": "^6.1.0",
     "react-infinite-scroller": "^1.0.15",
+    "react-meter-bar": "^1.0.2",
     "react-notification": "^6.8.5",
     "react-overlays": "0.8.3",
     "react-redux": "6.0.1",
@@ -93,7 +94,8 @@
     "reselect": "4.0.0",
     "serialize-javascript": "^3.0.0",
     "slugify": "^1.3.6",
-    "websocket.js": "^0.1.7"
+    "websocket.js": "^0.1.7",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",
@@ -210,7 +212,8 @@
       "bunyan-pretty",
       "@sentry/node",
       "source-map-support",
-      "convert-source-map"
+      "convert-source-map",
+      "react-meter-bar"
     ]
   },
   "moduleRoots": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@sentry/browser": "^5.24.2",
     "@sentry/integrations": "^5.20.1",
     "@sentry/node": "^5.15.4",
-    "@webkom/lego-editor": "^1.2.0",
+    "@webkom/lego-editor": "^1.2.1",
     "@webkom/react-meter-bar": "^1.0.3",
     "@webkom/react-prepare": "0.7.0",
     "animate.css": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,6 +1870,14 @@
     slate-hyperscript "^0.56.0"
     slate-react "^0.56.0"
 
+"@webkom/react-meter-bar@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@webkom/react-meter-bar/-/react-meter-bar-1.0.3.tgz#cf21ac7ae4f9524fe84567e1d5929082968641eb"
+  integrity sha512-tF5Ohd5MoyKSAK4xj6ekV4tmprNoPCdXsL6+6GoyC/89vjDCXsz46+xUKebDvWnvTy/TJ/d3LrLpZ/b5o6o/ow==
+  dependencies:
+    react "^16.4.0"
+    react-dom "^16.4.0"
+
 "@webkom/react-prepare@0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@webkom/react-prepare/-/react-prepare-0.7.0.tgz#8fee300cec6f5d169de49be83b35b7356ede34ac"
@@ -10307,6 +10315,16 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
+react-dom@^16.4.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
 "react-dom@npm:@hot-loader/react-dom@^16.8.6":
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.13.0.tgz#de245b42358110baf80aaf47a0592153d4047997"
@@ -10422,14 +10440,6 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-meter-bar@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-meter-bar/-/react-meter-bar-1.0.2.tgz#d0f782e5b9cd834b3444e7c5a0d67f6ebf4e77b3"
-  integrity sha512-DwWPeQpw8C9JnS/UW4VzMaTrfLAl+vHpdnHLGgMpXWrboW42KArhKCRjtPb9ErMmAL20IC2iB7C9gho8p1JyxA==
-  dependencies:
-    react "^16.4.0"
-    react-dom "^16.4.0"
 
 react-modal@^3.11.2:
   version "3.11.2"
@@ -10697,7 +10707,7 @@ react-youtube@^7.9.0:
     prop-types "15.7.2"
     youtube-player "5.5.2"
 
-react@^16.8.6:
+react@^16.4.0, react@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
@@ -11440,14 +11450,6 @@ scheduler@^0.19.0, scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.13.5:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.5.tgz#b7226625167041298af3b98088a9dbbf6d7733a8"
-  integrity sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -13686,15 +13688,11 @@ youtube-player@5.5.2:
   resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-5.5.2.tgz#052b86b1eabe21ff331095ffffeae285fa7f7cb5"
   integrity sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==
   dependencies:
-<<<<<<< HEAD
     debug "^2.6.6"
     load-script "^1.0.0"
     sister "^3.0.0"
-=======
-    fd-slicer "~1.0.1"
 
 zxcvbn@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
   integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=
->>>>>>> Add react-meter-bar dependency and implement password strength bar

--- a/yarn.lock
+++ b/yarn.lock
@@ -10423,6 +10423,14 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-meter-bar@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-meter-bar/-/react-meter-bar-1.0.2.tgz#d0f782e5b9cd834b3444e7c5a0d67f6ebf4e77b3"
+  integrity sha512-DwWPeQpw8C9JnS/UW4VzMaTrfLAl+vHpdnHLGgMpXWrboW42KArhKCRjtPb9ErMmAL20IC2iB7C9gho8p1JyxA==
+  dependencies:
+    react "^16.4.0"
+    react-dom "^16.4.0"
+
 react-modal@^3.11.2:
   version "3.11.2"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.2.tgz#bad911976d4add31aa30dba8a41d11e21c4ac8a4"
@@ -11432,6 +11440,14 @@ scheduler@^0.19.0, scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.5:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.5.tgz#b7226625167041298af3b98088a9dbbf6d7733a8"
+  integrity sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -13670,6 +13686,15 @@ youtube-player@5.5.2:
   resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-5.5.2.tgz#052b86b1eabe21ff331095ffffeae285fa7f7cb5"
   integrity sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==
   dependencies:
+<<<<<<< HEAD
     debug "^2.6.6"
     load-script "^1.0.0"
     sister "^3.0.0"
+=======
+    fd-slicer "~1.0.1"
+
+zxcvbn@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=
+>>>>>>> Add react-meter-bar dependency and implement password strength bar


### PR DESCRIPTION
## “Slow progress is better than no progress.”
Implement ZXCVBN password validator from Dropbox
https://github.com/dropbox/zxcvbn
https://blogs.dropbox.com/tech/2012/04/zxcvbn-realistic-password-strength-estimation/

Missing: Get user data to validator for reset password. Decided this is ok.


I also added confirm password fields to create user and reset password. 

Create user:
![Screenshot from 2019-03-26 16-46-58](https://user-images.githubusercontent.com/22156392/55011843-cbb1a480-4fe6-11e9-8d7c-c0bf943f114d.png)




Reset password:
![Screenshot from 2019-03-26 16-42-26](https://user-images.githubusercontent.com/22156392/55011675-83928200-4fe6-11e9-8806-49959314c572.png)




Change password:
![Screenshot from 2019-03-26 16-48-47](https://user-images.githubusercontent.com/22156392/55012023-0e737c80-4fe7-11e9-8350-bc0c730edab7.png)

