### PR TITLE
Correctly handle cases where activation time is null

### DIFF
--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -10,27 +10,21 @@ import Time from 'app/components/Time';
 import Tag from 'app/components/Tags/Tag';
 import { Flex } from 'app/components/Layout';
 import type { Event, EventTimeType } from 'app/models';
-import moment from 'moment-timezone';
 import { EVENTFIELDS } from 'app/utils/constants';
+import { eventStatus, eventAttendance } from 'app/utils/eventStatus';
 
 type AttendanceProps = {
-  registrationCount: number,
-  totalCapacity: number,
   event: Event
 };
 
-const Attendance = ({
-  registrationCount,
-  totalCapacity,
-  event
-}: AttendanceProps) => {
-  const isFuture = moment().isBefore(event.activationTime);
+const Attendance = ({ event }: AttendanceProps) => {
+  const attendance = eventAttendance(event);
   return (
-    <Pill style={{ marginLeft: '5px', color: 'black', whiteSpace: 'nowrap' }}>
-      {isFuture
-        ? `${totalCapacity} plasser`
-        : `${registrationCount} / ${totalCapacity}`}
-    </Pill>
+    attendance && (
+      <Pill style={{ marginLeft: '5px', color: 'black', whiteSpace: 'nowrap' }}>
+        {attendance}
+      </Pill>
+    )
   );
 };
 
@@ -40,16 +34,15 @@ type TimeStampProps = {
 };
 
 const TimeStamp = ({ event, field }: TimeStampProps) => {
-  const isFuture = moment().isBefore(event.activationTime);
-
-  const registration = isFuture
-    ? `Påmelding åpner ${moment(event.activationTime).format('ll HH:mm')}`
-    : `Påmelding åpen!`;
-
+  const registration = eventStatus(event, true);
   return (
     <div className={styles.eventTime}>
-      {registration}
-      <br />
+      {registration && (
+        <span>
+          {registration}
+          <br />
+        </span>
+      )}
       Starter <Time time={event.startTime} format="ll - HH:mm" />
     </div>
   );

--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -30,11 +30,12 @@ const Attendance = ({ event }: AttendanceProps) => {
 
 type TimeStampProps = {
   event: Event,
-  field: EventTimeType
+  field: EventTimeType,
+  loggedIn: boolean
 };
 
-const TimeStamp = ({ event, field }: TimeStampProps) => {
-  const registration = eventStatus(event, true);
+const TimeStamp = ({ event, field, loggedIn }: TimeStampProps) => {
+  const registration = eventStatus(event, loggedIn, true);
   return (
     <div className={styles.eventTime}>
       {registration && (
@@ -51,13 +52,15 @@ const TimeStamp = ({ event, field }: TimeStampProps) => {
 type EventItemProps = {
   event: Event,
   field?: EventTimeType,
-  showTags?: boolean
+  showTags?: boolean,
+  loggedIn: boolean
 };
 
 const EventItem = ({
   event,
   field = EVENTFIELDS.start,
-  showTags = true
+  showTags = true,
+  loggedIn = false
 }: EventItemProps) => (
   <div
     style={{ borderColor: colorForEvent(event.eventType) }}
@@ -74,7 +77,7 @@ const EventItem = ({
           />
         )}
       </Link>
-      <TimeStamp event={event} field={field} />
+      <TimeStamp event={event} field={field} loggedIn={loggedIn} />
       {showTags && (
         <Flex wrap>
           {event.tags.map((tag, index) => (

--- a/app/models.js
+++ b/app/models.js
@@ -60,6 +60,7 @@ type EventBase = {
 export type Event = EventBase & {
   actionGrant: Array<string>,
   activationTime: ?Dateish,
+  isAdmitted: ?boolean,
   activeCapacity: number,
   registrationCount: number,
   waitingRegistrationCount: number,

--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -45,17 +45,25 @@ const groupEvents = ({
 const EventListGroup = ({
   name,
   field = 'startTime',
-  events = []
+  events = [],
+  loggedIn = false
 }: {
   name: string,
   field?: EventTimeType,
-  events?: Array<Event>
+  events?: Array<Event>,
+  loggedIn: boolean
 }) => {
   return isEmpty(events) ? null : (
     <div className={styles.eventGroup}>
       <h2 className={styles.heading}>{name}</h2>
       {events.map((event, i) => (
-        <EventItem key={i} event={event} field={field} showTags={false} />
+        <EventItem
+          key={i}
+          event={event}
+          field={field}
+          showTags={false}
+          loggedIn={loggedIn}
+        />
       ))}
     </div>
   );
@@ -66,7 +74,8 @@ type EventListProps = {
   actionGrant: ActionGrant,
   icalToken: IcalToken,
   showFetchMore: boolean,
-  fetchMore: () => Promise<*>
+  fetchMore: () => Promise<*>,
+  loggedIn: boolean
 };
 
 type Option = {
@@ -94,7 +103,13 @@ class EventList extends Component<EventListProps, State> {
   };
 
   render() {
-    const { icalToken, showFetchMore, fetchMore, events } = this.props;
+    const {
+      icalToken,
+      showFetchMore,
+      fetchMore,
+      events,
+      loggedIn
+    } = this.props;
     const { field, filterFunc } = this.state.selectedOption;
 
     const groupedEvents = groupEvents({
@@ -147,16 +162,19 @@ class EventList extends Component<EventListProps, State> {
           name="Denne uken"
           events={groupedEvents.currentWeek}
           field={field}
+          loggedIn={loggedIn}
         />
         <EventListGroup
           name="Neste uke"
           events={groupedEvents.nextWeek}
           field={field}
+          loggedIn={loggedIn}
         />
         <EventListGroup
           name="Senere"
           events={groupedEvents.later}
           field={field}
+          loggedIn={loggedIn}
         />
 
         {isEmpty(this.props.events) && (

--- a/app/routes/overview/components/EventItem.js
+++ b/app/routes/overview/components/EventItem.js
@@ -13,13 +13,14 @@ import { eventStatus } from 'app/utils/eventStatus';
 type Props = {
   item: Event,
   url: string,
-  meta: Element<'span'> | null
+  meta: Element<'span'> | null,
+  loggedIn: boolean
 };
 
 class EventItem extends Component<Props, *> {
   render() {
-    const { item, url, meta } = this.props;
-    const info = eventStatus(item);
+    const { item, url, meta, loggedIn } = this.props;
+    const info = eventStatus(item, loggedIn);
 
     return (
       <div className={styles.body}>

--- a/app/routes/overview/components/EventItem.js
+++ b/app/routes/overview/components/EventItem.js
@@ -8,7 +8,7 @@ import { Link } from 'react-router';
 import { Flex } from 'app/components/Layout';
 import { colorForEvent } from 'app/routes/events/utils';
 import styles from './EventItem.css';
-import eventStatus from 'app/utils/eventStatus';
+import { eventStatus } from 'app/utils/eventStatus';
 
 type Props = {
   item: Event,

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -27,7 +27,8 @@ type Props = {
   readmes: Array<Object>,
   loadingFrontpage: boolean,
   poll: ?PollEntity,
-  votePoll: () => Promise<*>
+  votePoll: () => Promise<*>,
+  loggedIn: boolean
 };
 
 type State = {
@@ -89,7 +90,14 @@ class Overview extends Component<Props, State> {
 
   render() {
     const isEvent = o => typeof o['startTime'] !== 'undefined';
-    const { frontpage, loadingFrontpage, readmes, poll, votePoll } = this.props;
+    const {
+      loggedIn,
+      frontpage,
+      loadingFrontpage,
+      readmes,
+      poll,
+      votePoll
+    } = this.props;
     const pinned = frontpage[0];
     const compactEvents = (
       <CompactEvents
@@ -134,6 +142,7 @@ class Overview extends Component<Props, State> {
                 item={event}
                 url={this.itemUrl(event)}
                 meta={this.renderMeta(event)}
+                loggedIn={loggedIn}
               />
             ))}
         </Flex>

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -56,6 +56,7 @@ type Props = {
   feedItems: Array<any>,
   feed: Object,
   isMe: boolean,
+  loggedIn: boolean,
   loading: boolean,
   previousEvents: Array<Event>,
   upcomingEvents: Array<Event>,
@@ -70,7 +71,8 @@ type Props = {
 
 type EventsProps = {
   events: Array<Event>,
-  noEventsMessage: string
+  noEventsMessage: string,
+  loggedIn: boolean
 };
 
 const GroupPill = ({ group }: { group: Group }) =>
@@ -141,12 +143,17 @@ const GroupBadge = ({ memberships }: { memberships: Array<Object> }) => {
   );
 };
 
-const ListEvents = ({ events, noEventsMessage }: EventsProps) => (
+const ListEvents = ({ events, noEventsMessage, loggedIn }: EventsProps) => (
   <div>
     {events && events.length ? (
       <Flex column wrap>
         {events.map((event, i) => (
-          <EventItem key={i} event={event} showTags={false} />
+          <EventItem
+            key={i}
+            event={event}
+            showTags={false}
+            loggedIn={loggedIn}
+          />
         ))}
       </Flex>
     ) : (
@@ -178,6 +185,7 @@ export default class UserProfile extends Component<Props, EventsProps> {
     const {
       user,
       isMe,
+      loggedIn,
       showSettings,
       feedItems,
       feed,
@@ -342,6 +350,7 @@ export default class UserProfile extends Component<Props, EventsProps> {
                   <ListEvents
                     events={upcomingEvents.filter(e => e.userReg.pool !== null)}
                     noEventsMessage="Du har ingen kommende arrangementer"
+                    loggedIn={loggedIn}
                   />
                 )}
                 <h3>Arrangementer der du er på ventelista</h3>
@@ -352,6 +361,7 @@ export default class UserProfile extends Component<Props, EventsProps> {
                   <ListEvents
                     events={upcomingEvents.filter(e => e.userReg.pool === null)}
                     noEventsMessage="Du har ingen kommende arrangementer"
+                    loggedIn={loggedIn}
                   />
                 )}
               </div>
@@ -381,6 +391,7 @@ export default class UserProfile extends Component<Props, EventsProps> {
                       ).reverse()
                 }
                 noEventsMessage="Du har ingen tidligere arrangementer"
+                loggedIn={loggedIn}
               />
             )}
           </div>

--- a/app/utils/eventStatus.js
+++ b/app/utils/eventStatus.js
@@ -5,8 +5,11 @@ import moment from 'moment-timezone';
 
 // Calculate diplay message for an event based on
 // eventStatusType, activationTime, capacity and totalCapacity
-
-const eventStatus = (event: Event, pill: boolean = false) => {
+const eventStatus = (
+  event: Event,
+  loggedIn: boolean = false,
+  isPill: boolean = false
+) => {
   const {
     registrationCount,
     totalCapacity,
@@ -23,33 +26,42 @@ const eventStatus = (event: Event, pill: boolean = false) => {
     case 'OPEN':
       return 'Åpent arrangement';
     case 'INFINITE':
-      if (activationTime === null) {
+      if (!loggedIn) {
+        return 'Logg inn for å melde deg på';
+      } else if (activationTime === null) {
         return 'Ingen påmeldingsrett';
       }
       return 'Åpent med påmelding';
     case 'NORMAL':
-      if (!isAdmitted && activationTime === null) {
+      if (!loggedIn) {
+        return 'Logg inn for å melde deg på';
+      } else if (!isAdmitted && activationTime === null) {
         return 'Ingen påmeldingsrett';
       }
       // Check if the event is in the future
       if (future) {
-        return `Åpner ${moment(activationTime).format('dddd D MMM HH:mm')}`
+        return `Åpner ${moment(activationTime).format('dddd D MMM HH:mm')}`;
       }
-      return pill ? false : `${registrationCount}/${totalCapacity} påmeldte`;
+      return isPill ? false : `${registrationCount}/${totalCapacity} påmeldte`;
     default:
       return '';
   }
 };
 
 const eventAttendance = (event: Event) => {
-  const { registrationCount, totalCapacity, activationTime, isAdmitted } = event;
+  const {
+    registrationCount,
+    totalCapacity,
+    activationTime,
+    isAdmitted
+  } = event;
 
   if (!isAdmitted && activationTime === null) {
     return false;
   }
 
   const isFuture = moment().isBefore(activationTime);
-  return isFuture
+  return isFuture && !isAdmitted
     ? `${totalCapacity} plasser`
     : `${registrationCount} / ${totalCapacity}`;
 };

--- a/app/utils/eventStatus.js
+++ b/app/utils/eventStatus.js
@@ -6,7 +6,7 @@ import moment from 'moment-timezone';
 // Calculate diplay message for an event based on
 // eventStatusType, activationTime, capacity and totalCapacity
 
-const eventStatus = (event: Event) => {
+const eventStatus = (event: Event, pill: boolean = false) => {
   const {
     registrationCount,
     totalCapacity,
@@ -14,7 +14,6 @@ const eventStatus = (event: Event) => {
     eventStatusType
   } = event;
 
-  // Check if the event is in the future
   const future = moment().isBefore(activationTime);
 
   switch (eventStatusType) {
@@ -23,14 +22,36 @@ const eventStatus = (event: Event) => {
     case 'OPEN':
       return 'Åpent arrangement';
     case 'INFINITE':
+      if (activationTime === null) {
+        return 'Ingen påmeldingsrett';
+      }
       return 'Åpent med påmelding';
     case 'NORMAL':
+      if (activationTime === null) {
+        return 'Ingen påmeldingsrett';
+      }
+      // Check if the event is in the future
       return future
         ? `Åpner ${moment(activationTime).format('dddd D MMM HH:mm')}`
+        : pill
+        ? false
         : `${registrationCount}/${totalCapacity} påmeldte`;
     default:
       return '';
   }
 };
 
-export default eventStatus;
+const eventAttendance = (event: Event) => {
+  const { registrationCount, totalCapacity, activationTime } = event;
+
+  if (activationTime === null) {
+    return false;
+  }
+
+  const isFuture = moment().isBefore(activationTime);
+  return isFuture
+    ? `${totalCapacity} plasser`
+    : `${registrationCount} / ${totalCapacity}`;
+};
+
+export { eventStatus, eventAttendance };

--- a/app/utils/eventStatus.js
+++ b/app/utils/eventStatus.js
@@ -32,11 +32,10 @@ const eventStatus = (event: Event, pill: boolean = false) => {
         return 'Ingen påmeldingsrett';
       }
       // Check if the event is in the future
-      return future
-        ? `Åpner ${moment(activationTime).format('dddd D MMM HH:mm')}`
-        : pill
-        ? false
-        : `${registrationCount}/${totalCapacity} påmeldte`;
+      if (future) {
+        return `Åpner ${moment(activationTime).format('dddd D MMM HH:mm')}`
+      }
+      return pill ? false : `${registrationCount}/${totalCapacity} påmeldte`;
     default:
       return '';
   }

--- a/app/utils/eventStatus.js
+++ b/app/utils/eventStatus.js
@@ -11,6 +11,7 @@ const eventStatus = (event: Event, pill: boolean = false) => {
     registrationCount,
     totalCapacity,
     activationTime,
+    isAdmitted,
     eventStatusType
   } = event;
 
@@ -27,7 +28,7 @@ const eventStatus = (event: Event, pill: boolean = false) => {
       }
       return 'Åpent med påmelding';
     case 'NORMAL':
-      if (activationTime === null) {
+      if (!isAdmitted && activationTime === null) {
         return 'Ingen påmeldingsrett';
       }
       // Check if the event is in the future
@@ -42,9 +43,9 @@ const eventStatus = (event: Event, pill: boolean = false) => {
 };
 
 const eventAttendance = (event: Event) => {
-  const { registrationCount, totalCapacity, activationTime } = event;
+  const { registrationCount, totalCapacity, activationTime, isAdmitted } = event;
 
-  if (activationTime === null) {
+  if (!isAdmitted && activationTime === null) {
     return false;
   }
 


### PR DESCRIPTION
`event.activationTime` is `null` if a user is not a member of the groups that are in a pool for an event.

This caused issues with displaying the attendance count correctly.

This fixes webkom/lego#1378 and fixes webkom/lego#1381.

## Changes
### Event where `event_status_type` is `NORMAL` _Vanlig påmelding_ or `INFINITE` _Åpen (med påmelding)_:
**Before:** 
![Selection_128](https://user-images.githubusercontent.com/14221489/55350904-66195880-54bd-11e9-973f-67d372b04dab.png)

**After:**
![Selection_130](https://user-images.githubusercontent.com/14221489/55350939-74677480-54bd-11e9-995b-7358f1534bca.png)


**Before:** 
![Selection_132](https://user-images.githubusercontent.com/14221489/55351128-d627de80-54bd-11e9-8671-e4113b8b2e40.png)

**After:**
![Selection_131](https://user-images.githubusercontent.com/14221489/55351135-d922cf00-54bd-11e9-85d3-db07d74840fc.png)

### Event where `event_status_type` is `OPEN` _Åpen (uten påmelding)_:
**Before:**
![Selection_133](https://user-images.githubusercontent.com/14221489/55351673-3a976d80-54bf-11e9-8509-72ed1b16e0ee.png)

**After:** 
![Selection_134](https://user-images.githubusercontent.com/14221489/55352292-d1b0f500-54c0-11e9-90e0-a3fa7e660cf1.png)