### PR TITLE
Typo fix on CompanyDetail page

### DIFF
--- a/app/routes/company/components/CompanyDetail.js
+++ b/app/routes/company/components/CompanyDetail.js
@@ -27,7 +27,7 @@ function insertInfoBubbles(company) {
   const infos = [
     ['call', company.phone, 'Telefon'],
     ['at', company.website, 'Nettside'],
-    ['home', company.address, 'Addresse'],
+    ['home', company.address, 'Adresse'],
     ['briefcase', company.companyType, 'Type bedrift']
   ];
 


### PR DESCRIPTION
'Address' is written with one d in Norwegian: https://www.naob.no/ordbok/adresse