### PR TITLE
Remove option to require feedback on OPEN events

### DIFF
--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -368,7 +368,7 @@ function EventEditor({
               </Tooltip>
             )}
 
-            {['NORMAL', 'INFINITE', 'OPEN'].includes(event.eventStatusType) && (
+            {['NORMAL', 'INFINITE'].includes(event.eventStatusType) && (
               <Tooltip content="Et spørsmål alle må svare på før de melder seg på">
                 <Field
                   name="feedbackRequired"


### PR DESCRIPTION
This fixes https://github.com/webkom/lego/issues/1552.