### PR TITLE
Hide registration part of the event details on OPEN and TBA events

### DIFF
--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -212,7 +212,8 @@ export default class EventDetail extends Component<Props> {
             value: <FormatTime time={event.activationTime} />
           }
         : null,
-      event.unregistrationDeadline && event.eventStatusType !== 'OPEN'
+      event.unregistrationDeadline &&
+      !['OPEN', 'TBA'].includes(event.eventStatusType)
         ? {
             key: 'Avregistreringsfrist',
             value: <FormatTime time={event.unregistrationDeadline} />
@@ -264,11 +265,8 @@ export default class EventDetail extends Component<Props> {
                   <InfoList items={paidItems} />
                 </div>
               )}
-              {event.eventStatusType === 'OPEN' ? (
-                <Flex column>
-                  <div className={styles.joinHeader}>Påmelding</div>
-                  <div>Dette arrangementet krever ingen påmelding</div>
-                </Flex>
+              {['OPEN', 'TBA'].includes(event.eventStatusType) ? (
+                <JoinEventForm event={event} />
               ) : (
                 <Flex column>
                   <h3>Påmeldte</h3>

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -212,7 +212,7 @@ export default class EventDetail extends Component<Props> {
             value: <FormatTime time={event.activationTime} />
           }
         : null,
-      event.unregistrationDeadline
+      event.unregistrationDeadline && event.eventStatusType !== 'OPEN'
         ? {
             key: 'Avregistreringsfrist',
             value: <FormatTime time={event.unregistrationDeadline} />
@@ -264,77 +264,86 @@ export default class EventDetail extends Component<Props> {
                   <InfoList items={paidItems} />
                 </div>
               )}
-              <Flex column>
-                <h3>Påmeldte</h3>
-                {registrations ? (
-                  <Fragment>
-                    <UserGrid
-                      minRows={2}
-                      maxRows={2}
-                      users={registrations.slice(0, 14).map(reg => reg.user)}
-                    />
-                    <ModalParentComponent
-                      key="modal"
-                      pools={pools}
-                      registrations={registrations}
-                      title="Påmeldte"
-                    >
-                      <RegisteredSummary
-                        registrations={registrations}
-                        currentRegistration={currentRegistration}
+              {event.eventStatusType === 'OPEN' ? (
+                <Flex column>
+                  <div className={styles.joinHeader}>Påmelding</div>
+                  <div>Dette arrangementet krever ingen påmelding</div>
+                </Flex>
+              ) : (
+                <Flex column>
+                  <h3>Påmeldte</h3>
+                  {registrations ? (
+                    <Fragment>
+                      <UserGrid
+                        minRows={2}
+                        maxRows={2}
+                        users={registrations.slice(0, 14).map(reg => reg.user)}
                       />
-                      <AttendanceStatus />
-                    </ModalParentComponent>
-                  </Fragment>
-                ) : (
-                  <AttendanceStatus pools={pools} />
-                )}
+                      <ModalParentComponent
+                        key="modal"
+                        pools={pools}
+                        registrations={registrations}
+                        title="Påmeldte"
+                      >
+                        <RegisteredSummary
+                          registrations={registrations}
+                          currentRegistration={currentRegistration}
+                        />
+                        <AttendanceStatus />
+                      </ModalParentComponent>
+                    </Fragment>
+                  ) : (
+                    <AttendanceStatus pools={pools} />
+                  )}
 
-                {loggedIn && (
-                  <RegistrationMeta
-                    useConsent={event.useConsent}
-                    hasEnded={moment(event.endTime).isBefore(moment())}
-                    registration={currentRegistration}
-                    isPriced={event.isPriced}
-                    registrationIndex={currentRegistrationIndex}
-                    hasSimpleWaitingList={hasSimpleWaitingList}
-                  />
-                )}
-
-                {event.unansweredSurveys &&
-                event.unansweredSurveys.length > 0 ? (
-                  <div className={styles.unansweredSurveys}>
-                    <h3>
-                      Du kan ikke melde deg på dette arrangementet fordi du har
-                      ubesvarte spørreundersøkelser.
-                    </h3>
-                    <p>
-                      Man må svare på alle spørreundersøkelser for tidligere
-                      arrangementer før man kan melde seg på nye arrangementer.
-                      Du kan svare på undersøkelsene dine ved å trykke på
-                      følgende linker:
-                    </p>
-                    <ul>
-                      {event.unansweredSurveys.map((surveyId, i) => (
-                        <li key={surveyId}>
-                          <Link to={`/surveys/${surveyId}`}>
-                            Undersøkelse {i + 1}
-                          </Link>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ) : (
-                  <div>
-                    <JoinEventForm
-                      event={event}
+                  {loggedIn && (
+                    <RegistrationMeta
+                      useConsent={event.useConsent}
+                      hasEnded={moment(event.endTime).isBefore(moment())}
                       registration={currentRegistration}
-                      currentUser={currentUser}
-                      onToken={this.handleToken}
-                      onSubmit={this.handleRegistration}
+                      isPriced={event.isPriced}
+                      registrationIndex={currentRegistrationIndex}
+                      hasSimpleWaitingList={hasSimpleWaitingList}
                     />
-                  </div>
-                )}
+                  )}
+
+                  {event.unansweredSurveys &&
+                  event.unansweredSurveys.length > 0 ? (
+                    <div className={styles.unansweredSurveys}>
+                      <h3>
+                        Du kan ikke melde deg på dette arrangementet fordi du
+                        har ubesvarte spørreundersøkelser.
+                      </h3>
+                      <p>
+                        Man må svare på alle spørreundersøkelser for tidligere
+                        arrangementer før man kan melde seg på nye
+                        arrangementer. Du kan svare på undersøkelsene dine ved å
+                        trykke på følgende linker:
+                      </p>
+                      <ul>
+                        {event.unansweredSurveys.map((surveyId, i) => (
+                          <li key={surveyId}>
+                            <Link to={`/surveys/${surveyId}`}>
+                              Undersøkelse {i + 1}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : (
+                    <div>
+                      <JoinEventForm
+                        event={event}
+                        registration={currentRegistration}
+                        currentUser={currentUser}
+                        onToken={this.handleToken}
+                        onSubmit={this.handleRegistration}
+                      />
+                    </div>
+                  )}
+                </Flex>
+              )}
+              <Flex column>
                 <Admin
                   actionGrant={actionGrant}
                   event={event}

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -192,112 +192,134 @@ class JoinEventForm extends Component<Props> {
       );
     }
 
+    const registrationMessage = event => {
+      switch (event.eventStatusType) {
+        case 'OPEN':
+          return <div>Dette arrangementet krever ingen påmelding</div>;
+        case 'TBA':
+          return (
+            <div>Påmelding til dette arrangementet er ikke bestemt enda</div>
+          );
+        default:
+          return null;
+      }
+    };
+
     return (
       <>
         <div className={styles.joinHeader}>Påmelding</div>
         <Flex column className={styles.join}>
-          {!formOpen && event.activationTime && (
-            <div>
-              {new Date(event.activationTime) < new Date()
-                ? 'Åpnet '
-                : 'Åpner '}
-              <Time time={event.activationTime} format="nowToTimeInWords" />
-            </div>
-          )}
-          {disabledForUser && (
-            <div>Du kan ikke melde deg på dette arrangementet.</div>
-          )}
-          {formOpen && (
-            <Flex column>
-              <Form
-                onSubmit={this.submitWithType(
-                  handleSubmit,
-                  feedbackName,
-                  registrationType
-                )}
-              >
-                <label className={formStyles.label} htmlFor={feedbackName}>
-                  {feedbackLabel}
-                </label>
-                <Flex style={{ marginBottom: '20px' }}>
-                  <Field
-                    id={feedbackName}
-                    placeholder="Melding til arrangører"
-                    name={feedbackName}
-                    component={TextEditor.Field}
-                    labelClassName={styles.feedbackLabel}
-                    className={styles.feedbackText}
-                    fieldClassName={styles.feedbackField}
-                    rows={1}
-                  />
-                  {registration && (
-                    <Button
-                      type="button"
-                      onClick={this.submitWithType(
-                        handleSubmit,
-                        feedbackName,
-                        'feedback'
-                      )}
-                      className={styles.feedbackUpdateButton}
-                      disabled={pristine}
-                    >
-                      Oppdater
-                    </Button>
-                  )}
-                </Flex>
-                {showCaptcha && (
-                  <Field
-                    name="captchaResponse"
-                    fieldStyle={{ width: 304 }}
-                    component={Captcha.Field}
-                  />
-                )}
-                {event.activationTime && registrationOpensIn && (
-                  <Flex alignItems="center">
-                    <Button disabled={disabledButton}>
-                      {`Åpner om ${registrationOpensIn}`}
-                    </Button>
-                  </Flex>
-                )}
-                {buttonOpen && !submitting && (
-                  <>
-                    <Flex alignItems="center" justifyContent="space-between">
-                      <SubmitButton
-                        disabled={disabledButton}
-                        onSubmit={this.submitWithType(
-                          handleSubmit,
-                          feedbackName,
-                          registrationType
-                        )}
-                        type={registrationType}
-                        title={title || joinTitle}
-                        showPenaltyNotice={showPenaltyNotice}
+          {['OPEN', 'TBA'].includes(event.eventStatusType) ? (
+            registrationMessage(event)
+          ) : (
+            <>
+              {!formOpen && event.activationTime && (
+                <div>
+                  {new Date(event.activationTime) < new Date()
+                    ? 'Åpnet '
+                    : 'Åpner '}
+                  <Time time={event.activationTime} format="nowToTimeInWords" />
+                </div>
+              )}
+              {disabledForUser && (
+                <div>Du kan ikke melde deg på dette arrangementet.</div>
+              )}
+              {formOpen && (
+                <Flex column>
+                  <Form
+                    onSubmit={this.submitWithType(
+                      handleSubmit,
+                      feedbackName,
+                      registrationType
+                    )}
+                  >
+                    <label className={formStyles.label} htmlFor={feedbackName}>
+                      {feedbackLabel}
+                    </label>
+                    <Flex style={{ marginBottom: '20px' }}>
+                      <Field
+                        id={feedbackName}
+                        placeholder="Melding til arrangører"
+                        name={feedbackName}
+                        component={TextEditor.Field}
+                        labelClassName={styles.feedbackLabel}
+                        className={styles.feedbackText}
+                        fieldClassName={styles.feedbackField}
+                        rows={1}
                       />
-                      {registration && showStripe && (
-                        <PaymentRequestForm
-                          onToken={onToken}
-                          event={event}
-                          currentUser={currentUser}
-                          chargeStatus={registration.chargeStatus}
-                        />
+                      {registration && (
+                        <Button
+                          type="button"
+                          onClick={this.submitWithType(
+                            handleSubmit,
+                            feedbackName,
+                            'feedback'
+                          )}
+                          className={styles.feedbackUpdateButton}
+                          disabled={pristine}
+                        >
+                          Oppdater
+                        </Button>
                       )}
                     </Flex>
-                    {!registration && (
-                      <SpotsLeft
-                        activeCapacity={event.activeCapacity}
-                        spotsLeft={event.spotsLeft}
+                    {showCaptcha && (
+                      <Field
+                        name="captchaResponse"
+                        fieldStyle={{ width: 304 }}
+                        component={Captcha.Field}
                       />
                     )}
-                  </>
-                )}
-                {submitting && (
-                  <LoadingIndicator
-                    loading
-                    loadingStyle={{ margin: '5px auto' }}
-                  />
-                )}
-              </Form>
-            </Flex>
+                    {event.activationTime && registrationOpensIn && (
+                      <Flex alignItems="center">
+                        <Button disabled={disabledButton}>
+                          {`Åpner om ${registrationOpensIn}`}
+                        </Button>
+                      </Flex>
+                    )}
+                    {buttonOpen && !submitting && (
+                      <>
+                        <Flex
+                          alignItems="center"
+                          justifyContent="space-between"
+                        >
+                          <SubmitButton
+                            disabled={disabledButton}
+                            onSubmit={this.submitWithType(
+                              handleSubmit,
+                              feedbackName,
+                              registrationType
+                            )}
+                            type={registrationType}
+                            title={title || joinTitle}
+                            showPenaltyNotice={showPenaltyNotice}
+                          />
+                          {registration && showStripe && (
+                            <PaymentRequestForm
+                              onToken={onToken}
+                              event={event}
+                              currentUser={currentUser}
+                              chargeStatus={registration.chargeStatus}
+                            />
+                          )}
+                        </Flex>
+                        {!registration && (
+                          <SpotsLeft
+                            activeCapacity={event.activeCapacity}
+                            spotsLeft={event.spotsLeft}
+                          />
+                        )}
+                      </>
+                    )}
+                    {submitting && (
+                      <LoadingIndicator
+                        loading
+                        loadingStyle={{ margin: '5px auto' }}
+                      />
+                    )}
+                  </Form>
+                </Flex>
+              )}
+            </>
           )}
         </Flex>
       </>


### PR DESCRIPTION
There is no point in showing registrations or information related to who has registered on `OPEN` and `TBA` events. Hide this and show a simple message instead.

Will continue on with https://github.com/webkom/lego/issues/1526 once this has been merged.

## Before:
<img src="https://user-images.githubusercontent.com/14221489/56613338-bc8a3a80-6616-11e9-87eb-4db79278df8c.png" width="320px" />

## After:
<img src="https://user-images.githubusercontent.com/14221489/56613760-9ca74680-6617-11e9-9af1-4e2dfc7b6598.png" width="320px" />

