### PR TITLE
༼ つ ◕_◕ ༽つ

### DIFF
--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -8,7 +8,7 @@ export type eventTypes = $Values<typeof EVENT_CONSTANTS>;
 
 // Current eventTypes
 export const EVENT_CONSTANTS: eventTypes = {
-  company_presentation: 'Bedprespresentasjon',
+  company_presentation: 'Bedriftspresentasjon',
   lunch_presentation: 'Lunsjpresentasjon',
   alternative_presentation: 'Alternativt bedpres',
   course: 'Kurs',

--- a/app/routes/photos/components/GalleryPictureModal.js
+++ b/app/routes/photos/components/GalleryPictureModal.js
@@ -13,7 +13,7 @@ import { Link } from 'react-router';
 import CommentView from 'app/components/Comments/CommentView';
 import Modal from 'app/components/Modal';
 import styles from './GalleryPictureModal.css';
-import Swipeable from 'react-swipeable';
+import { Swipeable, RIGHT, LEFT } from 'react-swipeable';
 import type { EntityID } from 'app/types';
 import type { ID } from 'app/models';
 import Button from 'app/components/Button';
@@ -181,12 +181,9 @@ export default class GalleryPictureModal extends Component<Props, State> {
     }
   };
 
-  handleSwipeRight = () => {
-    this.previousGalleryPicture();
-  };
-
-  handleSwipeLeft = () => {
-    this.nextGalleryPicture();
+  handleSwipe = ({ dir }: { dir: RIGHT | LEFT }) => {
+    dir === RIGHT && this.previousGalleryPicture();
+    dir === LEFT && this.nextGalleryPicture();
   };
 
   render() {
@@ -204,10 +201,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
     const { showMore } = this.state;
 
     return (
-      <Swipeable
-        onSwipingLeft={this.handleSwipeLeft}
-        onSwipingRight={this.handleSwipeRight}
-      >
+      <Swipeable onSwiping={this.handleSwipe}>
         <Modal
           onHide={() => push(`/photos/${gallery.id}`)}
           backdropClassName={styles.backdrop}

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "serialize-javascript": "^1.4.0",
     "slugify": "^1.3.4",
     "source-map-support": "^0.5.8",
-    "validator": "^9.2.0",
     "victory": "^0.25.7",
     "websocket.js": "^0.1.7"
   },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-stickynode": "^2.1.1",
     "react-stripe-checkout": "^2.4.0",
     "react-stripe-elements": "^2.0.3",
-    "react-swipeable": "^4.2.1",
+    "react-swipeable": "5.0.0",
     "react-tagcloud": "^1.2.0",
     "react-textarea-autosize": "^5.1.0",
     "react-treeview": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "js-yaml": "^3.13.1",
     "jsdom": "^11.6.2",
     "jwt-decode": "2.2.0",
-    "lodash-es": "^4.17.11",
+    "lodash-es": "^4.17.15",
     "medium-draft": "^0.6.0-beta1",
     "minireset.css": "^0.0.4",
     "moment-timezone": "^0.5.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7546,7 +7546,12 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.11, lodash-es@^4.17.3:
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
+lodash-es@^4.17.3:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.14.tgz#12a95a963cc5955683cee3b74e85458954f37ecc"
   integrity sha512-7zchRrGa8UZXjD/4ivUWP1867jDkhzTG2c/uj739utSd7O/pFFdxspCemIFKEEjErbcqRzn8nKnGsi7mvTgRPA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13278,11 +13278,6 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-validator@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-9.2.0.tgz#ad216eed5f37cac31a6fe00ceab1f6b88bded03e"
-  integrity sha512-6Ij4Eo0KM4LkR0d0IegOwluG5453uqT5QyF5SV5Ezvm8/zmkKI/L4eoraafZGlZPC9guLkwKzgypcw8VGWWnGA==
-
 vary@~1.1.1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,11 +3862,6 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
-detect-passive-events@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/detect-passive-events/-/detect-passive-events-1.0.4.tgz#6ed477e6e5bceb79079735dcd357789d37f9a91a"
-  integrity sha1-btR35uW863kHlzXc01d4nTf5qRo=
-
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -10939,13 +10934,12 @@ react-styleguidist@^9.0.2:
     webpack-dev-server "^3.1.14"
     webpack-merge "^4.2.1"
 
-react-swipeable@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-4.2.1.tgz#dae68ecd041c299a9b55b4925baf940195858637"
-  integrity sha1-2uaOzQQcKZqbVbSSW6+UAZWFhjc=
+react-swipeable@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-5.0.0.tgz#1d80b2df126018d79dc8429b401f36733f85573e"
+  integrity sha512-AoWjR03yqNLuO94P0FGG6gRS8/KSMTA1mwRSDu4rh1oHbUarzftTwcYjpw5ASjOkxblGfOKsajl/+TuTmH6yXA==
   dependencies:
-    detect-passive-events "^1.0.4"
-    prop-types "^15.5.8"
+    prop-types "^15.6.2"
 
 react-tagcloud@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## 🚒 Bump some quick dependencies 🚒 

### lodash

Fix lodash-es security alert by bumping to `4.17.15`

<hr>

### validator

Resolves https://github.com/webkom/lego-webapp/pull/1569

This is unused?? I can't find one import using this, and everything seems to be working good without it. Removed the dependency.

<hr>

### react-swipeable

Resolves https://github.com/webkom/lego-webapp/pull/1531

Bump to v5. Some small migrations with prop changes. The latest version is 5.4.0, but anything above 5.0.0 created some unwanted behavior(aka no behavior at all, cant swipe). I could not figure out the reason behind this, as all the breaking changes stated in the changelog was from v4 to v5, and not from 5.0.0 to 5.1.0... 😢 