### PR TITLE
Fix styling for long pool names

### DIFF
--- a/app/components/UserAttendance/AttendanceStatus.css
+++ b/app/components/UserAttendance/AttendanceStatus.css
@@ -3,6 +3,7 @@
   flex-flow: row wrap;
   justify-content: flex-start;
   width: 100%;
+  text-align: center;
 }
 
 .poolBox {


### PR DESCRIPTION
Fixes: https://github.com/webkom/lego/issues/1588