### PR TITLE
Change unregistration deadline to 24 hours before event

### DIFF
--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -72,7 +72,7 @@ const mapStateToProps = (state, props) => {
       useConsent: false,
       feedbackDescription: '',
       pools: [],
-      unregistrationDeadline: time({ hours: 12 }),
+      unregistrationDeadline: time({ hours: 24 }),
       registrationDeadlineHours: 2
     },
     actionGrant,


### PR DESCRIPTION
Want to have the unregistration deadline 24 hours before event instead of 12