### PR TITLE
Quick alignments, break on default and colors

### DIFF
--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -36,7 +36,7 @@
 }
 
 .pollLight {
-  background: var(--lego-color-gray-light);
+  background: var(--lego-card-color);
 }
 
 .noVotes {

--- a/app/routes/overview/components/LatestReadme.css
+++ b/app/routes/overview/components/LatestReadme.css
@@ -12,7 +12,7 @@
 }
 
 .heading {
-  font-size: 22px;
+  font-size: 35px;
   color: #555;
 }
 

--- a/app/routes/overview/components/LatestReadme.js
+++ b/app/routes/overview/components/LatestReadme.js
@@ -38,7 +38,7 @@ class LatestReadme extends Component<Props, State> {
     return (
       <Flex column className={styles.latestReadme}>
         <button className={styles.heading} onClick={toggle}>
-          <Flex justifyContent="space-between">
+          <Flex justifyContent="space-between" alignItems="center">
             {readmeIfy('readme')}
             <Icon name={expanded ? 'close' : 'arrow-down'} />
           </Flex>

--- a/app/routes/overview/components/Pinned.css
+++ b/app/routes/overview/components/Pinned.css
@@ -7,10 +7,10 @@
 
 .innerPinned {
   composes: withShadow from 'app/styles/utilities.css';
+  background: var(--lego-card-color);
 }
 
 .innerLinks {
-  height: 212px;
   display: block;
 
   @media (--mobile-device) {
@@ -20,9 +20,8 @@
 
 .image {
   object-fit: contain;
-  background: white;
-  border-right: 1px solid rgba(0, 0, 0, 0.09);
-  border-radius: 3px 0 0 3px;
+  background: var(--lego-card-color);
+  border-radius: 5px 5px 0 0;
 
   @media (--mobile-device) {
     object-fit: scale-down;
@@ -34,11 +33,7 @@
 }
 
 .pinnedHeading {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
-  background: var(--lego-card-color);
-  padding: 20px;
+  padding: 0 20px;
   font-size: 30px;
   align-items: center;
 }

--- a/app/routes/overview/components/Pinned.js
+++ b/app/routes/overview/components/Pinned.js
@@ -27,7 +27,7 @@ class Pinned extends Component<Props, *> {
             <h2 className={styles.itemTitle}>
               <Link to={url}>{item.title}</Link>
             </h2>
-            {meta}
+            <p>{meta}</p>
           </div>
         </Flex>
       </Flex>


### PR DESCRIPTION
- Fixed some small ugly errors with `pinned` where images overlapped with border-radius and stuff

- Made `pinned` wrap on default so it's always the same hight, and therefore matches with the hight of `readme`

- Change background color on polls so it matches with the rest of the cards


# From 
![image](https://user-images.githubusercontent.com/23152018/64795156-ec15f100-d57d-11e9-9b05-1d7c0c2b65d8.png)

# To
![image](https://user-images.githubusercontent.com/23152018/64795172-f2a46880-d57d-11e9-8314-51380f93cf6b.png)
