### PR TITLE
Quickfix for navigation between bdb and companies

### DIFF
--- a/app/routes/company/components/CompaniesPage.js
+++ b/app/routes/company/components/CompaniesPage.js
@@ -17,7 +17,9 @@ type Props = {
 };
 
 const CompanyItem = ({ company }: Company) => {
-  const [protocol, , domain] = company.website.split('/');
+  const [protocol, , domain] = company.website
+    ? company.website.split('/')
+    : ['', '', ''];
   const websiteString = `${protocol}//${domain}`;
 
   return (


### PR DESCRIPTION
Going to `/bdb` loads a ton of companies, with a slightly different schema than that of `/companies`. The backend calls are different. You might argue it would be better to remove these different company objects from state and then re-fetching the correct call, but this PR at least keeps the website from crashing when you navigate from `/bdb` to `/companies`.