### PR TITLE
Quick fix

### DIFF
--- a/app/routes/overview/components/ArticleItem.css
+++ b/app/routes/overview/components/ArticleItem.css
@@ -9,6 +9,7 @@
   text-align: center;
   background: var(--lego-card-color);
   height: 388px;
+  width: 100%;
   margin-bottom: 20px;
   position: relative;
 

--- a/app/routes/overview/components/LatestReadme.css
+++ b/app/routes/overview/components/LatestReadme.css
@@ -12,7 +12,7 @@
 }
 
 .heading {
-  font-size: 35px;
+  font-size: 27px;
   color: #555;
 }
 


### PR DESCRIPTION
When an article has no image it lost its width, as the image was the
only thing pushing the card out. This just adds a 100% to ensure that
the card is always streched (mostly for staging).

Also scale down the readme text a bit, i went a bit overboard last time
i scaled it up :/