### PR TITLE
Render pagenotfound when accessing a poll with invalid id

### DIFF
--- a/app/actions/PollActions.js
+++ b/app/actions/PollActions.js
@@ -32,7 +32,8 @@ export function fetchPoll(pollId: number) {
     schema: pollSchema,
     meta: {
       errorMessage: 'Henting av avstemning feilet'
-    }
+    },
+    propagateError: true
   });
 }
 


### PR DESCRIPTION
The action did not dispatch error codes to redux before, so the page would just endlessly load...