### PR TITLE
Fix loading indicator in email routes

### DIFF
--- a/app/routes/admin/email/EmailListsRoute.js
+++ b/app/routes/admin/email/EmailListsRoute.js
@@ -12,7 +12,7 @@ const mapStateToProps = state => ({
   emailLists: selectEmailLists(state),
   fetching: state.emailLists.fetching,
   hasMore: state.emailLists.hasMore,
-  notFetching: !state.emailLists.fetching
+  notFetching: !state.emailLists.fetching || state.emailLists.items.length
 });
 
 const mapDispatchToProps = { fetch };

--- a/app/routes/admin/email/EmailUsersRoute.js
+++ b/app/routes/admin/email/EmailUsersRoute.js
@@ -11,7 +11,8 @@ import loadingIndicator from 'app/utils/loadingIndicator';
 const mapStateToProps = state => ({
   emailUsers: selectEmailUsers(state),
   fetching: state.emailUsers.fetching,
-  hasMore: state.emailUsers.hasMore
+  hasMore: state.emailUsers.hasMore,
+  notFetching: !state.emailUsers.fetching || state.emailUsers.items.length
 });
 
 const mapDispatchToProps = { fetch };
@@ -22,5 +23,5 @@ export default compose(
     mapStateToProps,
     mapDispatchToProps
   ),
-  loadingIndicator(['emailUsers.length'])
+  loadingIndicator(['notFetching'])
 )(EmailUsers);


### PR DESCRIPTION
The admin/email route bugs out after a previous bugfix