### PR TITLE
Add `resize: vertical` to .feedbackText

### DIFF
--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -17,6 +17,7 @@
   min-width: 200px;
   max-width: 893px;
   max-height: 300px;
+  resize: vertical;
 }
 
 .feedbackUpdateButton {


### PR DESCRIPTION
Currently you are allowed to resize the text-area horizontally, which can yield quite weird results. This fixes that.
