### PR TITLE
Bump moment-timezone for security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lodash-es": "^4.17.15",
     "medium-draft": "^0.6.0-beta1",
     "minireset.css": "^0.0.4",
-    "moment-timezone": "^0.5.23",
+    "moment-timezone": "^0.5.26",
     "morgan": "^1.9.1",
     "normalizr": "^3.2.2",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8188,10 +8188,10 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
-moment-timezone@^0.5.23:
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
-  integrity sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==
+moment-timezone@^0.5.26:
+  version "0.5.26"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.26.tgz#c0267ca09ae84631aa3dc33f65bedbe6e8e0d772"
+  integrity sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
### `0.5.26` _2019-06-06_
* Updated data to IANA TZDB `2019b`
* Fix: stabilize Array.sort [#762](https://github.com/moment/moment-timezone/pull/762)

### `0.5.25` _2019-04-17_
* Fix `moment.tz.dataVersion` to return `2019a` [#742](https://github.com/moment/moment-timezone/issues/742)
* Update path in bower.json

### `0.5.24` _2019-04-17_
* Updated data to IANA TZDB `2019a` [#737](https://github.com/moment/moment-timezone/issues/737)
* Start shipping both a 1970-1930 file and a rolling 10-year file [#614](https://github.com/moment/moment-timezone/issues/614) [#697](https://github.com/moment/moment-timezone/issues/697)
* Fixed bug where `_z` time zone name was not cleared with `.local()` or `.utcOffset(offset)` [#738](https://github.com/moment/moment-timezone/issues/738)