### PR TITLE
Require all poll options be visible before being able to vote

### DIFF
--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -37,8 +37,8 @@ type TimeStampProps = {
 
 const TimeStamp = ({ event, field, loggedIn }: TimeStampProps) => {
   const registration = eventStatus(event, loggedIn, true);
-  const hasStarted = moment().isBefore(event.startTime);
-  const startedStatus = hasStarted ? 'Starter' : 'Startet';
+  const hasStarted = moment().isAfter(event.startTime);
+  const startedStatus = hasStarted ? 'Startet' : 'Starter';
   return (
     <div className={styles.eventTime}>
       {registration && (

--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -146,3 +146,14 @@
   display: flex;
   justify-content: center;
 }
+
+@media (--mobile-device) {
+  .blurContainer {
+    display: flex;
+  }
+
+  .blurEffect {
+    filter: blur(3px);
+    pointer-events: none;
+  }
+}

--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -3,6 +3,8 @@
 .optionWrapper {
   justify-content: center;
   min-height: 120px;
+  cursor: pointer;
+  position: relative;
 }
 
 .pollTable {
@@ -110,4 +112,17 @@
     color: var(--color-red-3);
     transition: transform 0.2s;
   }
+}
+
+.blurContainer {
+  position: absolute;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.blurOverlay {
+  position: absolute;
+  z-index: 2;
+  color: var(--color-black);
 }

--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -115,6 +115,7 @@
 }
 
 .blurContainer {
+  display: none;
   position: absolute;
   justify-content: center;
   width: 100%;
@@ -125,4 +126,23 @@
   position: absolute;
   z-index: 2;
   color: var(--color-black);
+  margin-top: 25px;
+}
+
+.optionWrapper:hover .blurContainer {
+  display: flex;
+}
+
+.optionWrapper:hover .blurEffect {
+  filter: blur(3px);
+  pointer-events: none;
+}
+
+.blurArrow {
+  margin-top: 40px;
+}
+
+.alignItems {
+  display: flex;
+  justify-content: center;
 }

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -101,7 +101,7 @@ class Poll extends React.Component<Props, State> {
       .sort((a, b) => b.ratio - a.ratio);
   };
 
-  shuffle = array => {
+  shuffle = (array: Array<OptionEntityRatio>) => {
     let counter = array.length;
 
     while (counter > 0) {

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -21,10 +21,7 @@ type Props = {
 
 type State = {
   truncateOptions: boolean,
-  allOptions: Array<OptionEntityRatio>,
-  optionsToShow: Array<OptionEntityRatio>,
-  shuffledAllOptions: Array<OptionEntityRatio>,
-  shuffledOptionsToShow: Array<OptionEntityRatio>,
+  shuffledOptions: Array<OptionEntityRatio>,
   expanded: boolean
 };
 
@@ -40,62 +37,22 @@ class Poll extends React.Component<Props, State> {
     if (props.truncate && options.length > props.truncate) {
       this.state = {
         truncateOptions: true,
-        allOptions: options,
-        optionsToShow: options.slice(0, props.truncate),
-        shuffledAllOptions: shuffledOptions,
-        shuffledOptionsToShow: shuffledOptions.slice(0, props.truncate),
+        shuffledOptions: shuffledOptions,
         expanded: false
       };
     } else {
       this.state = {
         truncateOptions: false,
-        allOptions: options,
-        optionsToShow: options,
-        shuffledAllOptions: shuffledOptions,
-        shuffledOptionsToShow: shuffledOptions,
+        shuffledOptions: shuffledOptions,
         expanded: true
       };
     }
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (prevProps.poll.options !== this.props.poll.options) {
-      const options = this.optionsWithPerfectRatios(this.props.poll.options);
-      this.props.truncate && !this.state.expanded
-        ? this.setState({
-            allOptions: options,
-            optionsToShow: options.slice(0, this.props.truncate),
-            shuffledOptionsToShow: this.state.shuffledAllOptions.slice(
-              0,
-              this.props.truncate
-            )
-          })
-        : this.setState({
-            allOptions: options,
-            optionsToShow: options,
-            shuffledOptionsToShow: this.state.shuffledAllOptions
-          });
-    }
-  }
-
   toggleTruncate = () => {
-    const { truncate } = this.props;
-    const {
-      expanded,
-      allOptions,
-      shuffledAllOptions: shuffledAllOptions
-    } = this.state;
-    expanded
-      ? this.setState({
-          optionsToShow: allOptions.slice(0, truncate),
-          shuffledOptionsToShow: shuffledAllOptions.slice(0, truncate),
-          expanded: false
-        })
-      : this.setState({
-          optionsToShow: allOptions,
-          shuffledOptionsToShow: shuffledAllOptions,
-          expanded: true
-        });
+    this.setState({
+      expanded: !this.state.expanded
+    });
   };
 
   optionsWithPerfectRatios = (options: Array<OptionEntity>) => {
@@ -133,14 +90,14 @@ class Poll extends React.Component<Props, State> {
   };
 
   render() {
-    const { poll, handleVote, backgroundLight, details } = this.props;
-    const {
-      truncateOptions,
-      optionsToShow,
-      expanded,
-      shuffledOptionsToShow: shuffledOptionsToShow
-    } = this.state;
-    const { id, title, description, options, hasAnswered, totalVotes } = poll;
+    const { poll, handleVote, backgroundLight, details, truncate } = this.props;
+    const { truncateOptions, expanded, shuffledOptions } = this.state;
+    const { id, title, description, hasAnswered, totalVotes } = poll;
+    const options = this.optionsWithPerfectRatios(this.props.poll.options);
+    const orderedOptions = hasAnswered ? options : shuffledOptions;
+    const optionsToShow = expanded
+      ? orderedOptions
+      : orderedOptions.slice(0, truncate);
     return (
       <div className={cx(styles.poll, backgroundLight ? styles.pollLight : '')}>
         <Flex>
@@ -216,7 +173,7 @@ class Poll extends React.Component<Props, State> {
               </Flex>
             )}
             {options &&
-              shuffledOptionsToShow.map(option => (
+              optionsToShow.map(option => (
                 <Flex
                   className={cx(
                     styles.alignItems,

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -23,6 +23,7 @@ type State = {
   truncateOptions: boolean,
   allOptions: Array<OptionEntityRatio>,
   optionsToShow: Array<OptionEntityRatio>,
+  shuffledAllOptions: Array<OptionEntityRatio>,
   shuffledOptionsToShow: Array<OptionEntityRatio>,
   expanded: boolean
 };
@@ -35,29 +36,26 @@ class Poll extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     const options = this.optionsWithPerfectRatios(props.poll.options);
+    const shuffledOptions = this.shuffle(options);
     if (props.truncate && options.length > props.truncate) {
       this.state = {
         truncateOptions: true,
         allOptions: options,
-        shuffledOptionsToShow: [],
         optionsToShow: options.slice(0, props.truncate),
+        shuffledAllOptions: shuffledOptions,
+        shuffledOptionsToShow: shuffledOptions.slice(0, props.truncate),
         expanded: false
       };
     } else {
       this.state = {
         truncateOptions: false,
         allOptions: options,
-        shuffledOptionsToShow: [],
         optionsToShow: options,
+        shuffledAllOptions: shuffledOptions,
+        shuffledOptionsToShow: shuffledOptions,
         expanded: true
       };
     }
-  }
-
-  componentDidMount() {
-    this.setState({
-      shuffledOptionsToShow: this.shuffle(this.state.optionsToShow)
-    });
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -66,25 +64,36 @@ class Poll extends React.Component<Props, State> {
       this.props.truncate && !this.state.expanded
         ? this.setState({
             allOptions: options,
-            optionsToShow: options.slice(0, this.props.truncate)
+            optionsToShow: options.slice(0, this.props.truncate),
+            shuffledOptionsToShow: this.state.shuffledAllOptions.slice(
+              0,
+              this.props.truncate
+            )
           })
         : this.setState({
             allOptions: options,
-            optionsToShow: options
+            optionsToShow: options,
+            shuffledOptionsToShow: this.state.shuffledAllOptions
           });
     }
   }
 
   toggleTruncate = () => {
     const { truncate } = this.props;
-    const { expanded, allOptions } = this.state;
+    const {
+      expanded,
+      allOptions,
+      shuffledAllOptions: shuffledAllOptions
+    } = this.state;
     expanded
       ? this.setState({
           optionsToShow: allOptions.slice(0, truncate),
+          shuffledOptionsToShow: shuffledAllOptions.slice(0, truncate),
           expanded: false
         })
       : this.setState({
           optionsToShow: allOptions,
+          shuffledOptionsToShow: shuffledAllOptions,
           expanded: true
         });
   };
@@ -129,7 +138,7 @@ class Poll extends React.Component<Props, State> {
       truncateOptions,
       optionsToShow,
       expanded,
-      shuffledOptionsToShow
+      shuffledOptionsToShow: shuffledOptionsToShow
     } = this.state;
     const { id, title, description, options, hasAnswered, totalVotes } = poll;
     return (

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -22,7 +22,8 @@ type State = {
   truncateOptions: boolean,
   allOptions: Array<OptionEntityRatio>,
   optionsToShow: Array<OptionEntityRatio>,
-  expanded: boolean
+  expanded: boolean,
+  isHovering: boolean
 };
 
 type OptionEntityRatio = OptionEntity & {
@@ -38,14 +39,16 @@ class Poll extends React.Component<Props, State> {
         truncateOptions: true,
         allOptions: options,
         optionsToShow: options.slice(0, props.truncate),
-        expanded: false
+        expanded: false,
+        isHovering: false
       };
     } else {
       this.state = {
         truncateOptions: false,
         allOptions: options,
         optionsToShow: options,
-        expanded: true
+        expanded: true,
+        isHovering: false
       };
     }
   }
@@ -71,9 +74,18 @@ class Poll extends React.Component<Props, State> {
     expanded
       ? this.setState({
           optionsToShow: allOptions.slice(0, truncate),
-          expanded: false
+          expanded: false,
+          isHovering: false
         })
-      : this.setState({ optionsToShow: allOptions, expanded: true });
+      : this.setState({
+          optionsToShow: allOptions,
+          expanded: true,
+          isHovering: false
+        });
+  };
+
+  toggleHover = () => {
+    this.setState({ isHovering: !this.state.isHovering });
   };
 
   optionsWithPerfectRatios = (options: Array<OptionEntity>) => {
@@ -100,7 +112,7 @@ class Poll extends React.Component<Props, State> {
 
   render() {
     const { poll, handleVote, backgroundLight, details } = this.props;
-    const { truncateOptions, optionsToShow, expanded } = this.state;
+    const { truncateOptions, optionsToShow, expanded, isHovering } = this.state;
     const { id, title, description, options, hasAnswered, totalVotes } = poll;
 
     return (
@@ -163,11 +175,47 @@ class Poll extends React.Component<Props, State> {
           </Flex>
         )}
         {!hasAnswered && (
-          <Flex column className={styles.optionWrapper}>
+          <Flex
+            column
+            className={styles.optionWrapper}
+            onMouseEnter={this.toggleHover}
+            onMouseLeave={this.toggleHover}
+            style={{}}
+          >
+            {!expanded && (
+              <Flex
+                style={{ display: isHovering ? 'flex' : 'none' }}
+                className={styles.blurContainer}
+                onClick={this.toggleTruncate}
+              >
+                <p
+                  style={{
+                    marginTop: '25px'
+                  }}
+                  className={styles.blurOverlay}
+                >
+                  Klikk her for å stemme.
+                </p>
+                <Icon
+                  style={{
+                    marginTop: '40px'
+                  }}
+                  className={styles.blurOverlay}
+                  size={60}
+                  name={expanded ? 'arrow-up' : 'arrow-down'}
+                />
+              </Flex>
+            )}
+
             {options &&
               optionsToShow.map(option => (
                 <Flex style={{ justifyContent: 'center' }} key={option.id}>
                   <Button
+                    style={
+                      !expanded && isHovering
+                        ? { filter: 'blur(3px)', pointerEvents: 'none' }
+                        : {}
+                    }
                     className={styles.voteButton}
                     onClick={() => handleVote(poll.id, option.id)}
                   >

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -22,8 +22,7 @@ type State = {
   truncateOptions: boolean,
   allOptions: Array<OptionEntityRatio>,
   optionsToShow: Array<OptionEntityRatio>,
-  expanded: boolean,
-  isHovering: boolean
+  expanded: boolean
 };
 
 type OptionEntityRatio = OptionEntity & {
@@ -39,16 +38,14 @@ class Poll extends React.Component<Props, State> {
         truncateOptions: true,
         allOptions: options,
         optionsToShow: options.slice(0, props.truncate),
-        expanded: false,
-        isHovering: false
+        expanded: false
       };
     } else {
       this.state = {
         truncateOptions: false,
         allOptions: options,
         optionsToShow: options,
-        expanded: true,
-        isHovering: false
+        expanded: true
       };
     }
   }
@@ -74,18 +71,12 @@ class Poll extends React.Component<Props, State> {
     expanded
       ? this.setState({
           optionsToShow: allOptions.slice(0, truncate),
-          expanded: false,
-          isHovering: false
+          expanded: false
         })
       : this.setState({
           optionsToShow: allOptions,
-          expanded: true,
-          isHovering: false
+          expanded: true
         });
-  };
-
-  toggleHover = () => {
-    this.setState({ isHovering: !this.state.isHovering });
   };
 
   optionsWithPerfectRatios = (options: Array<OptionEntity>) => {
@@ -110,11 +101,25 @@ class Poll extends React.Component<Props, State> {
       .sort((a, b) => b.ratio - a.ratio);
   };
 
+  shuffle = array => {
+    let counter = array.length;
+
+    while (counter > 0) {
+      let index = Math.floor(Math.random() * counter);
+      counter--;
+      let temp = array[counter];
+      array[counter] = array[index];
+      array[index] = temp;
+    }
+
+    return array;
+  };
+
   render() {
     const { poll, handleVote, backgroundLight, details } = this.props;
-    const { truncateOptions, optionsToShow, expanded, isHovering } = this.state;
+    const { truncateOptions, optionsToShow, expanded } = this.state;
     const { id, title, description, options, hasAnswered, totalVotes } = poll;
-
+    const shuffledOptionsToShow = this.shuffle(optionsToShow);
     return (
       <div
         className={`${styles.poll} ${backgroundLight ? styles.pollLight : ''}`}
@@ -175,47 +180,29 @@ class Poll extends React.Component<Props, State> {
           </Flex>
         )}
         {!hasAnswered && (
-          <Flex
-            column
-            className={styles.optionWrapper}
-            onMouseEnter={this.toggleHover}
-            onMouseLeave={this.toggleHover}
-            style={{}}
-          >
+          <Flex column className={styles.optionWrapper}>
             {!expanded && (
               <Flex
-                style={{ display: isHovering ? 'flex' : 'none' }}
                 className={styles.blurContainer}
                 onClick={this.toggleTruncate}
               >
-                <p
-                  style={{
-                    marginTop: '25px'
-                  }}
-                  className={styles.blurOverlay}
-                >
-                  Klikk her for å stemme.
-                </p>
+                <p className={styles.blurOverlay}>Klikk her for å stemme.</p>
                 <Icon
-                  style={{
-                    marginTop: '40px'
-                  }}
-                  className={styles.blurOverlay}
+                  className={`${styles.blurOverlay} ${styles.blurArrow}`}
                   size={60}
                   name={expanded ? 'arrow-up' : 'arrow-down'}
                 />
               </Flex>
             )}
-
             {options &&
-              optionsToShow.map(option => (
-                <Flex style={{ justifyContent: 'center' }} key={option.id}>
+              shuffledOptionsToShow.map(option => (
+                <Flex
+                  className={`${styles.alignItems} ${
+                    expanded ? '' : styles.blurEffect
+                  }`}
+                  key={option.id}
+                >
                   <Button
-                    style={
-                      !expanded && isHovering
-                        ? { filter: 'blur(3px)', pointerEvents: 'none' }
-                        : {}
-                    }
                     className={styles.voteButton}
                     onClick={() => handleVote(poll.id, option.id)}
                   >
@@ -229,7 +216,7 @@ class Poll extends React.Component<Props, State> {
           <div className={styles.moreOptionsLink}>
             <span>{`Stemmer: ${totalVotes}`}</span>
             {truncateOptions && (
-              <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <div className={styles.alignItems}>
                 <Icon
                   onClick={this.toggleTruncate}
                   className={styles.arrow}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26925695/67414396-4bc2db80-f5c3-11e9-9b72-6ccc23835af2.png)

With this change, users have to click before giving their vote. A blur effect is applied when the user hovers over the poll. 

Solves https://github.com/webkom/lego/issues/1712 (Needs to be marked as closed manually)