### PR TITLE
Fix sentry error in company interest list

### DIFF
--- a/app/routes/companyInterest/components/CompanyInterestList.js
+++ b/app/routes/companyInterest/components/CompanyInterestList.js
@@ -77,6 +77,7 @@ class CompanyInterestList extends Component<Props, State> {
   };
 
   handleChange = (clickedOption: Option): void => {
+    if (!clickedOption) return;
     const { id } = clickedOption;
     this.props
       .fetch({


### PR DESCRIPTION
Solves https://github.com/webkom/lego/issues/1713.

This should solve the following sentry error. This error is not visible to the user, so it is a bit hard to reproduce.
https://sentry.abakus.no/webkom/lego-webapp/issues/7654/?referrer=slack