### PR TITLE
Ensure the Freshness™ of random quotes

### DIFF
--- a/app/actions/QuoteActions.js
+++ b/app/actions/QuoteActions.js
@@ -7,6 +7,7 @@ import callAPI from 'app/actions/callAPI';
 import { Quote } from './ActionTypes';
 import { addToast } from 'app/actions/ToastActions';
 import type { Thunk } from 'app/types';
+import type { ID } from 'app/models';
 
 const getEndpoint = (state, loadNextPage, queryString) => {
   const pagination = state.quotes.pagination;
@@ -79,12 +80,14 @@ export function fetchQuote(quoteId: number) {
   });
 }
 
-export function fetchRandomQuote() {
+export function fetchRandomQuote(seenQuotes?: Array<ID> = []) {
+  const queryString = `?seen=[${String(seenQuotes)}]`;
   return callAPI({
     types: Quote.FETCH_RANDOM,
-    endpoint: '/quotes/random/',
+    endpoint: '/quotes/random/' + queryString,
     method: 'GET',
     meta: {
+      queryString,
       errorMessage: 'Henting av tilfeldig quote feilet'
     },
     useCache: false,

--- a/app/components/RandomQuote/RandomQuote.js
+++ b/app/components/RandomQuote/RandomQuote.js
@@ -1,5 +1,6 @@
 // @flow
 
+// $FlowFixMe
 import React, { useState, useEffect } from 'react';
 import styles from './RandomQuote.css';
 import Button from '../Button';

--- a/app/components/RandomQuote/RandomQuote.js
+++ b/app/components/RandomQuote/RandomQuote.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './RandomQuote.css';
 import Button from '../Button';
 import type { QuoteEntity } from 'app/reducers/quotes';
@@ -11,7 +11,7 @@ import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import { Flex } from 'app/components/Layout';
 
 type Props = {
-  fetchRandomQuote: () => Promise<Object>,
+  fetchRandomQuote: (Array<ID>) => Promise<Object>,
   className?: string,
   addReaction: ({
     emoji: string,
@@ -35,6 +35,15 @@ const RandomQuote = (props: Props) => {
     currentQuote
   } = props;
 
+  const [seenQuotes, setSeenQuotes] = useState([]);
+
+  useEffect(() => {
+    const quoteId = props.currentQuote.id;
+    if (!seenQuotes.includes(quoteId)) {
+      setSeenQuotes([...seenQuotes, quoteId]);
+    }
+  });
+
   return (
     <div className={className ? className : ''}>
       <Flex justifyContent="space-between" alignItems="flex-start">
@@ -46,7 +55,7 @@ const RandomQuote = (props: Props) => {
         <Flex column justifyContent="space-between" className={styles.actions}>
           <Button
             flat
-            onClick={() => props.fetchRandomQuote()}
+            onClick={() => props.fetchRandomQuote(seenQuotes)}
             className={styles.fetchNew}
           >
             <i className="fa fa-refresh" />


### PR DESCRIPTION
Depends on the backend in https://github.com/webkom/lego/pull/1715.

Adds a local state to Random Quote (through hooks 😎) that keeps track of what random quotes the user already has seen. This prevents getting duplicates when repeatedly clicking ♻️to browse multiple random quotes, which of course is a behaviour we want to support.

When all quotes have been seen, the backend falls back to providing "stale" quotes.