### PR TITLE
Bump @webkom/react-prepare to v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "github.com/webkom/lego-webapp"
   },
   "dependencies": {
-    "@webkom/react-prepare": "^0.5.7",
+    "@webkom/react-prepare": "0.6.0",
     "animate.css": "^3.7.0",
     "bunyan": "^1.8.12",
     "bunyan-pretty": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,10 +1216,10 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@webkom/react-prepare@^0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@webkom/react-prepare/-/react-prepare-0.5.7.tgz#84a1788c444dea13e3633875533d4dce9c1c5632"
-  integrity sha512-cNt9a5cZEUbtKAYHz0QLp76JvA6NLtuutMBFDyC1jnehPX3XymPNKl8IWVqRpbQJT1FbhU+Cp+lBFl+8VcxdhQ==
+"@webkom/react-prepare@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@webkom/react-prepare/-/react-prepare-0.6.0.tgz#3cdd4064e5c561a1fdfd77ecba6c5ee583bcc000"
+  integrity sha512-vn+TOJjqBzkLSYTwoWLlG41tpbKJS/msPUe7YiJ4vFybAJmcFHne51z59n40zuuBh53y/LJ5eRLL4eQxZqj0BQ==
   dependencies:
     babel-runtime "^6.11.6"
 


### PR DESCRIPTION
This adds support for React.Context consumers (together with the
providers). Providers didn't crash the prepare util previously, as they
were just ignored.