### PR TITLE
Fix image aspect ratio

### DIFF
--- a/app/components/Image/Image.css
+++ b/app/components/Image/Image.css
@@ -1,4 +1,4 @@
 .image {
   width: 100%;
-  height: 100%;
+  height: auto;
 }

--- a/app/routes/overview/components/ArticleItem.css
+++ b/app/routes/overview/components/ArticleItem.css
@@ -20,12 +20,8 @@
 
 .image {
   object-fit: cover;
-  height: 100px;
-
-  @media (--mobile-device) {
-    width: 100%;
-    height: auto;
-  }
+  width: 100%;
+  height: auto;
 }
 
 .articleTitle {


### PR DESCRIPTION
Fixes an issue where images using the `<Image/>` component did not retain aspect ratio. As well as the article component on the frontpage.

Resolves https://github.com/webkom/lego/issues/1733
Resolves https://github.com/webkom/lego/issues/1732