### PR TITLE
Fix double/triple fetching of random quote

### DIFF
--- a/app/components/RandomQuote/index.js
+++ b/app/components/RandomQuote/index.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import { compose } from 'redux';
+import { isEmpty } from 'lodash';
 import prepare from 'app/utils/prepare';
 import { fetchRandomQuote } from 'app/actions/QuoteActions';
 import { connect } from 'react-redux';
@@ -35,12 +36,15 @@ const LoginToSeeQuotes = () => <div>Logg inn for å se sitater.</div>;
 
 export default compose(
   replaceUnlessLoggedIn(LoginToSeeQuotes),
-  prepare((props, dispatch) =>
-    Promise.all([dispatch(fetchRandomQuote()), dispatch(fetchEmojis())])
-  ),
   connect(
     mapStateToProps,
     mapDispatchToProps
+  ),
+  prepare((props, dispatch) =>
+    Promise.all([
+      isEmpty(props.currentQuote) && dispatch(fetchRandomQuote()),
+      dispatch(fetchEmojis())
+    ])
   ),
   loadingIndicator(['currentQuote.id'])
 )(RandomQuote);


### PR DESCRIPTION
Since the quote is fetched during ssr, it doesn't have to be fetched on
the client. Only fetch using prepare when there is no quote. The "new
random quote" button will still work.

This fixes the annoying flicker when the random quote change during
first client render.