### PR TITLE
Fix a shitload of gallery scrolling issues

### DIFF
--- a/app/Root.js
+++ b/app/Root.js
@@ -40,7 +40,23 @@ const RouteHandler = connect(
       <Router
         onError={err => setStatusCode(500)}
         {...restProps}
-        render={applyRouterMiddleware(useScroll())}
+        render={applyRouterMiddleware(
+          useScroll((prevRouterProps, { location, routes }) => {
+            if (
+              prevRouterProps &&
+              location.pathname === prevRouterProps.location.pathname
+            )
+              return false;
+            if (
+              routes
+                .concat(prevRouterProps ? prevRouterProps.routes : [])
+                .some(route => route.ignoreScrollBehavior)
+            ) {
+              return false;
+            }
+            return true;
+          })
+        )}
       />
     </ErrorBoundary>
   )

--- a/app/components/NavigationTab/NavigationLink.js
+++ b/app/components/NavigationTab/NavigationLink.js
@@ -7,7 +7,7 @@ import styles from './NavigationLink.css';
 
 type Props = {
   to?: string,
-  onClick?: () => void,
+  onClick?: (e: Event) => void,
   children?: Node
 };
 

--- a/app/routes/photos/components/GalleryDetail.js
+++ b/app/routes/photos/components/GalleryDetail.js
@@ -67,7 +67,15 @@ export default class GalleryDetail extends Component<Props, State> {
           title={gallery.title}
           details={<GalleryDetailsRow gallery={gallery} showDescription />}
         >
-          <NavigationLink to={'/photos'}>
+          <NavigationLink
+            onClick={(e: Event) => {
+              // TODO fix this hack when react-router is done
+              if (!window.location.hash) return;
+              window.history.back();
+              e.preventDefault();
+            }}
+            to={'/photos'}
+          >
             <i className="fa fa-angle-left" /> Tilbake
           </NavigationLink>
           {actionGrant && actionGrant.includes('edit') && (

--- a/app/routes/photos/components/GalleryPictureModal.js
+++ b/app/routes/photos/components/GalleryPictureModal.js
@@ -18,6 +18,7 @@ import type { EntityID } from 'app/types';
 import type { ID } from 'app/models';
 import Button from 'app/components/Button';
 import { Image } from 'app/components/Image';
+// $FlowFixMe
 import { useEffect } from 'react';
 
 type Props = {

--- a/app/routes/photos/components/GalleryPictureModal.js
+++ b/app/routes/photos/components/GalleryPictureModal.js
@@ -18,6 +18,7 @@ import type { EntityID } from 'app/types';
 import type { ID } from 'app/models';
 import Button from 'app/components/Button';
 import { Image } from 'app/components/Image';
+import { useEffect } from 'react';
 
 type Props = {
   picture: Object,
@@ -44,7 +45,16 @@ type State = {
   hasNext: boolean,
   hasPrevious: boolean
 };
-
+const OnKeyDownHandler = ({ handler }: { handler: KeyboardEvent => void }) => (
+  useEffect(
+    () => (
+      window.addEventListener('keydown', handler),
+      () => window.removeEventListener('keydown', handler)
+    ),
+    [handler]
+  ),
+  null
+);
 const Taggees = ({ taggees }: { taggees: Array<Object> }) => {
   if (taggees.length === 1) {
     return (
@@ -161,7 +171,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
     trailing: false
   });
 
-  handleKeyDown = (e: KeyboardEvent) => {
+  handleKeyDown = (e: KeyboardEvent): void => {
     // Dont handle events inside the comment form... :smile:
     // $FlowFixMe
     if (e.target.className === 'notranslate public-DraftEditor-content') {
@@ -205,13 +215,11 @@ export default class GalleryPictureModal extends Component<Props, State> {
       <Swipeable onSwiping={this.handleSwipe}>
         <Modal
           onHide={() => push(`/photos/${gallery.id}`)}
-          backdropClassName={styles.backdrop}
-          backdrop
           show
+          backdrop
           contentClassName={styles.content}
-          autoFocus
-          onKeyDown={this.handleKeyDown}
         >
+          <OnKeyDownHandler handler={this.handleKeyDown} />
           <Content className={styles.topContent}>
             <Flex
               width="100%"

--- a/app/routes/photos/components/Overview.js
+++ b/app/routes/photos/components/Overview.js
@@ -39,7 +39,7 @@ export default class Overview extends Component<Props> {
           hasMore={hasMore}
           fetching={fetching}
           fetchNext={() => fetch({ next: true })}
-          onClick={gallery => push(`/photos/${gallery.id}`)}
+          onClick={gallery => push(`/photos/${gallery.id}#list`)}
           renderBottom={photo => (
             <div className={styles.galleryInfo}>
               <h4 className={styles.galleryTitle}>{photo.title}</h4>

--- a/app/routes/photos/index.js
+++ b/app/routes/photos/index.js
@@ -18,10 +18,12 @@ export default {
       childRoutes: [
         {
           path: 'picture/:pictureId/edit',
+          ignoreScrollBehavior: true,
           ...resolveAsyncRoute(() => import('./GalleryPictureEditRoute'))
         },
         {
           path: 'picture/:pictureId',
+          ignoreScrollBehavior: true,
           ...resolveAsyncRoute(() => import('./GalleryPictureRoute'))
         }
       ]


### PR DESCRIPTION
Changes:

91db5ec1 (Odin Ugedal, 75 seconds ago)
   Fix scrolling to the botton when viewing photos

   onKeyDown is shitty

393f0d25 (Odin Ugedal, 2 minutes ago)
   Add hack that retains the scroll position

   When clicking "Back", it will use history.back in case there is something
   in the hash. This is only the case if the previous page was
   /photos

87a2fdda (Odin Ugedal, 3 minutes ago)
   Don't scroll when navigating inside gallery