### PR TITLE
Refetch quotes on query change

### DIFF
--- a/app/routes/quotes/QuotesRoute.js
+++ b/app/routes/quotes/QuotesRoute.js
@@ -49,18 +49,21 @@ const mapDispatchToProps = {
 
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
-  prepare((props, dispatch) => {
-    const {
-      location: { query }
-    } = props;
-    if (query.filter === 'unapproved') {
-      return dispatch(
-        fetchAllUnapproved({ loadNextPage: false }),
-        fetchEmojis()
-      );
-    }
-    return dispatch(fetchAllApproved({ loadNextPage: false }), fetchEmojis());
-  }),
+  prepare(
+    (props, dispatch) => {
+      const {
+        location: { query }
+      } = props;
+      if (query.filter === 'unapproved') {
+        return dispatch(
+          fetchAllUnapproved({ loadNextPage: false }),
+          fetchEmojis()
+        );
+      }
+      return dispatch(fetchAllApproved({ loadNextPage: false }), fetchEmojis());
+    },
+    ['location']
+  ),
   connect(
     mapStateToProps,
     mapDispatchToProps


### PR DESCRIPTION
Fixes an issue where the quotes route did not fetch approved/unapproved routes upon changing the query params.