### PR TITLE
Fetch groups before memberships on pages

### DIFF
--- a/app/routes/pages/PageDetailRoute.js
+++ b/app/routes/pages/PageDetailRoute.js
@@ -97,7 +97,7 @@ const getSection = sectionName =>
     fetchItemActions: []
   };
 
-const loadData = (props, dispatch) => {
+const loadData = async (props, dispatch) => {
   const { fetchItemActions } = getSection(props.params.section);
   const { pageSlug } = props.params;
 
@@ -109,13 +109,17 @@ const loadData = (props, dispatch) => {
         .concat(dispatch(fetchAllPages()))
     );
   }
+  const itemActions = [];
 
+  for (let i = 0; i < fetchItemActions.length; i++) {
+    itemActions[i] = await dispatch(fetchItemActions[i](pageSlug));
+  }
   return Promise.all(
     Object.keys(sections)
       .map(key => sections[key].fetchAll)
       .filter(Boolean)
       .map(fetch => dispatch(fetch()))
-      .concat(fetchItemActions.map(action => dispatch(action(pageSlug))))
+      .concat(itemActions)
   );
 };
 


### PR DESCRIPTION
I know the for loop is not ideal, yet none of the array.prototype was able to execute the dispatches in the correct order. Fixing this sentry error.
https://sentry.abakus.no/webkom/lego-webapp/issues/8198/?referrer=slack