### PR TITLE
Company interest / BDB requests

### DIFF
--- a/app/components/Form/SelectInput.js
+++ b/app/components/Form/SelectInput.js
@@ -88,6 +88,10 @@ function SelectInput({
 }
 
 SelectInput.Field = createField(SelectInput);
-SelectInput.AutocompleteField = withAutocomplete(SelectInput.Field);
-SelectInput.withAutocomplete = withAutocomplete(SelectInput);
+SelectInput.AutocompleteField = withAutocomplete({
+  WrappedComponent: SelectInput.Field
+});
+SelectInput.withAutocomplete = withAutocomplete({
+  WrappedComponent: SelectInput
+});
 export default SelectInput;

--- a/app/components/Search/withAutocomplete.js
+++ b/app/components/Search/withAutocomplete.js
@@ -16,10 +16,13 @@ type State = {
   result: Array</*Todo: AutocompleteResult */ Object>
 };
 
-function withAutocomplete<Props: {}>(
+function withAutocomplete<Props>({
+  WrappedComponent,
+  retainFailedQuery = false
+}: {
   WrappedComponent: ComponentType<Props>,
-  retainFailedQuery: boolean = false
-) {
+  retainFailedQuery?: boolean
+}) {
   const displayName =
     WrappedComponent.displayName || WrappedComponent.name || 'Unknown';
 

--- a/app/components/Search/withAutocomplete.js
+++ b/app/components/Search/withAutocomplete.js
@@ -78,9 +78,7 @@ function withAutocomplete<Props>({
         <WrappedComponent
           {...restProps}
           options={this.state.result}
-          onSearch={debounce(query => {
-            this.handleSearch(query, filter);
-          }, 100)}
+          onSearch={debounce(query => this.handleSearch(query, filter), 100)}
           fetching={this.state.searching}
         />
       );

--- a/app/components/Search/withAutocomplete.js
+++ b/app/components/Search/withAutocomplete.js
@@ -52,10 +52,12 @@ function withAutocomplete<Props>({
       this.props
         .autocomplete(query, filter)
         .then(result => {
-          const queryObj = retainFailedQuery
-            ? [{ title: query, label: query }]
-            : [];
-          const finalResult = result.length > 0 ? result : queryObj;
+          // Set the result to the response result
+          let finalResult = result;
+          // Retain a query with no match
+          if (retainFailedQuery && result.length == 0) {
+            finalResult = [{ title: query, label: query }];
+          }
 
           if (this._isMounted) {
             this.setState({

--- a/app/routes/bdb/components/OptionsBox.js
+++ b/app/routes/bdb/components/OptionsBox.js
@@ -63,6 +63,7 @@ export default class OptionsBox extends Component<Props, State> {
   };
 
   render() {
+    console.log('state', this.state);
     return (
       <div className={styles.optionsBox}>
         <span

--- a/app/routes/bdb/components/OptionsBox.js
+++ b/app/routes/bdb/components/OptionsBox.js
@@ -63,7 +63,6 @@ export default class OptionsBox extends Component<Props, State> {
   };
 
   render() {
-    console.log('state', this.state);
     return (
       <div className={styles.optionsBox}>
         <span

--- a/app/routes/bdb/components/SemesterStatusContent.js
+++ b/app/routes/bdb/components/SemesterStatusContent.js
@@ -35,11 +35,9 @@ export default class SemesterStatusContent extends Component<Props, State> {
     const statusesToRender = (
       <div style={{ width: '100%', ...style }}>
         {semesterStatus.contactedStatus.length > 0
-          ? sortStatusesByProminence(semesterStatus.contactedStatus).map(
-              (status, i) =>
-                getStatusString(status) +
-                (i !== semesterStatus.contactedStatus.length - 1 ? ', ' : '')
-            )
+          ? sortStatusesByProminence(semesterStatus.contactedStatus)
+              .map(status => getStatusString(status))
+              .join(', ')
           : getStatusString('not_contacted')}
       </div>
     );

--- a/app/routes/bdb/components/SemesterStatusContent.js
+++ b/app/routes/bdb/components/SemesterStatusContent.js
@@ -36,6 +36,7 @@ export default class SemesterStatusContent extends Component<Props, State> {
       <div style={{ width: '100%', ...style }}>
         {semesterStatus.contactedStatus.length > 0
           ? semesterStatus.contactedStatus
+              .slice()
               .sort(sortStatusesByProminence)
               .map(
                 (status, i) =>

--- a/app/routes/bdb/components/SemesterStatusContent.js
+++ b/app/routes/bdb/components/SemesterStatusContent.js
@@ -35,21 +35,18 @@ export default class SemesterStatusContent extends Component<Props, State> {
     const statusesToRender = (
       <div style={{ width: '100%', ...style }}>
         {semesterStatus.contactedStatus.length > 0
-          ? semesterStatus.contactedStatus
-              .slice()
-              .sort(sortStatusesByProminence)
-              .map(
-                (status, i) =>
-                  getStatusString(status) +
-                  (i !== semesterStatus.contactedStatus.length - 1 ? ', ' : '')
-              )
+          ? sortStatusesByProminence(semesterStatus.contactedStatus).map(
+              (status, i) =>
+                getStatusString(status) +
+                (i !== semesterStatus.contactedStatus.length - 1 ? ', ' : '')
+            )
           : getStatusString('not_contacted')}
       </div>
     );
 
-    const statusCodes = Object.keys(statusStrings)
-      .sort(sortStatusesByProminence)
-      .filter(code => code !== 'not_contacted');
+    const statusCodes = sortStatusesByProminence(
+      Object.keys(statusStrings)
+    ).filter(code => code !== 'not_contacted');
 
     const dropDownItems = (
       <Dropdown.List>

--- a/app/routes/bdb/utils.js
+++ b/app/routes/bdb/utils.js
@@ -54,6 +54,11 @@ export const sortStatusesByProminence = (
     contacted: 6,
     not_contacted: 7
   };
+  console.log(
+    'asd',
+    priority[a] === undefined ||
+      priority[b === undefined && 'asdasdasdasdasdasdasasd']
+  );
   return priority[a] - priority[b];
 };
 

--- a/app/routes/bdb/utils.js
+++ b/app/routes/bdb/utils.js
@@ -51,10 +51,15 @@ const priority = {
   contacted: 6,
   not_contacted: 7
 };
+
+export const sortStatusesByProminence = (
+  statuses: Array<CompanySemesterContactedStatus>
+) => sortBy(statuses, status => priority[status]);
+
 export const selectMostProminentStatus = (
   statuses: Array<CompanySemesterContactedStatus> = []
 ) => {
-  return sortBy(statuses, status => priority[status])[0];
+  return sortStatusesByProminence(statuses)[0];
 };
 
 export const semesterNameOf = (index: number) => {
@@ -126,7 +131,7 @@ export const getContactedStatuses = (
   contactedStatuses: Array<CompanySemesterContactedStatus>,
   statusString: CompanySemesterContactedStatus
 ) => {
-  const contacted = contactedStatuses.slice();
+  const contacted: Array<CompanySemesterContactedStatus> = contactedStatuses.slice();
   const statusIsAlreadySelected = contacted.indexOf(statusString) !== -1;
 
   if (statusIsAlreadySelected) {

--- a/app/routes/bdb/utils.js
+++ b/app/routes/bdb/utils.js
@@ -7,6 +7,7 @@ import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import type { Semester } from 'app/models';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import type { CompanySemesterContactedStatus } from 'app/models';
+import { sortBy } from 'lodash';
 
 export const statusStrings = {
   company_presentation: 'Bedpres',
@@ -40,32 +41,20 @@ export const selectColorCode = (
   return statusToClass[status];
 };
 
-export const sortStatusesByProminence = (
-  a: CompanySemesterContactedStatus,
-  b: CompanySemesterContactedStatus
-) => {
-  const priority = {
-    bedex: 0,
-    company_presentation: 1,
-    course: 2,
-    lunch_presentation: 3,
-    interested: 4,
-    not_interested: 5,
-    contacted: 6,
-    not_contacted: 7
-  };
-  console.log(
-    'asd',
-    priority[a] === undefined ||
-      priority[b === undefined && 'asdasdasdasdasdasdasasd']
-  );
-  return priority[a] - priority[b];
+const priority = {
+  bedex: 0,
+  company_presentation: 1,
+  course: 2,
+  lunch_presentation: 3,
+  interested: 4,
+  not_interested: 5,
+  contacted: 6,
+  not_contacted: 7
 };
-
 export const selectMostProminentStatus = (
   statuses: Array<CompanySemesterContactedStatus> = []
 ) => {
-  return statuses.sort(sortStatusesByProminence)[0];
+  return sortBy(statuses, status => priority[status])[0];
 };
 
 export const semesterNameOf = (index: number) => {
@@ -137,36 +126,33 @@ export const getContactedStatuses = (
   contactedStatuses: Array<CompanySemesterContactedStatus>,
   statusString: CompanySemesterContactedStatus
 ) => {
-  const statusIsAlreadySelected =
-    contactedStatuses.indexOf(statusString) !== -1;
+  const contacted = contactedStatuses.slice();
+  const statusIsAlreadySelected = contacted.indexOf(statusString) !== -1;
 
   if (statusIsAlreadySelected) {
-    contactedStatuses.splice(contactedStatuses.indexOf(statusString), 1);
+    contacted.splice(contacted.indexOf(statusString), 1);
   } else {
-    contactedStatuses.push(statusString);
+    contacted.push(statusString);
   }
 
   // Remove 'not contacted' if anything else is selected
-  if (
-    contactedStatuses.length > 1 &&
-    contactedStatuses.indexOf('not_contacted') !== -1
-  ) {
-    contactedStatuses.splice(contactedStatuses.indexOf('not_contacted'), 1);
+  if (contacted.length > 1 && contacted.indexOf('not_contacted') !== -1) {
+    contacted.splice(contacted.indexOf('not_contacted'), 1);
   }
 
   // Remove 'contacted', 'not_interested and 'interested'
   // as a statuses if any the other statuses are selected
   ['contacted', 'not_interested', 'interested'].map(status => {
     if (
-      contactedStatuses.length > 1 &&
-      contactedStatuses.indexOf(status) !== -1 &&
+      contacted.length > 1 &&
+      contacted.indexOf(status) !== -1 &&
       status !== statusString
     ) {
-      contactedStatuses.splice(contactedStatuses.indexOf(status), 1);
+      contacted.splice(contacted.indexOf(status), 1);
     }
   });
 
-  return contactedStatuses;
+  return contacted;
 };
 
 export const ListNavigation = ({ title }: { title: Node }) => (

--- a/app/routes/companyInterest/CompanyInterestEditRoute.js
+++ b/app/routes/companyInterest/CompanyInterestEditRoute.js
@@ -28,6 +28,7 @@ const mapStateToProps = (state, props) => {
   const companyInterest = selectCompanyInterestById(state, {
     companyInterestId
   });
+
   const semesters = selectCompanySemesters(state);
   if (!companyInterest || !semesters)
     return {

--- a/app/routes/companyInterest/CompanyInterestEditRoute.js
+++ b/app/routes/companyInterest/CompanyInterestEditRoute.js
@@ -42,6 +42,16 @@ const mapStateToProps = (state, props) => {
     allowedBdb,
     initialValues: {
       ...companyInterest,
+      company: companyInterest.company
+        ? {
+            label: companyInterest.company.name,
+            title: companyInterest.company.name,
+            value: '' + companyInterest.company.id
+          }
+        : {
+            label: companyInterest.companyName,
+            title: companyInterest.companyName
+          },
       events: allEvents.map(event => ({
         name: event,
         checked:

--- a/app/routes/companyInterest/components/CompanyInterestList.js
+++ b/app/routes/companyInterest/components/CompanyInterestList.js
@@ -100,7 +100,6 @@ class CompanyInterestList extends Component<Props, State> {
         title: 'Bedriftsnavn',
         dataIndex: 'companyName',
         render: (companyName: string, companyInterest: Object) => {
-          console.log('rendering', companyInterest.company, companyName);
           return (
             <Link to={`/companyInterest/${companyInterest.id}/edit`}>
               {companyInterest.company

--- a/app/routes/companyInterest/components/CompanyInterestList.js
+++ b/app/routes/companyInterest/components/CompanyInterestList.js
@@ -99,11 +99,16 @@ class CompanyInterestList extends Component<Props, State> {
       {
         title: 'Bedriftsnavn',
         dataIndex: 'companyName',
-        render: (companyName: string, companyInterest: Object) => (
-          <Link to={`/companyInterest/${companyInterest.id}/edit`}>
-            {companyName}
-          </Link>
-        )
+        render: (companyName: string, companyInterest: Object) => {
+          console.log('rendering', companyInterest.company, companyName);
+          return (
+            <Link to={`/companyInterest/${companyInterest.id}/edit`}>
+              {companyInterest.company
+                ? companyInterest.company.name
+                : companyName}
+            </Link>
+          );
+        }
       },
       {
         title: 'Kontaktperson',

--- a/app/routes/companyInterest/components/CompanyInterestList.js
+++ b/app/routes/companyInterest/components/CompanyInterestList.js
@@ -99,15 +99,13 @@ class CompanyInterestList extends Component<Props, State> {
       {
         title: 'Bedriftsnavn',
         dataIndex: 'companyName',
-        render: (companyName: string, companyInterest: Object) => {
-          return (
-            <Link to={`/companyInterest/${companyInterest.id}/edit`}>
-              {companyInterest.company
-                ? companyInterest.company.name
-                : companyName}
-            </Link>
-          );
-        }
+        render: (companyName: string, companyInterest: Object) => (
+          <Link to={`/companyInterest/${companyInterest.id}/edit`}>
+            {companyInterest.company
+              ? companyInterest.company.name
+              : companyName}
+          </Link>
+        )
       },
       {
         title: 'Kontaktperson',

--- a/app/routes/companyInterest/components/CompanyInterestPage.js
+++ b/app/routes/companyInterest/components/CompanyInterestPage.js
@@ -7,6 +7,7 @@ import {
   TextInput,
   Button,
   CheckBox,
+  SelectInput,
   Form
 } from 'app/components/Form';
 import { Image } from 'app/components/Image';
@@ -23,6 +24,7 @@ import { FlexRow } from '../../../components/FlexBox';
 import { Link } from 'react-router';
 import norwegian from 'app/assets/norway.svg';
 import english from 'app/assets/great_britain.svg';
+import withAutocomplete from 'app/components/Search/withAutocomplete';
 
 export const EVENT_TYPES = {
   company_presentation: {
@@ -165,10 +167,16 @@ const CompanyInterestPage = (props: Props) => {
   }
 
   const onSubmit = data => {
+    const { company } = data;
+    const companyId = company['value'] ? Number(company['value']) : null;
+    const companyName = companyId === null ? company['label'] : '';
+
     const newData = {
-      companyName: data.companyName,
+      companyName: companyName,
+      company: companyId,
       contactPerson: data.contactPerson,
       mail: data.mail,
+      phone: data.phone,
       semesters: data.semesters
         .filter(semester => semester.checked)
         .map(semester => semester.id),
@@ -202,7 +210,7 @@ const CompanyInterestPage = (props: Props) => {
       norwegian: 'Meld interesse',
       english: 'Contact us'
     },
-    companyName: {
+    company: {
       header: {
         norwegian: 'Navn på bedrift',
         english: 'Company'
@@ -225,6 +233,10 @@ const CompanyInterestPage = (props: Props) => {
     mail: {
       norwegian: 'Mail',
       english: 'E-Mail'
+    },
+    phone: {
+      norwegian: 'Telefonnummer',
+      english: 'Phone number'
     },
     semester: {
       norwegian: 'Semester',
@@ -263,11 +275,14 @@ const CompanyInterestPage = (props: Props) => {
             <LanguageFlag language={language} />
           </Link>
         </FlexRow>
+
         <Field
-          label={labels.companyName.header[language]}
-          placeholder={labels.companyName.placeholder[language]}
-          name="companyName"
-          component={TextInput.Field}
+          name="company"
+          label={labels.company.header[language]}
+          placeholder={labels.company.placeholder[language]}
+          filter={['companies.company']}
+          fieldClassName={styles.metaField}
+          component={withAutocomplete(SelectInput.Field, true)}
           required
         />
         <Field
@@ -281,6 +296,13 @@ const CompanyInterestPage = (props: Props) => {
           label={labels.mail[language]}
           placeholder="example@gmail.com"
           name="mail"
+          component={TextInput.Field}
+          required
+        />
+        <Field
+          label={labels.phone[language]}
+          placeholder="+47 909 09 090"
+          name="phone"
           component={TextInput.Field}
           required
         />
@@ -354,9 +376,10 @@ const CompanyInterestPage = (props: Props) => {
 };
 
 const validate = createValidator({
-  companyName: [required()],
+  company: [required()],
   contactPerson: [required()],
   mail: [required(), isEmail()],
+  phone: [required()],
   comment: [required()]
 });
 

--- a/app/routes/companyInterest/components/CompanyInterestPage.js
+++ b/app/routes/companyInterest/components/CompanyInterestPage.js
@@ -282,7 +282,10 @@ const CompanyInterestPage = (props: Props) => {
           placeholder={labels.company.placeholder[language]}
           filter={['companies.company']}
           fieldClassName={styles.metaField}
-          component={withAutocomplete(SelectInput.Field, true)}
+          component={withAutocomplete({
+            WrappedComponent: SelectInput.Field,
+            retainFailedQuery: true
+          })}
           required
         />
         <Field

--- a/app/routes/companyInterest/utils.js
+++ b/app/routes/companyInterest/utils.js
@@ -52,34 +52,21 @@ export const semesterToText = ({
 
 export const interestText = {
   comment: {
-    norwegian:
-      'For at vi skal kunne legge tilrette for deres ønsker på best ' +
-      'mulig måte, ønsker vi at dere skriver litt om hvordan dere ' +
-      'ønsker å gjennomføre arrangementet.',
-    english:
-      'Please explain your expectations and plans for the event to help us take your preferences ' +
-      'into consideration.'
+    norwegian: 'Skriv om bedriften eller arrangementet.',
+    english: 'Write about your company or the event.'
   },
   text: {
     first: {
       norwegian:
-        'Dersom dere ønsker noe utenfor de vanlige rammene, huk gjerne av på ' +
-        '“Alternativt arrangement” og skriv en kommentar om hva dere kunne ' +
-        'tenkt dere å gjøre i kommentarfeltet. Vi i Abakus ønsker å kunne tilby ' +
-        'et bredt spekter av arrangementer som er gunstig for våre studenter. ',
+        'Dersom dere ikke har hatt arrangement med Abakus før, eller om det er lenge siden vi har samarbeidet, ønsker vi at dere skriver litt om selskapet. Dette hjelper oss mye når vi skal sette sammen arrangementskalenderen.',
       english:
-        'If you wish to host something different than a traditional event, you can check the “other” box and ' +
-        'write a comment explaining what you have in mind. Abakus wishes to ' +
-        'offer a wide range of events that are beneficial for our students. '
+        "If you haven't held an event with Abakus previously, or if it has been a long time since we cooperated, we would like if you told us a bit about your company. This helps us when distributing dates for events."
     },
     second: {
       norwegian:
-        'Kommentarfeltet kan også brukes til å spesifisere annen informasjon, ' +
-        'som for eksempel hvilken teknologi dere ønsker å lære bort hvis dere ' +
-        'får faglig arrangement.',
+        'Vi ønsker også at dere skriver litt om hva slags type arrangement dere ser for dere å holde. Ønsker dere å gjøre noe utenfor de vanlige rammene, eller helst en standard bedpres? Uansett vil vi gjerne vite det!',
       english:
-        'The comment box can also be used for other types of information, such as ' +
-        'which technologies you would like to present for our students when hosting a course or a workshop.'
+        "We'd prefer that you also write a little bit about what kind of event you would like to have. Do you want something outside the given options, or is it a regular company presentation? Either way, we'd like to know!"
     }
   },
   bedex: {

--- a/cypress/integration/company_interest_spec.js
+++ b/cypress/integration/company_interest_spec.js
@@ -1,11 +1,16 @@
-import { field } from '../support/utils.js';
+import { field, selectField } from '../support/utils.js';
 
 const createCompanyInterest = () => {
   cy.visit('/interesse');
 
-  field('companyName')
-    .click()
-    .type('webkom consulting');
+  // Select company
+  selectField('company').click();
+  cy.focused().type('BEKK', { force: true });
+  selectField('company')
+    .find('.Select-menu-outer')
+    .should('not.contain', 'No results')
+    .and('contain', 'BEKK');
+  cy.focused().type('{enter}', { force: true });
 
   field('contactPerson')
     .click()
@@ -14,6 +19,10 @@ const createCompanyInterest = () => {
   field('mail')
     .click()
     .type('webkom@webkom.no');
+
+  field('phone')
+    .click()
+    .type('90909090');
 
   field('semesters[0].checked').check();
   field('events[0].checked').check();
@@ -46,21 +55,27 @@ describe('Admin company interest', () => {
     createCompanyInterest();
     cy.url().should('include', `/companyInterest`);
 
-    cy.contains('webkom');
+    cy.contains('BEKK');
     cy.contains('webkom@webkom.no');
+    cy.contains('90909090');
     cy.contains('Slett')
       .click()
       .click();
 
-    cy.should('not.contain', 'webkom');
+    cy.should('not.contain', 'BEKK');
   });
 
   it('should not be able to create if invalid input', () => {
     cy.visit('/interesse');
 
-    field('companyName')
-      .click()
-      .type('webkom consulting');
+    // Select company
+    selectField('company').click();
+    cy.focused().type('BEKK', { force: true });
+    selectField('company')
+      .find('.Select-menu-outer')
+      .should('not.contain', 'No results')
+      .and('contain', 'BEKK');
+    cy.focused().type('{enter}', { force: true });
 
     field('contactPerson')
       .click()
@@ -69,6 +84,10 @@ describe('Admin company interest', () => {
     field('mail')
       .click()
       .type('webkom@webko');
+
+    field('phone')
+      .click()
+      .type('');
 
     field('comment').type('random comment');
 
@@ -80,14 +99,15 @@ describe('Admin company interest', () => {
   it('should be able to edit company interest', () => {
     createCompanyInterest();
     cy.url().should('include', `/companyInterest`);
-    cy.contains('webkom consulting').click();
+    cy.contains('BEKK').click();
     cy.url().should('include', `edit`);
 
     field('contactPerson').should('have.value', 'webkom');
     field('mail').should('have.value', 'webkom@webkom.no');
+    field('phone').should('have.value', '90909090');
     field('comment').should('have.value', 'random comment');
 
-    field('companyName').type('plebkom');
+    field('contactPerson').type('plebkom');
 
     field('semesters[0].checked').should('have.attr', 'checked');
     field('events[0].checked').should('have.attr', 'checked');


### PR DESCRIPTION
Implements several updates to company-interest and BDB as per requests from bedkom:

- Adds functionality for selecting registered BDB companies when submitting a company interest form. If the company has not been registered previously, submitting with any name is still supported too. When a BDB company is chosen, the appropriate semester in the BDB table is updated to "Interested".
- Adds phone number as mandatory fields to company-interest.
- Updates the static text on the company-interest page.
- Additionally, the PR implements a "fix" to the BDB that made it crash in strict mode (didn't affect prod; made localhost crash).

Depends on backend in https://github.com/webkom/lego/pull/1794