### PR TITLE
Don't send UPPER ROUND char to backend

### DIFF
--- a/app/actions/FileActions.js
+++ b/app/actions/FileActions.js
@@ -5,18 +5,20 @@ import callAPI from './callAPI';
 import type { Thunk } from 'app/types';
 import slug from 'slugify';
 
-const slugOpts = { remove: /[#*+~.()'"!:@]/g };
-/**
- * Normalize filenames
- * Remove non-word chars and replace spaces.
- */
-const normalizeFilename: (filename: string) => string = filename => {
+const slugifyFilename: (filename: string) => string = filename => {
+  // Slug options
+  const slugOpts = {
+    replacement: '-', // replace all spaces with -
+    remove: /[^a-zA-Z0-9/-\w.]+/g // remove all letters that does not match this regex
+  };
   const extensionIndex = filename.lastIndexOf('.');
+  // If file has extension we slug the first part
   if (extensionIndex > 0) {
     const name = slug(filename.substr(0, extensionIndex), slugOpts);
     const extension = filename.substr(extensionIndex);
     return `${name}${extension}`;
   }
+  // If the file has no extension we slug the whole filename
   return slug(filename, slugOpts);
 };
 
@@ -26,7 +28,7 @@ export function fetchSignedPost(key: string, isPublic: boolean) {
     method: 'POST',
     endpoint: '/files/',
     body: {
-      key: normalizeFilename(key),
+      key: slugifyFilename(key),
       public: isPublic
     },
     meta: {


### PR DESCRIPTION
Per the mail regarding image upload issues. The problem was that the filename has `Å` in it (on mac). This was parsed as **JS** as as ["a", "<030a>", "a", "<030a>"], which is a `offset upper rounded` char. This will cause the backend to reject the image.

Example, running split on a string "ååå.png" gives:
![Screenshot 2020-02-24 at 23 53 32](https://user-images.githubusercontent.com/23152018/75199820-6325f700-5764-11ea-80cc-bf8802da7477.png)

To solve this we can swap the the `regex` so it removes all chars we dont want.