### PR TITLE
Fix aspect ratio in gallery images

### DIFF
--- a/app/components/ProgressiveImage/index.js
+++ b/app/components/ProgressiveImage/index.js
@@ -60,7 +60,8 @@ export default class ProgressiveImage extends PureComponent<Props, State> {
             ...this.state.style,
             ...this.props.onLoadStyle,
             filter: 'blur(0) contrast(100%)',
-            height: 'auto'
+            height: 'auto',
+            margin: 'auto'
           }
         });
       })

--- a/app/routes/photos/components/GalleryPictureModal.css
+++ b/app/routes/photos/components/GalleryPictureModal.css
@@ -57,7 +57,7 @@
 .pictureContainer {
   display: grid;
   justify-content: center;
-  background-color: black;
+  background-color: var(--color-white);
   min-height: 700px;
 }
 


### PR DESCRIPTION
https://github.com/webkom/lego/issues/1821
Before:
![format](https://user-images.githubusercontent.com/55149662/77255258-72ff0100-6c66-11ea-863a-40e77d71e78a.png)
After:
![format_fix](https://user-images.githubusercontent.com/55149662/77255259-73979780-6c66-11ea-81e9-74518c67908e.png)
