### PR TITLE
Fix: Improve client/ssr-side checks.

### DIFF
--- a/app/utils/themeUtils.js
+++ b/app/utils/themeUtils.js
@@ -3,15 +3,17 @@ import imageLogoDarkMode from 'app/assets/logo.png';
 import bannerLightMode from 'app/assets/om-abakus-banner.png';
 import bannerDarkMode from 'app/assets/om-abakus-banner-dark-mode.png';
 
+const isClientSide = () => typeof window !== 'undefined' && document;
+
 export const applySelectedTheme = theme => {
-  if (typeof window !== 'undefined') {
+  if (isClientSide()) {
     document.documentElement.setAttribute('data-theme', theme);
     global.dispatchEvent(new Event('themeChange'));
   }
 };
 
 export const getTheme = () =>
-  typeof window !== 'undefined'
+  isClientSide()
     ? document.documentElement.getAttribute('data-theme')
     : 'light';
 


### PR DESCRIPTION
Discovered that the checks needed to include document as well, in order to load the darkMode-modifided logos properly. Should be merged asap, as the logos will sometimes be loaded as their light-mode variant without this fix.
![image](https://user-images.githubusercontent.com/26925695/78174043-ed930200-7458-11ea-81ac-97466152f683.png)
