### PR TITLE
Fix sourcemaps on sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "url": "github.com/webkom/lego-webapp"
   },
   "dependencies": {
-    "@webkom/react-prepare": "0.7.0",
     "@sentry/browser": "^5.15.4",
     "@sentry/integrations": "^5.15.4",
     "@sentry/node": "^5.15.4",
+    "@webkom/react-prepare": "0.7.0",
     "animate.css": "^3.7.0",
     "bunyan": "^1.8.12",
     "bunyan-pretty": "^0.0.1",
@@ -93,12 +93,11 @@
     "redux-form": "8.3.1",
     "redux-logger": "^3.0.1",
     "redux-segment": "^1.6.2",
-    "redux-thunk": "2.3.0",
     "redux-sentry-middleware": "^0.1.6",
+    "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "serialize-javascript": "^3.0.0",
     "slugify": "^1.3.6",
-    "source-map-support": "^0.5.8",
     "victory": "34.1.3",
     "websocket.js": "^0.1.7"
   },

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,11 @@ Sentry.init({
   release: config.release,
   environment: config.environment,
   normalizeDepth: 10,
-  integrations: [new RewriteFrames()]
+  integrations: [
+    new RewriteFrames({
+      root: '/app/dist/'
+    })
+  ]
 });
 
 // This is a hack to use draft-convert on the server.

--- a/server/pageRenderer.js
+++ b/server/pageRenderer.js
@@ -8,8 +8,6 @@ import type { State } from '../app/types';
 import { selectCurrentUser } from 'app/reducers/auth';
 import { isEmpty } from 'lodash';
 
-import 'source-map-support/register';
-
 import manifest from '../app/assets/manifest.json';
 
 let cachedAssets;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11298,7 +11298,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@^0.5.8, source-map-support@~0.5.12:
+source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==


### PR DESCRIPTION
This will hopefully fix sourcemaps on sentry.

`source-map-support` is not compatible with sentry and will mess up sourcemap matching.