### PR TITLE
Fix editor in pagecreation route

### DIFF
--- a/app/routes/pages/components/PageEditor.js
+++ b/app/routes/pages/components/PageEditor.js
@@ -175,7 +175,7 @@ export default class PageEditor extends Component<Props, State> {
             name="content"
             component={EditorField.Field}
             uploadFile={uploadFile}
-            initialized={this.props.initialized}
+            initialized={this.props.initialized || isNew}
           />
         </Form>
       </Content>


### PR DESCRIPTION
Since the form for creating a new page does not have any initialvalues, we have to include a bypass the check on whether or not the form is loaded when creating a new page.