### PR TITLE
Fix bug where attendees route results in 404

### DIFF
--- a/app/routes/events/index.js
+++ b/app/routes/events/index.js
@@ -60,7 +60,6 @@ const eventRoute = ({ match }: { match: { path: string } }) => (
                 Component={EventAbacardRoute}
                 passedProps={{ currentUser, loggedIn }}
               />
-              <Route component={PageNotFound} />
             </EventAdministrateRoute>
           )}
         </Route>


### PR DESCRIPTION
Fixes a bug where the events/attendees route results in 404 by removing the 404 route component. While this results in an empty sub page when trying to access an invalid sub url of events/eventid/administrate, this is the way it has been done on the rest of the routing, and I do not consider it a massive problem