### PR TITLE
Fix this ugly ****

### DIFF
--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -1,9 +1,12 @@
 @import '~app/styles/variables.css';
 
 .tagline {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  display: inline-block;
+  white-space: nowrap;
+  vertical-align: middle;
+  overflow: auto;
+  height: 28px;
+  width: 340px;
   margin: 0;
 }
 

--- a/app/routes/overview/components/Pinned.js
+++ b/app/routes/overview/components/Pinned.js
@@ -27,7 +27,7 @@ class Pinned extends Component<Props, *> {
             <h2 className={styles.itemTitle}>
               <Link to={url}>{item.title}</Link>
             </h2>
-            <div>{meta}</div>
+            {meta}
           </div>
         </Flex>
       </Flex>


### PR DESCRIPTION
Revert and fix this https://github.com/webkom/lego-webapp/pull/1848

![image](https://user-images.githubusercontent.com/23152018/89128633-40f48a00-d4f7-11ea-8196-65418566cc94.png)

Just allocate x amount of space for tags, don't allow them to wrap all over the place.
![image](https://user-images.githubusercontent.com/23152018/89128925-4bb01e80-d4f9-11ea-9d9a-561ee5058543.png)
![image](https://user-images.githubusercontent.com/23152018/89128927-4f43a580-d4f9-11ea-82ef-c0451b69d159.png)

