### PR TITLE
Fix issue with missing user info in event routes

### DIFF
--- a/app/routes/events/index.js
+++ b/app/routes/events/index.js
@@ -18,10 +18,16 @@ const eventRoute = ({ match }: { match: { path: string } }) => (
   <UserContext.Consumer>
     {({ currentUser, loggedIn }) => (
       <Switch>
-        <Route exact path={`${match.path}`} component={EventListRoute} />
-        <Route
+        <RouteWrapper
+          exact
+          path={`${match.path}`}
+          Component={EventListRoute}
+          passedProps={{ currentUser, loggedIn }}
+        />
+        <RouteWrapper
           path={`${match.path}/calendar/:year?/:month?`}
-          component={CalendarRoute}
+          Component={CalendarRoute}
+          passedProps={{ currentUser, loggedIn }}
         />
         <RouteWrapper
           path={`${match.path}/create`}


### PR DESCRIPTION
Fixes an issue where user information was missing from event list and calendar routes.

This caused the "you must be logged in register" text showing up even though the user is registered
and the add to calendar missing from the bottom of both pages.
