### PR TITLE
Fix stripe payment request form

### DIFF
--- a/app/routes/events/components/StripeElement.js
+++ b/app/routes/events/components/StripeElement.js
@@ -170,11 +170,17 @@ class PaymentRequestForm extends React.Component<
   constructor(props) {
     super(props);
 
-    const { event } = props;
+    this.state = {
+      canMakePayment: undefined,
+      paymentInProgress: false,
+      paymentRequest: undefined,
+    };
+  }
 
-    let paymentRequest;
-    if (props.stripe) {
-      paymentRequest = props.stripe.paymentRequest({
+  componentDidUpdate(prevProps) {
+    if (!this.state.paymentRequest && this.props.stripe) {
+      const { event } = this.props;
+      const paymentRequest = this.props.stripe.paymentRequest({
         currency: 'nok',
         total: {
           label: event.title,
@@ -199,15 +205,10 @@ class PaymentRequestForm extends React.Component<
         this.setState({ canMakePayment: !!result });
         this.props.setPaymentRequest(!!result);
       });
-    }
-    this.state = {
-      canMakePayment: undefined,
-      paymentInProgress: false,
-      paymentRequest,
-    };
-  }
 
-  componentDidUpdate(prevProps) {
+      this.setState({ paymentRequest });
+    }
+
     const { clientSecret, paymentError } = this.props;
 
     if (!prevProps.clientSecret && clientSecret) {

--- a/server/pageRenderer.js
+++ b/server/pageRenderer.js
@@ -117,7 +117,7 @@ export default function pageRenderer({
       </script>`
             : ''
         }
-        <script async src="https://js.stripe.com/v3/"></script>
+        <script src="https://js.stripe.com/v3/"></script>
         ${dllPlugin}
         ${scripts}
       </body>


### PR DESCRIPTION
This was a PITA to test locally, but I'm 90% sure it's good now.

Note: To test payment request API (google pay, apple pay) you need to add a test card from https://stripe.com/docs/testing in order for the payment request button to show! (atleast for google pay).