### PR TITLE
Add Personvern to pages

### DIFF
--- a/app/reducers/pages.js
+++ b/app/reducers/pages.js
@@ -184,4 +184,5 @@ export const categoryOptions = [
   { value: 'bedrifter', label: 'Bedrifter' },
   { value: 'generelt', label: 'Generelt' },
   { value: 'grupper', label: 'Grupper' },
+  { value: 'personvern', label: 'Personvern' },
 ];

--- a/app/routes/pages/PageDetailRoute.js
+++ b/app/routes/pages/PageDetailRoute.js
@@ -83,6 +83,14 @@ const sections: {
     PageRenderer: FlatpageRenderer,
     fetchItemActions: [fetchPage],
   },
+  personvern: {
+    title: 'Personvern',
+    section: 'personvern',
+    pageSelector: selectFlatpageForPages,
+    hierarchySectionSelector: selectPagesForHierarchy('personvern'),
+    PageRenderer: FlatpageRenderer,
+    fetchItemActions: [fetchPage],
+  },
   'info-om-abakus': {
     title: 'Info om Abakus',
     section: 'info-om-abakus',


### PR DESCRIPTION
As we need a place for privacy information about abakus.no, a "personvern" category is needed.