### PR TITLE
Include joblistings where workplaces is [] when filtering for "Annet"

### DIFF
--- a/app/routes/joblistings/JoblistingRoute.js
+++ b/app/routes/joblistings/JoblistingRoute.js
@@ -29,7 +29,8 @@ function filterJoblistings(joblistings, grades, jobTypes, workplaces) {
         joblisting.workplaces.some(
           (workplace) =>
             !['Oslo', 'Trondheim', 'Bergen', 'Tromsø'].includes(workplace.town)
-        )) || (workplaces.includes('Annet') && joblisting.workplaces.length === 0);
+        )) ||
+      (workplaces.includes('Annet') && joblisting.workplaces.length === 0);
 
     return gradeBoolean && jobTypesBoolean && workplacesBoolean;
   });

--- a/app/routes/joblistings/JoblistingRoute.js
+++ b/app/routes/joblistings/JoblistingRoute.js
@@ -29,7 +29,7 @@ function filterJoblistings(joblistings, grades, jobTypes, workplaces) {
         joblisting.workplaces.some(
           (workplace) =>
             !['Oslo', 'Trondheim', 'Bergen', 'Tromsø'].includes(workplace.town)
-        ));
+        )) || (workplaces.includes('Annet') && joblisting.workplaces.length === 0);
 
     return gradeBoolean && jobTypesBoolean && workplacesBoolean;
   });


### PR DESCRIPTION
When a joblisting has workplaces: [], they are not included when filtering workplaces=Annet.
Before:
![Skjermbilde 2020-09-03 kl  00 37 19](https://user-images.githubusercontent.com/7096833/92044126-d5b00900-ed7d-11ea-83f5-c50410d5d00c.png)

After:
![Skjermbilde 2020-09-03 kl  00 37 33](https://user-images.githubusercontent.com/7096833/92044135-d8aaf980-ed7d-11ea-829b-46541b7bab44.png)
