### PR TITLE
Fix bug in editor datepicker

### DIFF
--- a/app/components/Form/DatePicker.js
+++ b/app/components/Form/DatePicker.js
@@ -94,6 +94,12 @@ class DatePicker extends Component<Props, State> {
     }));
   };
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.value !== this.props.value) {
+      this.setState({ value: parseDateValue(this.props.value) });
+    }
+  }
+
   render() {
     const { showTimePicker, className, name } = this.props;
     const { date } = this.state;

--- a/app/components/Form/DatePicker.js
+++ b/app/components/Form/DatePicker.js
@@ -94,7 +94,7 @@ class DatePicker extends Component<Props, State> {
     }));
   };
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     if (prevProps.value !== this.props.value) {
       this.setState({ value: parseDateValue(this.props.value) });
     }
@@ -115,6 +115,7 @@ class DatePicker extends Component<Props, State> {
               .tz(this.state.value, config.timezone)
               .format(this.props.dateFormat)}
             name={name}
+            readOnly
           />
         }
         componentClass="div"

--- a/app/components/Form/TextInput.js
+++ b/app/components/Form/TextInput.js
@@ -29,6 +29,7 @@ function TextInput({
         ref={inputRef}
         type={type}
         disabled={disabled}
+        readOnly={!!readOnly}
         className={cx(
           styles.input,
           disabled && styles.disabled,


### PR DESCRIPTION
Fix a bug where the datepicker field is not loaded with the correct initialvalue. This bug would result in the datepicker being initialized to the current date when editing an old meeting, which is rather annoying. Also remove an error with a field intended as read only not being set as read only