### PR TITLE
add/edit event options and fix color of headers in dark-theme

### DIFF
--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -61,7 +61,7 @@
 }
 
 .mainHeading {
-  color: var(--color-gray-1);
+  color: var(--lego-font-color);
   letter-spacing: 2px;
   text-transform: uppercase;
   font-size: 25px;
@@ -74,7 +74,7 @@
 }
 
 .heading {
-  color: var(--color-gray-1);
+  color: var(--lego-font-color);
   letter-spacing: 2px;
   font-weight: 400;
   text-transform: uppercase;

--- a/app/routes/companyInterest/components/CompanyInterestPage.js
+++ b/app/routes/companyInterest/components/CompanyInterestPage.js
@@ -39,9 +39,13 @@ export const EVENT_TYPES = {
     norwegian: 'Faglig arrangement',
     english: 'Course or workshop',
   },
+  digital_presentation: {
+    norwegian: 'Digital presentasjon',
+    english: 'Digital presentation',
+  },
   bedex: {
-    norwegian: 'Bedex',
-    english: 'BedEx',
+    norwegian: 'BedEx (vinter 2021)',
+    english: 'BedEx (winter 2021)',
   },
   other: {
     norwegian: 'Alternativt arrangement',

--- a/app/routes/companyInterest/utils.js
+++ b/app/routes/companyInterest/utils.js
@@ -73,6 +73,6 @@ export const interestText = {
     norwegian:
       '«Husk å ranger datoer og gruppestørrelse dersom du har huket av for BedEx (vinter 2021)»',
     english:
-      '«Remeber to rank dates and groupsize if you have checked BedEx (winter 2021)»',
+      '«Remember to rank dates and groupsize if you have checked BedEx (winter 2021)»',
   },
 };

--- a/app/routes/companyInterest/utils.js
+++ b/app/routes/companyInterest/utils.js
@@ -71,7 +71,8 @@ export const interestText = {
   },
   bedex: {
     norwegian:
-      '«Husk å ranger datoer og gruppestørrelse dersom du har huket av for BedEx»',
-    english: '«Remeber to rank dates and groupsize if you have checked BedEx»',
+      '«Husk å ranger datoer og gruppestørrelse dersom du har huket av for BedEx (vinter 2021)»',
+    english:
+      '«Remeber to rank dates and groupsize if you have checked BedEx (winter 2021)»',
   },
 };


### PR DESCRIPTION
Closes webkom/lego#1942
 Added "Digital presentation" as an event option, edited "BedEx" as requested and corrected header colors in dark theme