### PR TITLE
Changed Komtek name in public pages

### DIFF
--- a/app/routes/overview/components/PublicFrontpage.js
+++ b/app/routes/overview/components/PublicFrontpage.js
@@ -187,8 +187,8 @@ class PublicFrontpage extends Component<Props, State> {
               </a>
               <div className={styles.linkDescription}>
                 Vi bruker stadig mer av livene våre på nett, på jobb som i
-                fritid. Kommunikasjonsteknologi og digital sikkerhet brukes
-                etter hvert av alle og overalt.
+                fritid. Kommunikasjonsteknologi og digital sikkerhet blir stadig
+                viktigere i en digital verden.
               </div>
             </li>
             <li>

--- a/app/routes/overview/components/PublicFrontpage.js
+++ b/app/routes/overview/components/PublicFrontpage.js
@@ -82,9 +82,9 @@ class PublicFrontpage extends Component<Props, State> {
         <div className={styles.welcome}>
           <h2 className={'u-mb'}>Velkommen til Abakus</h2>
           <p>
-            Abakus er linjeforeningen for studentene ved Datateknologi og
-            Kommunikasjonsteknologi på NTNU, og drives av studenter ved disse
-            studiene.
+            Abakus er linjeforeningen for studentene ved <i>Datateknologi</i> og
+            <i> Kommunikasjonsteknologi og digital sikkerhet</i> på NTNU, og
+            drives av studenter ved disse studiene.
           </p>
           <p>
             Abakus
@@ -182,12 +182,13 @@ class PublicFrontpage extends Component<Props, State> {
             </li>
             <li>
               <a href="http://www.ntnu.no/studier/mtkom" target="blank">
-                <i className="fa fa-caret-right" /> Kommunikasjonsteknologi
+                <i className="fa fa-caret-right" /> Kommunikasjonsteknologi og
+                digital sikkerhet
               </a>
               <div className={styles.linkDescription}>
                 Vi bruker stadig mer av livene våre på nett, på jobb som i
-                fritid. Kommunikasjonsteknologi brukes etter hvert av alle og
-                overalt.
+                fritid. Kommunikasjonsteknologi og digital sikkerhet brukes
+                etter hvert av alle og overalt.
               </div>
             </li>
             <li>

--- a/app/routes/pages/components/LandingPage.js
+++ b/app/routes/pages/components/LandingPage.js
@@ -48,13 +48,13 @@ const LandingPage = ({
       <Image
         className={cx(styles.banner, styles.bannerLightMode)}
         src={bannerLightMode}
-        alt="Abakus - Linjeforeningen for Datateknologi og Kommunikasjonsteknologi ved NTNU"
+        alt="Abakus - Linjeforeningen for Datateknologi og Kommunikasjonsteknologi og digital sikkerhet ved NTNU"
       />
 
       <Image
         className={cx(styles.banner, styles.bannerDarkMode)}
         src={bannerDarkMode}
-        alt="Abakus - Linjeforeningen for Datateknologi og Kommunikasjonsteknologi ved NTNU"
+        alt="Abakus - Linjeforeningen for Datateknologi og Kommunikasjonsteknologi og digital sikkerhet ved NTNU"
       />
 
       <Flex className={styles.whoWhatWhyContainer}>
@@ -220,8 +220,13 @@ const LandingPage = ({
 };
 
 LandingPage.defaultProps = {
-  whoWeAre:
-    'Abakus er linjeforeningen for studentene ved Datateknologi og Kommunikasjonsteknologi på NTNU, og drives av studenter ved disse studiene.',
+  whoWeAre: (
+    <span>
+      Abakus er linjeforeningen for studentene ved Datateknologi og{' '}
+      <i>Kommunikasjonsteknologi og digital sikkerhet</i> på NTNU, og drives av
+      studenter ved disse studiene.
+    </span>
+  ),
   whatWeDo:
     "Abakus' formål er å gi disse studentene veiledning i studiesituasjonen, arrangere kurs som utfyller fagtilbudet ved NTNU, fremme kontakten med næringslivet og bidra med sosiale aktiviteter.",
   whyWeDoIt:

--- a/app/routes/pages/components/subcomponents/TextWithTitle/index.js
+++ b/app/routes/pages/components/subcomponents/TextWithTitle/index.js
@@ -4,7 +4,7 @@ import styles from './TextWithTitle.css';
 
 type Props = {
   title: string,
-  text: string,
+  text: React.component,
   extraStyle?: Object,
 };
 

--- a/app/routes/pages/components/subcomponents/TextWithTitle/index.js
+++ b/app/routes/pages/components/subcomponents/TextWithTitle/index.js
@@ -1,5 +1,5 @@
 //@flow
-import React, {type Node} from 'react';
+import React, { type Node } from 'react';
 import styles from './TextWithTitle.css';
 
 type Props = {

--- a/app/routes/pages/components/subcomponents/TextWithTitle/index.js
+++ b/app/routes/pages/components/subcomponents/TextWithTitle/index.js
@@ -1,10 +1,10 @@
 //@flow
-import React from 'react';
+import React, {type Node} from 'react';
 import styles from './TextWithTitle.css';
 
 type Props = {
   title: string,
-  text: React.component,
+  text: Node,
   extraStyle?: Object,
 };
 


### PR DESCRIPTION
Change "Kommunikasjonsteknologi" to "Kommunikasjonsteknologi og digital sikkerhet" on public pages. Image on om Abakus page needs an update as well.