### PR TITLE
Speedup ssr by a s***ton

### DIFF
--- a/app/actions/FrontpageActions.js
+++ b/app/actions/FrontpageActions.js
@@ -46,6 +46,9 @@ export function fetchReadmes(first: number) {
   // $FlowFixMe
   return async (dispatch) => {
     try {
+      dispatch({
+        type: Readme.FETCH.BEGIN,
+      });
       const res = await fetch(readmeUrl, {
         method: 'POST',
         headers: {

--- a/app/components/RandomQuote/index.js
+++ b/app/components/RandomQuote/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 import { compose } from 'redux';
-import { isEmpty } from 'lodash';
-import prepare from 'app/utils/prepare';
 import { fetchRandomQuote } from 'app/actions/QuoteActions';
 import { connect } from 'react-redux';
 import RandomQuote from './RandomQuote';
@@ -37,11 +35,5 @@ const LoginToSeeQuotes = () => <div>Logg inn for å se sitater.</div>;
 export default compose(
   replaceUnlessLoggedIn(LoginToSeeQuotes),
   connect(mapStateToProps, mapDispatchToProps),
-  prepare((props, dispatch) =>
-    Promise.all([
-      isEmpty(props.currentQuote) && dispatch(fetchRandomQuote()),
-      dispatch(fetchEmojis()),
-    ])
-  ),
   loadingIndicator(['currentQuote.id'])
 )(RandomQuote);

--- a/app/routes/app/AppRoute.js
+++ b/app/routes/app/AppRoute.js
@@ -190,7 +190,7 @@ export default compose(
   prepare((_, dispatch) => dispatch(fetchMeta()), [], {
     componentDidMount: false,
     componentWillReceiveProps: false,
-    hasSsrDataDeps: false,
+    awaitOnSsr: false,
   }),
   prepare(
     (props, dispatch) =>
@@ -208,7 +208,7 @@ export default compose(
         }),
       ]),
     [],
-    { hasSsrDataDeps: false }
+    { awaitOnSsr: false }
   ),
   connect(mapStateToProps, mapDispatchToProps)
 )(App);

--- a/app/routes/app/AppRoute.js
+++ b/app/routes/app/AppRoute.js
@@ -182,33 +182,33 @@ const mapDispatchToProps = {
   loginAutomaticallyIfPossible,
 };
 
-function fetchInitialOnServer(props, dispatch) {
-  return dispatch(loginAutomaticallyIfPossible()).then(() =>
-    Promise.all([
-      dispatch(fetchMeta()),
-      //dispatch(fetchNotificationData()),
-      //dispatch(fetchNotificationFeed())
-    ])
-  );
-}
-
 export default compose(
-  prepare(fetchInitialOnServer, [], {
+  prepare((_, dispatch) => dispatch(loginAutomaticallyIfPossible()), [], {
     componentDidMount: false,
     componentWillReceiveProps: false,
   }),
-  prepare((props, dispatch) => dispatch(fetchNotificationData())),
-  prepare((props, dispatch) =>
-    dispatch((dispatch, getState) => {
-      if (!selectIsLoggedIn(getState())) {
-        return Promise.resolve();
-      }
-      return dispatch(
-        fetchMeetings({
-          dateAfter: moment().format('YYYY-MM-DD'),
-        })
-      );
-    })
+  prepare((_, dispatch) => dispatch(fetchMeta()), [], {
+    componentDidMount: false,
+    componentWillReceiveProps: false,
+    hasSsrDataDeps: false,
+  }),
+  prepare(
+    (props, dispatch) =>
+      Promise.all([
+        dispatch(fetchNotificationData()),
+        dispatch((dispatch, getState) => {
+          if (!selectIsLoggedIn(getState())) {
+            return Promise.resolve();
+          }
+          return dispatch(
+            fetchMeetings({
+              dateAfter: moment().format('YYYY-MM-DD'),
+            })
+          );
+        }),
+      ]),
+    [],
+    { hasSsrDataDeps: false }
   ),
   connect(mapStateToProps, mapDispatchToProps)
 )(App);

--- a/app/routes/events/EventDetailRoute.js
+++ b/app/routes/events/EventDetailRoute.js
@@ -145,10 +145,11 @@ const loadData = async (
     loggedIn,
   },
   dispatch
-) => [
-  await dispatch(fetchEvent(eventId)),
-  loggedIn && (await dispatch(isUserFollowing(eventId))),
-];
+) =>
+  Promise.all([
+    dispatch(fetchEvent(eventId)),
+    loggedIn && dispatch(isUserFollowing(eventId)),
+  ]);
 
 const propertyGenerator = (props, config) => {
   if (!props.event) return;

--- a/app/routes/overview/IndexRoute.js
+++ b/app/routes/overview/IndexRoute.js
@@ -45,7 +45,7 @@ export default compose(
         dispatch(fetchReadmes(loggedIn ? 4 : 1)),
       ]),
     [],
-    { hasSsrDataDeps: false }
+    { awaitOnSsr: false }
   ),
   prepare(({ loggedIn }, dispatch) => dispatch(fetchData())),
   replaceUnlessLoggedIn(PublicFrontpage)

--- a/app/routes/overview/IndexRoute.js
+++ b/app/routes/overview/IndexRoute.js
@@ -3,11 +3,14 @@ import { connect } from 'react-redux';
 import prepare from 'app/utils/prepare';
 import { fetchData, fetchReadmes } from 'app/actions/FrontpageActions';
 import { login, logout } from 'app/actions/UserActions';
+import { isEmpty } from 'lodash';
 import Overview from './components/Overview';
 import { selectFrontpage } from 'app/reducers/frontpage';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import PublicFrontpage from './components/PublicFrontpage';
-import { fetchPersonalFeed } from 'app/actions/FeedActions';
+import { selectRandomQuote } from 'app/reducers/quotes';
+import { fetchRandomQuote } from 'app/actions/QuoteActions';
+// import { fetchPersonalFeed } from 'app/actions/FeedActions';
 import {
   selectFeedById,
   selectFeedActivitesByFeedId,
@@ -19,6 +22,7 @@ const mapStateToProps = (state) => ({
   loadingFrontpage: state.frontpage.fetching,
   frontpage: selectFrontpage(state),
   feed: selectFeedById(state, { feedId: 'personal' }),
+  shouldFetchQuote: isEmpty(selectRandomQuote(state)),
   feedItems: selectFeedActivitesByFeedId(state, {
     feedId: 'personal',
   }),
@@ -29,14 +33,20 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = { login, logout, votePoll };
 
 export default compose(
-  prepare(({ loggedIn }, dispatch) =>
-    Promise.all([
-      dispatch(fetchData()),
-      dispatch(fetchReadmes(loggedIn ? 4 : 1)),
-    ]).then(() =>
-      loggedIn ? dispatch(fetchPersonalFeed()) : Promise.resolve()
-    )
-  ),
+  // Feed not in use
+  // prepare(({ loggedIn }, dispatch) =>
+  //   loggedIn ? dispatch(fetchPersonalFeed()) : Promise.resolve()
+  // ),
   connect(mapStateToProps, mapDispatchToProps),
+  prepare(
+    ({ shouldFetchQuote, loggedIn }, dispatch) =>
+      Promise.all([
+        loggedIn && shouldFetchQuote && dispatch(fetchRandomQuote()),
+        dispatch(fetchReadmes(loggedIn ? 4 : 1)),
+      ]),
+    [],
+    { hasSsrDataDeps: false }
+  ),
+  prepare(({ loggedIn }, dispatch) => dispatch(fetchData())),
   replaceUnlessLoggedIn(PublicFrontpage)
 )(Overview);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@sentry/node": "^5.15.4",
     "@webkom/lego-editor": "^1.2.1",
     "@webkom/react-meter-bar": "^1.0.3",
-    "@webkom/react-prepare": "0.7.0",
+    "@webkom/react-prepare": "0.8.0",
     "animate.css": "^4.1.0",
     "bunyan": "^1.8.12",
     "bunyan-pretty": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,10 +1878,10 @@
     react "^16.4.0"
     react-dom "^16.4.0"
 
-"@webkom/react-prepare@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@webkom/react-prepare/-/react-prepare-0.7.0.tgz#8fee300cec6f5d169de49be83b35b7356ede34ac"
-  integrity sha512-kEU+M1W6LvYrET1ZOQpxdG4PGXbznhKuJXszElbNl2IqeQjf+jzH9NrueQUQXwzuK7x1MjhdyQNilP1CDd9ssw==
+"@webkom/react-prepare@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@webkom/react-prepare/-/react-prepare-0.8.0.tgz#e26eaba5c3b0f609f2ffa44b1018b76392ea03ed"
+  integrity sha512-GCOmqZgBcLRTrb9eOFlJ4u0JS3bTse/PEVHsh8PBb4RbajKKo3YT5D00JgwCUEg6HryaVuBL+/411K7L/Rb52A==
   dependencies:
     babel-runtime "^6.11.6"
 


### PR DESCRIPTION
Stop waterfall fetching stuff in ssr. This cleans up a bit, but require
the fixes in @webkom/react-prepare to properly speedup stuff...

My simple testing gives when running ssr locally (compared to abakus.no):
- `/` (authenticated as me) 0.80s - 1.20s vs 3-4-5sec (and constant timeouts, since 4sec is ssr timeout).

This also fixes some crazy double fetching of quotes...

(might be some rough edges, so I guess we can try it on staging first...)