### PR TITLE
Check if event is using penalties when displaying penalty notice

### DIFF
--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -263,7 +263,7 @@ class JoinEventForm extends Component<Props> {
               {disabledForUser && (
                 <div>Du kan ikke melde deg på dette arrangementet.</div>
               )}
-              {sumPenalties(penalties) > 0 && (
+              {sumPenalties(penalties) > 0 && event.heedPenalties && (
                 <div className={styles.penalties}>
                   <p>
                     NB!{' '}


### PR DESCRIPTION
Only show penalty notice when event is actually using penalties. By doing this we avoid saying that the registration has been postponed for the user, even though that is not the case.