### PR TITLE
[DISCUSSION] Rename prod -> docker

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -274,10 +274,10 @@ steps:
       password:
         from_secret: docker_password
       tags:
-        - ${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:7}
+        - ${DRONE_CALVER_SHORT}-${DRONE_COMMIT_SHA:0:7}
         - latest
       build_args:
-        - RELEASE=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:7}
+        - RELEASE=${DRONE_CALVER_SHORT}-${DRONE_COMMIT_SHA:0:7}
         - COMMIT_SHA=${DRONE_COMMIT_SHA}
         - SENTRY_ORG=abakus
         - SENTRY_PROJECT=lego-webapp
@@ -324,7 +324,7 @@ steps:
       tags:
         - webapp
       limit: ${DRONE_DEPLOY_TO}
-      extra_vars: webapp_version=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:7}
+      extra_vars: webapp_version=${DRONE_CALVER_SHORT}-${DRONE_COMMIT_SHA:0:7}
       inventory: /infrastructure/inventory
       vault_password:
         from_secret: ansible_vault_password
@@ -352,4 +352,4 @@ image_pull_secrets:
 
 ---
 kind: signature
-hmac: 372fab30840e379402d56cbf6e7bbab9791ec8f24a5e715407656e16052114b3
+hmac: 1130fab23c413ded73625fc822d1ee6165eed0d2e57a6505ffe1c5b9eec124cf 

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ prod ]
+        exclude: [ docker ]
 
   - name: minio
     image: minio/minio
@@ -26,7 +26,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ prod ]
+        exclude: [ docker ]
 
   - name: thumbor
     image: apsl/thumbor:latest
@@ -49,7 +49,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ prod ]
+        exclude: [ docker ]
 
   - name: redis
     image: redis
@@ -57,7 +57,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ prod ]
+        exclude: [ docker ]
 
   - name: api
     image: registry.webkom.dev/webkom/lego:latest
@@ -107,7 +107,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [prod]
+        exclude: [ docker ]
 
   - name: legocypresshelper
     image: abakus/lego-cypress-helper:latest
@@ -116,7 +116,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [prod]
+        exclude: [ docker ]
     environment:
       PG_HOST: postgres
       PG_USERNAME: lego
@@ -150,7 +150,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [prod]
+        exclude: [ docker ]
     depends_on:
       - setup
     commands:
@@ -161,7 +161,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [prod]
+        exclude: [ docker ]
     depends_on:
       - setup
     commands:
@@ -199,7 +199,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [prod]
+        exclude: [ docker ]
     depends_on:
       - setup
     environment:
@@ -213,7 +213,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [prod]
+        exclude: [ docker ]
     depends_on:
       - build_client
       - build_server
@@ -231,7 +231,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [prod]
+        exclude: [ docker ]
     depends_on:
       - legocypresshelper
       - install_cypress
@@ -252,7 +252,7 @@ steps:
     image: plugins/docker
     when:
       branch:
-        - prod
+        - docker
       event: push
       status: success
     depends_on:
@@ -309,7 +309,7 @@ steps:
         - promote
         - rollback
       branch:
-        - prod
+        - docker
 
 
   - name: Deploy
@@ -335,7 +335,7 @@ steps:
         - promote
         - rollback
       branch:
-        - prod
+        - docker
     depends_on:
       - clone_infrastructure
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
 
   - name: minio
     image: minio/minio
@@ -26,7 +26,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
 
   - name: thumbor
     image: apsl/thumbor:latest
@@ -49,7 +49,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
 
   - name: redis
     image: redis
@@ -57,7 +57,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
 
   - name: api
     image: registry.webkom.dev/webkom/lego:latest
@@ -107,7 +107,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
 
   - name: legocypresshelper
     image: abakus/lego-cypress-helper:latest
@@ -116,7 +116,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
     environment:
       PG_HOST: postgres
       PG_USERNAME: lego
@@ -150,7 +150,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
     depends_on:
       - setup
     commands:
@@ -161,7 +161,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
     depends_on:
       - setup
     commands:
@@ -199,7 +199,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
     depends_on:
       - setup
     environment:
@@ -213,7 +213,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
     depends_on:
       - build_client
       - build_server
@@ -231,7 +231,7 @@ steps:
     when:
       event: [push]
       branch:
-        exclude: [ docker ]
+        exclude: [ build ]
     depends_on:
       - legocypresshelper
       - install_cypress
@@ -252,7 +252,7 @@ steps:
     image: plugins/docker
     when:
       branch:
-        - docker
+        - build
       event: push
       status: success
     depends_on:
@@ -309,7 +309,7 @@ steps:
         - promote
         - rollback
       branch:
-        - docker
+        - build
 
 
   - name: Deploy
@@ -335,7 +335,7 @@ steps:
         - promote
         - rollback
       branch:
-        - docker
+        - build
     depends_on:
       - clone_infrastructure
 
@@ -352,4 +352,4 @@ image_pull_secrets:
 
 ---
 kind: signature
-hmac: 1130fab23c413ded73625fc822d1ee6165eed0d2e57a6505ffe1c5b9eec124cf 
+hmac: 6c3f64a3b604defee071f46fa139b00352b518a02d6b1fbc41315296e508629e


### PR DESCRIPTION
## The Problem

Yesterday @odinuge and I talked about **prod**, and that prod can be a little misleading branch name, as it doesn't actually mean that anything will go into production. The real action is that a **docker build** will occur, and the result will be an **image**

This has always been difficult to explain to new members, as we say things like:

> 1. Push the master to prod??
> 2. Then push the prod to staging??
> 3. Then push the prod to prod??

It's obvious for us what it means, but it doesn't really make sense when you try to talk about it, and/or explain it.

## The Proposed Solution

Rename the prod branch to **docker** as this is what actually happens. Then we can more easily explain the process like:

> 1. Push master to the docker branch in order to trigger a new build
> 2. Deploy this new build staging to check that your changes work
> 3. Then deploy the new build to production in order for it to go live

### TODO for this change

- [x] Rename prod to docker in `.drone.yml`

- [x] Decide on a name for the `tags`. Today the tag is equal to the **branch-sha**, and **docker-fn371ghf** is kind of a dumb name. We can hardcode prod-{SHA}, but i also feel like the prod part of the image tag is unnessesary, as the image will always be a prod image. I suggest using **version-{DRONE_SHA:0:7}**, og just the **sha**.
https://github.com/webkom/lego-webapp/blob/3958d760999346dfecc472e2dbdf6f7b19e0b098/.drone.yml#L277

- [ ] Make the same changes in **LEGO**

- [x] Required changes in **infrastructure** are allready done, since we use `registry.webkom.dev/webkom/lego:{{ lego_version }}` and `registry.webkom.dev/webkom/lego-webapp:{{ webapp_version }}`

- [ ] Update docs where we say push to prod

- [ ] Anywhere else this breaks?

