### PR TITLE
Update brand colours to be consistent with wiki

### DIFF
--- a/app/routes/brand/components/BrandPage.js
+++ b/app/routes/brand/components/BrandPage.js
@@ -94,15 +94,10 @@ const BrandPage = () => (
           <ul>
             <li>Hvit: CMYK(0,0,0,0)</li>
             <li>Svart: CMYK(0,0,0,95)</li>
-            <li>Lysegrå: CMYK(48,39,42,39) HEX(525251)</li>
-            <li>Grå: CMYK(53,44,46,52) HEX(343434)</li>
-            <li>
-              Lyserød: CMYK(1,98,98,0) — (Fra logo:)(5,100,100,1) HEX(E20D13)
-            </li>
-            <li>
-              Mørkerød: CMYK(20,99,100,13) — (Fra logo:)(18,100,100,9)
-              HEX(BC1818)
-            </li>
+            <li>Lysegrå: CMYK(48,39,42,39) RGB(525251)</li>
+            <li>Grå: CMYK(53,44,46,52) RGB(343434)</li>
+            <li>Lyserød: CMYK(1,98,98,0) RGB(E21617)</li>
+            <li>Mørkerød: CMYK(20,99,100,13) RGB(B21C17)</li>
           </ul>
           <h2 className={styles.h2Padding}>Powerpointmal</h2>
           <p>


### PR DESCRIPTION
There have been colour updates to the wiki not reflected on abakus.no, this commit gets the standard colours up to date.
https://wiki.abakus.no/display/pr/Grafisk+profil:
![image](https://user-images.githubusercontent.com/33288640/97026582-d8e39c00-1559-11eb-9b57-ac6b8163137b.png)
https://abakus.no/brand:
![image](https://user-images.githubusercontent.com/33288640/97026600-e13bd700-1559-11eb-88b0-a787c30f7163.png)
