### PR TITLE
Move loading indicator

### DIFF
--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -23,6 +23,7 @@ import { Image } from 'app/components/Image';
 import type { UserEntity } from 'app/reducers/users';
 import logoLightMode from 'app/assets/logo-dark.png';
 import logoDarkMode from 'app/assets/logo.png';
+import LoadingIndicator from 'app/components/LoadingIndicator';
 
 type Props = {
   searchOpen: boolean,
@@ -37,6 +38,7 @@ type Props = {
   markAllNotifications: () => Promise<void>,
   fetchNotificationData: () => Promise<void>,
   upcomingMeeting: string,
+  loading: boolean,
 };
 
 type State = {
@@ -115,7 +117,7 @@ class Header extends Component<Props, State> {
   };
 
   render() {
-    const { loggedIn, currentUser } = this.props;
+    const { loggedIn, currentUser, loading } = this.props;
     const isLogin = this.state.mode === 'login';
     let title, form;
 
@@ -153,12 +155,16 @@ class Header extends Component<Props, State> {
       <header className={styles.header}>
         <FancyNodesCanvas height={300} />
         <div className={styles.content}>
-          <Link to="/" className={styles.logo}>
-            <Image
-              src={logoLightMode}
-              className={styles.logoLightMode}
-              alt=""
-            />
+          <Link to="/">
+            <LoadingIndicator loading={loading}>
+              <div className={styles.logo}>
+                <Image
+                  src={logoLightMode}
+                  className={styles.logoLightMode}
+                  alt=""
+                />
+              </div>
+            </LoadingIndicator>
             <Image src={logoDarkMode} className={styles.logoDarkMode} alt="" />
           </Link>
 

--- a/app/routes/app/AppRoute.js
+++ b/app/routes/app/AppRoute.js
@@ -131,6 +131,7 @@ class App extends PureComponent<AppProps> {
             markAllNotifications={this.props.markAllNotifications}
             fetchNotificationData={this.props.fetchNotificationData}
             upcomingMeeting={this.props.upcomingMeeting}
+            loading={this.props.loading}
           />
           <AppChildren
             currentUser={this.props.currentUser}
@@ -168,6 +169,7 @@ function mapStateToProps(state) {
     }),
     statusCode: state.router.statusCode,
     upcomingMeeting: upcomingMeetings.length ? upcomingMeetings[0] : undefined,
+    loading: state.frontpage.fetching,
   };
 }
 

--- a/app/routes/overview/IndexRoute.js
+++ b/app/routes/overview/IndexRoute.js
@@ -19,7 +19,6 @@ import { selectPinnedPolls } from 'app/reducers/polls';
 import { votePoll } from 'app/actions/PollActions';
 
 const mapStateToProps = (state) => ({
-  loadingFrontpage: state.frontpage.fetching,
   frontpage: selectFrontpage(state),
   feed: selectFeedById(state, { feedId: 'personal' }),
   shouldFetchQuote: isEmpty(selectRandomQuote(state)),

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -4,7 +4,6 @@ import styles from './Overview.css';
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
 import { Container, Flex } from 'app/components/Layout';
-import LoadingIndicator from 'app/components/LoadingIndicator';
 import LatestReadme from './LatestReadme';
 import CompactEvents from './CompactEvents';
 import type { Event, Article } from 'app/models';
@@ -24,7 +23,6 @@ import { renderMeta } from './utils';
 type Props = {
   frontpage: Array<Object>,
   readmes: Array<Object>,
-  loadingFrontpage: boolean,
   poll: ?PollEntity,
   votePoll: () => Promise<*>,
   loggedIn: boolean,
@@ -54,14 +52,7 @@ class Overview extends Component<Props, State> {
 
   render() {
     const isEvent = (o) => typeof o['startTime'] !== 'undefined';
-    const {
-      loggedIn,
-      frontpage,
-      loadingFrontpage,
-      readmes,
-      poll,
-      votePoll,
-    } = this.props;
+    const { loggedIn, frontpage, readmes, poll, votePoll } = this.props;
     const pinned = frontpage[0];
     const compactEvents = (
       <CompactEvents
@@ -70,18 +61,14 @@ class Overview extends Component<Props, State> {
       />
     );
 
-    const pinnedComponent = (
-      <LoadingIndicator loading={loadingFrontpage}>
-        {pinned && (
-          <div className={styles.pinned}>
-            <Pinned
-              item={pinned}
-              url={this.itemUrl(pinned)}
-              meta={renderMeta(pinned)}
-            />
-          </div>
-        )}
-      </LoadingIndicator>
+    const pinnedComponent = pinned && (
+      <div className={styles.pinned}>
+        <Pinned
+          item={pinned}
+          url={this.itemUrl(pinned)}
+          meta={renderMeta(pinned)}
+        />
+      </div>
     );
 
     const readMe = (


### PR DESCRIPTION
Moved the front pages' loading icon from pinned article to website logo.

Before:
![image](https://user-images.githubusercontent.com/42469466/98026875-1b379380-1e0c-11eb-8bb9-bc6bb69ee5cc.png)

After:
![image](https://user-images.githubusercontent.com/42469466/98026541-93ea2000-1e0b-11eb-9c49-576bb5bb44a8.png)
