### PR TITLE
Revert "Bump webpack-node-externals from 1.7.2 to 2.5.2"

### DIFF
--- a/config/webpack.server.js
+++ b/config/webpack.server.js
@@ -22,7 +22,7 @@ module.exports = (env, argv) => {
       minimize: false,
     },
     externals: [
-      nodeExternals({ allowlist: ['webpack/hot/poll?1000', /css$/] }),
+      nodeExternals({ whitelist: ['webpack/hot/poll?1000', /css$/] }),
     ],
 
     output: {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "webpack-dev-middleware": "^3.7.2",
     "webpack-filter-warnings-plugin": "^1.2.1",
     "webpack-hot-middleware": "^2.24.4",
-    "webpack-node-externals": "^2.5.2",
+    "webpack-node-externals": "^1.7.2",
     "webpack-stats-plugin": "^0.3.0"
   },
   "stylelint": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13317,10 +13317,10 @@ webpack-merge@^4.2.2:
   dependencies:
     lodash "^4.17.15"
 
-webpack-node-externals@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-2.5.2.tgz#178e017a24fec6015bc9e672c77958a6afac861d"
-  integrity sha512-aHdl/y2N7PW2Sx7K+r3AxpJO+aDMcYzMQd60Qxefq3+EwhewSbTBqNumOsCE1JsCUNoyfGj5465N0sSf6hc/5w==
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+  integrity sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==
 
 webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
Reverts webkom/lego-webapp#1949
Failed cypress tests after merge :eyes: 