### PR TITLE
Replace @babel/polyfill with corejs directly

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,12 @@
 {
-  "presets": ["@babel/preset-flow", "@babel/preset-env", "@babel/preset-react"],
+  "presets": ["@babel/preset-flow", ["@babel/preset-env", {
+    useBuiltIns: "usage",
+    corejs: 3
+  }], "@babel/preset-react"],
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
     "react-hot-loader/babel",
     "@babel/plugin-proposal-class-properties"
-  ]
+  ],
+  sourceType: "unambiguous"
 }

--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,8 @@
 // @flow
 /* eslint no-console: 0 */
 
-import '@babel/polyfill';
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import 'animate.css/animate.css';
 import 'minireset.css/minireset.css';
 import 'app/styles/globals.css';

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "url": "github.com/webkom/lego-webapp"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.10.4",
     "@sentry/browser": "^5.26.0",
     "@sentry/integrations": "^5.20.1",
     "@sentry/node": "^5.15.4",
@@ -46,6 +45,7 @@
     "classnames": "^2.2.6",
     "connected-react-router": "^6.3.2",
     "cookie-parser": "^1.4.3",
+    "core-js": "^3.7.0",
     "es6-promise-pool": "^2.5.0",
     "fuzzy": "^0.1.3",
     "immer": "^5.0.0",
@@ -92,6 +92,7 @@
     "redux-segment": "^1.6.2",
     "redux-sentry-middleware": "^0.1.8",
     "redux-thunk": "2.3.0",
+    "regenerator-runtime": "^0.13.7",
     "reselect": "4.0.0",
     "serialize-javascript": "^3.0.0",
     "slugify": "^1.3.6",

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
-import '@babel/polyfill';
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import app from './server';
 import * as Sentry from '@sentry/node';
 import { RewriteFrames } from '@sentry/integrations';

--- a/yarn.lock
+++ b/yarn.lock
@@ -825,14 +825,6 @@
     "@babel/helper-create-regexp-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/polyfill@^7.10.4":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.11.5.tgz#df550b2ec53abbc2ed599367ec59e64c7a707bb5"
-  integrity sha512-FunXnE0Sgpd61pKSj2OSOs1D44rKTD3pGOfGilZ6LGrrIH0QEtJlTjqOqdF8Bs98JmjfGhni2BBkTfv9KcKJ9g==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
-
 "@babel/preset-env@^7.8.7":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.11.5.tgz#18cb4b9379e3e92ffea92c07471a99a2914e4272"
@@ -943,6 +935,14 @@
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.0.tgz#db54a2251206f0f8579b41918acb14488b8dd2c0"
   integrity sha512-K0ioacsw8JgzDSPpUiGWokMvLzGvnZPXLrTsJfyHPrFsnp4yoKn+Ap/8NNZgWKZG9o5+qotH8tAa8AXn8gTN5A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime-corejs3@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz#ffee91da0eb4c6dae080774e94ba606368e414f4"
+  integrity sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==
   dependencies:
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
@@ -3600,7 +3600,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.10, core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -3609,6 +3609,11 @@ core-js@^3.4.2, core-js@^3.6.4, core-js@^3.6.5:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+
+core-js@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.7.0.tgz#b0a761a02488577afbf97179e4681bf49568520f"
+  integrity sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -10937,7 +10942,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==


### PR DESCRIPTION
`@babel/polyfill` is deprecated. The latest version of `@babel/polyfill` also uses `corejs2`, so this should fix the `(...).flat` is undefined errors we are getting:tm:. As `flat` and `flatMap` are stable as of corejs3 (is my understanding at lest)