### PR TITLE
Fix darkmode logo in header

### DIFF
--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -163,9 +163,13 @@ class Header extends Component<Props, State> {
                   className={styles.logoLightMode}
                   alt=""
                 />
+                <Image
+                  src={logoDarkMode}
+                  className={styles.logoDarkMode}
+                  alt=""
+                />
               </div>
             </LoadingIndicator>
-            <Image src={logoDarkMode} className={styles.logoDarkMode} alt="" />
           </Link>
 
           <div className={styles.menu}>


### PR DESCRIPTION
Changes in #2033 was not properly tested in dark mode
fix #2033
Before
![image](https://user-images.githubusercontent.com/42469466/98943752-48610180-24f0-11eb-8d64-6fbecdbf0965.png)

After
![image](https://user-images.githubusercontent.com/42469466/98943724-367f5e80-24f0-11eb-9281-a81b1fbdf8b7.png)
