### PR TITLE
Route users to login page from interest groups when not logged in

### DIFF
--- a/app/routes/interestgroups/InterestGroupEditRoute.js
+++ b/app/routes/interestgroups/InterestGroupEditRoute.js
@@ -7,8 +7,10 @@ import { fetchGroup } from 'app/actions/GroupActions';
 import { editInterestGroup } from 'app/actions/InterestGroupActions';
 import { uploadFile } from 'app/actions/FileActions';
 import { selectGroup } from 'app/reducers/groups';
+import { LoginPage } from 'app/components/LoginForm';
 import InterestGroupEdit from './components/InterestGroupEdit';
 import loadingIndicator from 'app/utils/loadingIndicator';
+import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 
 const mapDispatchToProps = {
   editInterestGroup,
@@ -29,6 +31,7 @@ const mapStateToProps = (state, props) => {
 };
 
 export default compose(
+  replaceUnlessLoggedIn(LoginPage),
   prepare(({ match: { params: { interestGroupId } } }, dispatch) =>
     dispatch(fetchGroup(Number(interestGroupId)))
   ),

--- a/app/routes/interestgroups/InterestGroupListRoute.js
+++ b/app/routes/interestgroups/InterestGroupListRoute.js
@@ -7,6 +7,8 @@ import { fetchAllWithType } from 'app/actions/GroupActions';
 import InterestGroupList from './components/InterestGroupList';
 import { selectGroupsWithType } from 'app/reducers/groups';
 import { GroupTypeInterest } from 'app/models';
+import { LoginPage } from 'app/components/LoginForm';
+import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 
 const groupType = GroupTypeInterest;
 const mapStateToProps = (state) => ({
@@ -15,6 +17,7 @@ const mapStateToProps = (state) => ({
 });
 
 export default compose(
+  replaceUnlessLoggedIn(LoginPage),
   prepare((props, dispatch) => dispatch(fetchAllWithType(groupType))),
   connect(mapStateToProps, {})
 )(InterestGroupList);


### PR DESCRIPTION
As the [sentry error](https://github.com/webkom/lego/issues/1945) states, a user that is not logged in and tries to edit or view the interest groups, receives a 401 error. Therefore, the user is now displayed the login page instead.

https://github.com/webkom/lego/issues/1945


Btw, the commit message references another PR by mistake :upside_down_face: 