### PR TITLE
Improve event administrate table

### DIFF
--- a/app/components/Form/RadioButton.css
+++ b/app/components/Form/RadioButton.css
@@ -14,7 +14,10 @@
 }
 
 .label {
+  position: relative;
+  display: inline-block;
   cursor: pointer;
+  padding: 4px 26px;
 }
 
 .input:disabled,
@@ -26,6 +29,8 @@
 .label::before {
   content: '';
   position: absolute;
+  top: 0;
+  left: 0;
   width: 22px;
   height: 22px;
   border: 1px solid var(--color-mono-gray-1);
@@ -39,6 +44,8 @@
 .label::after {
   content: '';
   position: absolute;
+  top: 0;
+  left: 0;
   width: 16px;
   height: 16px;
   border-radius: 8px;

--- a/app/components/Form/RadioButton.js
+++ b/app/components/Form/RadioButton.js
@@ -30,6 +30,7 @@ function RadioButton({
         checked={inputValue === value}
         type="radio"
         id={id}
+        value={inputValue}
       />
       <span className={styles.label}>{label}</span>
     </div>

--- a/app/components/Form/RadioButton.js
+++ b/app/components/Form/RadioButton.js
@@ -30,7 +30,6 @@ function RadioButton({
         checked={inputValue === value}
         type="radio"
         id={id}
-        value={inputValue}
       />
       <span className={styles.label}>{label}</span>
     </div>

--- a/app/components/Table/Table.css
+++ b/app/components/Table/Table.css
@@ -1,18 +1,29 @@
+.tableDiv {
+  overflow-x: scroll;
+}
+
 .table {
   width: 100%;
 }
 
+.tableHeader {
+  display: flex;
+  padding: 0 10px;
+}
+
 .sorter {
   display: inline-block;
-  margin-left: 10px;
+  margin-right: 5px;
+  margin-top: 5px;
   vertical-align: middle;
   line-height: 1;
   cursor: pointer;
+  position: relative;
 }
 
 .searchIcon {
   display: inline-block;
-  margin-left: 10px;
+  margin-left: 5px;
   vertical-align: middle;
   line-height: 1;
   cursor: pointer;
@@ -21,7 +32,7 @@
 
 .filterIcon {
   display: inline-block;
-  margin-left: 10px;
+  margin-right: 5px;
   vertical-align: middle;
   line-height: 1;
   cursor: pointer;
@@ -30,7 +41,7 @@
 
 .arrowDownIcon {
   display: inline-block;
-  margin-left: 10px;
+  margin-left: 5px;
   vertical-align: middle;
   line-height: 1;
   cursor: pointer;

--- a/app/components/Table/Table.css
+++ b/app/components/Table/Table.css
@@ -28,6 +28,15 @@
   position: relative;
 }
 
+.arrowDownIcon {
+  display: inline-block;
+  margin-left: 10px;
+  vertical-align: middle;
+  line-height: 1;
+  cursor: pointer;
+  position: relative;
+}
+
 .checkbox {
   position: absolute;
   min-width: 150px;

--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -435,9 +435,6 @@ export default class Table extends Component<Props, State> {
 
     let sorter = this.state.sort.sorter;
     const { direction, dataIndex } = this.state.sort;
-
-    console.log(dataIndex);
-    console.log(sorter);
     
     if (typeof(sorter) == "boolean") sorter = (a,b) => {
       if (a[dataIndex] > b[dataIndex]) return 1;
@@ -447,9 +444,6 @@ export default class Table extends Component<Props, State> {
     const sortedData = [...data].sort((a,b) => 
     sorter != undefined ? sorter(a,b) : -1);
     if (direction == 'desc') sortedData.reverse();
-
-    console.log(sortedData);
-
     
     return (
       <table className={styles.table}>

--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -18,7 +18,7 @@ import Button from '../Button';
 type sortProps = {
   direction?: 'asc' | 'desc',
   dataIndex?: string,
-  sorter?: any,
+  sorter?: boolean | ((any, any) => number),
 };
 
 type checkFilter = {
@@ -29,7 +29,7 @@ type checkFilter = {
 type columnProps = {
   dataIndex: string,
   title?: string,
-  sorter?: boolean | (any, any) => number,
+  sorter?: boolean | ((any, any) => number),
   filter?: Array<checkFilter>,
   /*
    * Map the value to to "another" value to use
@@ -138,18 +138,20 @@ export default class Table extends Component<Props, State> {
   };
 
   onChooseColumnInput = (columnIndex: any, dataIndex: any) => {
-    this.setState(
-      { showColumn: { [dataIndex]: columnIndex } }, 
-      () => this.onChange()
+    this.setState({ showColumn: { [dataIndex]: columnIndex } }, () =>
+      this.onChange()
     );
   };
 
   onSortInput = (dataIndex: any, sorter: any) => {
-    const direction = this.state.sort.dataIndex == dataIndex && this.state.sort.direction == 'asc' ? 'desc' : 'asc'
+    const direction =
+      this.state.sort.dataIndex === dataIndex &&
+      this.state.sort.direction === 'asc'
+        ? 'desc'
+        : 'asc';
 
-    this.setState(
-      { sort: { direction, dataIndex, sorter } },
-      () => this.onChange()
+    this.setState({ sort: { direction, dataIndex, sorter } }, () =>
+      this.onChange()
     );
   };
 
@@ -205,7 +207,12 @@ export default class Table extends Component<Props, State> {
       filterMessage,
     } = chosenProps;
 
-    const sortIconName = this.state.sort.dataIndex == dataIndex ? this.state.sort.direction == 'asc' ? "sort-asc" : "sort-desc" : "sort";
+    const sortIconName =
+      this.state.sort.dataIndex === dataIndex
+        ? this.state.sort.direction === 'asc'
+          ? 'sort-asc'
+          : 'sort-desc'
+        : 'sort';
 
     const { filters, isShown } = this.state;
     return (
@@ -215,7 +222,7 @@ export default class Table extends Component<Props, State> {
       >
         {sorter && (
           <div className={styles.sorter}>
-            <Icon 
+            <Icon
               onClick={() => this.onSortInput(dataIndex, sorter)}
               name={sortIconName}
               prefix="fa fa-"
@@ -428,16 +435,18 @@ export default class Table extends Component<Props, State> {
 
     let sorter = this.state.sort.sorter;
     const { direction, dataIndex } = this.state.sort;
-    
-    if (typeof(sorter) == "boolean") sorter = (a,b) => {
-      if (a[dataIndex] > b[dataIndex]) return 1;
-      return -1;
-    }
 
-    const sortedData = [...data].sort((a,b) => 
-    sorter != undefined ? sorter(a,b) : -1);
-    if (direction == 'desc') sortedData.reverse();
-    
+    if (typeof sorter == 'boolean')
+      sorter = (a, b) => {
+        if (a[dataIndex] > b[dataIndex]) return 1;
+        return -1;
+      };
+
+    const sortedData = [...data].sort((a, b) =>
+      sorter !== undefined && typeof sorter !== 'boolean' ? sorter(a, b) : -1
+    );
+    if (direction === 'desc') sortedData.reverse();
+
     return (
       <table className={styles.table}>
         <thead>

--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -220,6 +220,7 @@ export default class Table extends Component<Props, State> {
         key={`${dataIndex}-${index}`}
         style={center ? { textAlign: 'center' } : {}}
       >
+        <div className={styles.tableHeader}>
         {sorter && (
           <div className={styles.sorter}>
             <Icon
@@ -227,6 +228,7 @@ export default class Table extends Component<Props, State> {
               name={sortIconName}
               prefix="fa fa-"
               size={18}
+              className={styles.icon}
             />
           </div>
         )}
@@ -384,6 +386,7 @@ export default class Table extends Component<Props, State> {
             </Overlay>
           </div>
         )}
+        </div>
       </th>
     );
   };
@@ -448,6 +451,7 @@ export default class Table extends Component<Props, State> {
     if (direction === 'desc') sortedData.reverse();
 
     return (
+      <div className={styles.tableDiv}> 
       <table className={styles.table}>
         <thead>
           <tr>
@@ -476,6 +480,7 @@ export default class Table extends Component<Props, State> {
           </tr>
         </InfiniteScroll>
       </table>
+      </div>
     );
   }
 }

--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -221,171 +221,171 @@ export default class Table extends Component<Props, State> {
         style={center ? { textAlign: 'center' } : {}}
       >
         <div className={styles.tableHeader}>
-        {sorter && (
-          <div className={styles.sorter}>
-            <Icon
-              onClick={() => this.onSortInput(dataIndex, sorter)}
-              name={sortIconName}
-              prefix="fa fa-"
-              size={18}
-              className={styles.icon}
-            />
-          </div>
-        )}
-        {title}
-        {search && (
-          <div className={styles.searchIcon}>
-            <div
-              ref={(c) => (this.components[dataIndex] = c)}
-              className={styles.searchIcon}
-            >
+          {sorter && (
+            <div className={styles.sorter}>
               <Icon
-                onClick={() => this.toggleSearch(dataIndex)}
-                name="search"
-                className={cx(
-                  styles.icon,
-                  ((filters[dataIndex] && filters[dataIndex].length) ||
-                    isShown[dataIndex]) &&
-                    styles.iconActive
-                )}
-              />
-            </div>
-            <Overlay
-              show={isShown[dataIndex]}
-              onHide={() => this.toggleSearch(dataIndex)}
-              placement="bottom"
-              container={this.components[dataIndex]}
-              target={() => this.components[dataIndex]}
-              rootClose
-            >
-              <div className={styles.overlay}>
-                <TextInput
-                  autoFocus
-                  placeholder={filterMessage}
-                  value={filters[dataIndex]}
-                  onChange={(e) => this.onSearchInput(e, dataIndex)}
-                  onKeyDown={({ keyCode }) => {
-                    if (keyCode === 13) {
-                      this.toggleSearch(dataIndex);
-                    }
-                  }}
-                />
-              </div>
-            </Overlay>
-          </div>
-        )}
-        {filter && (
-          <div className={styles.filterIcon}>
-            <div
-              ref={(c) => (this.components[dataIndex] = c)}
-              className={styles.filterIcon}
-            >
-              <Icon
-                onClick={() => this.toggleFilter(dataIndex)}
-                name="funnel"
-                className={cx(
-                  styles.icon,
-                  (filters[dataIndex] !== undefined || isShown[dataIndex]) &&
-                    styles.iconActive
-                )}
-              />
-            </div>
-            <Overlay
-              show={isShown[dataIndex]}
-              onHide={() => this.toggleFilter(dataIndex)}
-              placement="bottom"
-              container={this.components[dataIndex]}
-              target={() => this.components[dataIndex]}
-              rootClose
-            >
-              <div className={styles.checkbox}>
-                {filter.map(({ label, value }) => (
-                  <div
-                    key={label}
-                    onClick={() =>
-                      this.onFilterInput(
-                        this.state.filters[dataIndex] === value
-                          ? undefined
-                          : value,
-                        dataIndex
-                      )
-                    }
-                  >
-                    <p key={label}>
-                      <CheckBox
-                        label={label}
-                        value={value === this.state.filters[dataIndex]}
-                      />
-                    </p>
-                  </div>
-                ))}
-                <Button
-                  flat
-                  onClick={() =>
-                    this.setState(
-                      (state) => ({
-                        filters: {
-                          ...state.filters,
-                          [dataIndex]: undefined,
-                        },
-                      }),
-                      () => {
-                        this.toggleFilter(dataIndex);
-                        this.onChange();
-                      }
-                    )
-                  }
-                >
-                  Nullstill
-                </Button>
-              </div>
-            </Overlay>
-          </div>
-        )}
-        {columnChoices && (
-          <div className={styles.arrowDownIcon}>
-            <div
-              ref={(c) => (this.components[dataIndex] = c)}
-              className={styles.arrowDownIcon}
-            >
-              <Icon
-                onClick={() => this.toggleChooseColumn(dataIndex)}
-                name="arrow-down"
+                onClick={() => this.onSortInput(dataIndex, sorter)}
+                name={sortIconName}
+                prefix="fa fa-"
+                size={18}
                 className={styles.icon}
               />
             </div>
-            <Overlay
-              show={isShown[dataIndex]}
-              onHide={() => this.toggleChooseColumn(dataIndex)}
-              placement="bottom"
-              container={this.components[dataIndex]}
-              target={() => this.components[dataIndex]}
-              rootClose
-            >
-              <div className={styles.overlay}>
-                {columnChoices.map(({ title }, index) => (
-                  <div
-                    key={title}
+          )}
+          {title}
+          {search && (
+            <div className={styles.searchIcon}>
+              <div
+                ref={(c) => (this.components[dataIndex] = c)}
+                className={styles.searchIcon}
+              >
+                <Icon
+                  onClick={() => this.toggleSearch(dataIndex)}
+                  name="search"
+                  className={cx(
+                    styles.icon,
+                    ((filters[dataIndex] && filters[dataIndex].length) ||
+                      isShown[dataIndex]) &&
+                      styles.iconActive
+                  )}
+                />
+              </div>
+              <Overlay
+                show={isShown[dataIndex]}
+                onHide={() => this.toggleSearch(dataIndex)}
+                placement="bottom"
+                container={this.components[dataIndex]}
+                target={() => this.components[dataIndex]}
+                rootClose
+              >
+                <div className={styles.overlay}>
+                  <TextInput
+                    autoFocus
+                    placeholder={filterMessage}
+                    value={filters[dataIndex]}
+                    onChange={(e) => this.onSearchInput(e, dataIndex)}
+                    onKeyDown={({ keyCode }) => {
+                      if (keyCode === 13) {
+                        this.toggleSearch(dataIndex);
+                      }
+                    }}
+                  />
+                </div>
+              </Overlay>
+            </div>
+          )}
+          {filter && (
+            <div className={styles.filterIcon}>
+              <div
+                ref={(c) => (this.components[dataIndex] = c)}
+                className={styles.filterIcon}
+              >
+                <Icon
+                  onClick={() => this.toggleFilter(dataIndex)}
+                  name="funnel"
+                  className={cx(
+                    styles.icon,
+                    (filters[dataIndex] !== undefined || isShown[dataIndex]) &&
+                      styles.iconActive
+                  )}
+                />
+              </div>
+              <Overlay
+                show={isShown[dataIndex]}
+                onHide={() => this.toggleFilter(dataIndex)}
+                placement="bottom"
+                container={this.components[dataIndex]}
+                target={() => this.components[dataIndex]}
+                rootClose
+              >
+                <div className={styles.checkbox}>
+                  {filter.map(({ label, value }) => (
+                    <div
+                      key={label}
+                      onClick={() =>
+                        this.onFilterInput(
+                          this.state.filters[dataIndex] === value
+                            ? undefined
+                            : value,
+                          dataIndex
+                        )
+                      }
+                    >
+                      <p key={label}>
+                        <CheckBox
+                          label={label}
+                          value={value === this.state.filters[dataIndex]}
+                        />
+                      </p>
+                    </div>
+                  ))}
+                  <Button
+                    flat
                     onClick={() =>
-                      this.onChooseColumnInput(index, dataIndexColumnChoices)
+                      this.setState(
+                        (state) => ({
+                          filters: {
+                            ...state.filters,
+                            [dataIndex]: undefined,
+                          },
+                        }),
+                        () => {
+                          this.toggleFilter(dataIndex);
+                          this.onChange();
+                        }
+                      )
                     }
                   >
-                    <p key={title}>
-                      <RadioButton
-                        name={dataIndexColumnChoices}
-                        inputValue={
-                          this.state.showColumn[dataIndexColumnChoices]
-                        }
-                        value={index}
-                        label={title}
-                      />
-                    </p>
-                  </div>
-                ))}
+                    Nullstill
+                  </Button>
+                </div>
+              </Overlay>
+            </div>
+          )}
+          {columnChoices && (
+            <div className={styles.arrowDownIcon}>
+              <div
+                ref={(c) => (this.components[dataIndex] = c)}
+                className={styles.arrowDownIcon}
+              >
+                <Icon
+                  onClick={() => this.toggleChooseColumn(dataIndex)}
+                  name="arrow-down"
+                  className={styles.icon}
+                />
               </div>
-            </Overlay>
-          </div>
-        )}
+              <Overlay
+                show={isShown[dataIndex]}
+                onHide={() => this.toggleChooseColumn(dataIndex)}
+                placement="bottom"
+                container={this.components[dataIndex]}
+                target={() => this.components[dataIndex]}
+                rootClose
+              >
+                <div className={styles.overlay}>
+                  {columnChoices.map(({ title }, index) => (
+                    <div
+                      key={title}
+                      onClick={() =>
+                        this.onChooseColumnInput(index, dataIndexColumnChoices)
+                      }
+                    >
+                      <p key={title}>
+                        <RadioButton
+                          name={dataIndexColumnChoices}
+                          inputValue={
+                            this.state.showColumn[dataIndexColumnChoices]
+                          }
+                          value={index}
+                          label={title}
+                        />
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </Overlay>
+            </div>
+          )}
         </div>
       </th>
     );
@@ -451,35 +451,35 @@ export default class Table extends Component<Props, State> {
     if (direction === 'desc') sortedData.reverse();
 
     return (
-      <div className={styles.tableDiv}> 
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            {columns
-              .filter(isVisible)
-              .map((column, index) => this.renderHeadCell(column, index))}
-          </tr>
-        </thead>
-        <InfiniteScroll
-          element="tbody"
-          hasMore={hasMore && !loading}
-          loadMore={this.loadMore}
-          threshold={50}
-        >
-          {sortedData.filter(this.filter).map((item, index) => (
-            <tr key={item[rowKey]}>
+      <div className={styles.tableDiv}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
               {columns
                 .filter(isVisible)
-                .map((column, index) => this.renderCell(column, item, index))}
+                .map((column, index) => this.renderHeadCell(column, index))}
             </tr>
-          ))}
-          <tr>
-            <td className={styles.loader} colSpan={columns.length}>
-              <LoadingIndicator loading={loading} />
-            </td>
-          </tr>
-        </InfiniteScroll>
-      </table>
+          </thead>
+          <InfiniteScroll
+            element="tbody"
+            hasMore={hasMore && !loading}
+            loadMore={this.loadMore}
+            threshold={50}
+          >
+            {sortedData.filter(this.filter).map((item, index) => (
+              <tr key={item[rowKey]}>
+                {columns
+                  .filter(isVisible)
+                  .map((column, index) => this.renderCell(column, item, index))}
+              </tr>
+            ))}
+            <tr>
+              <td className={styles.loader} colSpan={columns.length}>
+                <LoadingIndicator loading={loading} />
+              </td>
+            </tr>
+          </InfiniteScroll>
+        </table>
       </div>
     );
   }

--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -145,10 +145,7 @@ export default class Table extends Component<Props, State> {
   };
 
   onSortInput = (dataIndex: any, sorter: any) => {
-    let direction = 'asc';
-    if (this.state.sort.dataIndex == dataIndex){
-      if (this.state.sort.direction == 'asc') direction = 'desc';
-    }
+    const direction = this.state.sort.dataIndex == dataIndex && this.state.sort.direction == 'asc' ? 'desc' : 'asc'
 
     this.setState(
       { sort: { direction, dataIndex, sorter } },
@@ -208,11 +205,7 @@ export default class Table extends Component<Props, State> {
       filterMessage,
     } = chosenProps;
 
-    let sortIconName = "sort";
-    if (this.state.sort.dataIndex == dataIndex){
-      if (this.state.sort.direction == 'asc') sortIconName = "sort-asc";
-      else sortIconName = "sort-desc";
-    }
+    const sortIconName = this.state.sort.dataIndex == dataIndex ? this.state.sort.direction == 'asc' ? "sort-asc" : "sort-desc" : "sort";
 
     const { filters, isShown } = this.state;
     return (

--- a/app/routes/events/EventAdministrateRoute.js
+++ b/app/routes/events/EventAdministrateRoute.js
@@ -4,16 +4,30 @@ import prepare from 'app/utils/prepare';
 import { fetchAdministrate } from 'app/actions/EventActions';
 import EventAdministrateIndex from './components/EventAdministrate';
 import { selectEventById } from 'app/reducers/events';
+import {
+  selectPoolsWithRegistrationsForEvent,
+  selectMergedPoolWithRegistrations,
+} from 'app/reducers/events';
 
 const mapStateToProps = (state, props) => {
   const eventId = props.match.params.eventId;
 
   const event = selectEventById(state, { eventId });
+
+  const poolsWithRegistrations = event.isMerged
+    ? selectMergedPoolWithRegistrations(state, { eventId })
+    : selectPoolsWithRegistrationsForEvent(state, {
+        eventId,
+      });
+
+  const pools = poolsWithRegistrations;
+
   return {
     actionGrant: state.events.actionGrant,
     loading: state.events.fetching,
     eventId,
     event,
+    pools,
   };
 };
 

--- a/app/routes/events/components/EventAdministrate/Attendees.js
+++ b/app/routes/events/components/EventAdministrate/Attendees.js
@@ -91,6 +91,7 @@ export default class Attendees extends Component<Props, State> {
       registered,
       unregistered,
       currentUser,
+      pools,
     } = this.props;
     const registerCount = registered.filter(
       (reg) => reg.presence === 'PRESENT' && reg.pool
@@ -188,6 +189,7 @@ export default class Attendees extends Component<Props, State> {
             handleUnregister={this.handleUnregister}
             clickedUnregister={this.state.clickedUnregister}
             showUnregister={showUnregister}
+            pools={pools}
           />
           <strong style={{ marginTop: '10px' }}>Avmeldte:</strong>
           <UnregisteredTable unregistered={unregistered} loading={loading} />

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -105,10 +105,10 @@ export class RegisteredTable extends Component<Props> {
         render: (pool, registration) => (
           <span>{registered.indexOf(registration) + 1}.</span>
         ),
-        sorter: (a,b) => {
+        sorter: (a, b) => {
           if (registered.indexOf(a) > registered.indexOf(b)) return 1;
           else return -1;
-        }
+        },
       },
       {
         title: 'Bruker',
@@ -117,7 +117,7 @@ export class RegisteredTable extends Component<Props> {
         render: (user) => (
           <Link to={`/users/${user.username}`}>{user.fullName}</Link>
         ),
-        sorter: (a,b) => {
+        sorter: (a, b) => {
           if (a.user.username > b.user.username) return 1;
           else return -1;
         },
@@ -183,9 +183,9 @@ export class RegisteredTable extends Component<Props> {
             title: 'Klassetrinn',
             dataIndex: 'user.grade',
             render: GradeRenderer,
-            sorter: (a,b) => {
-              if (a.user.grade && b.user.grade){
-                if (a.user.grade.name > b.user.grade.name) return 1
+            sorter: (a, b) => {
+              if (a.user.grade && b.user.grade) {
+                if (a.user.grade.name > b.user.grade.name) return 1;
               }
               if (!a.user.grade && b.user.grade) return 1;
               else return -1;
@@ -225,7 +225,7 @@ export class RegisteredTable extends Component<Props> {
             {`Allergier: ${registration.user.allergies || '-'}`}
           </span>
         ),
-        sorter: (a,b) => {
+        sorter: (a, b) => {
           if (a.feedback > b.feedback) return 1;
           else return -1;
         },

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -1,11 +1,5 @@
 // @flow
 
-// Må få henta inn pools ordentlig
-// Må skjønne hvordan search fungerer
-
-// Må lage nedtrekksmeny hvor man kan velge mellom å vise pool og klassetrinn
-// Må fikse mulighet til å sortere etter en colonne
-
 import styles from './Administrate.css';
 import { Component } from 'react';
 import { Link } from 'react-router-dom';
@@ -111,6 +105,10 @@ export class RegisteredTable extends Component<Props> {
         render: (pool, registration) => (
           <span>{registered.indexOf(registration) + 1}.</span>
         ),
+        sorter: (a,b) => {
+          if (registered.indexOf(a) > registered.indexOf(b)) return 1;
+          else return -1;
+        }
       },
       {
         title: 'Bruker',
@@ -119,6 +117,10 @@ export class RegisteredTable extends Component<Props> {
         render: (user) => (
           <Link to={`/users/${user.username}`}>{user.fullName}</Link>
         ),
+        sorter: (a,b) => {
+          if (a.user.username > b.user.username) return 1;
+          else return -1;
+        },
         filterMapping: (user) => user.fullName,
       },
       {
@@ -181,6 +183,13 @@ export class RegisteredTable extends Component<Props> {
             title: 'Klassetrinn',
             dataIndex: 'user.grade',
             render: GradeRenderer,
+            sorter: (a,b) => {
+              if (a.user.grade && b.user.grade){
+                if (a.user.grade.name > b.user.grade.name) return 1
+              }
+              if (!a.user.grade && b.user.grade) return 1;
+              else return -1;
+            },
           },
           {
             title: 'Pool',
@@ -189,6 +198,7 @@ export class RegisteredTable extends Component<Props> {
               const poolName = getPoolName(pools, pool);
               return <span>{poolName}</span>;
             },
+            sorter: true,
           },
         ],
       },
@@ -215,6 +225,10 @@ export class RegisteredTable extends Component<Props> {
             {`Allergier: ${registration.user.allergies || '-'}`}
           </span>
         ),
+        sorter: (a,b) => {
+          if (a.feedback > b.feedback) return 1;
+          else return -1;
+        },
       },
       {
         title: 'Administrer',
@@ -298,6 +312,7 @@ type UnregisteredTableProps = {
 export class UnregisteredTable extends Component<UnregisteredTableProps> {
   render() {
     const { loading, unregistered } = this.props;
+
     const columns = [
       {
         title: 'Bruker',

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -1,5 +1,11 @@
 // @flow
 
+// Må få henta inn pools ordentlig
+// Må skjønne hvordan search fungerer
+
+// Må lage nedtrekksmeny hvor man kan velge mellom å vise pool og klassetrinn
+// Må fikse mulighet til å sortere etter en colonne
+
 import styles from './Administrate.css';
 import { Component } from 'react';
 import { Link } from 'react-router-dom';
@@ -21,6 +27,7 @@ import {
   PresenceIcons,
   Unregister,
 } from './AttendeeElements';
+import type { EventPool } from 'app/models';
 
 type Props = {
   registered: Array<EventRegistration>,
@@ -37,6 +44,7 @@ type Props = {
   clickedUnregister: ID,
   showUnregister: boolean,
   event: Event,
+  pools: Array<EventPool>,
 };
 const GradeRenderer = (group: { name: string }) =>
   !!group && (
@@ -50,6 +58,11 @@ const GradeRenderer = (group: { name: string }) =>
   );
 
 const hasWebkomGroup = (user) => user.abakusGroups.includes(WEBKOM_GROUP_ID);
+
+const getPoolName = (pools, poolId) => {
+  const pool = pools.find((pool) => pool.id === poolId);
+  return pool && pool.name;
+};
 
 const getRegistrationInfo = (pool, registration) => {
   let registrationInfo = {
@@ -89,19 +102,29 @@ export class RegisteredTable extends Component<Props> {
       clickedUnregister,
       showUnregister,
       event,
+      pools,
     } = this.props;
     const columns = [
       {
+        title: 'Nr.',
+        dataIndex: 'nr',
+        render: (pool, registration) => (
+          <span>{registered.indexOf(registration) + 1}.</span>
+        ),
+      },
+      {
         title: 'Bruker',
         dataIndex: 'user',
+        search: true,
         render: (user) => (
           <Link to={`/users/${user.username}`}>{user.fullName}</Link>
         ),
+        filterMapping: (user) => user.fullName,
       },
       {
         title: 'Status',
         center: true,
-        dataIndex: 'pool',
+        dataIndex: 'status',
         render: (pool, registration) => {
           const registrationInfo = getRegistrationInfo(pool, registration);
           return (
@@ -152,9 +175,22 @@ export class RegisteredTable extends Component<Props> {
           ),
       },
       {
-        title: 'Klassetrinn',
-        dataIndex: 'user.grade',
-        render: GradeRenderer,
+        dataIndex: 'gradeOrPool',
+        columnChoices: [
+          {
+            title: 'Klassetrinn',
+            dataIndex: 'user.grade',
+            render: GradeRenderer,
+          },
+          {
+            title: 'Pool',
+            dataIndex: 'pool',
+            render: (pool, registration) => {
+              const poolName = getPoolName(pools, pool);
+              return <span>{poolName}</span>;
+            },
+          },
+        ],
       },
       {
         title: 'Betaling',

--- a/app/routes/events/components/EventAdministrate/index.js
+++ b/app/routes/events/components/EventAdministrate/index.js
@@ -9,6 +9,7 @@ import { Content } from 'app/components/Content';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { LoginPage } from 'app/components/LoginForm';
 import type { EventEntity } from 'app/reducers/events';
+import type { EventPool } from 'app/models';
 
 type Props = {
   children: Array<Element<*>>,
@@ -20,6 +21,7 @@ type Props = {
       eventId: string,
     },
   },
+  pools: Array<EventPool>,
 };
 
 const EventAdministrateIndex = (props: Props) => {


### PR DESCRIPTION
Fixes https://github.com/webkom/lego/issues/1993

Added: 
- column with a number for every attendee (the number is the index of the attendee in the array of all registered attendees, ie. the numbers will be arranged so that number 1 is the first who signed up for the event, number 2 is the second and so on)
- column with the pool of the attendee
- ability to choose which column to show given a set of possibilities (for example i have used this for the columns grade and pool, because they're normally the same (so you don't want to show them both), but in the few cases when they aren't it's nice to be able to choose which one you want to see)
- ability to search in the name column (functionality was already implemented, just added the ability for this specific column)
- ability to sort the table based on a chosen column (first click sorts ascending, second sorts descending) 

(don't know if i can add example-photos to github, as an example from staging would contain personal info about users... so i hope this illustrates the concepts well enough)

Table header with all the functions (search, sort, choose column, and new coulmns)
![image](https://user-images.githubusercontent.com/69513864/108838136-85e72780-75d3-11eb-93e0-01fd42aa5cc0.png)

Choose between pool and grade:
![image](https://user-images.githubusercontent.com/69513864/108840014-10308b00-75d6-11eb-9977-d600e5b03283.png)


Nr. column and example of sorting:
![image](https://user-images.githubusercontent.com/69513864/108838904-9a77ef80-75d4-11eb-9042-f22cd931f3f8.png)
![image](https://user-images.githubusercontent.com/69513864/108838934-a794de80-75d4-11eb-84c4-d50be93a3ca0.png)
