### PR TITLE
Remove react-select filtering for autocomplete

### DIFF
--- a/app/components/Search/withAutocomplete.js
+++ b/app/components/Search/withAutocomplete.js
@@ -85,6 +85,7 @@ function withAutocomplete<Props>({
           options={this.state.result}
           onSearch={debounce((query) => this.handleSearch(query, filter), 100)}
           fetching={this.state.searching}
+          filterOption={() => true}
         />
       );
     }


### PR DESCRIPTION
We pass filtered options with the autocomplete action. If we use
react-select default filtering, the already filtered results will be
filtered once again, removing some of the results that we want.

With some changes I am making to the postgres search backend, this will greatly improve the searching experience.

F.ex if there is a person with the name `Bob Carl Johnson`, searching `Bob John` on LEGO will return this user (with the new search), but react-select will filter it out :-1:.