### PR TITLE
Dont show pinned article twice on articles

### DIFF
--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -134,6 +134,7 @@ class Overview extends Component<Props, State> {
           {frontpage
             .filter((item) => item.documentType === 'article')
             .filter((article) => !article.tags.includes('weekly'))
+            .filter((article) => article.id !== pinned.id)
             .slice(0, this.state.articlesToShow)
             .map((article) => (
               <ArticleItem


### PR DESCRIPTION
This is at least a temp solution to the "Pinned articles show up in both the _pinned_ component and the article list" problem.