### PR TITLE
Show multiple leaders of interest groups

### DIFF
--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -94,8 +94,20 @@ const Contact = ({ group }: { group: Group }) => {
     );
   }
 
-  const leader = leaders[0];
+  if (leaders.length > 1) {
+    return (
+      <Flex column>
+        <h4>Ledere</h4>
+        <ul>
+          {leaders.map((leader) => (
+            <li key={leader.user.username}>{leader.user.fullName}</li>
+          ))}
+        </ul>
+      </Flex>
+    );
+  }
 
+  const leader = leaders[0];
   return (
     <Flex column>
       <h4>Leder</h4>


### PR DESCRIPTION
Fix webkom/lego#2152 
Now will all leaders of an interest group be shown, also if there are multiple leaders.

E.g. if there are 5 leaders in an interest group:
Before:
![image](https://user-images.githubusercontent.com/31897129/115439658-1d04e000-a20f-11eb-84e3-29492823a001.png)

After:
![image](https://user-images.githubusercontent.com/31897129/115439468-e75ff700-a20e-11eb-81f6-e7bb5ab712b2.png)
