### PR TITLE
Set nice style on unanswered surveys warning

### DIFF
--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -93,6 +93,7 @@
 
 .eventWarning {
   padding: 10px;
+  margin-bottom: 10px;
   border-radius: 10px;
   background: var(--color-red-4);
   text-align: center;
@@ -104,13 +105,13 @@
   margin: 0;
 }
 
-.eventWarning > a {
+.eventWarning a {
   font-weight: bold;
   color: var(--color-event-red);
 }
 
-.eventWarning > a:hover {
-  color: var(--color-black);
+.eventWarning a:hover {
+  color: #6b0d06;
 }
 
 .eventPrice {

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -21,12 +21,3 @@
 .paymentInfo {
   margin-top: 10px;
 }
-
-.unansweredSurveys {
-  max-width: 625px;
-  margin-top: 15px;
-}
-
-.unansweredSurveys h3 {
-  color: var(--color-red-3);
-}

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -352,11 +352,12 @@ export default class EventDetail extends Component<Props> {
 
                   {event.unansweredSurveys &&
                   event.unansweredSurveys.length > 0 ? (
-                    <div className={styles.unansweredSurveys}>
-                      <h3>
+                    <div className={styles.eventWarning}>
+                      <p>
                         Du kan ikke melde deg på dette arrangementet fordi du
                         har ubesvarte spørreundersøkelser.
-                      </h3>
+                      </p>
+                      <br />
                       <p>
                         Man må svare på alle spørreundersøkelser for tidligere
                         arrangementer før man kan melde seg på nye

--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -94,8 +94,20 @@ const Contact = ({ group }: { group: Group }) => {
     );
   }
 
-  const leader = leaders[0];
+  if (leaders.length > 1) {
+    return (
+      <Flex column>
+        <h4>Ledere</h4>
+        <ul>
+          {leaders.map((leader) => (
+            <li key={leader.user.username}>{leader.user.fullName}</li>
+          ))}
+        </ul>
+      </Flex>
+    );
+  }
 
+  const leader = leaders[0];
   return (
     <Flex column>
       <h4>Leder</h4>


### PR DESCRIPTION
Fix webkom/lego#2151

Have the same style for warnings when you have unanswered surveys and penalties.

Before:
![image](https://user-images.githubusercontent.com/31897129/115466364-471aca00-a230-11eb-9d60-05ac8e7bbc50.png)


After:
![image](https://user-images.githubusercontent.com/31897129/115466259-20f52a00-a230-11eb-838c-5625551a2465.png)

After (dark theme):
![image](https://user-images.githubusercontent.com/31897129/115466296-2e121900-a230-11eb-825d-65e65ddb5ec4.png)
