### PR TITLE
Fix active NavLink

### DIFF
--- a/app/routes/events/components/Toolbar.css
+++ b/app/routes/events/components/Toolbar.css
@@ -43,9 +43,10 @@
   padding: 5px 20px;
   font-size: 20px;
   border-bottom: 1px solid var(--color-almost-white-5);
+  transition: all .3s ease-in-out;
 }
 
-html[data-theme='dark'] .pickerItem {
+html[data-theme='dark'] .pickerItem, .pickerItem:hover {
   border-bottom: 1px solid var(--color-mono-gray-4);
 }
 
@@ -54,7 +55,8 @@ html[data-theme='dark'] .pickerItem {
   border-bottom: 1px solid var(--color-mono-gray-4);
 }
 
-html[data-theme='dark'] .active {
+html[data-theme='dark'] .active, 
+html[data-theme='dark'] .pickerItem:hover {
   border-bottom: 1px solid #f5f5f5;
 }
 

--- a/app/routes/events/components/Toolbar.css
+++ b/app/routes/events/components/Toolbar.css
@@ -43,10 +43,11 @@
   padding: 5px 20px;
   font-size: 20px;
   border-bottom: 1px solid var(--color-almost-white-5);
-  transition: all .3s ease-in-out;
+  transition: all 0.3s ease-in-out;
 }
 
-html[data-theme='dark'] .pickerItem, .pickerItem:hover {
+html[data-theme='dark'] .pickerItem,
+.pickerItem:hover {
   border-bottom: 1px solid var(--color-mono-gray-4);
 }
 
@@ -55,7 +56,7 @@ html[data-theme='dark'] .pickerItem, .pickerItem:hover {
   border-bottom: 1px solid var(--color-mono-gray-4);
 }
 
-html[data-theme='dark'] .active, 
+html[data-theme='dark'] .active,
 html[data-theme='dark'] .pickerItem:hover {
   border-bottom: 1px solid #f5f5f5;
 }

--- a/app/routes/events/components/Toolbar.css
+++ b/app/routes/events/components/Toolbar.css
@@ -46,8 +46,8 @@
   transition: all 0.3s ease-in-out;
 }
 
-html[data-theme='dark'] .pickerItem,
-.pickerItem:hover {
+.pickeritem:hover,
+html[data-theme='dark'] .pickerItem {
   border-bottom: 1px solid var(--color-mono-gray-4);
 }
 

--- a/app/routes/events/components/Toolbar.js
+++ b/app/routes/events/components/Toolbar.js
@@ -31,7 +31,7 @@ class Toolbar extends Component<Props, State> {
         </div>
 
         <NavLink
-          to="/events"
+          to="/events" exact={true}
           activeClassName={styles.active}
           className={cx(styles.pickerItem, styles.list)}
         >

--- a/app/routes/events/components/Toolbar.js
+++ b/app/routes/events/components/Toolbar.js
@@ -31,7 +31,8 @@ class Toolbar extends Component<Props, State> {
         </div>
 
         <NavLink
-          to="/events" exact={true}
+          to="/events"
+          exact={true}
           activeClassName={styles.active}
           className={cx(styles.pickerItem, styles.list)}
         >


### PR DESCRIPTION
NavLink need an exact prop, in order for it not always be active (see images)

*Before:*
![Screenshot from 2021-05-04 20-01-26](https://user-images.githubusercontent.com/69514187/117048669-8870a680-ad13-11eb-9812-e95d3706cd5c.png)


*After:*
![fixedNavLink](https://user-images.githubusercontent.com/69514187/117048563-6a0aab00-ad13-11eb-95e5-eb5e12e20fb5.png)
 