### PR TITLE
Enable hiding number of votes cast for individual poll options

### DIFF
--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -34,7 +34,6 @@
   composes: withShadow from '~app/styles/utilities.css';
   background: var(--lego-card-color);
   padding: 15px 20px 8px;
-  min-height: 195px;
 }
 
 .pollLight {

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -97,7 +97,14 @@ class Poll extends Component<Props, State> {
   render() {
     const { poll, handleVote, backgroundLight, details, truncate } = this.props;
     const { truncateOptions, expanded, shuffledOptions } = this.state;
-    const { id, title, description, hasAnswered, totalVotes } = poll;
+    const {
+      id,
+      title,
+      description,
+      hasAnswered,
+      totalVotes,
+      resultsHidden,
+    } = poll;
     const options = this.optionsWithPerfectRatios(this.props.poll.options);
     const orderedOptions = hasAnswered ? options : shuffledOptions;
     const optionsToShow = expanded
@@ -123,7 +130,8 @@ class Poll extends Component<Props, State> {
             <p>{description}</p>
           </div>
         )}
-        {hasAnswered && (
+        {hasAnswered && resultsHidden && <p>Resultatet er skjult</p>}
+        {hasAnswered && !resultsHidden && (
           <Flex column className={styles.optionWrapper}>
             <table className={styles.pollTable}>
               <tbody>

--- a/app/reducers/polls.js
+++ b/app/reducers/polls.js
@@ -15,6 +15,7 @@ export type PollEntity = {
   id: ID,
   title: string,
   description: string,
+  resultsHidden: boolean,
   pinned: boolean,
   tags: Tags,
   hasAnswered: boolean,

--- a/app/routes/polls/PollsDetailRoute.js
+++ b/app/routes/polls/PollsDetailRoute.js
@@ -27,6 +27,7 @@ const mapStateToProps = (state, props) => {
       pollId: id,
       title: poll.title,
       description: poll.description,
+      resultsHidden: poll.resultsHidden,
       pinned: poll.pinned,
       tags: poll.tags.map((value) => ({
         className: 'Select-create-option-placeholder',

--- a/app/routes/polls/components/PollEditor.js
+++ b/app/routes/polls/components/PollEditor.js
@@ -127,6 +127,11 @@ class EditPollForm extends Component<Props, *> {
             component={CheckBox.Field}
           />
           <Field
+            name="resultsHidden"
+            label="Skjul resultatet"
+            component={CheckBox.Field}
+          />
+          <Field
             name="tags"
             label="Tags"
             filter={['tags.tag']}
@@ -176,12 +181,14 @@ const onSubmit = (
     tags,
     options,
     pinned,
+    resultsHidden,
     ...rest
   }: {
     title: string,
     description: string,
     tags: Array<{ value: string }>,
     options: Array<{ id: ?ID, name: string }>,
+    resultsHidden: boolean,
     pinned: boolean,
   },
   dispatch,
@@ -191,6 +198,7 @@ const onSubmit = (
     .editOrCreatePoll({
       title,
       description,
+      resultsHidden,
       tags: tags ? tags.map((val) => val.value) : [],
       options,
       pinned: pinned ? pinned : false,


### PR DESCRIPTION
As requested by Glorious Leader @AdrianAndersen, this PR will enable a poll to hide the number of votes cast for each option if the corresponding backend-PR is accepted. See PR [webkom/lego#2196](https://github.com/webkom/lego/pull/2196) for more details.