### PR TITLE
Auto theme option

### DIFF
--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -127,17 +127,11 @@ class Header extends Component<Props, State> {
     const isLogin = this.state.mode === 'login';
     let title, form;
 
-    if (loggedIn) {
-      if (
-        currentUser &&
-        ((currentUser.selectedTheme === 'auto' &&
-          getTheme() !== getOSTheme()) ||
-          currentUser.selectedTheme !== getTheme())
-      ) {
-        applySelectedTheme(currentUser.selectedTheme || 'auto');
-      }
-    } else {
-      applySelectedTheme('auto');
+    if (loggedIn && currentUser &&
+      ((currentUser.selectedTheme === 'auto' &&
+        getTheme() !== getOSTheme()) ||
+        currentUser.selectedTheme !== getTheme())) {
+      applySelectedTheme(currentUser.selectedTheme || 'light');
     }
 
     switch (this.state.mode) {

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -127,10 +127,12 @@ class Header extends Component<Props, State> {
     const isLogin = this.state.mode === 'login';
     let title, form;
 
-    if (loggedIn && currentUser &&
-      ((currentUser.selectedTheme === 'auto' &&
-        getTheme() !== getOSTheme()) ||
-        currentUser.selectedTheme !== getTheme())) {
+    if (
+      loggedIn &&
+      currentUser &&
+      ((currentUser.selectedTheme === 'auto' && getTheme() !== getOSTheme()) ||
+        currentUser.selectedTheme !== getTheme())
+    ) {
       applySelectedTheme(currentUser.selectedTheme || 'light');
     }
 

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -18,7 +18,7 @@ import {
 } from 'app/components/LoginForm';
 import { Flex } from 'app/components/Layout';
 import cx from 'classnames';
-import { applySelectedTheme, getTheme } from 'app/utils/themeUtils';
+import { applySelectedTheme, getOSTheme, getTheme } from 'app/utils/themeUtils';
 
 import type { UserEntity } from 'app/reducers/users';
 import logoLightMode from 'app/assets/logo-dark.png';
@@ -127,8 +127,17 @@ class Header extends Component<Props, State> {
     const isLogin = this.state.mode === 'login';
     let title, form;
 
-    if (loggedIn && currentUser && currentUser.selectedTheme !== getTheme()) {
-      applySelectedTheme(currentUser.selectedTheme || 'light');
+    if (loggedIn) {
+      if (
+        currentUser &&
+        ((currentUser.selectedTheme === 'auto' &&
+          getTheme() !== getOSTheme()) ||
+          currentUser.selectedTheme !== getTheme())
+      ) {
+        applySelectedTheme(currentUser.selectedTheme || 'auto');
+      }
+    } else {
+      applySelectedTheme('auto');
     }
 
     switch (this.state.mode) {

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -130,8 +130,9 @@ class Header extends Component<Props, State> {
     if (
       loggedIn &&
       currentUser &&
-      ((currentUser.selectedTheme === 'auto' && getTheme() !== getOSTheme()) ||
-        currentUser.selectedTheme !== getTheme())
+      (currentUser.selectedTheme === 'auto'
+        ? getTheme() !== getOSTheme()
+        : getTheme() !== currentUser.selectedTheme)
     ) {
       applySelectedTheme(currentUser.selectedTheme || 'light');
     }

--- a/app/routes/users/components/UserSettings.js
+++ b/app/routes/users/components/UserSettings.js
@@ -126,6 +126,12 @@ const UserSettings = (props: Props) => {
         <RadioButtonGroup label="Theme" name="selectedTheme">
           <Field
             name="selectedTheme"
+            label="Auto"
+            inputValue="auto"
+            component={RadioButton.Field}
+          />
+          <Field
+            name="selectedTheme"
             label="Light"
             inputValue="light"
             component={RadioButton.Field}

--- a/app/utils/themeUtils.js
+++ b/app/utils/themeUtils.js
@@ -1,6 +1,9 @@
 export const applySelectedTheme = (theme) => {
   if (__CLIENT__) {
-    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.setAttribute(
+      'data-theme',
+      theme === 'auto' ? getOSTheme() : theme
+    );
     global.dispatchEvent(new Event('themeChange'));
   }
 };
@@ -10,4 +13,10 @@ export const getTheme = () =>
 
 export const getFancyNodeColor = () => {
   return getTheme() !== 'dark' ? 'rgba(0,0,0, 0.3)' : 'rgba(255,255,255, 0.5)';
+};
+
+export const getOSTheme = () => {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
 };

--- a/server/pageRenderer.js
+++ b/server/pageRenderer.js
@@ -58,7 +58,8 @@ export default function pageRenderer({
 
   const getDataTheme = () => {
     if (!isEmpty(state)) {
-      return selectCurrentUser(state).selectedTheme;
+      let selectedTheme = selectCurrentUser(state).selectedTheme;
+      return selectedTheme !== 'auto' ? selectedTheme : 'light';
     }
   };
 


### PR DESCRIPTION
Solves https://github.com/webkom/lego/issues/2000

See https://github.com/webkom/lego/pull/2197 for backend PR

Added option for auto theme where the theme is chosen based on device settings. This is now the default theme option (does not affect existing user preferences) and is applied when not logged in.

'Light' and 'Dark' options take precedence and will ignore OS theme.

![image](https://user-images.githubusercontent.com/24361490/119258545-69ef2400-bbca-11eb-8052-62cb95bc4a4e.png)

![image](https://user-images.githubusercontent.com/24361490/119258589-a0c53a00-bbca-11eb-94df-1bec7b9ec216.png)

![image](https://user-images.githubusercontent.com/24361490/119258626-c81c0700-bbca-11eb-8472-e2e867c3e1aa.png)

