### PR TITLE
Don't set theme unless on client side.

### DIFF
--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -128,6 +128,7 @@ class Header extends Component<Props, State> {
     let title, form;
 
     if (
+      __CLIENT__ &&
       loggedIn &&
       currentUser &&
       (currentUser.selectedTheme === 'auto'


### PR DESCRIPTION
This broke SSR for users with theme set to `auto` (default).
We already set the theme in the pagerenderer. So this was redundant
anyways.