### PR TITLE
Add info page title to website title

### DIFF
--- a/app/routes/pages/components/PageDetail.js
+++ b/app/routes/pages/components/PageDetail.js
@@ -3,6 +3,7 @@
 
 import type { Node } from 'react';
 
+import { Helmet } from 'react-helmet';
 import { Component } from 'react';
 import styles from './PageDetail.css';
 import { Flex } from 'app/components/Layout';
@@ -73,6 +74,7 @@ class PageDetail extends Component<Props, State> {
 
     return (
       <Content className={styles.cont}>
+        <Helmet title={selectedPageInfo.title} />
         <div className={styles.main}>
           <button className={styles.sidebarOpenBtn} onClick={this.openSidebar}>
             <Icon size={30} name="arrow-forward" />


### PR DESCRIPTION
Adds helmet title to infopage. It was very annoying not having a title on the page, as well as on links.

We could also add some more opengraph tags, like image and perhaps a short description if we need :thinking:. Let me know what people think.