### PR TITLE
Change banner to revyopptak

### DIFF
--- a/app/components/Banner/Banner.css
+++ b/app/components/Banner/Banner.css
@@ -37,11 +37,6 @@
   color: var(--color-white);
 }
 
-.revyBlue {
-  background-color: var(--color-blue-revy);
-  color: var(--color-white);
-}
-
 @keyframes wiggle {
   0% {
     transform: rotate(0deg);

--- a/app/components/Banner/index.js
+++ b/app/components/Banner/index.js
@@ -10,7 +10,6 @@ export const COLORS = {
   white: styles.white,
   gray: styles.gray,
   lightBlue: styles.lightBlue,
-  revyBlue: styles.revyBlue,
 };
 
 type Color = $Keys<typeof COLORS>;

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -193,9 +193,9 @@ class Overview extends Component<Props, State> {
       <Container>
         <Helmet title="Hjem" />
         <Banner
-          header="Abakus has opptak!"
-          subHeader="Søk her"
-          link="https://opptak.abakus.no"
+          header="Abakusrevyen har opptak!"
+          subHeader="Søk her innen 17. september!"
+          link="https://abakusrevyen.no"
           color={COLORS.red}
         />
         <Flex className={styles.desktopContainer}>

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -76,7 +76,6 @@
   --color-blue-3: #137cbd;
   --color-blue-4: #2b95d6;
   --color-blue-5: #48aff0;
-  --color-blue-revy: #495ea9;
 
   --color-orange-1: #a66321;
   --color-orange-2: #bf7326;


### PR DESCRIPTION
![Screenshot from 2021-09-06 14-16-11](https://user-images.githubusercontent.com/42469466/132216214-ef3f884b-70d9-4d9e-a555-dc7391d92037.png)
Text is longer to make sure people notice the change:)
Also removes 'revyBlue' and '--color-blue-revy' variables, as they were only used by the banner