### PR TITLE
Status is ment to show pool information, and not registration status …

### DIFF
--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -126,7 +126,7 @@ export class RegisteredTable extends Component<Props> {
       {
         title: 'Status',
         center: true,
-        dataIndex: 'status',
+        dataIndex: 'pool',
         render: (pool, registration) => {
           const registrationInfo = getRegistrationInfo(pool, registration);
           return (


### PR DESCRIPTION
An issue was pointed out regarding the symbols for the admin `RegistrationTable`. We used to have a separate icon for people on the waiting list, but that was suddenly gone. This is due to a mixup with the name of the column and the `dataIndex`. **Status** is supposed to show "GREEN" for people who are in a pool and "ORANGE" for people who are on the waiting list. As can be seen on line 130 (next line after change), the render method is looking for a pool object to use in its `getRegistartionInfo`, but with the wrong index, it's given a "STATUS_SUCCESS" string.

> Current:
![image](https://user-images.githubusercontent.com/23152018/133477623-397332b3-85c6-448e-8010-08d48bb051d1.png)

> Proposed:
![image](https://user-images.githubusercontent.com/23152018/133477673-87ff4966-94b8-473a-80fd-ad0f3bbb65f0.png)
