### PR TITLE
prevent cypress test from entering usersettings too early

### DIFF
--- a/app/routes/users/UserProfileRoute.js
+++ b/app/routes/users/UserProfileRoute.js
@@ -72,7 +72,8 @@ const mapStateToProps = (state, props) => {
   const isMe =
     params.username === 'me' || params.username === state.auth.username;
   const actionGrant = (user && user.actionGrant) || [];
-  const showSettings = isMe || actionGrant.includes('edit');
+  const showSettings =
+    (isMe || actionGrant.includes('edit')) && user && user.username;
   const canChangeGrade = state.allowed.groups;
   const canEditEmailLists = state.allowed.email;
   const canDeletePenalties = state.allowed.penalties;

--- a/cypress/integration/profile_spec.js
+++ b/cypress/integration/profile_spec.js
@@ -41,14 +41,14 @@ describe('Profile settings', () => {
 
   it('can navigate to settings from profile', () => {
     cy.visit('/users/me');
-    cy.contains('Innstillinger').click();
-
-    // TODO: Should use me in URL instead of username
-    // cy.url().should('include', '/users/me/settings/profile');
-    cy.url().should(
-      'include',
-      `/users/${initialUser.username}/settings/profile`
-    );
+    cy.contains('Innstillinger')
+      .click()
+      .then(() => {
+        cy.url().should(
+          'include',
+          `/users/${initialUser.username}/settings/profile`
+        );
+      });
   });
 
   it('edit profile shows correct initial values', () => {


### PR DESCRIPTION
cypress attempted to enter usersettings with the "Instillinger"-button before the given profilepage was fully loaded. 
This lead to cypress loading a page containing `... /users/undefined/settings/profile`, which does not exist. The button will now appear after all necessary props are loaded.