### PR TITLE
Set container for table overlays to a div that contains the table

### DIFF
--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -88,6 +88,7 @@ export default class Table extends Component<Props, State> {
     };
   }
 
+  container: HTMLDivElement;
   components: { [string]: ?HTMLDivElement } = {};
 
   static defaultProps = {
@@ -254,7 +255,7 @@ export default class Table extends Component<Props, State> {
                 show={isShown[dataIndex]}
                 onHide={() => this.toggleSearch(dataIndex)}
                 placement="bottom"
-                container={this.components[dataIndex]}
+                container={this.container}
                 target={() => this.components[dataIndex]}
                 rootClose
               >
@@ -294,7 +295,7 @@ export default class Table extends Component<Props, State> {
                 show={isShown[dataIndex]}
                 onHide={() => this.toggleFilter(dataIndex)}
                 placement="bottom"
-                container={this.components[dataIndex]}
+                container={this.container}
                 target={() => this.components[dataIndex]}
                 rootClose
               >
@@ -358,7 +359,7 @@ export default class Table extends Component<Props, State> {
                 show={isShown[dataIndex]}
                 onHide={() => this.toggleChooseColumn(dataIndex)}
                 placement="bottom"
-                container={this.components[dataIndex]}
+                container={this.container}
                 target={() => this.components[dataIndex]}
                 rootClose
               >
@@ -451,35 +452,39 @@ export default class Table extends Component<Props, State> {
     if (direction === 'desc') sortedData.reverse();
 
     return (
-      <div className={styles.tableDiv}>
-        <table className={styles.table}>
-          <thead>
-            <tr>
-              {columns
-                .filter(isVisible)
-                .map((column, index) => this.renderHeadCell(column, index))}
-            </tr>
-          </thead>
-          <InfiniteScroll
-            element="tbody"
-            hasMore={hasMore && !loading}
-            loadMore={this.loadMore}
-            threshold={50}
-          >
-            {sortedData.filter(this.filter).map((item, index) => (
-              <tr key={item[rowKey]}>
+      <div>
+        <div className={styles.tableDiv}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
                 {columns
                   .filter(isVisible)
-                  .map((column, index) => this.renderCell(column, item, index))}
+                  .map((column, index) => this.renderHeadCell(column, index))}
               </tr>
-            ))}
-            <tr>
-              <td className={styles.loader} colSpan={columns.length}>
-                <LoadingIndicator loading={loading} />
-              </td>
-            </tr>
-          </InfiniteScroll>
-        </table>
+            </thead>
+            <InfiniteScroll
+              element="tbody"
+              hasMore={hasMore && !loading}
+              loadMore={this.loadMore}
+              threshold={50}
+            >
+              {sortedData.filter(this.filter).map((item, index) => (
+                <tr key={item[rowKey]}>
+                  {columns
+                    .filter(isVisible)
+                    .map((column, index) =>
+                      this.renderCell(column, item, index)
+                    )}
+                </tr>
+              ))}
+              <tr>
+                <td className={styles.loader} colSpan={columns.length}>
+                  <LoadingIndicator loading={loading} />
+                </td>
+              </tr>
+            </InfiniteScroll>
+          </table>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Fix webkom/lego#2322

By setting the container for the overlays to a container div that contains the table, they are no longer hidden by the tables overflow rules.

Before:
![Screenshot 2021-09-28 at 19 16 12](https://user-images.githubusercontent.com/8343002/135134504-aa257f4f-d932-4d8d-b152-8c7466cbde25.png)

After:
![Screenshot 2021-09-28 at 19 16 44](https://user-images.githubusercontent.com/8343002/135134584-3af77526-7693-49e8-a6b6-4c3e4e0d3ccc.png)


