### PR TITLE
Fix inconsistent admin registration list

### DIFF
--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -446,7 +446,7 @@ export default class Table extends Component<Props, State> {
       };
 
     const sortedData = [...data].sort((a, b) =>
-      sorter !== undefined && typeof sorter !== 'boolean' ? sorter(a, b) : -1
+      sorter !== undefined && typeof sorter !== 'boolean' ? sorter(a, b) : 0
     );
     if (direction === 'desc') sortedData.reverse();
 

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -13,6 +13,7 @@ import type {
   EventRegistrationPaymentStatus,
   ID,
   Event,
+  EventPool,
 } from 'app/models';
 import Table from 'app/components/Table';
 import {
@@ -21,7 +22,6 @@ import {
   PresenceIcons,
   Unregister,
 } from './AttendeeElements';
-import type { EventPool } from 'app/models';
 
 type Props = {
   registered: Array<EventRegistration>,
@@ -102,7 +102,7 @@ export class RegisteredTable extends Component<Props> {
       {
         title: 'Nr.',
         dataIndex: 'nr',
-        render: (pool, registration) => (
+        render: (_, registration) => (
           <span>{registered.indexOf(registration) + 1}.</span>
         ),
         sorter: (a, b) => {


### PR DESCRIPTION
`Array.prototype.sort` has different implementations in Node and on
browsers, meaning that the resulting list was inverted on the browser,
leading to undefined behaviour. Returning 0 should quick fix this small
issue.

Fixes https://github.com/webkom/lego/issues/2318