### PR TITLE
Hide past interest group memberships with duration under two weeks

### DIFF
--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -247,9 +247,15 @@ export default class UserProfile extends Component<Props, EventsProps> {
           ? 'pastMembershipsAsBadges'
           : 'pastMembershipsAsPills'
     );
-    const filteredPastMembershipsAsBadges = pastMembershipsAsBadges.filter(membership => {
-        const membershipDuration = moment.duration(moment(membership.endDate).diff(membership.startDate));
-        return membership.abakusGroup.type !== 'interesse' || membershipDuration.asWeeks() > 2;
+    const filteredPastMembershipsAsBadges = pastMembershipsAsBadges.filter(
+      (membership) => {
+        const membershipDuration = moment.duration(
+          moment(membership.endDate).diff(membership.startDate)
+        );
+        return (
+          membership.abakusGroup.type !== 'interesse' ||
+          membershipDuration.asWeeks() > 2
+        );
       }
     );
     // $FlowFixMe

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -247,10 +247,15 @@ export default class UserProfile extends Component<Props, EventsProps> {
           ? 'pastMembershipsAsBadges'
           : 'pastMembershipsAsPills'
     );
+    const filteredPastMembershipsAsBadges = pastMembershipsAsBadges.filter(membership => {
+        const membershipDuration = moment.duration(moment(membership.endDate).diff(membership.startDate));
+        return membership.abakusGroup.type !== 'interesse' || membershipDuration.asWeeks() > 2;
+      }
+    );
     // $FlowFixMe
     const groupedMemberships = orderBy(
       groupBy(
-        pastMembershipsAsBadges.concat(membershipsAsBadges),
+        filteredPastMembershipsAsBadges.concat(membershipsAsBadges),
         'abakusGroup.id'
       ),
       (memberships) => !memberships.some((membership) => membership.isActive)


### PR DESCRIPTION
Fix webkom/lego#2333

Filters the badges for past memberships in interest groups, to only show interest groups where the user has been a member for more than two weeks.