### PR TITLE
Fix radio button alignment

### DIFF
--- a/app/components/Form/RadioButton.css
+++ b/app/components/Form/RadioButton.css
@@ -1,5 +1,5 @@
 .box {
-  display: inline-block;
+  display: inline-flex;
   width: 21px;
   height: 21px;
   margin-right: 10px;
@@ -29,7 +29,6 @@
 .label::before {
   content: '';
   position: absolute;
-  top: 0;
   left: 0;
   width: 22px;
   height: 22px;
@@ -44,7 +43,6 @@
 .label::after {
   content: '';
   position: absolute;
-  top: 0;
   left: 0;
   width: 16px;
   height: 16px;
@@ -90,5 +88,4 @@
   display: flex;
   flex-direction: row-reverse;
   justify-content: flex-end;
-  align-items: center;
 }


### PR DESCRIPTION
Fixes webkom/lego#2315

Before:
![Screenshot 2021-10-05 at 20 30 01](https://user-images.githubusercontent.com/8343002/136081880-e12de9e6-a8bb-49f6-b927-0d5d6c77cf24.png)
After:
![Screenshot 2021-10-05 at 20 27 39](https://user-images.githubusercontent.com/8343002/136081671-26d03cf1-6e64-48e2-a595-362e4fc933e0.png)

Tested with chrome, firefox and safari on macos, and chrome and firefox on linux.