### PR TITLE
Updated interestGroup to fetch all members

### DIFF
--- a/app/routes/interestgroups/InterestGroupDetailRoute.js
+++ b/app/routes/interestgroups/InterestGroupDetailRoute.js
@@ -5,7 +5,7 @@ import {
   joinGroup,
   leaveGroup,
   fetchGroup,
-  fetchMemberships,
+  fetchAllMemberships,
 } from 'app/actions/GroupActions';
 import InterestGroupDetail from './components/InterestGroupDetail';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
@@ -46,7 +46,7 @@ export default compose(
     ) =>
       Promise.all([
         dispatch(fetchGroup(Number(interestGroupId))),
-        dispatch(fetchMemberships(interestGroupId)),
+        dispatch(fetchAllMemberships(interestGroupId)),
       ]),
 
     ['match.params.interestGroupId']


### PR DESCRIPTION
Fetches all members on page load to solve the following problems:
- Not all members were loaded in the member list
- Not all leaders were displayed as they are filtered from the member list in the frontend