### PR TITLE
Add temporary link to contact form in footer

### DIFF
--- a/app/components/Footer/index.js
+++ b/app/components/Footer/index.js
@@ -9,12 +9,13 @@ import Octocat from 'app/assets/Octocat.png';
 import Icon from 'app/components/Icon';
 import styles from './Footer.css';
 import moment from 'moment-timezone';
+import { Link } from 'react-router-dom';
 
 type Props = {
   loggedIn: boolean,
 };
 
-const Footer = (props: Props) => (
+const Footer = ({ loggedIn }: Props) => (
   <footer className={styles.footer}>
     <div className={styles.footerContent}>
       <Flex column>
@@ -64,6 +65,11 @@ const Footer = (props: Props) => (
             />
             <h2>Kontakt</h2>
             <a href="mailto:abakus@abakus.no">abakus@abakus.no</a>
+            {loggedIn && (
+              <p>
+                <Link to="/contact">Anonymt kontaktskjema</Link>
+              </p>
+            )}
             <p>Abakus</p>
             <p>Sem Sælands vei 7-9</p>
             <p>7491 Trondheim</p>


### PR DESCRIPTION
Contact forms have reportedly been difficult to find, which is why we're adding an additional link in the footer. The link is only visible when a user is logged in, as the form itself can currently only be used by them (see https://github.com/webkom/lego/issues/2345). 

The word "Anonymt" is temporary, and may be removed with the new frontpage or when the form becomes accessible to outside individuals.

![image](https://user-images.githubusercontent.com/42469466/139593111-217e577f-4fd4-40c6-a1aa-460f38a9e53e.png)
mobile:
![image](https://user-images.githubusercontent.com/42469466/139593147-c3ae1d98-6622-4e97-8743-2ec283901ed1.png)
