### PR TITLE
Add button to delete user

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -248,6 +248,7 @@ export const User = {
   PASSWORD_CHANGE: (generateStatuses('User.PASSWORD_CHANGE'): AAT),
   LOGIN: (generateStatuses('User.LOGIN'): AAT),
   LOGOUT: 'User.LOGOUT',
+  DELETE: (generateStatuses('User.DELETE'): AAT),
   SOCKET: (generateStatuses('User.SOCKET'): AAT),
   SEND_REGISTRATION_TOKEN: (generateStatuses(
     'User.SEND_REGISTRATION_TOKEN'

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -383,6 +383,19 @@ export function createUser(token: string, user: string): Thunk<*> {
     });
 }
 
+export function deleteUser(username: string): Thunk<any> {
+  return callAPI({
+    types: User.DELETE,
+    endpoint: `/users/${username}/delete_user`,
+    method: 'DELETE',
+    schema: userSchema,
+    meta: {
+      errorMessage: 'Sletting av bruker feilet',
+    },
+    body: {},
+  });
+}
+
 export function sendStudentConfirmationEmail(user: string): Thunk<any> {
   return callAPI({
     types: User.SEND_STUDENT_CONFIRMATION_TOKEN,

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -8,6 +8,7 @@ import moment from 'moment-timezone';
 import { push } from 'connected-react-router';
 import { userSchema, penaltySchema } from 'app/reducers';
 import callAPI from 'app/actions/callAPI';
+import { addToast } from 'app/actions/ToastActions';
 import { User, FetchHistory, Penalty } from './ActionTypes';
 import { uploadFile } from './FileActions';
 import { fetchMeta } from './MetaActions';
@@ -383,17 +384,22 @@ export function createUser(token: string, user: string): Thunk<*> {
     });
 }
 
-export function deleteUser(username: string): Thunk<any> {
-  return callAPI({
-    types: User.DELETE,
-    endpoint: `/users/${username}/delete_user`,
-    method: 'DELETE',
-    schema: userSchema,
-    meta: {
-      errorMessage: 'Sletting av bruker feilet',
-    },
-    body: {},
-  });
+export function deleteUser(username: string): Thunk<Promise<*>> {
+  return (dispatch) =>
+    dispatch(
+      callAPI({
+        types: User.DELETE,
+        endpoint: `/users/${username}/`,
+        method: 'DELETE',
+        meta: {
+          id: username,
+          errorMessage: 'Sletting av bruker feilet',
+        },
+      })
+    ).then(() => {
+      dispatch(addToast({ message: 'Deleted' }));
+      dispatch(push('/'));
+    });
 }
 
 export function sendStudentConfirmationEmail(user: string): Thunk<any> {

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -384,21 +384,22 @@ export function createUser(token: string, user: string): Thunk<*> {
     });
 }
 
-export function deleteUser(username: string): Thunk<Promise<*>> {
+export function deleteUser(password: string): Thunk<Promise<*>> {
   return (dispatch) =>
     dispatch(
       callAPI({
         types: User.DELETE,
-        endpoint: `/users/${username}/`,
-        method: 'DELETE',
+        endpoint: '/user-delete/',
+        method: 'POST',
+        body: {
+          password,
+        },
         meta: {
           errorMessage: 'Sletting av bruker feilet',
           successMessage: 'Bruker har blitt slettet',
         },
       })
-    ).then(() => {
-      dispatch(push('/'));
-    });
+    );
 }
 
 export function sendStudentConfirmationEmail(user: string): Thunk<any> {

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -8,7 +8,6 @@ import moment from 'moment-timezone';
 import { push } from 'connected-react-router';
 import { userSchema, penaltySchema } from 'app/reducers';
 import callAPI from 'app/actions/callAPI';
-import { addToast } from 'app/actions/ToastActions';
 import { User, FetchHistory, Penalty } from './ActionTypes';
 import { uploadFile } from './FileActions';
 import { fetchMeta } from './MetaActions';

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -392,12 +392,11 @@ export function deleteUser(username: string): Thunk<Promise<*>> {
         endpoint: `/users/${username}/`,
         method: 'DELETE',
         meta: {
-          id: username,
           errorMessage: 'Sletting av bruker feilet',
+          successMessage: 'Bruker har blitt slettet',
         },
       })
     ).then(() => {
-      dispatch(addToast({ succsessMessage: 'Bruker har blitt slettet' }));
       dispatch(push('/'));
     });
 }

--- a/app/actions/UserActions.js
+++ b/app/actions/UserActions.js
@@ -397,7 +397,7 @@ export function deleteUser(username: string): Thunk<Promise<*>> {
         },
       })
     ).then(() => {
-      dispatch(addToast({ message: 'Deleted' }));
+      dispatch(addToast({ succsessMessage: 'Bruker har blitt slettet' }));
       dispatch(push('/'));
     });
 }

--- a/app/routes/users/UserSettingsRoute.js
+++ b/app/routes/users/UserSettingsRoute.js
@@ -11,6 +11,7 @@ import {
   fetchUser,
   updateUser,
   updatePicture,
+  deleteUser,
   changePassword,
   removePicture,
 } from 'app/actions/UserActions';
@@ -44,6 +45,7 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = {
   updateUser,
   updatePicture,
+  deleteUser,
   changePassword,
   push,
   removePicture,

--- a/app/routes/users/components/DeleteUser.css
+++ b/app/routes/users/components/DeleteUser.css
@@ -1,0 +1,4 @@
+.saveButton {
+  margin-top: 10px;
+  width: 100%;
+}

--- a/app/routes/users/components/DeleteUser.js
+++ b/app/routes/users/components/DeleteUser.js
@@ -2,18 +2,12 @@
 
 import { useState } from 'react';
 import Button from 'app/components/Button';
-import Flex from 'app/components/Layout/Flex';
-import styles from './RemovePicture.css';
+import styles from './DeleteUser.css';
 import { TextInput, Form, legoForm } from 'app/components/Form';
 import type { FormProps } from 'redux-form';
 import { Field } from 'redux-form';
 import { type UserEntity } from 'app/reducers/users';
-import {
-  createValidator,
-  required,
-  validPassword,
-  sameAs,
-} from 'app/utils/validation';
+import { createValidator, required } from 'app/utils/validation';
 
 type Props = FormProps & {
   push: (string) => void,
@@ -70,5 +64,5 @@ export default legoForm({
   form: 'deleteUser',
   validate,
   onSubmit: (data, dispatch, { deleteUser, push }: Props) =>
-    deleteUser(data.password).then(() => push('/users/me')),
+    deleteUser(data.password).then(() => push('/')),
 })(DeleteUser);

--- a/app/routes/users/components/DeleteUser.js
+++ b/app/routes/users/components/DeleteUser.js
@@ -1,0 +1,76 @@
+// @flow
+
+import { Component } from 'react';
+import Button from 'app/components/Button';
+import Flex from 'app/components/Layout/Flex';
+import styles from './RemovePicture.css';
+import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
+
+type ButtonProps = {
+  deleteUser: (string) => Promise<*>,
+  username: string,
+};
+
+type State = {
+  uName: string,
+  show: boolean,
+};
+
+class DeleteUser extends Component<ButtonProps, State> {
+  state = {
+    uName: '',
+    show: false,
+  };
+  render() {
+    const { deleteUser, username } = this.props;
+    let deleteUserButton;
+
+    if (this.state.uName === username) {
+      deleteUserButton = (
+        <ConfirmModalWithParent
+          title="Slett bruker"
+          message="Er du sikker på at du vil slette denne brukeren?"
+          onConfirm={() => deleteUser(username)}
+        >
+          <Button dark className={styles.saveButton}>
+            Slett bruker
+          </Button>
+        </ConfirmModalWithParent>
+      );
+    }
+
+    return (
+      <div>
+        {this.state.show === false && (
+          <Button
+            className={styles.saveButton}
+            onClick={() => this.setState({ show: true })}
+          >
+            Gå videre til slett bruker
+          </Button>
+        )}
+        {this.state.show && (
+          <>
+            <Button
+              className={styles.saveButton}
+              onClick={() => this.setState({ show: false })}
+            >
+              Angre
+            </Button>
+            <h3> Skriv inn brukernavnet ditt: </h3>
+            <input
+              type="text"
+              id="slettBruker"
+              placeholder="Brukernavn"
+              onChange={(e) => this.setState({ uName: e.target.value })}
+            />{' '}
+            <br />
+            {deleteUserButton}
+          </>
+        )}
+      </div>
+    );
+  }
+}
+
+export default DeleteUser;

--- a/app/routes/users/components/UserSettings.js
+++ b/app/routes/users/components/UserSettings.js
@@ -18,6 +18,7 @@ import ChangePassword from './ChangePassword';
 import styles from './UserSettings.css';
 import { createValidator, required, isEmail } from 'app/utils/validation';
 import RemovePicture from 'app/routes/users/components/RemovePicture';
+import DeleteUser from 'app/routes/users/components/DeleteUser';
 
 export type PasswordPayload = {
   newPassword: string,
@@ -47,6 +48,7 @@ const UserSettings = (props: Props) => {
     removePicture,
     push,
     user,
+    deleteUser,
   } = props;
 
   const disabledButton = invalid || pristine || submitting;
@@ -176,6 +178,8 @@ const UserSettings = (props: Props) => {
           />
         </div>
       )}
+      <h2>Slette bruker</h2>
+      <DeleteUser username={user.username} deleteUser={deleteUser} />
     </div>
   );
 };

--- a/app/routes/users/components/UserSettings.js
+++ b/app/routes/users/components/UserSettings.js
@@ -29,6 +29,7 @@ export type PasswordPayload = {
 type Props = FormProps & {
   changePassword: (PasswordPayload) => Promise<void>,
   updateUser: (Object) => Promise<void>,
+  deleteUser: (Object) => Promise<void>,
   user: any,
   isMe: boolean,
   push: (string) => void,
@@ -169,17 +170,19 @@ const UserSettings = (props: Props) => {
       </Form>
 
       {isMe && (
-        <div className={styles.changePassword}>
-          <h2>Endre passord</h2>
-          <ChangePassword
-            push={push}
-            changePassword={changePassword}
-            user={user}
-          />
-        </div>
+        <>
+          <div className={styles.changePassword}>
+            <h2>Endre passord</h2>
+            <ChangePassword
+              push={push}
+              changePassword={changePassword}
+              user={user}
+            />
+          </div>
+          <h2>Slette bruker</h2>
+          <DeleteUser push={push} user={user} deleteUser={deleteUser} />
+        </>
       )}
-      <h2>Slette bruker</h2>
-      <DeleteUser username={user.username} deleteUser={deleteUser} />
     </div>
   );
 };


### PR DESCRIPTION
Fixes https://github.com/webkom/lego/issues/2340.
Linked to https://github.com/webkom/lego/pull/2369

- [x] Add action
- [x] Add button-component
- [x] Fix flow?
- [x] Add password auth

It is only possible to delete your **OWN** user, meaning the JWT token + password of a user is used to authenticate the delete action.

Added lot of steps (password auth) to make sure you do not delete your user on accident: 
1.
![image](https://user-images.githubusercontent.com/55149662/151078054-4d7343a6-0be4-4a5d-b36b-ff04c9222de9.png)
2. 
![image](https://user-images.githubusercontent.com/55149662/151078087-fcea19a4-3a4d-4d40-bcff-ba6646ad53ad.png)
3. 
![image](https://user-images.githubusercontent.com/55149662/151078120-1d81d147-583a-476b-a5f1-dbe034335be6.png)

