### PR TITLE
Add active field for groups

### DIFF
--- a/app/actions/GroupActions.js
+++ b/app/actions/GroupActions.js
@@ -221,7 +221,7 @@ export function fetchMembershipsPagination({
 
 export function createGroup(group: Object): Thunk<*> {
   return (dispatch) => {
-    const { name, description, text, logo, type } = group;
+    const { name, description, text, logo, type, showBadge, active } = group;
     return dispatch(
       callAPI({
         types: Group.CREATE,
@@ -234,6 +234,8 @@ export function createGroup(group: Object): Thunk<*> {
           text,
           logo,
           type,
+          showBadge,
+          active,
         },
         meta: {
           group,

--- a/app/components/GroupForm/index.js
+++ b/app/components/GroupForm/index.js
@@ -63,6 +63,14 @@ function GroupForm({
           normalize={(v) => !!v}
         />
       </Tooltip>
+      <Tooltip content="Er dette en aktiv gruppe?">
+        <Field
+          label="Aktiv gruppe"
+          name="active"
+          component={CheckBox.Field}
+          normalize={(v) => !!v}
+        />
+      </Tooltip>
       <Field
         label="Beskrivelse"
         placeholder="Vil du strikke din egen lue? Eller har du allerede […]"

--- a/app/models.js
+++ b/app/models.js
@@ -120,6 +120,7 @@ export type Group = {
   text: string,
   logo: ?string,
   showBadge: boolean,
+  active: boolean,
   contactEmail: string,
 };
 

--- a/app/routes/interestgroups/InterestGroupCreateRoute.js
+++ b/app/routes/interestgroups/InterestGroupCreateRoute.js
@@ -20,6 +20,8 @@ const mapStateToProps = (state, props) => {
   return {
     initialValues: {
       text: '',
+      showBadge: true,
+      active: true,
     },
     groupMembers: valueSelector(state, 'members') || [],
   };

--- a/app/routes/interestgroups/components/InterestGroup.css
+++ b/app/routes/interestgroups/components/InterestGroup.css
@@ -5,10 +5,18 @@
   max-width: 500px;
 }
 
-.logoSmall {
+.logoMedium {
   max-height: 100px;
   max-width: 100px;
   border-radius: 100%;
+}
+
+.logoSmall {
+  max-height: 50px;
+  max-width: 50px;
+  border-radius: 100%;
+  filter: grayscale(100%);
+  opacity: 0.7;
 }
 
 .description {

--- a/app/routes/interestgroups/components/InterestGroup.js
+++ b/app/routes/interestgroups/components/InterestGroup.js
@@ -11,20 +11,28 @@ const SAMPLE_LOGO = 'https://i.imgur.com/Is9VKjb.jpg';
 
 type Props = {
   group: Group,
+  active: boolean,
 };
 
-const InterestGroupComponent = ({ group }: Props) => {
+const InterestGroupComponent = ({ group, active }: Props) => {
   return (
     <Flex className={styles.listItem}>
       <Flex column className={styles.listItemContent} style={{ flex: '1' }}>
         <Link to={`/interestgroups/${group.id}`} className={styles.link}>
-          <h2>{group.name}</h2>
+          <h2 style={!active ? { color: 'grey' } : {}}>{group.name}</h2>
         </Link>
-        <div>{group.description}</div>
-        <div>{group.numberOfUsers} medlemmer</div>
+        {active && (
+          <>
+            <div>{group.description}</div>
+            <div>{group.numberOfUsers} medlemmer</div>
+          </>
+        )}
       </Flex>
       <Flex justifyContent="center" column>
-        <Image className={styles.logoSmall} src={group.logo || SAMPLE_LOGO} />
+        <Image
+          className={active ? styles.logoMedium : styles.logoSmall}
+          src={group.logo || SAMPLE_LOGO}
+        />
       </Flex>
     </Flex>
   );

--- a/app/routes/interestgroups/components/InterestGroupList.js
+++ b/app/routes/interestgroups/components/InterestGroupList.js
@@ -15,6 +15,15 @@ export type Props = {
 
 const InterestGroupList = ({ actionGrant, interestGroups }: Props) => {
   const canCreate = actionGrant.includes('create');
+  // Sorts interest groups in alphabetical order. Sorting using localeCompare will fail to sort ÆØÅ correctly.
+  // Use spread operator to do sorting not in-place
+  const activeGroups = [...interestGroups]
+    .filter((a) => a.active)
+    .sort((obj1, obj2) => obj1.name.localeCompare(obj2.name));
+  const notActiveGroups = [...interestGroups]
+    .filter((a) => !a.active)
+    .sort((obj1, obj2) => obj1.name.localeCompare(obj2.name));
+
   return (
     <Content>
       <div className={styles.section}>
@@ -36,12 +45,18 @@ const InterestGroupList = ({ actionGrant, interestGroups }: Props) => {
         </div>
       </div>
       <div className="groups">
-        {/* Sorts interest groups in alphabetical order. Sorting using localeCompare will fail to sort ÆØÅ correctly. Use spread operator to do sorting not in-place*/}
-        {[...interestGroups]
-          .sort((obj1, obj2) => obj1.name.localeCompare(obj2.name))
-          .map((group) => (
-            <InterestGroupComponent group={group} key={group.id} />
-          ))}
+        {activeGroups.map((g) => (
+          <InterestGroupComponent group={g} key={g.id} active={true} />
+        ))}
+        <h2> Ikke aktive interessegrupper </h2>
+        <p>
+          Send gjerne mail til
+          <a href="mailTo:interessegrupper@abakus.no"> oss </a> hvis du ønsker å
+          åpne en av disse igjen!
+        </p>
+        {notActiveGroups.map((g) => (
+          <InterestGroupComponent group={g} key={g.id} active={false} />
+        ))}
       </div>
     </Content>
   );


### PR DESCRIPTION
> Also fix showBadge field that used by the action

This PR makes it possible to mark groups as active/inactive. For now, all I use it for is to differentiate between active and inactive interestgroups.

![image](https://user-images.githubusercontent.com/23152018/140662690-9e74ed29-2100-4094-840d-1b537ee9206c.png)


