### PR TITLE
Add a more informative loading component when waiting for a pending registration.

### DIFF
--- a/app/components/LoadingIndicator/LoadingIndicator.css
+++ b/app/components/LoadingIndicator/LoadingIndicator.css
@@ -18,7 +18,7 @@
   height: 100%;
   border-radius: 50%;
   background-color: #e20d13;
-  opacity: 0.6;
+  opacity: 60%;
   position: absolute;
   top: 0;
   left: 0;
@@ -38,5 +38,42 @@
 
   40% {
     transform: scale(1);
+  }
+}
+
+.progressLine,
+.progressLine::before {
+  height: 3px;
+  width: 100%;
+  margin: 0;
+}
+
+.progressLine {
+  border-radius: 3px;
+  overflow: hidden;
+  background-color: rgba(178, 28, 23, 30%);
+  display: flex;
+}
+
+.progressLine::before {
+  background-color: var(--lego-red-color);
+  content: '';
+  animation: running-progress 2s cubic-bezier(0.25, 0.5, 0.75, 0.5) infinite;
+  transform-origin: 0% 100%;
+  width: 100%;
+  height: 100%;
+}
+
+@keyframes running-progress {
+  0% {
+    transform: translateX(0) scaleX(0);
+  }
+
+  50% {
+    transform: translateX(0) scaleX(0.4);
+  }
+
+  100% {
+    transform: translateX(100%) scaleX(0.5);
   }
 }

--- a/app/components/LoadingIndicator/index.js
+++ b/app/components/LoadingIndicator/index.js
@@ -33,3 +33,7 @@ export default class LoadingIndicator extends Component<Props> {
     return this.props.children ? <div>{this.props.children}</div> : null;
   }
 }
+
+export const ProgressBar = () => {
+  return <div className={styles.progressLine} />;
+};

--- a/app/reducers/forms.js
+++ b/app/reducers/forms.js
@@ -76,6 +76,14 @@ export default formReducer.plugin({
           submitting: true,
         };
       }
+      case Event.REQUEST_REGISTER.SUCCESS:
+      case Event.REQUEST_UNREGISTER.SUCCESS: {
+        return {
+          ...state,
+          submitting: false,
+          registrationPending: true,
+        };
+      }
       case Event.REQUEST_REGISTER.FAILURE:
       case Event.REQUEST_UNREGISTER.FAILURE: {
         return {
@@ -94,6 +102,7 @@ export default formReducer.plugin({
           ...state,
           submitting: false,
           submitSucceeded: true,
+          registrationPending: false,
         };
       }
       case Event.SOCKET_REGISTRATION.FAILURE:
@@ -107,6 +116,7 @@ export default formReducer.plugin({
           registrationId: null,
           submitting: false,
           submitSucceeded: false,
+          registrationPending: false,
         };
       }
       default:

--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -91,6 +91,21 @@
   flex-wrap: wrap-reverse;
 }
 
+.registrationPending {
+  background-color: var(--lego-card-color);
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  box-shadow: rgba(149, 157, 165, 20%) 0 8px 24px;
+  padding: 5px;
+  text-align: center;
+}
+
+.registrationPendingHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+}
+
 .eventWarning {
   padding: 10px;
   margin-bottom: 10px;

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -10,11 +10,13 @@ import { Form, Captcha, TextInput } from 'app/components/Form';
 import Button from 'app/components/Button';
 import PaymentRequestForm from './StripeElement';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
-import LoadingIndicator from 'app/components/LoadingIndicator';
+import LoadingIndicator, { ProgressBar } from 'app/components/LoadingIndicator';
 import Time from 'app/components/Time';
 import { Flex } from 'app/components/Layout';
 import withCountdown from './JoinEventFormCountdownProvider';
 import formStyles from 'app/components/Form/Field.css';
+import Icon from 'app/components/Icon';
+import Tooltip from 'app/components/Tooltip';
 import moment from 'moment-timezone';
 import {
   paymentSuccess,
@@ -44,6 +46,7 @@ export type Props = {
   invalid: boolean,
   pristine: boolean,
   submitting: boolean,
+  registrationPending: boolean,
   formOpen: boolean,
   captchaOpen: boolean,
   buttonOpen: boolean,
@@ -102,6 +105,26 @@ const SubmitButton = ({
     </ConfirmModalWithParent>
   );
 };
+
+const RegistrationPending = () => (
+  <div className={styles.registrationPending}>
+    <span className={styles.registrationPendingHeader}>
+      <h3>Vi behandler din registrering.</h3>
+    </span>
+    <p>
+      Det kan ta et øyeblikk eller to.
+      <br />
+      <i>Du trenger ikke refreshe siden.</i>
+      <Tooltip
+        content="Om det tar lang tid, kan du refreshe siden for å hente siste status på din registrering. Denne boksen vil da forsvinne, men din registrering vil fortsatt behandles."
+        renderDirection="center"
+      >
+        <Icon name="information-circle-outline" size={20} />
+      </Tooltip>
+    </p>
+    <ProgressBar />
+  </div>
+);
 
 const PaymentForm = ({
   createPaymentIntent,
@@ -193,6 +216,7 @@ class JoinEventForm extends Component<Props> {
       penalties,
       captchaOpen,
       registrationOpensIn,
+      registrationPending,
     } = this.props;
 
     const joinTitle = !registration ? 'Meld deg på' : 'Avregistrer';
@@ -214,7 +238,11 @@ class JoinEventForm extends Component<Props> {
         registration.pool
     );
     const showCaptcha =
-      !submitting && !registration && captchaOpen && event.useCaptcha;
+      !submitting &&
+      !registrationPending &&
+      !registration &&
+      captchaOpen &&
+      event.useCaptcha;
     const showStripe =
       event.useStripe &&
       event.isPriced &&
@@ -324,7 +352,7 @@ class JoinEventForm extends Component<Props> {
                           </Button>
                         </Flex>
                       )}
-                      {buttonOpen && !submitting && (
+                      {buttonOpen && !submitting && !registrationPending && (
                         <>
                           <Flex
                             alignItems="center"
@@ -356,6 +384,7 @@ class JoinEventForm extends Component<Props> {
                           loadingStyle={{ margin: '5px auto' }}
                         />
                       )}
+                      {registrationPending && <RegistrationPending />}
                     </Form>
 
                     <label className={formStyles.label} htmlFor={feedbackName}>
@@ -436,6 +465,7 @@ function mapStateToProps(state, { event, registration }) {
       },
     };
   }
+  const registrationPending = state.form?.joinEvent?.registrationPending;
   const user = state.auth
     ? selectUserByUsername(state, { username: state.auth.username })
     : null;
@@ -444,6 +474,7 @@ function mapStateToProps(state, { event, registration }) {
     : [];
   return {
     penalties,
+    registrationPending,
   };
 }
 


### PR DESCRIPTION
This component will show between a REGISTRATION.REQUEST_REGISTER_SUCCESS and a
SOCKET_REGISTRATION.SUCCESS or FAILURE. The normal loading component
will still show between the registration initition and the request
register success. Note that since there is no coupling between the
registration and events, this logic is only stored in state and we cannot
determine whether to show the component based on the registration alone.

It's a _bit_ weird to store the `pendingRegistration` status in the form state, but it was where it sort of made the most sense to put it, and it should not affect any other form logic.

Solves https://github.com/webkom/lego/issues/2346


![Kooha-11-10-2021-02-00-49](https://user-images.githubusercontent.com/42850232/141031100-2c526a75-85de-4721-99e2-d88b7e7dd16d.gif)