### PR TITLE
Codesplitting on all routes using loadable-components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,8 @@
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
     "react-hot-loader/babel",
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-proposal-class-properties",
+    "@loadable/babel-plugin"
   ],
   sourceType: "unambiguous"
 }

--- a/app/render.js
+++ b/app/render.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { loadableReady } from '@loadable/component';
 import { hydrate, render } from 'react-dom';
 import Root from './Root';
 import routes from 'app/routes';
@@ -16,7 +17,9 @@ const renderApp = ({
 }) => {
   const rootElement: HTMLElement = (document.getElementById('root'): any);
   const reactRenderFunc = isSSR ? hydrate : render;
-  reactRenderFunc(<Root {...{ store, history, routes }} />, rootElement);
+  loadableReady(() => {
+    reactRenderFunc(<Root {...{ store, history, routes }} />, rootElement);
+  });
 };
 
 export default renderApp;

--- a/app/routes/events/index.js
+++ b/app/routes/events/index.js
@@ -1,17 +1,22 @@
 // @flow
+import loadable from '@loadable/component';
 import { Route, Switch } from 'react-router-dom';
-import RouteWrapper from 'app/components/RouteWrapper';
-import CalendarRoute from './CalendarRoute';
-import CreateRoute from './EventCreateRoute';
-import DetailRoute from './EventDetailRoute';
-import EventListRoute from './EventListRoute';
 import { UserContext } from 'app/routes/app/AppRoute';
-import EventEditRoute from './EventEditRoute';
-import EventAdministrateRoute from './EventAdministrateRoute';
-import EventAttendeeRoute from './EventAttendeeRoute';
-import EventAdminRegisterRoute from './EventAdminRegisterRoute';
-import EventAbacardRoute from './EventAbacardRoute';
-import PageNotFound from '../pageNotFound';
+const EventEditRoute = loadable(() => import('./EventEditRoute'));
+const EventAdministrateRoute = loadable(() =>
+  import('./EventAdministrateRoute')
+);
+const EventAttendeeRoute = loadable(() => import('./EventAttendeeRoute'));
+const EventAdminRegisterRoute = loadable(() =>
+  import('./EventAdminRegisterRoute')
+);
+const EventAbacardRoute = loadable(() => import('./EventAbacardRoute'));
+const PageNotFound = loadable(() => import('../pageNotFound'));
+const RouteWrapper = loadable(() => import('app/components/RouteWrapper'));
+const CalendarRoute = loadable(() => import('./CalendarRoute'));
+const CreateRoute = loadable(() => import('./EventCreateRoute'));
+const DetailRoute = loadable(() => import('./EventDetailRoute'));
+const EventListRoute = loadable(() => import('./EventListRoute'));
 
 const eventRoute = ({ match }: { match: { path: string } }) => (
   <UserContext.Consumer>

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,32 +1,39 @@
+import loadable from '@loadable/component';
 import { Route, Switch } from 'react-router-dom';
 import { AppRoute } from './app';
-import Overview from './overview';
-import Events from './events';
-import Companies from './company';
-import Users from './users';
-import Articles from './articles';
-import Meetings from './meetings';
-import Admin from './admin';
-import Quotes from './quotes';
-import Podcasts from './podcasts';
-import Photos from './photos';
-import Pages from './pages';
-import Search from './search';
-import InterestGroups from './interestgroups';
-import Joblistings from './joblistings';
-import PageNotFound from './pageNotFound';
-import Announcements from './announcements';
-import { CompanyInterestInfoRoute, CompanyInterest } from './companyInterest';
-import Bdb from './bdb';
-import Contact from './contact';
-import Timeline from './timeline';
-import Surveys from './surveys';
-import Tags from './tags';
-import Brand from './brand';
-import UserValidator from './userValidator';
-import Polls from './polls';
-import RouteWrapper from 'app/components/RouteWrapper';
 import { UserContext } from 'app/routes/app/AppRoute';
+import RouteWrapper from 'app/components/RouteWrapper';
+const CompanyInterestInfoRoute = loadable(() => import('./companyInterest'), {
+  resolveComponent: (components) => components.CompanyInterestInfoRoute,
+});
+
+const CompanyInterest = loadable(() => import('./companyInterest'), {
+  resolveComponent: (components) => components.CompanyInterest,
+});
+const Companies = loadable(() => import('./company'));
+const Users = loadable(() => import('./users'));
+const Articles = loadable(() => import('./articles'));
+const Meetings = loadable(() => import('./meetings'));
+const Admin = loadable(() => import('./admin'));
+const Quotes = loadable(() => import('./quotes'));
+const Podcasts = loadable(() => import('./podcasts'));
+const Photos = loadable(() => import('./photos'));
+const Pages = loadable(() => import('./pages'));
+const Search = loadable(() => import('./search'));
+const InterestGroups = loadable(() => import('./interestgroups'));
+const Joblistings = loadable(() => import('./joblistings'));
+const PageNotFound = loadable(() => import('./pageNotFound'));
+const Announcements = loadable(() => import('./announcements'));
+const Bdb = loadable(() => import('./bdb'));
+const Contact = loadable(() => import('./contact'));
+const Timeline = loadable(() => import('./timeline'));
+const Surveys = loadable(() => import('./surveys'));
+const Tags = loadable(() => import('./tags'));
+const Brand = loadable(() => import('./brand'));
+const UserValidator = loadable(() => import('./userValidator'));
+const Polls = loadable(() => import('./polls'));
+const Events = loadable(() => import('./events'));
+const Overview = loadable(() => import('./overview'));
 
 const RouterConfig = () => (
   <>

--- a/app/routes/users/components/ChangePassword.js
+++ b/app/routes/users/components/ChangePassword.js
@@ -4,12 +4,8 @@ import { Field } from 'redux-form';
 import type { FormProps } from 'redux-form';
 import Button from 'app/components/Button';
 import { TextInput, Form, legoForm } from 'app/components/Form';
-import {
-  createValidator,
-  required,
-  validPassword,
-  sameAs,
-} from 'app/utils/validation';
+import { createValidator, required, sameAs } from 'app/utils/validation';
+import { validPassword } from '../utils';
 import PasswordField from './PasswordField';
 import { type UserEntity } from 'app/reducers/users';
 

--- a/app/routes/users/components/UserConfirmation.js
+++ b/app/routes/users/components/UserConfirmation.js
@@ -13,12 +13,8 @@ import {
 } from 'app/components/Form';
 import { Field } from 'redux-form';
 import { Link } from 'react-router-dom';
-import {
-  createValidator,
-  required,
-  validPassword,
-  sameAs,
-} from 'app/utils/validation';
+import { createValidator, required, sameAs } from 'app/utils/validation';
+import { validPassword } from '../utils';
 import PasswordField from './PasswordField';
 import { type UserEntity } from 'app/reducers/users';
 

--- a/app/routes/users/components/UserResetPassword.js
+++ b/app/routes/users/components/UserResetPassword.js
@@ -4,12 +4,8 @@ import { reduxForm, Field } from 'redux-form';
 import { Content } from 'app/components/Content';
 import type { Action } from 'app/types';
 import { Form, Button, TextInput } from 'app/components/Form';
-import {
-  createValidator,
-  required,
-  validPassword,
-  sameAs,
-} from 'app/utils/validation';
+import { createValidator, required, sameAs } from 'app/utils/validation';
+import { validPassword } from '../utils';
 import PasswordField from './PasswordField';
 
 type Props = {

--- a/app/routes/users/utils.js
+++ b/app/routes/users/utils.js
@@ -1,0 +1,15 @@
+import zxcvbn from 'zxcvbn';
+import { pick } from 'lodash';
+
+export const validPassword = (
+  message = 'Passordet er for svakt. Minimum styrke er 3.'
+) => (value, data) => {
+  if (value === undefined) {
+    return [true];
+  }
+  const userValues = Object.values(
+    pick(data, ['username', 'firstName', 'lastName'])
+  );
+  const evalPass = zxcvbn(value, userValues);
+  return [evalPass.score >= 3, message];
+};

--- a/app/utils/validation.js
+++ b/app/utils/validation.js
@@ -1,5 +1,4 @@
-import zxcvbn from 'zxcvbn';
-import { pick, merge } from 'lodash';
+import { merge } from 'lodash';
 
 export const EMAIL_REGEX = /.+@.+\..+/;
 const YOUTUBE_URL_REGEX = /(?:https?:\/\/)?(?:www[.])?(?:youtube[.]com\/watch[?]v=|youtu[.]be\/)([^&]{11})/;
@@ -26,19 +25,6 @@ export const isEmail = (message = 'Ugyldig e-post') =>
 
 export const validYoutubeUrl = (message = 'Ikke gyldig YouTube URL.') =>
   matchesRegex(YOUTUBE_URL_REGEX, message);
-
-export const validPassword = (
-  message = 'Passordet er for svakt. Minimum styrke er 3.'
-) => (value, data) => {
-  if (value === undefined) {
-    return [true];
-  }
-  const userValues = Object.values(
-    pick(data, ['username', 'firstName', 'lastName'])
-  );
-  const evalPass = zxcvbn(value, userValues);
-  return [evalPass.score >= 3, message];
-};
 
 export const whenPresent = (validator) => (value, context) =>
   value ? validator(value, context) : [true];

--- a/config/webpack.client.js
+++ b/config/webpack.client.js
@@ -144,12 +144,6 @@ module.exports = (env, argv) => {
             chunks: 'all',
             enforce: true,
           },
-          defaultVendors: {
-            name: 'vendors',
-            test: /node_modules/,
-            reuseExistingChunk: true,
-            type: 'javascript/auto',
-          },
         },
       },
       minimize: true,

--- a/config/webpack.client.js
+++ b/config/webpack.client.js
@@ -10,6 +10,8 @@ const AssetsPlugin = require('assets-webpack-plugin');
 const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
+const LoadablePlugin = require('@loadable/webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const root = path.resolve(__dirname, '..');
 const packageJson = require('../package.json');
@@ -100,13 +102,15 @@ module.exports = (env, argv) => {
       new FilterWarningsPlugin({
         // suppress conflicting order warnings from mini-css-extract-plugin.
         // see https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250
-        exclude: /Conflicting order between:/,
+        exclude: /Conflicting order. Following module has been added/,
       }),
 
       new webpack.ProvidePlugin({
         Buffer: ['buffer', 'Buffer'],
         process: 'process/browser',
       }),
+
+      isProduction && new LoadablePlugin(),
 
       new AssetsPlugin({
         path: outputPath,
@@ -143,14 +147,13 @@ module.exports = (env, argv) => {
           defaultVendors: {
             name: 'vendors',
             test: /node_modules/,
-            chunks: 'all',
-            enforce: true,
             reuseExistingChunk: true,
             type: 'javascript/auto',
           },
         },
       },
-      minimizer: [new CssMinimizerPlugin()],
+      minimize: true,
+      minimizer: [new CssMinimizerPlugin(), new TerserPlugin()],
     },
 
     module: {

--- a/config/webpack.server.js
+++ b/config/webpack.server.js
@@ -48,7 +48,7 @@ module.exports = (env, argv) => {
       new FilterWarningsPlugin({
         // suppress conflicting order warnings from mini-css-extract-plugin.
         // see https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250
-        exclude: /Conflicting order between:/,
+        exclude: /Conflicting order. Following module has been added/,
       }),
       isProduction &&
         new MiniCssExtractPlugin({

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "github.com/webkom/lego-webapp"
   },
   "dependencies": {
+    "@loadable/component": "^5.15.0",
     "@sentry/browser": "^6.2.2",
     "@sentry/integrations": "^6.13.3",
     "@sentry/node": "^6.13.3",
@@ -109,12 +110,15 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
-    "@babel/eslint-parser": "^7.15.7",
+    "@babel/eslint-parser": "^7.16.3",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-flow": "^7.16.0",
     "@babel/preset-react": "^7.12.13",
+    "@loadable/babel-plugin": "^5.13.2",
+    "@loadable/server": "^5.15.1",
+    "@loadable/webpack-plugin": "^5.15.1",
     "assets-webpack-plugin": "^7.1.1",
     "babel-loader": "^8.2.2",
     "concurrently": "^6.4.0",
@@ -157,6 +161,7 @@
     "style-loader": "^3.3.0",
     "stylelint": "13.13.1",
     "stylelint-config-standard": "^22.0.0",
+    "terser-webpack-plugin": "^5.2.5",
     "timekeeper": "^2.2.0",
     "webpack": "^5.58.2",
     "webpack-bundle-analyzer": "^4.5.0",
@@ -230,6 +235,15 @@
       "@webkom/react-meter-bar"
     ]
   },
+  "sideEffects": [
+    "*.css",
+    "./app/index.js",
+    "./app/utils/fetchJSON.js",
+    "./app/routes/surveys/SubmissionRoute.js",
+    "./app/components/form/EditorField.js",
+    "./app/components/form/SelectInput.js",
+    "./app/components/DisplayContent/index.js"
+  ],
   "moduleRoots": [
     "./"
   ]

--- a/server/ssr.js
+++ b/server/ssr.js
@@ -1,5 +1,4 @@
 //@flow
-import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router';
 import RouteConfig from '../app/routes';
 // $FlowFixMe
@@ -45,13 +44,13 @@ const createServerSideRenderer = (
   next: express$Middleware<express$Request, express$Response>
 ) => {
   const render = (
-    body: string = '',
+    app: ?React$Element<*> = undefined,
     state: State | {||} = Object.freeze({})
   ) => {
     const helmet = Helmet.rewind();
     return res.send(
       pageRenderer({
-        body,
+        app,
         state,
         helmet,
       })
@@ -111,11 +110,10 @@ const createServerSideRenderer = (
       return res.redirect(302, context.url);
     }
     const state: State = store.getState();
-    const body = renderToString(app);
     // $FlowFixMe
     const statusCode = state.router.statusCode || 200;
     res.status(statusCode);
-    return render(body, state);
+    return render(app, state);
   };
 
   prepareWithTimeout(app)

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,10 +56,10 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/eslint-parser@^7.15.7":
-  version "7.15.7"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.15.7.tgz#2dc3d0ff0ea22bb1e08d93b4eeb1149bf1c75f2d"
-  integrity sha512-yJkHyomClm6A2Xzb8pdAo4HzYMSXFn1O5zrCYvbFP0yQFvHueLedV8WiEno8yJOKStjUXzBZzJFeWQ7b3YMsqQ==
+"@babel/eslint-parser@^7.16.3":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz#2a6b1702f3f5aea48e00cea5a5bcc241c437e459"
+  integrity sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==
   dependencies:
     eslint-scope "^5.1.1"
     eslint-visitor-keys "^2.1.0"
@@ -603,7 +603,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-dynamic-import@^7.8.3":
+"@babel/plugin-syntax-dynamic-import@^7.7.4", "@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
@@ -1116,6 +1116,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.7":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
+  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -1454,6 +1461,36 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@loadable/babel-plugin@^5.13.2":
+  version "5.13.2"
+  resolved "https://registry.yarnpkg.com/@loadable/babel-plugin/-/babel-plugin-5.13.2.tgz#373cddc64ee5437814f7dca1c1b6a7b2c1665a9f"
+  integrity sha512-vSZUVeTH1S1sDbk8Tzft0plZSkN7W4zmVR5w/Bmy4UmvBiu9lin7ztrDpoUTUzxpoups+OJbTc/OosvN0aMXWg==
+  dependencies:
+    "@babel/plugin-syntax-dynamic-import" "^7.7.4"
+
+"@loadable/component@^5.15.0":
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.15.0.tgz#48b9524237be553f48b158f8c9152593f3f3fded"
+  integrity sha512-g63rQzypPOZi0BeGsK4ST2MYhsFR+i7bhL8k/McUoWDNMDuTTdUlQ2GACKxqh5sI/dNC/6nVoPrycMnSylnAgQ==
+  dependencies:
+    "@babel/runtime" "^7.7.7"
+    hoist-non-react-statics "^3.3.1"
+    react-is "^16.12.0"
+
+"@loadable/server@^5.15.1":
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/@loadable/server/-/server-5.15.1.tgz#fe8e8b2a631ad0ae48dfb765ec96d758ed5206dd"
+  integrity sha512-LdwzskjMtCMDJoz73JhbkBzTfaopx8U/Bfb0uKkqTxrsjH0uC+h4+cPo5mqKYyHz/dwPRf7aJsvQNcLQZdKHHw==
+  dependencies:
+    lodash "^4.17.15"
+
+"@loadable/webpack-plugin@^5.15.1":
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/@loadable/webpack-plugin/-/webpack-plugin-5.15.1.tgz#826891c76611d22b5e8259709664f9f18ab91526"
+  integrity sha512-DqGJmazsh9XEG4CtMbaR+Ay+6+iw3NvzYqzqVIb7nsTi7UB38gEQJkT/enXdCkMZhLNSYL2HAr4rbFerhfyL2Q==
+  dependencies:
+    make-dir "^3.0.2"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -6558,7 +6595,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10993,7 +11030,7 @@ react-input-autosize@^2.1.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.10.2, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.4.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.2, react-is@^16.8.6:
+react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.4.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.2, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -13011,6 +13048,17 @@ terser-webpack-plugin@^5.1.3:
   dependencies:
     jest-worker "^27.0.6"
     p-limit "^3.1.0"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.0"
+    source-map "^0.6.1"
+    terser "^5.7.2"
+
+terser-webpack-plugin@^5.2.5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz#ce65b9880a0c36872555c4874f45bbdb02ee32c9"
+  integrity sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==
+  dependencies:
+    jest-worker "^27.0.6"
     schema-utils "^3.1.1"
     serialize-javascript "^6.0.0"
     source-map "^0.6.1"


### PR DESCRIPTION
Also adds some tree-shaking and webpack optimization tweaks.

~The vendors chunk is still quite large. With zxcvbn using \~700KiB and recharts using \~500KiB. We should find a way to split these out from the main vendor chunk, and load async. (looking at this now).~

In the mean time, this should be alot better.

**Before:**
```
[1] WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
[1] This can impact web performance.
[1] Assets: 
[1]   a10340ceb228c90cbeb6.ttf (8.95 MiB)
[1]   app.20320511.js (6.44 MiB)
[1]   c2bd9cd4b22ff17d91c4.jpg (280 KiB)
[1]   5c3185a787083623adb4.png (348 KiB)
[1]   fa60fac19a5deb240e84.png (819 KiB)
[1]   45b8e04fc7022ab64c11.png (331 KiB)
[1]   vendors.ef812859.js (5.78 MiB)
[1]   styles.c6b02716d66620b130e6.css (272 KiB)
[1]


[1] Entrypoints:
[1]   app (12.6 MiB)
[1]       vendors.ef812859.js
[1]       styles.6df2013d.js
[1]       styles.c6b02716d66620b130e6.css
[1]       app.20320511.js
```
![image](https://user-images.githubusercontent.com/42850232/144059053-be9780d5-cdf0-443a-b810-3179eb6f462d.png)


**After:**
```
[1] WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
[1] This can impact web performance.
[1] Assets: 
[1]   a10340ceb228c90cbeb6.ttf (8.95 MiB)
[1]   app.3f2c1a49.js (584 KiB)
[1]   c2bd9cd4b22ff17d91c4.jpg (280 KiB)
[1]   5c3185a787083623adb4.png (348 KiB)
[1]   45b8e04fc7022ab64c11.png (331 KiB)
[1]   fa60fac19a5deb240e84.png (819 KiB)
[1]   5677.168c437d.js (1.26 MiB)
[1]   8464.chunk.9dd1bb57.js (366 KiB)
[1]   1840.chunk.ec49e232.js (812 KiB)
[1]   styles.9c103041b67ea59185ad.css (272 KiB)

[1] Entrypoints:
[1]   app (2.16 MiB)
[1]       styles.85f811b8.js
[1]       styles.9c103041b67ea59185ad.css
[1]       5677.168c437d.js
[1]       app.3f2c1a49.js
```

![image](https://user-images.githubusercontent.com/42850232/144058386-7e47d75c-1f17-412f-8753-817945a1d183.png)
