### PR TITLE
Fix development build

### DIFF
--- a/config/webpack.client.js
+++ b/config/webpack.client.js
@@ -115,6 +115,11 @@ module.exports = (env, argv) => {
 
       isProduction && new CompressionPlugin(),
 
+      !isProduction &&
+        new webpack.optimize.LimitChunkCountPlugin({
+          maxChunks: 1,
+        }),
+
       new AssetsPlugin({
         path: outputPath,
       }),
@@ -150,7 +155,10 @@ module.exports = (env, argv) => {
         },
       },
       minimize: true,
-      minimizer: [new CssMinimizerPlugin(), new TerserPlugin()],
+      minimizer: [
+        new CssMinimizerPlugin(),
+        isProduction && new TerserPlugin(),
+      ].filter(Boolean),
     },
 
     module: {


### PR DESCRIPTION
The introduction of loadable-components and chunk-splitting broke the
development server. This fixes it by ignoring loadable-components
SSR, limiting chunk count to 1, and manually processing stats.

In the process of fixing SSR and the static build, I broke the dev build and HMR. Sadly,
loadable-components is not compatible with HMR, but we can just force webpack to only use one bundle
and we essentially bypass loadable-components and HMR works as intended.
