### PR TITLE
Change dependabot schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
     time: "04:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot has been awfully quiet on the webapp lately, so I suggest changing the schedule back to daily