### PR TITLE
Add automatic progressive image loading when possible

### DIFF
--- a/app/components/Content/Content.css
+++ b/app/components/Content/Content.css
@@ -31,6 +31,7 @@
   border-bottom-left-radius: 0;
   overflow: hidden;
   position: relative;
+  width: 100%;
 
   img {
     object-fit: cover;

--- a/app/components/Content/Content.js
+++ b/app/components/Content/Content.js
@@ -68,7 +68,7 @@ function Content({ banner, youtubeUrl, children, className }: Props) {
       ) : (
         banner && (
           <div className={cx(styles.cover, className)}>
-            <Image src={banner} />
+            <Image src={banner} width={1667} height={500} />
           </div>
         )
       )}

--- a/app/components/Content/Content.js
+++ b/app/components/Content/Content.js
@@ -15,6 +15,7 @@ import getParamsFromUrl from 'app/utils/getParamsFromUrl';
 
 type Props = {
   banner?: string,
+  bannerPlaceholder?: string,
   youtubeUrl?: string,
   className?: string,
   children: Node,
@@ -37,7 +38,13 @@ type Props = {
  * ```
  */
 
-function Content({ banner, youtubeUrl, children, className }: Props) {
+function Content({
+  banner,
+  bannerPlaceholder,
+  youtubeUrl,
+  children,
+  className,
+}: Props) {
   const [isClicked, click] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const youtubeParams = youtubeUrl && getParamsFromUrl(youtubeUrl);
@@ -68,7 +75,12 @@ function Content({ banner, youtubeUrl, children, className }: Props) {
       ) : (
         banner && (
           <div className={cx(styles.cover, className)}>
-            <Image src={banner} width={1667} height={500} />
+            <Image
+              src={banner}
+              placeholder={bannerPlaceholder}
+              width={1667}
+              height={500}
+            />
           </div>
         )
       )}

--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -91,7 +91,9 @@ const EventItem = ({
     </div>
 
     <div className={styles.companyLogo}>
-      {event.cover && <Image src={event.cover} />}
+      {event.cover && (
+        <Image src={event.cover} placeholder={event.coverPlaceholder} />
+      )}
     </div>
   </div>
 );

--- a/app/components/Gallery/index.js
+++ b/app/components/Gallery/index.js
@@ -4,7 +4,7 @@ import type { Node } from 'react';
 
 import { PureComponent } from 'react';
 import { chunk, get } from 'lodash';
-import ProgressiveImage from 'app/components/ProgressiveImage';
+import { Image } from 'app/components/Image';
 import Paginator from 'app/components/Paginator';
 import styles from './Gallery.css';
 
@@ -117,7 +117,7 @@ export default class Gallery extends PureComponent<Props, State> {
               onClick={() => this.onClick(photo)}
               className={styles.galleryPhoto}
             >
-              <ProgressiveImage
+              <Image
                 className={styles.image}
                 src={src}
                 beforeLoadstyle={{

--- a/app/components/GroupMember/index.js
+++ b/app/components/GroupMember/index.js
@@ -22,7 +22,11 @@ const GroupMember = ({ user, profilePicture, leader, co_leader }: Props) => {
           co_leader && styles.co_leader
         )}
       >
-        <Image alt="profilePicture" src={user.profilePicture} />
+        <Image
+          alt="profilePicture"
+          src={user.profilePicture}
+          placeholder={user.profilePicturePlaceholder}
+        />
         {leader && <div className={styles.title}>LEDER</div>}
         {co_leader && <div className={styles.title}>NESTLEDER</div>}
         <div className={styles.name}>{user.fullName}</div>

--- a/app/components/GroupMember/index.js
+++ b/app/components/GroupMember/index.js
@@ -8,11 +8,10 @@ import { Image } from 'app/components/Image';
 
 type Props = {
   user: User,
-  profilePicture: string,
   leader?: boolean,
   co_leader?: boolean,
 };
-const GroupMember = ({ user, profilePicture, leader, co_leader }: Props) => {
+const GroupMember = ({ user, leader, co_leader }: Props) => {
   return (
     <Link to={`/users/${user.username}`}>
       <div

--- a/app/components/Image/CircularPicture.js
+++ b/app/components/Image/CircularPicture.js
@@ -4,14 +4,23 @@ import Image from './Image';
 
 type Props = {
   src: any,
+  placeholder?: string,
   alt: string,
   size: number,
   style?: Object,
 };
 
-const CircularPicture = ({ src, alt, size = 100, style, ...props }: Props) => (
+const CircularPicture = ({
+  src,
+  placeholder,
+  alt,
+  size = 100,
+  style,
+  ...props
+}: Props) => (
   <Image
     src={src}
+    placeholder={placeholder}
     alt={alt}
     width={size}
     height={size}

--- a/app/components/Image/Image.css
+++ b/app/components/Image/Image.css
@@ -1,6 +1,9 @@
 .image {
   width: 100%;
   height: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .hidden {

--- a/app/components/Image/Image.css
+++ b/app/components/Image/Image.css
@@ -2,3 +2,22 @@
   width: 100%;
   height: auto;
 }
+
+.hidden {
+  opacity: 0;
+}
+
+.show {
+  opacity: 1;
+}
+
+.blur {
+  filter: blur(0.2vw);
+  overflow: hidden;
+}
+
+.finalImage {
+  transition-property: filter, opacity;
+  transition-duration: 500ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}

--- a/app/components/Image/Image.js
+++ b/app/components/Image/Image.js
@@ -4,32 +4,89 @@ import { Component } from 'react';
 import cx from 'classnames';
 import styles from './Image.css';
 
+type SrcWithPlaceholder = {
+  final: string,
+  placeholder: string,
+};
+
 type Props = {
-  src: string,
+  src: string | SrcWithPlaceholder,
   className?: string,
   alt: string,
   style: Object,
 };
 
-class Image extends Component<Props> {
-  static defaultProps = {
-    alt: 'image',
-  };
+type State = {
+  src: string,
+  imageLoaded: boolean,
+};
+
+const isSrcProgressive = (src: string | SrcWithPlaceholder): boolean %checks =>
+  typeof src === 'object';
+
+const EMPTY_IMAGE =
+  'data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+class ImageComponent extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    const { src } = this.props;
+
+    this.state = {
+      imageLoaded: false,
+      src: isSrcProgressive(src) ? src.placeholder || EMPTY_IMAGE : EMPTY_IMAGE,
+    };
+  }
+
+  componentDidMount() {
+    const { src } = this.props;
+    if (typeof src === 'object') {
+      const srcObj: Object = src;
+      this.setState({ src: srcObj.placeholder });
+      const image = new Image();
+      image.src = srcObj.final;
+      image.onload = () => {
+        this.setState({ imageLoaded: true, src: srcObj.final });
+      };
+    }
+  }
 
   render() {
-    const { src, className, alt, style, ...props } = this.props;
-    const finalClass = cx(styles.image, className);
-    if (!src) return <div className={finalClass} style={style} />;
-    return (
+    const { src, className, alt = 'image', style, ...rest } = this.props;
+    const isProgressive = typeof src === 'object';
+
+    const defaultClass = cx(styles.image, className);
+
+    const finalClass = cx(
+      styles.image,
+      styles.finalImage,
+      className,
+      !this.state.imageLoaded && isProgressive && styles.blur
+    );
+    if (!src)
+      return <div className={finalClass} style={style} {...(rest: Object)} />;
+
+    return isProgressive ? (
       <img
         className={finalClass}
+        data-src={(src: Object).final}
+        src={this.state.src}
+        loading="lazy"
+        alt={alt}
+        style={style}
+        {...(rest: Object)}
+      />
+    ) : (
+      <img
+        className={defaultClass}
         src={src}
         alt={alt}
         style={style}
-        {...(props: Object)}
+        {...(rest: Object)}
       />
     );
   }
 }
 
-export default Image;
+export default ImageComponent;

--- a/app/components/Image/Image.js
+++ b/app/components/Image/Image.js
@@ -4,13 +4,9 @@ import { Component } from 'react';
 import cx from 'classnames';
 import styles from './Image.css';
 
-type SrcWithPlaceholder = {
-  final: string,
-  placeholder: string,
-};
-
 type Props = {
-  src: string | SrcWithPlaceholder,
+  src: string,
+  placeholder: string,
   className?: string,
   alt: string,
   style: Object,
@@ -21,40 +17,38 @@ type State = {
   imageLoaded: boolean,
 };
 
-const isSrcProgressive = (src: string | SrcWithPlaceholder): boolean %checks =>
-  typeof src === 'object';
-
 const EMPTY_IMAGE =
   'data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 class ImageComponent extends Component<Props, State> {
+  isProgressive: boolean;
+
   constructor(props: Props) {
     super(props);
 
-    const { src } = this.props;
+    const { placeholder } = this.props;
+
+    this.isProgressive = !!placeholder;
 
     this.state = {
       imageLoaded: false,
-      src: isSrcProgressive(src) ? src.placeholder || EMPTY_IMAGE : EMPTY_IMAGE,
+      src: this.isProgressive ? placeholder || EMPTY_IMAGE : EMPTY_IMAGE,
     };
   }
 
   componentDidMount() {
     const { src } = this.props;
-    if (typeof src === 'object') {
-      const srcObj: Object = src;
-      this.setState({ src: srcObj.placeholder });
+    if (this.isProgressive) {
       const image = new Image();
-      image.src = srcObj.final;
+      image.src = src;
       image.onload = () => {
-        this.setState({ imageLoaded: true, src: srcObj.final });
+        this.setState({ imageLoaded: true, src });
       };
     }
   }
 
   render() {
     const { src, className, alt = 'image', style, ...rest } = this.props;
-    const isProgressive = typeof src === 'object';
 
     const defaultClass = cx(styles.image, className);
 
@@ -62,12 +56,12 @@ class ImageComponent extends Component<Props, State> {
       styles.image,
       styles.finalImage,
       className,
-      !this.state.imageLoaded && isProgressive && styles.blur
+      !this.state.imageLoaded && this.isProgressive && styles.blur
     );
     if (!src)
       return <div className={finalClass} style={style} {...(rest: Object)} />;
 
-    return isProgressive ? (
+    return this.isProgressive ? (
       <img
         className={finalClass}
         data-src={(src: Object).final}
@@ -83,6 +77,7 @@ class ImageComponent extends Component<Props, State> {
         src={src}
         alt={alt}
         style={style}
+        loading="lazy"
         {...(rest: Object)}
       />
     );

--- a/app/components/Image/ProfilePicture.js
+++ b/app/components/Image/ProfilePicture.js
@@ -1,9 +1,10 @@
 // @flow
 
 import CircularPicture from './CircularPicture';
+import { type User } from 'app/models';
 
 type Props = {
-  user: any,
+  user: User,
   alt: string,
   size: number,
   style?: Object,
@@ -13,6 +14,7 @@ const ProfilePicture = ({ alt, user, size = 100, style, ...props }: Props) => (
   <CircularPicture
     alt={alt}
     src={user.profilePicture}
+    placeholder={user.profilePicturePlaceholder}
     size={size}
     style={style}
     {...(props: Object)}

--- a/app/models.js
+++ b/app/models.js
@@ -40,6 +40,7 @@ export type User = {
   grade: Grade,
   allergies: string,
   profilePicture: string,
+  profilePicturePlaceholder?: string,
   email?: string,
   phoneNumber?: string,
 };
@@ -50,6 +51,7 @@ type EventBase = {
   id: ID,
   title: string,
   cover: string,
+  coverPlaceholder: string,
   description: string,
   createdAt: ?Dateish,
   createdBy: User,
@@ -119,6 +121,7 @@ export type Group = {
   description: string,
   text: string,
   logo: ?string,
+  logo?: string,
   showBadge: boolean,
   active: boolean,
   contactEmail: string,

--- a/app/models.js
+++ b/app/models.js
@@ -121,7 +121,7 @@ export type Group = {
   description: string,
   text: string,
   logo: ?string,
-  logo?: string,
+  logoPlaceholder?: string,
   showBadge: boolean,
   active: boolean,
   contactEmail: string,

--- a/app/reducers/articles.js
+++ b/app/reducers/articles.js
@@ -17,6 +17,7 @@ export type ArticleEntity = {
   description: string,
   author: Object,
   cover: string,
+  coverPlaceholder: string,
   createdAt: string,
   content: string,
   startTime: string,

--- a/app/reducers/pages.js
+++ b/app/reducers/pages.js
@@ -136,7 +136,6 @@ const groupMemberships = (memberships, groupId) => {
 };
 
 export const selectCommitteeForPages = createSelector(
-  // $FlowFixMe what is this err?????+
   (state, { pageSlug }) => selectGroup(state, { groupId: pageSlug }),
   (state, props) =>
     // $FlowFixMe pls

--- a/app/routes/articles/components/ArticleDetail.js
+++ b/app/routes/articles/components/ArticleDetail.js
@@ -49,7 +49,11 @@ const ArticleDetail = ({
   fetchingEmojis,
 }: Props) => {
   return (
-    <Content banner={article.cover} youtubeUrl={article.youtubeUrl}>
+    <Content
+      banner={article.cover}
+      bannerPlaceholder={article.coverPlaceholder}
+      youtubeUrl={article.youtubeUrl}
+    >
       <NavigationTab
         headerClassName={styles.headerClassName}
         className={styles.articleHeader}

--- a/app/routes/articles/components/Overview.css
+++ b/app/routes/articles/components/Overview.css
@@ -35,24 +35,28 @@
 
 .headline,
 .normal {
-  display: flex;
-  flex-direction: row;
-  margin: 0 30px;
+  display: grid;
+  grid-auto-rows: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   width: inherit;
 
   @media (--mobile-device) {
-    flex-direction: column;
     margin: auto;
     justify-content: center;
+    grid-template-columns: initial;
   }
 }
 
-.normal {
-  flex-wrap: wrap;
+.imageLink {
+  width: 100%;
 }
 
-.rest {
-  flex-direction: column;
+.normal {
+  grid-template-columns: repeat(3, minmax(100px, 1fr));
+
+  @media (--mobile-device) {
+    grid-template-columns: initial;
+  }
 }
 
 .item {
@@ -66,22 +70,6 @@
   padding: 0 20px;
 }
 
-.headline > .item {
-  width: 50%;
-
-  @media (--mobile-device) {
-    width: 100%;
-  }
-}
-
-.normal > .item {
-  width: 33%;
-
-  @media (--mobile-device) {
-    width: 100%;
-  }
-}
-
 .itemInfo {
   transition: color 0.2s;
   font-size: 0.8rem;
@@ -93,7 +81,7 @@
   color: var(--color-black);
 }
 
-.item:not(:last-child) {
+.item:not(:last-child):not(:nth-child(3n)) {
   border-right: 1px solid var(--color-mono-gray-4);
 
   @media (--mobile-device) {

--- a/app/routes/articles/components/Overview.css
+++ b/app/routes/articles/components/Overview.css
@@ -61,6 +61,7 @@
   justify-content: flex-start;
   align-items: center;
   flex-direction: column;
+  min-height: 60px;
   margin: 30px 0;
   padding: 0 20px;
 }

--- a/app/routes/articles/components/Overview.js
+++ b/app/routes/articles/components/Overview.js
@@ -18,12 +18,8 @@ const HEADLINE_EVENTS = 2;
 
 const OverviewItem = ({ article }: { article: ArticleEntity }) => (
   <div className={styles.item}>
-    <Link to={`/articles/${article.id}`}>
-      <Image
-        height={60}
-        src={article.cover}
-        placeholder={article.coverPlaceholder}
-      />
+    <Link to={`/articles/${article.id}`} className={styles.imageLink}>
+      <Image src={article.cover} placeholder={article.coverPlaceholder} />
     </Link>
     <h2 className={styles.itemTitle}>
       <Link to={`/articles/${article.id}`}>{article.title}</Link>

--- a/app/routes/articles/components/Overview.js
+++ b/app/routes/articles/components/Overview.js
@@ -19,7 +19,11 @@ const HEADLINE_EVENTS = 2;
 const OverviewItem = ({ article }: { article: ArticleEntity }) => (
   <div className={styles.item}>
     <Link to={`/articles/${article.id}`}>
-      <Image height={60} src={article.cover} />
+      <Image
+        height={60}
+        src={article.cover}
+        placeholder={article.coverPlaceholder}
+      />
     </Link>
     <h2 className={styles.itemTitle}>
       <Link to={`/articles/${article.id}`}>{article.title}</Link>

--- a/app/routes/company/components/CompaniesPage.js
+++ b/app/routes/company/components/CompaniesPage.js
@@ -30,7 +30,12 @@ const CompanyItem = ({ company }: Company) => {
         <div className={styles.companyLogoContainer}>
           <Link to={`/companies/${company.id}`}>
             <div className={styles.companyLogo}>
-              {<Image src={company.logo} />}
+              {
+                <Image
+                  src={company.logo}
+                  placeholder={company.logoPlaceholder}
+                />
+              }
             </div>
           </Link>
         </div>

--- a/app/routes/events/EventListRoute.js
+++ b/app/routes/events/EventListRoute.js
@@ -10,6 +10,7 @@ import { selectSortedEvents } from 'app/reducers/events';
 import moment from 'moment-timezone';
 import { selectPagination } from '../../reducers/selectors';
 import createQueryString from 'app/utils/createQueryString';
+import loadingIndicator from 'app/utils/loadingIndicator';
 
 const mapStateToProps = (state, ownProps) => {
   const dateAfter = moment().format('YYYY-MM-DD');
@@ -27,6 +28,7 @@ const mapStateToProps = (state, ownProps) => {
       actionGrant,
     })(state, ownProps),
     icalToken,
+    notLoading: !state.events.fetching,
   };
 };
 
@@ -47,5 +49,6 @@ const mapDispatchToProps = {
 
 export default compose(
   prepare((props, dispatch) => dispatch(fetchData())),
-  connect(mapStateToProps, mapDispatchToProps)
+  connect(mapStateToProps, mapDispatchToProps),
+  loadingIndicator(['notLoading'])
 )(EventList);

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -264,7 +264,10 @@ export default class EventDetail extends Component<Props> {
     return (
       <div>
         <Content
-          banner={event.cover || (event.company && event.company.logo)}
+          banner={event.cover || event.company?.logo}
+          bannerPlaceholder={
+            event.coverPlaceholder || event.company?.logoPlaceholder
+          }
           youtubeUrl={event.youtubeUrl}
         >
           <ContentHeader

--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -139,7 +139,11 @@ function InterestGroupDetail(props: Props) {
           <ButtonRow {...props} />
         </ContentMain>
         <ContentSidebar>
-          <Image className={styles.logo} src={logo} />
+          <Image
+            className={styles.logo}
+            src={logo}
+            placeholder={group.logoPlaceholder}
+          />
           <Members group={group} members={group.memberships} />
           <Contact group={group} />
           <AnnouncementInLine

--- a/app/routes/joblistings/components/JoblistingList.js
+++ b/app/routes/joblistings/components/JoblistingList.js
@@ -23,6 +23,7 @@ function JoblistingItem({ joblisting }: JobListingItemProps) {
               <Image
                 className={styles.companyLogo}
                 src={joblisting.company.logo}
+                placeholder={joblisting.company.logoPlaceholder}
               />
             )}
           </div>

--- a/app/routes/overview/components/ArticleItem.js
+++ b/app/routes/overview/components/ArticleItem.js
@@ -26,7 +26,12 @@ class ArticleItem extends Component<Props, *> {
         <Flex column>
           <Flex column>
             <Link to={url} className={styles.link}>
-              <Image className={styles.image} src={item.cover} />
+              <Image
+                className={styles.image}
+                src={item.cover}
+                placeholder={item.coverPlaceholder}
+                height="110"
+              />
               <div className={styles.infoWrapper}>
                 <h2 className={styles.articleTitle}>
                   {truncateString(item.title, TITLE_MAX_LENGTH)}

--- a/app/routes/overview/components/EventItem.css
+++ b/app/routes/overview/components/EventItem.css
@@ -43,7 +43,7 @@
   padding: 20px;
   height: 100%;
   flex: 1;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 5px 0;
   background: var(--lego-card-color);
 
   @media (--mobile-device) {
@@ -96,10 +96,9 @@
 .info {
   background: var(--color-white);
   text-align: center;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 0 5px;
   color: var(--lego-font-color);
   padding: 3px 6px;
-  height: 100%;
 
   @media (--mobile-device) {
     display: none;

--- a/app/routes/overview/components/EventItem.js
+++ b/app/routes/overview/components/EventItem.js
@@ -30,14 +30,24 @@ class EventItem extends Component<Props, *> {
             {isFrontPage ? (
               <Flex column className={styles.leftFrontpage}>
                 {item.cover && (
-                  <Image className={styles.imageFrontpage} src={item.cover} />
+                  <Image
+                    className={styles.imageFrontpage}
+                    width={270}
+                    height={80}
+                    src={item.cover}
+                  />
                 )}
                 <span className={styles.info}>{info}</span>
               </Flex>
             ) : (
               <Flex column className={styles.left}>
                 {item.cover && (
-                  <Image className={styles.image} src={item.cover} />
+                  <Image
+                    className={styles.image}
+                    src={item.cover}
+                    width={390}
+                    height={80}
+                  />
                 )}
                 <span className={styles.info}>{info}</span>
               </Flex>

--- a/app/routes/overview/components/EventItem.js
+++ b/app/routes/overview/components/EventItem.js
@@ -35,6 +35,7 @@ class EventItem extends Component<Props, *> {
                     width={270}
                     height={80}
                     src={item.cover}
+                    placeholder={item.coverPlaceholder}
                   />
                 )}
                 <span className={styles.info}>{info}</span>
@@ -45,6 +46,7 @@ class EventItem extends Component<Props, *> {
                   <Image
                     className={styles.image}
                     src={item.cover}
+                    placeholder={item.coverPlaceholder}
                     width={390}
                     height={80}
                   />

--- a/app/routes/overview/components/Pinned.js
+++ b/app/routes/overview/components/Pinned.js
@@ -24,6 +24,7 @@ class Pinned extends Component<Props, *> {
             <Image
               className={styles.image}
               src={item.cover}
+              placeholder={item.coverPlaceholder}
               height={500}
               width={1667}
             />

--- a/app/routes/overview/components/Pinned.js
+++ b/app/routes/overview/components/Pinned.js
@@ -21,7 +21,12 @@ class Pinned extends Component<Props, *> {
         <h3 className="u-ui-heading">Festet oppslag</h3>
         <Flex column className={styles.innerPinned}>
           <Link to={url} className={styles.innerLinks}>
-            <Image className={styles.image} src={item.cover} />
+            <Image
+              className={styles.image}
+              src={item.cover}
+              height={500}
+              width={1667}
+            />
           </Link>
           <div className={styles.pinnedHeading}>
             <h2 className={styles.itemTitle}>

--- a/app/routes/overview/components/PublicFrontpage.js
+++ b/app/routes/overview/components/PublicFrontpage.js
@@ -57,7 +57,7 @@ class PublicFrontpage extends Component<Props, State> {
             </h5>
           </div>
           <Link to={`/articles/${item.id}`}>
-            <Image src={item.cover} />
+            <Image src={item.cover} placeholder={item.coverPlaceholder} />
           </Link>
           {truncateString(item.description, 500)}
         </div>

--- a/app/routes/pages/components/LandingPage.js
+++ b/app/routes/pages/components/LandingPage.js
@@ -48,12 +48,14 @@ const LandingPage = ({
         className={cx(styles.banner, styles.bannerLightMode)}
         src={bannerLightMode}
         alt="Abakus - Linjeforeningen for Datateknologi og Kommunikasjonsteknologi og digital sikkerhet ved NTNU"
+        height="265"
       />
 
       <Image
         className={cx(styles.banner, styles.bannerDarkMode)}
         src={bannerDarkMode}
         alt="Abakus - Linjeforeningen for Datateknologi og Kommunikasjonsteknologi og digital sikkerhet ved NTNU"
+        height="265"
       />
 
       <Flex className={styles.whoWhatWhyContainer}>

--- a/app/routes/pages/components/PageDetail.js
+++ b/app/routes/pages/components/PageDetail.js
@@ -130,6 +130,7 @@ export const MainPageRenderer = ({
   loggedIn: boolean,
 }) => {
   const pageBanner = page.logo || page.picture; //Splittet fra hverandre, var pageBanner = pic || logo
+  const pageBannerPlaceholder = page.logoPlaceholder || page.picturePlaceholder;
   const { title } = pageInfo;
 
   return (
@@ -137,7 +138,11 @@ export const MainPageRenderer = ({
       <div className={styles.headWrapper}>
         {pageBanner && (
           <div className={styles.banner}>
-            <Image alt={`${title} page banner`} src={pageBanner} />
+            <Image
+              alt={`${title} page banner`}
+              src={pageBanner}
+              placeholder={pageBannerPlaceholder}
+            />
           </div>
         )}
         {title !== 'Info om Abakus' && (
@@ -173,42 +178,24 @@ export const GroupRenderer = ({ page }: { page: Object }) => {
       <div className={styles.membersSection}>
         <div className={styles.leaderBoard}>
           <div className={styles.leader}>
-            {leaders.map(({ user, profilePicture }, key) => (
-              <GroupMember
-                user={user}
-                profilePicture={profilePicture}
-                key={key}
-                leader
-              />
+            {leaders.map(({ user }, key) => (
+              <GroupMember user={user} key={key} leader />
             ))}
           </div>
           <div className={styles.co_leader}>
-            {co_leaders.map(({ user, profilePicture }, key) => (
-              <GroupMember
-                user={user}
-                profilePicture={profilePicture}
-                key={key}
-                co_leader
-              />
+            {co_leaders.map(({ user }, key) => (
+              <GroupMember user={user} key={key} co_leader />
             ))}
           </div>
         </div>
         <div className={styles.members}>
-          {members.map(({ user, profilePicture }, key) => (
-            <GroupMember
-              user={user}
-              profilePicture={profilePicture}
-              key={key}
-            />
+          {members.map(({ user }, key) => (
+            <GroupMember user={user} key={key} />
           ))}
         </div>
         <div className={styles.members}>
-          {activeRetirees.map(({ user, profilePicture }, key) => (
-            <GroupMember
-              user={user}
-              profilePicture={profilePicture}
-              key={key}
-            />
+          {activeRetirees.map(({ user }, key) => (
+            <GroupMember user={user} key={key} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Modifies the Image component to be able to take an object as the src
prop, rendering a low-res placeholder image while waiting for the
full-res image to load.

This is a first draft, and does not use the existing `<ProgressiveImage/>` component at all (it's not used). As this PR will automatically make use of progressive images if the format follows a standard (subject to change). If anyone has any ideas or changes feel free to share!

This makes use of some backend changes to provide low-res images from thumbor: https://github.com/webkom/lego/pull/2479

**Example with throttling set to _Regular 3G_ in Firefox (which is quite slow)**

<details>
<summary>_See updated screens in new comment_</summary>

Frontpage:

https://user-images.githubusercontent.com/42850232/149673651-9d5a5dee-e39a-44a0-b700-330e84a67230.mp4


Events:

https://user-images.githubusercontent.com/42850232/149673660-bb43c47f-9837-4b3e-930e-d2b1bec45668.mp4

</details>

