### PR TITLE
Remove slate-editor cypress workarounds

### DIFF
--- a/cypress/integration/create_event_spec.js
+++ b/cypress/integration/create_event_spec.js
@@ -36,7 +36,7 @@ describe('Create event', () => {
 
     cy.contains('button', 'OPPRETT').should('be.disabled');
     // click editor to initialize form and enable OPPRETT button
-    selectEditor().editorType('test');
+    selectEditor().type('test');
     cy.wait(1000);
 
     cy.contains('button', 'OPPRETT').should('not.be.disabled').click();
@@ -97,7 +97,7 @@ describe('Create event', () => {
 
     cy.get('._legoEditor_Toolbar_root button').first().click();
     // Format text
-    cy.focused().editorType('This text should be large');
+    cy.focused().type('This text should be large');
     cy.get('._legoEditor_root h1')
       .should('be.visible')
       .contains('This text should be large');
@@ -154,7 +154,7 @@ describe('Create event', () => {
     //cy.get('div[data-slate-editor="true"]').click();
     //cy.focused().type('{downarrow}');
     //cy.focused().type('{enter}EOF{enter}');
-    cy.focused().editorType('EOF');
+    cy.focused().type('EOF');
 
     // Fill rest of form
     cy.upload_file(
@@ -192,7 +192,7 @@ describe('Create event', () => {
     // Set title, description and text
     field('title').type('Standard event').blur();
     field('description').type('standard event').blur();
-    selectEditor().editorType('standard event');
+    selectEditor().type('standard event');
 
     // Select type
     selectField('eventType').click();
@@ -235,7 +235,7 @@ describe('Create event', () => {
     // Set title, description and text
     field('title').type('Ubestemt event').blur();
     field('description').type('mer info kommer').blur();
-    selectEditor().editorType('mer info kommer');
+    selectEditor().type('mer info kommer');
 
     // Select type
     selectField('eventType').click();
@@ -262,7 +262,7 @@ describe('Create event', () => {
     // Set title, description and text
     field('title').type('Normal event').blur();
     field('description').type('normal event').blur();
-    selectEditor().editorType('normal event');
+    selectEditor().type('normal event');
 
     // Select type
     selectField('eventType').click();
@@ -332,7 +332,7 @@ describe('Create event', () => {
     // Set title, description and text
     field('title').type('Open event').blur();
     field('description').type('open event').blur();
-    selectEditor().editorType('open event');
+    selectEditor().type('open event');
 
     // Select type
     selectField('eventType').click();
@@ -363,7 +363,7 @@ describe('Create event', () => {
     // Set title, description and text
     field('title').type('Infinite event').blur();
     field('description').type('infinite event').blur();
-    selectEditor().editorType('infinite event');
+    selectEditor().type('infinite event');
 
     // Select type
     selectField('eventType').click();

--- a/cypress/integration/event_editor_spec.js
+++ b/cypress/integration/event_editor_spec.js
@@ -1,5 +1,8 @@
 import { c, field } from '../support/utils.js';
 
+const IS_MACOS = Cypress.platform.toLowerCase().search('darwin') !== -1;
+const ctrlKey = IS_MACOS ? '{cmd}' : '{ctrl}';
+
 describe('Editor (Firefox only)', { browser: 'firefox' }, () => {
   /*
    * This test is here to be able to run proper tests against the editor.
@@ -33,10 +36,10 @@ describe('Editor (Firefox only)', { browser: 'firefox' }, () => {
 
     // Format bold and italic with keyboard shortcuts
     cy.focused()
-      .type('{ctrl}b')
-      .type('This should be bold{ctrl}b')
-      .type('{ctrl}i')
-      .type('This should be italic{ctrl}i')
+      .type(`${ctrlKey}b`)
+      .type(`This should be bold${ctrlKey}b`)
+      .type(`${ctrlKey}i`)
+      .type(`This should be italic${ctrlKey}i`)
       .type('No format');
     cy.get('._legoEditor_root strong').contains('This should be bold');
     cy.get('._legoEditor_root em').contains('This should be italic');

--- a/cypress/integration/event_editor_spec.js
+++ b/cypress/integration/event_editor_spec.js
@@ -3,7 +3,7 @@ import { c, field } from '../support/utils.js';
 const IS_MACOS = Cypress.platform.toLowerCase().search('darwin') !== -1;
 const ctrlKey = IS_MACOS ? '{cmd}' : '{ctrl}';
 
-describe('Editor (Firefox only)', { browser: 'firefox' }, () => {
+describe('Editor', () => {
   /*
    * This test is here to be able to run proper tests against the editor.
    * Since we use electron in ci, and using cypress methods for type and click

--- a/cypress/integration/event_editor_spec.js
+++ b/cypress/integration/event_editor_spec.js
@@ -64,6 +64,9 @@ describe('Editor', () => {
       'images/screenshot.png'
     );
 
+    // Wait for image to appear
+    cy.get('.ReactCrop').should('be.visible');
+
     cy.get('._legoEditor_modal_applyButton')
       .contains('Apply')
       .should('not.be.disabled')

--- a/cypress/integration/event_payment_spec.js
+++ b/cypress/integration/event_payment_spec.js
@@ -38,7 +38,7 @@ describe('Event registration & payment', () => {
       // Set title, description and text
       field('title').type('Priced event').blur();
       field('description').type('priced event').blur();
-      selectEditor().editorType('priced event');
+      selectEditor().type('priced event');
 
       // Select type
       selectField('eventType').click();

--- a/cypress/integration/event_visit_spec.js
+++ b/cypress/integration/event_visit_spec.js
@@ -52,7 +52,6 @@ describe('View event', () => {
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
       .last()
       .as('form')
-      .editorFocus()
       .click();
     cy.wait(500);
     // We have to click twice due to our ssr hack. This is not needed in a real setting, as a
@@ -82,7 +81,6 @@ describe('View event', () => {
     cy.reload();
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
       .last()
-      .editorFocus()
       .click();
     cy.wait(100);
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]').click({
@@ -103,7 +101,6 @@ describe('View event', () => {
     cy.contains('allergier').click();
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
       .first()
-      .editorFocus()
       .click()
       .wait(100);
     cy.focused().editorType('This is a child comment');

--- a/cypress/integration/event_visit_spec.js
+++ b/cypress/integration/event_visit_spec.js
@@ -60,7 +60,7 @@ describe('View event', () => {
       force: true,
     });
     cy.contains('button', 'Kommenter').as('button').should('not.be.disabled');
-    cy.focused().editorType('This event will be awesome');
+    cy.focused().type('This event will be awesome');
     cy.wait(700);
     cy.contains('button', 'Kommenter').click();
 
@@ -86,7 +86,7 @@ describe('View event', () => {
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]').click({
       force: true,
     });
-    cy.focused().editorType('This is the top comment');
+    cy.focused().type('This is the top comment');
     cy.wait(500);
     cy.contains('button', 'Kommenter').click();
 
@@ -103,7 +103,7 @@ describe('View event', () => {
       .first()
       .click()
       .wait(100);
-    cy.focused().editorType('This is a child comment');
+    cy.focused().type('This is a child comment');
     cy.contains('button', 'Send svar').click();
     cy.get(c('CommentTree__nested')).contains('This is a child comment');
   });

--- a/cypress/integration/joblistings_specs.js
+++ b/cypress/integration/joblistings_specs.js
@@ -31,8 +31,8 @@ describe('Create joblisting', () => {
 
     // TODO sometimes there is an issue in the joblisting editor where you have to click
     // the top editor twice. Not a breaking bug.
-    selectEditor('description').editorType('A joblisting description');
-    selectEditor('text').editorType('Joblisting text');
+    selectEditor('description').type('A joblisting description');
+    selectEditor('text').type('Joblisting text');
 
     cy.contains('button', 'Lagre').should('not.be.disabled');
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -77,13 +77,6 @@ Cypress.Commands.add('editorType', { prevSubject: true }, (subject, text) =>
   })
 );
 
-Cypress.Commands.add('editorFocus', { prevSubject: true }, (subject, text) =>
-  cy.wrap(subject).then((subject) => {
-    subject[0].dispatchEvent(new FocusEvent('focus'));
-    return subject;
-  })
-);
-
 // Commands for interacting with iframes
 Cypress.Commands.add('getIframeBody', (selector) => {
   return cy

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -67,16 +67,6 @@ Cypress.Commands.overwrite('type', (originalFn, subject, string, options) =>
   originalFn(subject, string, Object.assign({}, options, { delay: 1 }))
 );
 
-// Slate editor commands
-Cypress.Commands.add('editorType', { prevSubject: true }, (subject, text) =>
-  cy.wrap(subject).then((subject) => {
-    subject[0].dispatchEvent(
-      new InputEvent('beforeinput', { inputType: 'insertText', data: text })
-    );
-    return subject;
-  })
-);
-
 // Commands for interacting with iframes
 Cypress.Commands.add('getIframeBody', (selector) => {
   return cy

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -19,15 +19,9 @@ export const selectEditor = (name) =>
     ? cy
         .wait(500)
         .get(`[name="${name}"] div[data-slate-editor="true"]`)
-        .editorFocus()
         .click()
         .wait(500)
-    : cy
-        .wait(500)
-        .get('div[data-slate-editor="true"]')
-        .editorFocus()
-        .click()
-        .wait(500);
+    : cy.wait(500).get('div[data-slate-editor="true"]').click().wait(500);
 
 // Used to either confirm or deny the 3D secure pop-up from Stripe.
 export const confirm3DSecureDialog = (confirm = true) => {


### PR DESCRIPTION
As of Cypress v5.5 the type() command works fine with the slate editor so our workarounds are no longer needed. This also allows the editor test to be run on all browsers, not just Firefox, so i moved it into the same file as all the other event tests (event_editor_spec.js)

I also removed all editorFocus() commands, as it seems that clicking the editor also focuses it.

Closes webkom/lego#2353