### PR TITLE
Remove traces of segment

### DIFF
--- a/app/actions/SearchActions.js
+++ b/app/actions/SearchActions.js
@@ -1,7 +1,6 @@
 // @flow
 
 import callAPI from 'app/actions/callAPI';
-import { EventTypes } from 'redux-segment';
 import { Search } from './ActionTypes';
 import { selectAutocomplete } from 'app/reducers/search';
 import type { Action, Thunk } from 'app/types';
@@ -9,11 +8,6 @@ import type { Action, Thunk } from 'app/types';
 export function toggleSearch(): Action {
   return {
     type: Search.TOGGLE_OPEN,
-    meta: {
-      analytics: {
-        eventType: EventTypes.track,
-      },
-    },
   };
 }
 

--- a/app/utils/configureStore.js
+++ b/app/utils/configureStore.js
@@ -2,7 +2,6 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { User } from 'app/actions/ActionTypes';
-import { createTracker, EventTypes } from 'redux-segment';
 import { createLogger } from 'redux-logger';
 import jwtDecode from 'jwt-decode';
 import config from 'app/config';
@@ -17,41 +16,6 @@ import createMessageMiddleware from './messageMiddleware';
 import type { State, Store, GetCookie } from 'app/types';
 import { omit } from 'lodash';
 import createRootReducer from '../reducers';
-
-const trackerMiddleware = createTracker({
-  mapper: {
-    [User.FETCH.SUCCESS]: (getState, { meta, payload }) => {
-      if (meta.isCurrentUser) {
-        const user = payload.entities.users[payload.result];
-
-        return {
-          eventType: EventTypes.identify,
-          eventPayload: {
-            userId: user.id,
-            traits: {
-              avatar: user.profilePicture,
-              email: user.email,
-              firstName: user.firstName,
-              gender: user.gender,
-              id: user.id,
-              lastName: user.lastName,
-              name: user.fullName,
-              username: user.username,
-            },
-          },
-        };
-      }
-    },
-    [User.LOGOUT]: () => [
-      {
-        eventType: EventTypes.reset,
-      },
-      {
-        eventType: EventTypes.page,
-      },
-    ],
-  },
-});
 
 const sentryMiddlewareOptions = {
   stateTransformer: (state) => {

--- a/config/env.js
+++ b/config/env.js
@@ -8,8 +8,6 @@ const config = {
   wsServerUrl: process.env.WS_URL || 'ws://127.0.0.1:8000',
   baseUrl: process.env.BASE_URL || 'http://127.0.0.1:8000',
   webUrl: process.env.WEB_URL || 'http://127.0.0.1:3000',
-  segmentWriteKey:
-    process.env.SEGMENT_WRITE_KEY || 'AwzecATYd1qiH21IY0hruqg63Q4QwZtO',
   captchaKey:
     process.env.CAPTCHA_KEY || '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
   // Requires captchaKey to be the default value (test key)

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "redux": "4.1.2",
     "redux-form": "8.3.7",
     "redux-logger": "^3.0.1",
-    "redux-segment": "^1.6.2",
     "redux-sentry-middleware": "^0.2.2",
     "redux-thunk": "2.4.1",
     "regenerator-runtime": "^0.13.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9236,11 +9236,6 @@ redux-mock-store@^1.5.4:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-redux-segment@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/redux-segment/-/redux-segment-1.6.2.tgz#15768779937ee02cd92e0a812b379abbbb1b7b1f"
-  integrity sha1-FXaHeZN+4CzZLgqBKzeau7sbex8=
-
 redux-sentry-middleware@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/redux-sentry-middleware/-/redux-sentry-middleware-0.2.2.tgz#79140377b4fa6a606797cb2a13cc1b8ab7d68cec"


### PR DESCRIPTION
Okay, \*Record Scratch* \*Freeze Frame\*, you're probably wondering how I ended up here ... so, it all started with my Wappalyzer showing Google Analytics on abakus.no. What? Yes, indeed. This made me go through our codebase in great rage and despair, but instead, all I found was traces of segment. That was _odd_, I thought to myself, in the dawn of night. I ended up removing the traces, but my curiosity led me elsewhere. Deep down in `pass old/pws` I found an ever forgotten username and password combination for no other than segment.io. And, well, you can bet your ass I went and checked it out. Surprisingly enough, two destinations had been set up ... one postgres database pointing to leia.abakus.no ... I checked it out, it was empty. The second, however, Google Universal Analytics™️. How sad ... While looking fiercely into its eyes, I promptly killed it, with only a click of a button. However, funny enough, Wappalyzer had somehow cached Google Analytics to abakus.no, and by clearing it, it was merely gone ... reduced to atoms. Hmm, my job is done. Funny how life goes around, huh? Anyway, what's everybody up to on this ever so beautiful Friday night?

<img src="https://user-images.githubusercontent.com/69514187/151628645-c3e10f3d-181c-45d1-8583-56254de7df4f.png" width="400" />

