### PR TITLE
Remove --ignore-scripts from yarn in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine as builder
 WORKDIR /app/
 COPY . /app
 
-RUN yarn --ignore-scripts
+RUN yarn
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Mazemap needs to run a script in order to install correctly, and yarn
does not allow us to only ignore some scripts.
See https://github.com/yarnpkg/yarn/issues/7338
