### PR TITLE
Make registration pending component more robust

### DIFF
--- a/app/models.js
+++ b/app/models.js
@@ -142,6 +142,14 @@ export type EventRegistrationPaymentStatus =
   | 'failed'
   | 'card_declined';
 
+export type EventRegistrationStatus =
+  | 'PENDING_REGISTER'
+  | 'SUCCESS_REGISTER'
+  | 'FAILURE_REGISTER'
+  | 'PENDING_UNREGISTER'
+  | 'SUCCESS_UNREGISTER'
+  | 'FAILURE_UNREGISTER';
+
 export type EventRegistration = {
   id: number,
   user: User,
@@ -150,6 +158,7 @@ export type EventRegistration = {
   adminRegistrationReason: string,
   registrationDate: Dateish,
   unregistrationDate: Dateish,
+  status: EventRegistrationStatus,
   pool: number,
   presence: EventRegistrationPresence,
   paymentStatus: EventRegistrationPaymentStatus,

--- a/app/reducers/events.js
+++ b/app/reducers/events.js
@@ -350,6 +350,15 @@ export const selectWaitingRegistrationsForEvent = createSelector(
   }
 );
 
+export const selectRegistrationForEventByUserId = createSelector(
+  selectAllRegistrationsForEvent,
+  (state, props) => props.userId,
+  (registrations, userId) => {
+    const userReg = registrations.filter((reg) => reg.user.id === userId);
+    return userReg.length > 0 ? userReg[0] : null;
+  }
+);
+
 export const selectCommentsForEvent = createSelector(
   selectEventById,
   (state) => state.comments.byId,

--- a/app/reducers/forms.js
+++ b/app/reducers/forms.js
@@ -81,7 +81,7 @@ export default formReducer.plugin({
         return {
           ...state,
           submitting: false,
-          registrationPending: true,
+          submitSucceeded: false,
         };
       }
       case Event.REQUEST_REGISTER.FAILURE:
@@ -102,7 +102,6 @@ export default formReducer.plugin({
           ...state,
           submitting: false,
           submitSucceeded: true,
-          registrationPending: false,
         };
       }
       case Event.SOCKET_REGISTRATION.FAILURE:
@@ -116,7 +115,6 @@ export default formReducer.plugin({
           registrationId: null,
           submitting: false,
           submitSucceeded: false,
-          registrationPending: false,
         };
       }
       default:

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -162,6 +162,7 @@ export const eventSchema = (new schema.Entity('events', {
   pools: [poolSchema],
   comments: [commentSchema],
   waitingRegistrations: [registrationSchema],
+  pendingRegistration: registrationSchema,
 }): Schema);
 export const eventAdministrateSchema = (new schema.Entity('events', {
   pools: [poolSchema],

--- a/app/reducers/registrations.js
+++ b/app/reducers/registrations.js
@@ -53,6 +53,14 @@ export default createEntityReducer({
         newState.byId[action.meta.id].fetching = true;
         break;
 
+      case Event.REQUEST_UNREGISTER.SUCCESS: {
+        const registrations = normalize(action.payload, registrationSchema)
+          .entities.registrations;
+        newState.byId = mergeObjects(newState.byId, registrations);
+        newState.items = union(newState.items, [action.payload.id]);
+        break;
+      }
+
       case Event.REQUEST_UNREGISTER.FAILURE:
         newState.byId[action.meta.id].fetching = false;
         break;

--- a/app/routes/events/EventDetailRoute.js
+++ b/app/routes/events/EventDetailRoute.js
@@ -22,6 +22,7 @@ import {
   selectMergedPoolWithRegistrations,
   selectMergedPool,
   selectWaitingRegistrationsForEvent,
+  selectRegistrationForEventByUserId,
 } from 'app/reducers/events';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import helmet from 'app/utils/helmet';
@@ -110,6 +111,11 @@ const mapStateToProps = (state, props) => {
   }
   const hasSimpleWaitingList = poolsWithRegistrations.length <= 1;
 
+  const pendingRegistration = selectRegistrationForEventByUserId(state, {
+    eventId,
+    userId: currentUser.id,
+  });
+
   return {
     comments,
     actionGrant,
@@ -120,6 +126,7 @@ const mapStateToProps = (state, props) => {
     registrations,
     currentRegistration,
     currentRegistrationIndex,
+    pendingRegistration,
     hasSimpleWaitingList,
     penalties,
     currentUserFollowing: selectFollowersCurrentUser(state, {

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -83,6 +83,7 @@ type Props = {
   registrations: Array<EventRegistration>,
   currentRegistration: EventRegistration,
   currentRegistrationIndex: number,
+  pendingRegistration?: EventRegistration,
   hasSimpleWaitingList: boolean,
   waitingRegistrations: Array<EventRegistration>,
   penalties: Array<AddPenalty>,
@@ -158,6 +159,7 @@ export default class EventDetail extends Component<Props> {
       registrations,
       currentRegistration,
       currentRegistrationIndex,
+      pendingRegistration,
       hasSimpleWaitingList,
       deleteEvent,
       penalties,
@@ -387,6 +389,7 @@ export default class EventDetail extends Component<Props> {
                         event={event}
                         registration={currentRegistration}
                         currentUser={currentUser}
+                        pendingRegistration={pendingRegistration}
                         createPaymentIntent={this.handlePaymentMethod}
                         onSubmit={this.handleRegistration}
                       />


### PR DESCRIPTION
The previous logic just relied on state stored in the JoinEventForm form
state, often causing problems with the form mounting and unmounting, clearing the form state etc. It was generally a really bad idea and stupid. I blame only myself :3rd_place_medal:.

This **new** logic makes use of https://github.com/webkom/lego/pull/2539, and keeps the current status of the registration in it's proper place in redux, making it more robust. With the changes, the status of any pending registrations are always fetched together with the event as well, making it persistent across reloads and devices.

**Better loading component in action**:

https://user-images.githubusercontent.com/42850232/155623632-5a7a539e-c26e-447e-9d46-769278979c49.mp4

**And now also loading unregistration**:

https://user-images.githubusercontent.com/42850232/155623649-cbc6d2c7-17af-47f1-a8cd-2f231702cf0e.mp4


