### PR TITLE
Hide registrationDeadline when heedPenalties is false

### DIFF
--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -245,6 +245,7 @@ export default class EventDetail extends Component<Props> {
             key: 'Avregistrering stenger',
           }
         : null,
+      event.heedPenalties &&
       event.unregistrationDeadline &&
       !['OPEN', 'TBA'].includes(event.eventStatusType)
         ? {


### PR DESCRIPTION
Hide the registration deadline when heedplenalties is false. This deadline only determines when you should get a penalty for unregistering too late.\nWhen an event does not heed penalties, this deadline is redundant.