### PR TITLE
Fix progressive images showing wrong image

### DIFF
--- a/app/components/Image/Image.js
+++ b/app/components/Image/Image.js
@@ -20,6 +20,7 @@ const ImageComponent = (props: Props) => {
     props.placeholder || EMPTY_IMAGE
   );
   const [imageLoaded, setImageLoaded] = useState<boolean>(false);
+  const [imageError, setImageError] = useState<boolean>(false);
   const [loadStart, setLoadStart] = useState<number>(0);
   const [loadEnd, setLoadEnd] = useState<number>(0);
 
@@ -34,6 +35,7 @@ const ImageComponent = (props: Props) => {
   useEffect(() => {
     if (isProgressive) {
       setImageLoaded(false);
+      setImageError(false);
       setLoadStart(Date.now());
     }
     const image = new Image();
@@ -42,6 +44,9 @@ const ImageComponent = (props: Props) => {
       setImageLoaded(true);
       setLoadEnd(Date.now());
       setProgressiveSrc(src);
+    };
+    image.onerror = () => {
+      setImageError(true);
     };
   }, [isProgressive, src]);
 
@@ -55,7 +60,7 @@ const ImageComponent = (props: Props) => {
     styles.image,
     !skipTransition && styles.finalImage,
     className,
-    !imageLoaded && isProgressive && styles.blur
+    !imageLoaded && !imageError && isProgressive && styles.blur
   );
 
   if (!src)

--- a/app/components/Image/Image.js
+++ b/app/components/Image/Image.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Component } from 'react';
+import { useEffect, useState } from 'react';
 import cx from 'classnames';
 import styles from './Image.css';
 
@@ -12,84 +12,65 @@ type Props = {
   style: Object,
 };
 
-type State = {
-  src: string,
-  imageLoaded: boolean,
-  loadStart: number,
-  loadEnd: number,
-};
-
 const EMPTY_IMAGE =
   'data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-class ImageComponent extends Component<Props, State> {
-  isProgressive: boolean;
+const ImageComponent = (props: Props) => {
+  const [progressiveSrc, setProgressiveSrc] = useState<string>(
+    props.placeholder || EMPTY_IMAGE
+  );
+  const [imageLoaded, setImageLoaded] = useState<boolean>(false);
+  const [loadStart, setLoadStart] = useState<number>(0);
+  const [loadEnd, setLoadEnd] = useState<number>(0);
 
-  constructor(props: Props) {
-    super(props);
+  const { src, className, alt = 'image', style, ...rest } = props;
 
-    const { placeholder } = this.props;
+  const isProgressive = !!props.placeholder;
 
-    this.isProgressive = !!placeholder;
+  useEffect(() => {
+    setProgressiveSrc(props.placeholder || EMPTY_IMAGE);
+  }, [props.placeholder]);
 
-    this.state = {
-      imageLoaded: false,
-      src: this.isProgressive ? placeholder || EMPTY_IMAGE : EMPTY_IMAGE,
-      loadStart: 0,
-      loadEnd: 0,
-    };
-  }
-
-  componentDidMount() {
-    const { src } = this.props;
-    if (this.isProgressive) {
-      this.setState({ loadStart: Date.now() });
-      const image = new Image();
-      image.src = src;
-      image.onload = () => {
-        this.setState({ imageLoaded: true, loadEnd: Date.now(), src });
-      };
+  useEffect(() => {
+    if (isProgressive) {
+      setImageLoaded(false);
+      setLoadStart(Date.now());
     }
-  }
+    const image = new Image();
+    image.src = src;
+    image.onload = () => {
+      setImageLoaded(true);
+      setLoadEnd(Date.now());
+      setProgressiveSrc(src);
+    };
+  }, [isProgressive, src]);
 
-  render() {
-    const { src, className, alt = 'image', style, ...rest } = this.props;
+  const defaultClass = cx(styles.image, className);
 
-    const defaultClass = cx(styles.image, className);
+  // Skip the transition effect if the image loads very quick.
+  // F.ex. when high bandwith or cached
+  const skipTransition = loadEnd - loadStart < 500;
 
-    // Skip the transition effect if the image loads very quick.
-    // F.ex. when high bandwith or cached
-    const skipTransition = this.state.loadEnd - this.state.loadStart < 500;
+  const finalClass = cx(
+    styles.image,
+    !skipTransition && styles.finalImage,
+    className,
+    !imageLoaded && isProgressive && styles.blur
+  );
 
-    const finalClass = cx(
-      styles.image,
-      !skipTransition && styles.finalImage,
-      className,
-      !this.state.imageLoaded && this.isProgressive && styles.blur
-    );
-    if (!src)
-      return <div className={finalClass} style={style} {...(rest: Object)} />;
+  if (!src)
+    return <div className={finalClass} style={style} {...(rest: Object)} />;
 
-    return this.isProgressive ? (
-      <img
-        className={finalClass}
-        src={this.state.src}
-        loading="lazy"
-        alt={alt}
-        style={style}
-        {...(rest: Object)}
-      />
-    ) : (
-      <img
-        className={defaultClass}
-        src={src}
-        alt={alt}
-        style={style}
-        loading="lazy"
-        {...(rest: Object)}
-      />
-    );
-  }
-}
+  return (
+    <img
+      className={isProgressive ? finalClass : defaultClass}
+      src={isProgressive ? progressiveSrc : src}
+      loading="lazy"
+      alt={alt}
+      style={style}
+      {...(rest: Object)}
+    />
+  );
+};
 
 export default ImageComponent;


### PR DESCRIPTION
Fixes a bug where progressive images don't update when the src prop is changed. I also rewrote `ImageComponent` to be a functional component.

Also fixes https://github.com/webkom/lego/issues/2558