### PR TITLE
Fix gallery photo dropdown

### DIFF
--- a/app/components/Modal/Modal.css
+++ b/app/components/Modal/Modal.css
@@ -39,6 +39,7 @@
   right: 10px;
   font-size: 42px;
   padding: 0;
+  color: var(--color-black);
 }
 
 .confirmContainer {

--- a/app/routes/photos/components/GalleryPictureModal.css
+++ b/app/routes/photos/components/GalleryPictureModal.css
@@ -77,6 +77,11 @@
   margin-top: 20px;
   font-size: 27px;
   padding: 0 1px;
+  color: var(--color-black);
+}
+
+.dropdownContent {
+  z-index: 4;
 }
 
 .form {

--- a/app/routes/photos/components/GalleryPictureModal.js
+++ b/app/routes/photos/components/GalleryPictureModal.js
@@ -246,6 +246,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
                 placement="bottom"
                 toggle={this.toggleDropdown}
                 className={styles.dropdown}
+                contentClassName={styles.dropdownContent}
                 iconName="more"
               >
                 <Dropdown.List>


### PR DESCRIPTION
Fixed the `z-index` for the gallery picture dropdown to make it actually clickable...

Also fixed the color for the dropdown and modal buttons to match the text color.

_Before_:
![bilde](https://user-images.githubusercontent.com/24361490/160102599-3cb87fcd-3de1-470b-ae02-dcdda9ed74b1.png) | ![bilde](https://user-images.githubusercontent.com/24361490/160102629-d9839a4f-ae55-45e2-82a7-56f958b8bd43.png)
-|-

_After_:
![bilde](https://user-images.githubusercontent.com/24361490/160102670-05e0a5fa-1687-4c11-8f83-87b59ed5dfdf.png) | ![bilde](https://user-images.githubusercontent.com/24361490/160102703-18a15d04-0bc6-472f-899b-d87a28655dc8.png)
-|-
