### PR TITLE
Add option to verify as two year masters student

### DIFF
--- a/app/routes/users/components/StudentConfirmation.js
+++ b/app/routes/users/components/StudentConfirmation.js
@@ -1,7 +1,7 @@
 // @flow
 
 import styles from './UserConfirmation.css';
-import { Container } from 'app/components/Layout';
+import { Container, Flex } from 'app/components/Layout';
 import { reduxForm, Field } from 'redux-form';
 import {
   Form,
@@ -12,6 +12,8 @@ import {
   Captcha,
 } from 'app/components/Form';
 import { Link } from 'react-router-dom';
+import Tooltip from 'app/components/Tooltip';
+import Icon from 'app/components/Icon';
 
 import { createValidator, required } from 'app/utils/validation';
 import type { ReduxFormProps } from 'app/types';
@@ -81,12 +83,14 @@ const StudentConfirmation = ({
       <div>
         <h2>Verifiser studentepost</h2>
         <Form onSubmit={handleSubmit(handleSendConfirmation)}>
-          <Field
-            name="studentUsername"
-            placeholder="NTNU Brukernavn"
-            label="NTNU Brukernavn"
-            component={TextInput.Field}
-          />
+          <Tooltip content="Brukernavnet du logger inn på NTNU med. Dette er delen som er foran @stud.ntnu.no. OBS: Ikke skriv inn hele eposten">
+            <Field
+              name="studentUsername"
+              placeholder="NTNU Brukernavn"
+              label="NTNU Brukernavn"
+              component={TextInput.Field}
+            />
+          </Tooltip>
           <RadioButtonGroup name="course" label="Hvilken linje tilhører du?">
             <Field
               name="studentCompScience"
@@ -101,7 +105,67 @@ const StudentConfirmation = ({
               inputValue="komtek"
             />
           </RadioButtonGroup>
+          <RadioButtonGroup
+            name="isTwoYears"
+            label={
+              <Flex>
+                <div>Begynner du på 2-årig eller 5-årig master?</div>
+                <div style={{ marginLeft: '5px' }}>
+                  <Tooltip
+                    style={{ marginLeft: '3px' }}
+                    content="Huk av 2-årig master her kun hvis du begynner på to-arig master studiet på din respektive linje. Dvs. du har en bachelor fra før av. Begynner du i første klasse og skal studere i 5 år, huk av 5-årig master."
+                  >
+                    <Icon
+                      name="information-circle-outline"
+                      size={20}
+                      style={{ cursor: 'pointer' }}
+                    />
+                  </Tooltip>
+                </div>
+              </Flex>
+            }
+          >
+            <Field
+              name="isTwoYearsYes"
+              label="2-årig master"
+              component={RadioButton.Field}
+              inputValue="true"
+            />
+            <Field
+              name="isTwoYearsNo"
+              label="5-årig master"
+              component={RadioButton.Field}
+              inputValue="false"
+            />
+          </RadioButtonGroup>
           <RadioButtonGroup name="member" label="Vil du bli medlem i Abakus?">
+            <Flex>
+              <div style={{ marginLeft: '5px' }}>
+                <p className={styles.infoText}>
+                  Alle som går Kommunikasjonsteknologi & Digital Sikkerhet eller
+                  Datateknologi kan bli medlem av Abakus. Du må bli medlem for å
+                  kunne delta på arrangementer, kurs og annet Abakus tilbyr. Vi
+                  anbefaler alle nye studenter å melde seg inn. Du kan lese mer
+                  om{' '}
+                  <a
+                    href="https://abakus.no/pages/info-om-abakus"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Abakus
+                  </a>{' '}
+                  og{' '}
+                  <a
+                    href="https://statutter.abakus.no#medlemskap"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    medlemskapet.
+                  </a>
+                  Det koster ingenting å være medlem i Abakus.
+                </p>
+              </div>
+            </Flex>
             <Field
               name="studentIsMemberYes"
               label="Ja"
@@ -133,10 +197,12 @@ const validate = createValidator({
   studentUsername: [required()],
   course: [required()],
   member: [required()],
+  isTwoYears: [required()],
   captchaResponse: [required('Captcha er ikke validert')],
 });
 
 export default reduxForm({
   form: 'ConfirmationForm',
+  initialValues: { isTwoYears: 'false', member: 'true' },
   validate,
 })(StudentConfirmation);

--- a/app/routes/users/components/UserConfirmation.css
+++ b/app/routes/users/components/UserConfirmation.css
@@ -4,3 +4,9 @@
   composes: contentContainer from '~app/styles/utilities.css';
   max-width: 500px;
 }
+
+.infoText {
+  color: var(--color-gray-light);
+  font-size: 0.9em;
+  line-height: 1.4em;
+}

--- a/app/routes/users/components/UserConfirmation.js
+++ b/app/routes/users/components/UserConfirmation.js
@@ -44,9 +44,14 @@ const UserConfirmation = ({
             <div>
               <h2>Du er nå registrert!</h2>
               <h3 style={{ margin: 0 }}>Er du student?</h3>
+              <p className={styles.infoText}>
+                For å kunne melde deg på arrangementer i Abakus må du verifisere
+                at du er student. Om du ikke har fått studentepost enda, kan du
+                alltids verifisere kontoen din senere.
+              </p>
               <Flex>
                 <Link to="/users/me/settings/student-confirmation/">
-                  <b>Verifiser studentepost</b>
+                  <Button>Verifiser studentepost</Button>
                 </Link>
               </Flex>
               <Flex>


### PR DESCRIPTION
Also cleans up the registration and student confirmation forms a bit by
changing some text to buttons, adding some tooltips, and some
explanatory text.

If anyone feels it can be cleaned up a bit more or change any of the text, let me know!

**Register**
Before: (dont have it, but it's jsut without the text, and the button was as the text below)
After:
![image](https://user-images.githubusercontent.com/42850232/160934592-a3429478-b1e1-41b2-8427-234872a6bf26.png)

**Student confirmation**:
![image](https://user-images.githubusercontent.com/42850232/160934840-bbf67cfc-0ae1-4b41-a251-bf970ee672be.png)
