### PR TITLE
Fix fields using deprecated simpleValue prop

### DIFF
--- a/app/routes/admin/groups/components/AddGroupMember.js
+++ b/app/routes/admin/groups/components/AddGroupMember.js
@@ -35,7 +35,6 @@ const AddGroupMember = ({ submitting, groupId, handleSubmit }: Props) => {
       />
 
       <Field
-        simpleValue
         label="Rolle"
         name="role"
         placeholder="Velg rolle"

--- a/app/routes/admin/groups/components/AddGroupMember.js
+++ b/app/routes/admin/groups/components/AddGroupMember.js
@@ -57,7 +57,7 @@ const validate = createValidator({
 export default legoForm({
   form: 'add-user',
   validate,
-  initialValues: { role: 'member' },
+  initialValues: { role: roles.find(({ value }) => value === 'member') },
   onSubmitSuccess: (result, dispatch, { reset }: Props) => reset(),
   onSubmit: (
     {

--- a/app/routes/events/components/EventAdministrate/AdminRegister.js
+++ b/app/routes/events/components/EventAdministrate/AdminRegister.js
@@ -48,7 +48,6 @@ const AdminRegister = ({
           options={pools
             .map((pool) => ({ value: pool.id, label: pool.name }))
             .concat([{ value: waitinglistPoolId, label: 'Venteliste' }])}
-          simpleValue
         />
         <Field
           name="user"

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -204,7 +204,6 @@ function EventEditor({
             <Field
               name="eventType"
               label="Type arrangement"
-              simpleValue
               fieldClassName={styles.metaField}
               component={SelectInput.Field}
               options={Object.keys(EVENT_CONSTANTS).map((type) => ({
@@ -259,7 +258,6 @@ function EventEditor({
               component={SelectInput.Field}
               fieldClassName={styles.metaField}
               options={eventStatusTypes}
-              simpleValue
             />
             {['NORMAL', 'OPEN', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value

--- a/app/routes/joblistings/JoblistingCreateRoute.js
+++ b/app/routes/joblistings/JoblistingCreateRoute.js
@@ -8,6 +8,7 @@ import { push } from 'connected-react-router';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import time from 'app/utils/time';
+import { yearValues, jobTypes } from './constants';
 
 const mapStateToProps = () => ({
   initialValues: {
@@ -18,9 +19,9 @@ const mapStateToProps = () => ({
     visibleFrom: time({ hours: 12 }),
     visibleTo: time({ days: 31, hours: 23, minutes: 59 }),
     deadline: time({ days: 30, hours: 23, minutes: 59 }),
-    fromYear: 1,
-    toYear: 5,
-    jobType: 'summer_job',
+    fromYear: yearValues.find(({ value }) => value === 1),
+    toYear: yearValues.find(({ value }) => value === 5),
+    jobType: jobTypes.find(({ value }) => value === 'summer_job'),
     workplaces: [],
   },
   isNew: true,

--- a/app/routes/joblistings/JoblistingEditRoute.js
+++ b/app/routes/joblistings/JoblistingEditRoute.js
@@ -15,6 +15,7 @@ import { formValueSelector } from 'redux-form';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
+import { yearValues, jobTypes } from './constants';
 
 const mapStateToProps = (state, props) => {
   const { joblistingId } = props.match.params;
@@ -37,6 +38,9 @@ const mapStateToProps = (state, props) => {
       text: joblisting.text || '<p></p>',
       description: joblisting.description || '',
       company: initialCompany,
+      fromYear: yearValues.find(({ value }) => value === joblisting.fromYear),
+      toYear: yearValues.find(({ value }) => value === joblisting.toYear),
+      jobType: jobTypes.find(({ value }) => value === joblisting.jobType),
       responsible: joblisting.responsible
         ? {
             label: joblisting.responsible.name,

--- a/app/routes/joblistings/components/JoblistingEditor.js
+++ b/app/routes/joblistings/components/JoblistingEditor.js
@@ -63,6 +63,9 @@ class JoblistingEditor extends Component<Props, State> {
       .submitJoblisting({
         ...newJoblisting,
         id: this.props.joblistingId,
+        fromYear: newJoblisting.fromYear?.value,
+        toYear: newJoblisting.toYear?.value,
+        jobType: newJoblisting.jobType?.value,
         applicationUrl:
           newJoblisting.applicationUrl &&
           httpCheck(newJoblisting.applicationUrl),
@@ -154,7 +157,6 @@ class JoblistingEditor extends Component<Props, State> {
             label="Jobbtype"
             component={SelectInput.Field}
             placeholder="Jobbtype"
-            simpleValue
             options={jobTypes}
             required
           />
@@ -187,7 +189,6 @@ class JoblistingEditor extends Component<Props, State> {
             name="fromYear"
             label="For klasse trinn fra"
             placeholder="Jobbtype"
-            simpleValue
             component={SelectInput.Field}
             options={yearValues}
             required
@@ -196,7 +197,6 @@ class JoblistingEditor extends Component<Props, State> {
             name="toYear"
             label="Til klasse"
             placeholder="Jobbtype"
-            simpleValue
             component={SelectInput.Field}
             options={yearValues}
             required

--- a/app/routes/pages/PageEditRoute.js
+++ b/app/routes/pages/PageEditRoute.js
@@ -10,7 +10,7 @@ import {
 import { uploadFile } from 'app/actions/FileActions';
 import PageEditor from './components/PageEditor';
 import { legoForm } from 'app/components/Form/';
-import { selectPageBySlug } from 'app/reducers/pages';
+import { selectPageBySlug, categoryOptions } from 'app/reducers/pages';
 import { push } from 'connected-react-router';
 import { objectPermissionsToInitialValues } from 'app/components/Form/ObjectPermissions';
 
@@ -25,7 +25,13 @@ function mapStateToProps(state, props) {
   return {
     page,
     pageSlug,
-    initialValues: { ...page, ...objectPermissionsToInitialValues(page) },
+    initialValues: {
+      ...page,
+      ...objectPermissionsToInitialValues(page),
+      category: categoryOptions.find(
+        ({ value, label }) => value === page.category
+      ),
+    },
   };
 }
 

--- a/app/routes/pages/components/PageEditor.js
+++ b/app/routes/pages/components/PageEditor.js
@@ -81,13 +81,18 @@ export default class PageEditor extends Component<Props, State> {
     return deletePage(pageSlug).then(() => push('/pages/info/om-oss'));
   };
 
-  onSubmit = (data: Page) => {
+  onSubmit = (data: {
+    title: string,
+    content: string,
+    picture?: string,
+    category: { label: string, value: string },
+  }) => {
     const body = {
       ...normalizeObjectPermissions(data),
       title: data.title,
       content: data.content,
       picture: undefined,
-      category: data.category,
+      category: data.category?.value,
     };
 
     const { push, pageSlug } = this.props;
@@ -154,7 +159,6 @@ export default class PageEditor extends Component<Props, State> {
               name="category"
               component={SelectInput.Field}
               placeholder="Velg kategori"
-              simpleValue
               options={categoryOptions}
             />
 

--- a/app/routes/surveys/EditSurveyRoute.js
+++ b/app/routes/surveys/EditSurveyRoute.js
@@ -14,6 +14,7 @@ import { push } from 'connected-react-router';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import { formValueSelector } from 'redux-form';
 import qs from 'qs';
+import { mappings } from './utils';
 
 const loadData = (props, dispatch) => {
   const { surveyId } = props.match.params;
@@ -58,14 +59,14 @@ const mapStateToProps = (state, props) => {
         event: initialEvent,
         questions:
           survey.questions &&
-          survey.questions.map((question) =>
-            question.options
-              ? {
-                  ...question,
-                  options: question.options.concat({ optionText: '' }),
-                }
-              : question
-          ),
+          survey.questions.map((question) => ({
+            ...question,
+            options:
+              question.options && question.options.concat({ optionText: '' }),
+            questionType: mappings.find(
+              ({ value }) => value === question.questionType
+            ),
+          })),
       };
     }
   }

--- a/app/routes/surveys/components/SurveyEditor/Question.js
+++ b/app/routes/surveys/components/SurveyEditor/Question.js
@@ -87,7 +87,6 @@ const Question = ({
           <div className={styles.questionType}>
             <Field
               name={`${question}.questionType`}
-              simpleValue
               component={SelectInput.Field}
               components={{
                 Option: (props: any) => {

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.js
@@ -298,6 +298,7 @@ const onSubmit = (formContent: Object, dispatch, props: Props) => {
   const cleanQuestions = questions.map((q, i) => {
     const question = {
       ...q,
+      questionType: q.questionType?.value,
       relativeIndex: i,
     };
 


### PR DESCRIPTION
The very old version we were using for react select used an old prop that made us able to simply use a string for the value, instead of an object. This was removed quite a few versions about. This is a fix that simply takes modifies the value sent in `onSubmit`. A more sophisticated alternative would be to implement the old `simpleValue` prop ourselves, but the only way I saw that working was by adding internal state to our react select field.