### PR TITLE
Change dependabot schedule to 10 AM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "04:00"
+    time: "10:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
As of now, the current schedule collides with our daily backup at 6 AM, which prevents dependabot's PR to be delivered to drone due to drone locking its database during backup.

I propose changing the schedule to 10 AM. Side benefit, it'll be nice to not be awaken at 6 AM by 14 dependabot messages on slack 🙃