### PR TITLE
Automatically merge devdeps PR's from dependabot

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,3 @@
+- match:
+    dependency_type: development
+    update_type: 'semver:minor' # includes patch updates!

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,13 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I enabled it for dev-deps `minors`. This might a bit much. If it works we can maybe enable it for `patch` on normal deps :o 