### PR TITLE
replace react-copy-to-clipboard with custom code

### DIFF
--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -5,7 +5,6 @@ import styles from './surveys.css';
 import { Link } from 'react-router-dom';
 import type { ActionGrant } from 'app/models';
 import { ContentSidebar } from 'app/components/Content';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Button from 'app/components/Button';
 import config from 'app/config';
 import { CheckBox } from 'app/components/Form';
@@ -72,18 +71,16 @@ class AdminSideBar extends Component<Props, State> {
             )}
             {token && (
               <li>
-                <CopyToClipboard
-                  text={shareLink}
-                  onCopy={() => {
-                    this.setState({ copied: true });
-                    setTimeout(() => this.setState({ copied: false }), 2000);
+                <Button
+                  onClick={() => {
+                    navigator.clipboard.writeText(shareLink).then(() => {
+                      this.setState({ copied: true });
+                      setTimeout(() => this.setState({ copied: false }), 2000);
+                    });
                   }}
-                  style={{ marginTop: '5px' }}
                 >
-                  <Button>
-                    {this.state.copied ? 'Kopiert!' : 'Kopier delbar link'}
-                  </Button>
-                </CopyToClipboard>
+                  {this.state.copied ? 'Kopiert!' : 'Kopier delbar link'}
+                </Button>
               </li>
             )}
             {actionGrant && actionGrant.includes('csv') && exportSurvey && (

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "qs": "^6.10.3",
     "react": "16.14.0",
     "react-collapse": "^5.1.1",
-    "react-copy-to-clipboard": "^5.0.4",
     "react-cropper": "^2.1.8",
     "react-dom": "npm:@hot-loader/react-dom@^16.8.6",
     "react-dropzone": "^12.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,13 +3293,6 @@ cookie@0.4.2, cookie@^0.4.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
-copy-to-clipboard@^3:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
-  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
-  dependencies:
-    toggle-selection "^1.0.6"
-
 core-js-compat@^3.20.0, core-js-compat@^3.20.2:
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.20.2.tgz#d1ff6936c7330959b46b2e08b122a8b14e26140b"
@@ -8416,14 +8409,6 @@ react-collapse@^5.1.1:
   resolved "https://registry.yarnpkg.com/react-collapse/-/react-collapse-5.1.1.tgz#a2fa08ef13f372141b02e6a7d49ef72427bcbc2b"
   integrity sha512-k6cd7csF1o9LBhQ4AGBIdxB60SUEUMQDAnL2z1YvYNr9KoKr+nDkhN6FK7uGaBd/rYrYfrMpzpmJEIeHRYogBw==
 
-react-copy-to-clipboard@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.4.tgz#42ec519b03eb9413b118af92d1780c403a5f19bf"
-  integrity sha512-IeVAiNVKjSPeGax/Gmkqfa/+PuMTBhutEvFUaMQLwE2tS0EXrAdgOpWDX26bWTXF3HrioorR7lr08NqeYUWQCQ==
-  dependencies:
-    copy-to-clipboard "^3"
-    prop-types "^15.5.8"
-
 react-cropper@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/react-cropper/-/react-cropper-2.1.8.tgz#bf35a7de65769f8ad357e8ae884e791fe3fe9212"
@@ -9935,11 +9920,6 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
-
-toggle-selection@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
-  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The entire package could be replaced with **1** line of code. We are losing IE11 support, but I think that's fine, especially since it's in an admin page. 