### PR TITLE
Start using paginationNext in quotes

### DIFF
--- a/app/actions/QuoteActions.js
+++ b/app/actions/QuoteActions.js
@@ -9,67 +9,21 @@ import { addToast } from 'app/actions/ToastActions';
 import type { Thunk } from 'app/types';
 import type { ID } from 'app/models';
 
-const getEndpoint = (state, loadNextPage, queryString) => {
-  const pagination = state.quotes.pagination;
-  let endpoint = `/quotes/${queryString}`;
-  const paginationObject = pagination[queryString];
-  if (
-    loadNextPage &&
-    paginationObject &&
-    paginationObject.queryString === queryString
-  ) {
-    endpoint = pagination[queryString].nextPage;
-  }
-  return endpoint;
-};
-
-export const fetchAll =
-  ({
-    approved = true,
-    refresh = false,
-    loadNextPage = false,
-  }: {
-    approved?: boolean,
-    refresh?: boolean,
-    loadNextPage?: boolean,
-  } = {}): Thunk<*> =>
-  (dispatch, getState) => {
-    const queryString = `?approved=${String(approved)}`;
-    const endpoint = getEndpoint(getState(), loadNextPage, queryString);
-    if (!endpoint) {
-      return Promise.resolve(null);
-    }
-    return dispatch(
-      callAPI({
-        types: Quote.FETCH,
-        endpoint,
-        schema: [quoteSchema],
-        meta: {
-          queryString,
-          errorMessage: `Henting av ${
-            approved ? '' : 'ikke '
-          }godkjente sitater feilet`,
-        },
-        propagateError: true,
-        cacheSeconds: Infinity, // don't expire cache unless we pass force
-      })
-    );
-  };
-
-export function fetchAllApproved({
-  loadNextPage,
-}: {
-  loadNextPage: boolean,
-}): Thunk<any> {
-  return fetchAll({ approved: true, loadNextPage });
-}
-
-export function fetchAllUnapproved({
-  loadNextPage,
-}: {
-  loadNextPage: boolean,
-}): Thunk<any> {
-  return fetchAll({ approved: false, loadNextPage });
+export function fetchAll({
+  query,
+  next = false,
+}: { query?: Object, next?: boolean } = {}): Thunk<*> {
+  return callAPI({
+    types: Quote.FETCH,
+    endpoint: '/quotes/',
+    schema: [quoteSchema],
+    query,
+    pagination: { fetchNext: next },
+    meta: {
+      errorMessage: 'Henting av sitater feilet',
+    },
+    propagateError: true,
+  });
 }
 
 export function fetchQuote(quoteId: number): Thunk<any> {

--- a/app/components/Search/utils.js
+++ b/app/components/Search/utils.js
@@ -62,7 +62,7 @@ const LINKS: Array<Link> = [
   {
     key: 'quotes',
     title: 'Overhørt',
-    url: '/quotes/?filter=all',
+    url: '/quotes/',
   },
   {
     key: 'companies',

--- a/app/reducers/__tests__/quotes.spec.js
+++ b/app/reducers/__tests__/quotes.spec.js
@@ -6,6 +6,22 @@ describe('reducers', () => {
     const baseState = {
       actionGrant: [],
       pagination: {},
+      paginationNext: {
+        '?approved=true': {
+          hasMore: true,
+          hasMoreBackwards: false,
+          query: { approved: 'true' },
+          next: { cursor: 'next-cur', approved: 'true' },
+          items: [4],
+        },
+        '?approved=false': {
+          hasMore: true,
+          hasMoreBackwards: false,
+          query: { approved: 'false' },
+          next: { cursor: 'next-cur', approved: 'false' },
+          items: [3],
+        },
+      },
       items: [3, 4],
       byId: {
         3: {
@@ -29,6 +45,22 @@ describe('reducers', () => {
       expect(quotes(prevState, action)).toEqual({
         actionGrant: [],
         pagination: {},
+        paginationNext: {
+          '?approved=true': {
+            hasMore: true,
+            hasMoreBackwards: false,
+            query: { approved: 'true' },
+            next: { cursor: 'next-cur', approved: 'true' },
+            items: [4],
+          },
+          '?approved=false': {
+            hasMore: true,
+            hasMoreBackwards: false,
+            query: { approved: 'false' },
+            next: { cursor: 'next-cur', approved: 'false' },
+            items: [],
+          },
+        },
         items: [3, 4],
         byId: {
           3: {
@@ -53,6 +85,22 @@ describe('reducers', () => {
       expect(quotes(prevState, action)).toEqual({
         actionGrant: [],
         pagination: {},
+        paginationNext: {
+          '?approved=true': {
+            hasMore: true,
+            hasMoreBackwards: false,
+            query: { approved: 'true' },
+            next: { cursor: 'next-cur', approved: 'true' },
+            items: [],
+          },
+          '?approved=false': {
+            hasMore: true,
+            hasMoreBackwards: false,
+            query: { approved: 'false' },
+            next: { cursor: 'next-cur', approved: 'false' },
+            items: [3],
+          },
+        },
         items: [3, 4],
         byId: {
           3: {

--- a/app/reducers/quotes.js
+++ b/app/reducers/quotes.js
@@ -53,12 +53,6 @@ export default createEntityReducer({
   mutate,
 });
 
-const compareByDate = (a, b) => {
-  const date1 = new Date(a.createdAt);
-  const date2 = new Date(b.createdAt);
-  return date2.getTime() - date1.getTime();
-};
-
 export const selectQuotes = createSelector(
   (state) => state.quotes.byId,
   (state) => state.quotes.items,
@@ -77,22 +71,6 @@ export const selectQuoteById = createSelector(
   (quotes, quoteId) => {
     if (!quotes || !quoteId) return {};
     return quotes.find((quote) => Number(quote.id) === Number(quoteId));
-  }
-);
-
-export const selectSortedQuotes = createSelector(
-  selectQuotes,
-  (state, props) => ({ filter: props.filter }),
-  (_, props) => props && props.pagination,
-  (quotes, query, pagination) => {
-    return quotes
-      .filter(
-        (quote) =>
-          typeof quote !== 'undefined' &&
-          quote.approved.toString() ===
-            (pagination.query.approved && pagination.query.approved.toString())
-      )
-      .sort(compareByDate);
   }
 );
 

--- a/app/reducers/quotes.js
+++ b/app/reducers/quotes.js
@@ -62,9 +62,12 @@ const compareByDate = (a, b) => {
 export const selectQuotes = createSelector(
   (state) => state.quotes.byId,
   (state) => state.quotes.items,
-  (quotesById, ids) => {
+  (_, props) => props && props.pagination,
+  (quotesById, ids, pagination) => {
     if (!quotesById || !ids) return [];
-    return ids.map((quoteId) => quotesById[quoteId]);
+    return (pagination ? pagination.items : ids).map(
+      (quoteId) => quotesById[quoteId]
+    );
   }
 );
 
@@ -80,12 +83,14 @@ export const selectQuoteById = createSelector(
 export const selectSortedQuotes = createSelector(
   selectQuotes,
   (state, props) => ({ filter: props.filter }),
-  (quotes, query) => {
+  (_, props) => props && props.pagination,
+  (quotes, query, pagination) => {
     return quotes
       .filter(
         (quote) =>
           typeof quote !== 'undefined' &&
-          quote.approved === (query.filter !== 'unapproved')
+          quote.approved.toString() ===
+            (pagination.query.approved && pagination.query.approved.toString())
       )
       .sort(compareByDate);
   }

--- a/app/reducers/quotes.js
+++ b/app/reducers/quotes.js
@@ -26,10 +26,38 @@ const mutateQuote = produce((newState: State, action: any): void => {
   switch (action.type) {
     case Quote.UNAPPROVE.SUCCESS:
       newState.byId[action.meta.quoteId].approved = false;
+      // Explicitly remove the quote from the paginated list to remove it from the list shown to the user
+      // note: this will _not_ add it to the other pagination lists, since we cannot guarntee the order
+      // as well as the other filtering
+      Object.keys(newState.paginationNext).forEach((paginationKey) => {
+        const paginationEntry = newState.paginationNext[paginationKey];
+        if (
+          paginationEntry.items.includes(action.meta.quoteId) &&
+          paginationEntry.query.approved === 'true'
+        ) {
+          paginationEntry.items = paginationEntry.items.filter(
+            (item) => item !== action.meta.quoteId
+          );
+        }
+      });
       break;
 
     case Quote.APPROVE.SUCCESS:
       newState.byId[action.meta.quoteId].approved = true;
+      // Explicitly remove the quote from the paginated list to remove it from the list shown to the user
+      // note: this will _not_ add it to the other pagination lists, since we cannot guarntee the order
+      // as well as the other filtering
+      Object.keys(newState.paginationNext).forEach((paginationKey) => {
+        const paginationEntry = newState.paginationNext[paginationKey];
+        if (
+          paginationEntry.items.includes(action.meta.quoteId) &&
+          paginationEntry.query.approved === 'false'
+        ) {
+          paginationEntry.items = paginationEntry.items.filter(
+            (item) => item !== action.meta.quoteId
+          );
+        }
+      });
       break;
 
     case Quote.FETCH_RANDOM.SUCCESS:
@@ -55,14 +83,9 @@ export default createEntityReducer({
 
 export const selectQuotes = createSelector(
   (state) => state.quotes.byId,
-  (state) => state.quotes.items,
-  (_, props) => props && props.pagination,
-  (quotesById, ids, pagination) => {
-    if (!quotesById || !ids) return [];
-    return (pagination ? pagination.items : ids).map(
-      (quoteId) => quotesById[quoteId]
-    );
-  }
+  (_, props) => props.pagination,
+  (quotesById, pagination) =>
+    pagination.items.map((quoteId) => quotesById[quoteId])
 );
 
 export const selectQuoteById = createSelector(

--- a/app/routes/quotes/QuotesRoute.js
+++ b/app/routes/quotes/QuotesRoute.js
@@ -56,8 +56,7 @@ export default compose(
       dispatch(
         fetchAll({
           query: qsParamsParser(props.location.search),
-        }),
-        fetchEmojis()
+        })
       ),
     ['location']
   ),

--- a/app/routes/quotes/QuotesRoute.js
+++ b/app/routes/quotes/QuotesRoute.js
@@ -1,8 +1,7 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import {
-  fetchAllApproved,
-  fetchAllUnapproved,
+  fetchAll,
   approve,
   unapprove,
   deleteQuote,
@@ -12,24 +11,28 @@ import prepare from 'app/utils/prepare';
 import { selectSortedQuotes } from 'app/reducers/quotes';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
-import { selectPagination } from '../../reducers/selectors';
+import { selectPaginationNext } from 'app/reducers/selectors';
 import { addReaction, deleteReaction } from 'app/actions/ReactionActions';
 import { selectEmojis } from 'app/reducers/emojis';
 import { fetchEmojis } from 'app/actions/EmojiActions';
 import qs from 'qs';
 
+const qsParamsParser = (search) => ({
+  approved: qs.parse(search, { ignoreQueryPrefix: true }).approved || 'true',
+});
+
 const mapStateToProps = (state, props) => {
-  const queryString = ['?approved=true', '?approved=false'];
-  const showFetchMore = selectPagination('quotes', { queryString })(state);
+  const { pagination } = selectPaginationNext({
+    endpoint: `/quotes/`,
+    query: qsParamsParser(props.location.search),
+    entity: 'quotes',
+  })(state);
   const emojis = selectEmojis(state);
   return {
-    quotes: selectSortedQuotes(
-      state,
-      qs.parse(props.location.search, { ignoreQueryPrefix: true })
-    ),
-    query: qs.parse(props.location.search, { ignoreQueryPrefix: true }),
+    quotes: selectSortedQuotes(state, { pagination }),
+    query: pagination.query,
     actionGrant: state.quotes.actionGrant,
-    showFetchMore,
+    showFetchMore: pagination.hasMore,
     emojis,
     fetching: state.quotes.fetching,
     fetchingEmojis: state.emojis.fetching,
@@ -37,15 +40,10 @@ const mapStateToProps = (state, props) => {
 };
 
 const mapDispatchToProps = {
-  fetchAllApproved,
-  fetchAllUnapproved,
   approve,
   unapprove,
   deleteQuote,
-  fetchMore: ({ approved }) =>
-    approved
-      ? fetchAllApproved({ loadNextPage: true })
-      : fetchAllUnapproved({ loadNextPage: true }),
+  fetchAll,
   addReaction,
   deleteReaction,
   fetchEmojis,
@@ -54,19 +52,13 @@ const mapDispatchToProps = {
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
   prepare(
-    (props, dispatch) => {
-      const query = qs.parse(props.location.search, {
-        ignoreQueryPrefix: true,
-      });
-
-      if (query.filter === 'unapproved') {
-        return dispatch(
-          fetchAllUnapproved({ loadNextPage: false }),
-          fetchEmojis()
-        );
-      }
-      return dispatch(fetchAllApproved({ loadNextPage: false }), fetchEmojis());
-    },
+    (props, dispatch) =>
+      dispatch(
+        fetchAll({
+          query: qsParamsParser(props.location.search),
+        }),
+        fetchEmojis()
+      ),
     ['location']
   ),
   connect(mapStateToProps, mapDispatchToProps)

--- a/app/routes/quotes/QuotesRoute.js
+++ b/app/routes/quotes/QuotesRoute.js
@@ -8,7 +8,7 @@ import {
 } from 'app/actions/QuoteActions';
 import QuotePage from './components/QuotePage';
 import prepare from 'app/utils/prepare';
-import { selectSortedQuotes } from 'app/reducers/quotes';
+import { selectQuotes } from 'app/reducers/quotes';
 import { LoginPage } from 'app/components/LoginForm';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import { selectPaginationNext } from 'app/reducers/selectors';
@@ -29,7 +29,7 @@ const mapStateToProps = (state, props) => {
   })(state);
   const emojis = selectEmojis(state);
   return {
-    quotes: selectSortedQuotes(state, { pagination }),
+    quotes: selectQuotes(state, { pagination }),
     query: pagination.query,
     actionGrant: state.quotes.actionGrant,
     showFetchMore: pagination.hasMore,

--- a/app/routes/quotes/components/QuotePage.js
+++ b/app/routes/quotes/components/QuotePage.js
@@ -12,13 +12,13 @@ import type { EmojiEntity } from 'app/reducers/emojis';
 
 type Props = {
   reactions: Array<Object>,
-  query: Object,
+  query: { approved: string },
   quotes: Array<QuoteEntity>,
   actionGrant: ActionGrant,
   approve: (number) => Promise<*>,
   unapprove: (number) => Promise<*>,
   deleteQuote: (number) => Promise<*>,
-  fetchAll: ({ query: { approved?: string } }, next?: boolean) => Promise<*>,
+  fetchAll: ({ query: { approved: string } }, next?: boolean) => Promise<*>,
   showFetchMore: boolean,
   currentUser: any,
   loggedIn: boolean,
@@ -54,7 +54,7 @@ export default function QuotePage({
   let errorMessage = undefined;
   if (quotes.length === 0) {
     errorMessage =
-      !query.approved || query.approved === 'false'
+      query.approved === 'false'
         ? 'Ingen sitater venter på godkjenning.'
         : 'Fant ingen sitater. Hvis du har sendt inn et sitat venter det trolig på godkjenning.';
   }

--- a/app/routes/quotes/components/QuotePage.js
+++ b/app/routes/quotes/components/QuotePage.js
@@ -18,7 +18,7 @@ type Props = {
   approve: (number) => Promise<*>,
   unapprove: (number) => Promise<*>,
   deleteQuote: (number) => Promise<*>,
-  fetchMore: ({ approved: boolean }) => Promise<*>,
+  fetchAll: ({ query: { approved?: string } }, next?: boolean) => Promise<*>,
   showFetchMore: boolean,
   currentUser: any,
   loggedIn: boolean,
@@ -40,7 +40,7 @@ export default function QuotePage({
   unapprove,
   actionGrant,
   deleteQuote,
-  fetchMore,
+  fetchAll,
   showFetchMore,
   currentUser,
   loggedIn,
@@ -54,7 +54,7 @@ export default function QuotePage({
   let errorMessage = undefined;
   if (quotes.length === 0) {
     errorMessage =
-      query.filter === 'unapproved'
+      !query.approved || query.approved === 'false'
         ? 'Ingen sitater venter på godkjenning.'
         : 'Fant ingen sitater. Hvis du har sendt inn et sitat venter det trolig på godkjenning.';
   }
@@ -82,9 +82,7 @@ export default function QuotePage({
         />
       )}
       {showFetchMore && (
-        <Button
-          onClick={() => fetchMore({ approved: query.filter !== 'unapproved' })}
-        >
+        <Button onClick={() => fetchAll({ query, next: true })}>
           Last inn flere
         </Button>
       )}

--- a/app/routes/quotes/utils.js
+++ b/app/routes/quotes/utils.js
@@ -4,9 +4,9 @@ import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
 
 export const navigation = (title: string, actionGrant: Array<string>) => (
   <NavigationTab title={title}>
-    <NavigationLink to="/quotes/?filter=all">Sitater</NavigationLink>
+    <NavigationLink to="/quotes/">Sitater</NavigationLink>
     {actionGrant.indexOf('approve') !== -1 && (
-      <NavigationLink to="/quotes?filter=unapproved">
+      <NavigationLink to="/quotes?approved=false">
         Ikke godkjente sitater
       </NavigationLink>
     )}

--- a/cypress/integration/router_spec.js
+++ b/cypress/integration/router_spec.js
@@ -204,7 +204,7 @@ describe('Create event', () => {
     cy.contains('Brukerinfo');
 
     // Quotes
-    openMenuAndSelect('Overhørt', '/quotes/?filter=all');
+    openMenuAndSelect('Overhørt', '/quotes');
     cy.contains('Just do it!');
 
     // Tags


### PR DESCRIPTION
This will as a side effect remove the "random quote" from the list, make
pagination cleaner and easier, as well as reuse code => less code.

Otherwise, this works as before. I'm unable to test the 'approved=false' flow since I'm no longer an admin, but I can test if you give me access to it on staging. I caaaaaaaaaaan start the backed, but my xps still only has 8GiB of memory :rip:

This will also as a sideeffect do as @LudvigHz suggested here; https://github.com/webkom/lego-webapp/pull/2567#pullrequestreview-915770283 to fix the issue https://github.com/webkom/lego/issues/2587 :eyes: 

@LudvigHz:
> - Or some other way.