### PR TITLE
Allow adding non-obligatory questions in event-editor

### DIFF
--- a/app/models.js
+++ b/app/models.js
@@ -219,6 +219,7 @@ export type TransformEvent = EventBase & {
   eventType: SelectInput,
   mazemapPoi: Object,
   useMazemap: boolean,
+  hasFeedbackQuestion: boolean,
 };
 
 export type UserFollowing = {

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -57,6 +57,7 @@ const mapStateToProps = (state, props) => {
           'hours'
         ),
       mazemapPoi: valueSelector(state, 'mazemapPoi'),
+      hasFeedbackQuestion: valueSelector(state, 'hasFeedbackQuestion'),
     },
     pools: valueSelector(state, 'pools'),
   };

--- a/app/routes/events/EventEditRoute.js
+++ b/app/routes/events/EventEditRoute.js
@@ -71,6 +71,7 @@ const mapStateToProps = (state, props) => {
       separateDeadlines:
         event.registrationDeadlineHours !== event.unregistrationDeadlineHours,
       useMazemap: event.mazemapPoi > 0,
+      hasFeedbackQuestion: !!event.feedbackDescription,
     },
     actionGrant,
     event: {
@@ -97,6 +98,7 @@ const mapStateToProps = (state, props) => {
           valueSelector(state, 'unregistrationDeadlineHours'),
           'hours'
         ),
+      hasFeedbackQuestion: valueSelector(state, 'hasFeedbackQuestion'),
     },
     eventId,
     pools: valueSelector(state, 'pools'),

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -616,6 +616,9 @@ const validate = (data) => {
   if (data.useMazemap && !data.mazemapPoi) {
     errors.mazemapPoi = 'Sted eller Mazemap-rom er påkrevd.';
   }
+  if (data.hasFeedbackQuestion && !data.feedbackDescription) {
+    errors.feedbackDescription = 'Spørsmål er tomt.';
+  }
   if (!data.id && !data.cover) {
     errors.cover = 'Cover er påkrevet';
   }

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -112,6 +112,11 @@ function EventEditor({
   const isTBA = (value) =>
     value && value === 'TBA' ? `Velg påmeldingstype TBA` : undefined;
 
+  const containsAllergier = (value) =>
+    value && value.toLowerCase().indexOf('allergi') !== -1
+      ? `Allergier kan hentes fra profilene til deltakere`
+      : undefined;
+
   const tooLow = (value) =>
     value && value <= 3 ? `Summen må være større enn 3 kr` : undefined;
 
@@ -515,6 +520,7 @@ function EventEditor({
                     component={TextInput.Field}
                     fieldClassName={styles.metaField}
                     className={styles.formField}
+                    warn={containsAllergier}
                   />
                   <Field
                     name="feedbackRequired"

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -493,10 +493,10 @@ function EventEditor({
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (
-              <Tooltip content="Et spørsmål alle må svare på før de melder seg på">
+              <Tooltip content="Still et spørsmål ved påmelding">
                 <Field
-                  name="feedbackRequired"
-                  label="Obligatorisk spørsmål"
+                  label="Påmeldingsspørsmål"
+                  name="hasFeedbackQuestion"
                   component={CheckBox.Field}
                   fieldClassName={styles.metaField}
                   className={styles.formField}
@@ -504,10 +504,10 @@ function EventEditor({
                 />
               </Tooltip>
             )}
-            {['NORMAL', 'INFINITE', 'OPEN'].includes(
+            {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) &&
-              event.feedbackRequired && (
+              event.hasFeedbackQuestion && (
                 <div className={styles.subSection}>
                   <Field
                     name="feedbackDescription"
@@ -515,6 +515,14 @@ function EventEditor({
                     component={TextInput.Field}
                     fieldClassName={styles.metaField}
                     className={styles.formField}
+                  />
+                  <Field
+                    name="feedbackRequired"
+                    label="Obligatorisk"
+                    component={CheckBox.Field}
+                    fieldClassName={styles.metaField}
+                    className={styles.formField}
+                    normalize={(v) => !!v}
                   />
                 </div>
               )}

--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -187,6 +187,9 @@ export const transformEvent = (data: TransformEvent) => ({
   useCaptcha: true, // always use Captcha, this blocks the use of CLI
   youtubeUrl: data.youtubeUrl,
   mazemapPoi: calculateMazemapPoi(data),
+  feedbackDescription:
+    (data.hasFeedbackQuestion && data.feedbackDescription) || '',
+  feedbackRequired: data.hasFeedbackQuestion && data.feedbackRequired,
 });
 
 export const paymentPending = 'pending';

--- a/cypress/integration/create_event_spec.js
+++ b/cypress/integration/create_event_spec.js
@@ -368,6 +368,7 @@ describe('Create event', () => {
     field('useConsent').check();
 
     // Question
+    field('hasFeedbackQuestion').check();
     field('feedbackRequired').check();
     field('feedbackDescription').type('Burger eller sushi');
 


### PR DESCRIPTION
Currently in the event editor, the only way to create non-obligatory questions is to check the box for "Obligatorisk spørsmål", add the question, and then uncheck "Obligatorisk spørsmål" again. Although this hides the text field, the question is still in form-state, so it works fine. But it's not very intuitive.

1. <img width="357" alt="Screenshot 2022-04-26 at 12 45 04" src="https://user-images.githubusercontent.com/8343002/165314097-3ad3bf70-d0ce-4744-8b03-1dd39a69eac5.png">
2. <img width="357" alt="Screenshot 2022-04-26 at 12 45 11" src="https://user-images.githubusercontent.com/8343002/165314180-f9399b76-8b0a-43cd-9e3b-c99644ecf077.png">

Because of this people often set questions as obligatory when they shouldn't be. (of course allergies shouldn't be in this question field anyways, I added a warning for that)

I've changed it to be one checkbox for having a question, and a separate checkbox for marking the question as obligatory.

1. <img width="357" alt="Screenshot 2022-04-26 at 12 43 35" src="https://user-images.githubusercontent.com/8343002/165315526-58be73d2-0c9e-4041-860d-44473469f855.png">
2. <img width="357" alt="Screenshot 2022-04-26 at 12 43 28" src="https://user-images.githubusercontent.com/8343002/165315184-14afb05b-fd62-4e25-bb59-96e3e4455ff8.png">





