### PR TITLE
Minimal redesign of event details

### DIFF
--- a/app/components/Content/ContentHeader.css
+++ b/app/components/Content/ContentHeader.css
@@ -1,4 +1,7 @@
 .header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
   border-bottom-width: 2px;
   border-bottom-style: solid;
   margin-bottom: 1em;

--- a/app/components/Content/ContentHeader.js
+++ b/app/components/Content/ContentHeader.js
@@ -3,11 +3,15 @@
 import type { Node } from 'react';
 import cx from 'classnames';
 import styles from './ContentHeader.css';
+import { eventTypeToString } from 'app/routes/events/utils';
+import type { Event } from 'app/models';
 
 type Props = {
   className?: string,
   borderColor?: string,
   children: Node,
+  event?: Event,
+  color: string,
 };
 
 const DEFAULT_BORDER_COLOR = '#FCD748';
@@ -19,16 +23,23 @@ function ContentHeader({
   children,
   className,
   borderColor = DEFAULT_BORDER_COLOR,
+  event,
+  color,
   ...props
 }: Props) {
   return (
-    <h2
+    <div
       style={{ borderColor }}
       className={cx(styles.header, className)}
       {...(props: Object)}
     >
-      {children}
-    </h2>
+      <h2>{children}</h2>
+      {event && (
+        <strong style={{ color: borderColor }}>
+          {eventTypeToString(event.eventType)}
+        </strong>
+      )}
+    </div>
   );
 }
 

--- a/app/components/InfoList/index.js
+++ b/app/components/InfoList/index.js
@@ -4,6 +4,7 @@ import type { Node } from 'react';
 
 type Item = {
   key: string,
+  keyNode?: Node,
   value: Node,
 };
 
@@ -20,11 +21,9 @@ type Props = {
 function InfoList({ items, className }: Props) {
   return (
     <table className={className}>
-      {items.filter(Boolean).map(({ key, value }) => (
+      {items.filter(Boolean).map(({ key, keyNode, value }) => (
         <tr key={key}>
-          <td>
-            <span style={{ marginRight: 5 }}>{key}</span>
-          </td>
+          <td>{keyNode ?? <span style={{ marginRight: 5 }}>{key}</span>}</td>
           <td>
             <strong>{value}</strong>
           </td>

--- a/app/components/InfoList/index.js
+++ b/app/components/InfoList/index.js
@@ -9,6 +9,7 @@ type Item = {
 
 type Props = {
   items: Array<?Item>,
+  className?: string,
 };
 
 /**
@@ -16,16 +17,20 @@ type Props = {
  * Location <strong>Oslo</strong>
  * Time <strong>Yesterday</strong>
  */
-function InfoList({ items }: Props) {
+function InfoList({ items, className }: Props) {
   return (
-    <ul>
+    <table className={className}>
       {items.filter(Boolean).map(({ key, value }) => (
-        <li key={key}>
-          <span style={{ marginRight: 5 }}>{key}</span>
-          <strong>{value}</strong>
-        </li>
+        <tr key={key}>
+          <td>
+            <span style={{ marginRight: 5 }}>{key}</span>
+          </td>
+          <td>
+            <strong>{value}</strong>
+          </td>
+        </tr>
       ))}
-    </ul>
+    </table>
   );
 }
 

--- a/app/components/Time/Time.spec.js
+++ b/app/components/Time/Time.spec.js
@@ -72,7 +72,16 @@ describe('<FromToTime />', () => {
   it('should render both days fully when start day != end day', () => {
     const from = '2016-01-18T20:00:00Z';
     const to = '2016-01-19T22:00:00Z';
-    const output = 'Monday 18. Jan 2016 20:00 - Tuesday 19. Jan 2016 22:00';
+    const output = 'Mo 18. Jan 2016 20:00 - Tu 19. Jan 2016 22:00';
+
+    const wrapper = shallow(<FromToTime from={from} to={to} />);
+    expect(wrapper.render().text()).toEqual(output);
+  });
+
+  it('should render only one day fully if end - start < 1 day', () => {
+    const from = '2016-01-18T20:00:00Z';
+    const to = '2016-01-19T02:00:00Z';
+    const output = 'Monday 18. Jan 2016 20:00 - 02:00';
 
     const wrapper = shallow(<FromToTime from={from} to={to} />);
     expect(wrapper.render().text()).toEqual(output);
@@ -81,7 +90,7 @@ describe('<FromToTime />', () => {
   it('should not render year if year == currentYear', () => {
     const from = '2017-01-18T20:00:00Z';
     const to = '2017-01-19T22:00:00Z';
-    const output = 'Wednesday 18. January, 20:00 - Thursday 19. January, 22:00';
+    const output = 'We 18. Jan, 20:00 - Th 19. Jan, 22:00';
 
     const _now = Date.now;
     const mockDate = +moment(from);
@@ -97,7 +106,7 @@ describe('<FromToTime />', () => {
   it('should not render year if year == currentYear, and day only once if equal', () => {
     const from = '2017-01-18T20:00:00Z';
     const to = '2017-01-18T21:00:00Z';
-    const output = 'Wednesday 18. January, 20:00 - 21:00';
+    const output = 'Wednesday 18. Jan, 20:00 - 21:00';
 
     const _now = Date.now;
     const mockDate = +moment(from);

--- a/app/components/Time/index.js
+++ b/app/components/Time/index.js
@@ -64,9 +64,20 @@ export const FormatTime = ({
 export const FromToTime = ({ from, to }: { from: Dateish, to: Dateish }) => {
   const fromTime = moment(from);
   const toTime = moment(to);
-  const fromFormat =
-    moment().isSame(fromTime, 'year') && 'dddd DD. MMMM, HH:mm';
-  const toFormat = fromTime.isSame(toTime, 'day') ? 'HH:mm' : fromFormat;
+
+  const toIsUnderADayAfter = toTime.diff(fromTime) < moment.duration(1, 'day');
+
+  let fromFormat = 'dd DD. MMM, HH:mm';
+  if (!moment().isSame(fromTime, 'year')) {
+    fromFormat = 'dd DD. MMM YYYY HH:mm';
+    if (toIsUnderADayAfter) {
+      fromFormat = 'dddd DD. MMM YYYY HH:mm';
+    }
+  } else if (toIsUnderADayAfter) {
+    fromFormat = 'dddd DD. MMM, HH:mm';
+  }
+
+  const toFormat = toIsUnderADayAfter ? 'HH:mm' : fromFormat;
 
   return (
     <span>

--- a/app/routes/events/components/Admin.css
+++ b/app/routes/events/components/Admin.css
@@ -4,3 +4,8 @@
   color: var(--lego-link-color);
   cursor: pointer;
 }
+
+.abacardButton {
+  width: 100%;
+  height: 4em;
+}

--- a/app/routes/events/components/Admin.js
+++ b/app/routes/events/components/Admin.js
@@ -5,6 +5,8 @@ import { Link } from 'react-router-dom';
 import type { ID, Event, ActionGrant } from 'app/models';
 import AnnouncementInLine from 'app/components/AnnouncementInLine';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
+import Button from 'app/components/Button';
+import moment from 'moment-timezone';
 import styles from './Admin.css';
 
 type Props = {
@@ -76,6 +78,11 @@ class DeleteButton extends Component<ButtonProps, State> {
 const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
   const canEdit = actionGrant.includes('edit');
   const canDelete = actionGrant.includes('delete');
+  const showRegisterButton =
+    Math.abs(
+      moment.duration(moment(event.startTime).diff(moment.now())).get('days')
+    ) < 2;
+
   return (
     <div style={{ marginTop: '10px' }}>
       {(canEdit || canDelete) && (
@@ -83,6 +90,15 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
           <li>
             <strong>Admin</strong>
           </li>
+          {showRegisterButton && (
+            <li>
+              <Link to={`/events/${event.id}/administrate/abacard`}>
+                <Button className={styles.abacardButton} success>
+                  Registrer oppmøte
+                </Button>
+              </Link>
+            </li>
+          )}
           {canEdit && (
             <li>
               <Link to={`/events/${event.id}/administrate/attendees`}>

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -32,3 +32,29 @@
   color: var(--lego-link-color);
   cursor: pointer;
 }
+
+.infoList tr {
+  & td {
+    width: unset;
+  }
+
+  &:last-of-type td {
+    border-bottom: none;
+  }
+}
+
+.iconWithText {
+  display: flex;
+  align-items: center;
+}
+
+.infoIcon {
+  min-width: 26px;
+  display: flex;
+  justify-content: center;
+  padding-right: 0.2em;
+}
+
+.registeredBox {
+  margin-top: 1em;
+}

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -21,3 +21,14 @@
 .paymentInfo {
   margin-top: 10px;
 }
+
+.line {
+  margin: 18px 0;
+  background-color: var(--color-gray-5);
+  height: 1px;
+}
+
+.simulateLink {
+  color: var(--lego-link-color);
+  cursor: pointer;
+}

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -1,7 +1,6 @@
 // @flow
 
 import styles from './EventDetail.css';
-import type { Node } from 'react';
 import { Component, Fragment } from 'react';
 import CommentView from 'app/components/Comments/CommentView';
 import Icon from 'app/components/Icon';
@@ -191,7 +190,7 @@ export default class EventDetail extends Component<Props, State> {
       'hours'
     );
 
-    const deadlines: Array<?{ key: string, value: Node }> = [
+    const deadlines = [
       event.activationTime
         ? {
             key: 'Påmelding åpner',
@@ -208,6 +207,21 @@ export default class EventDetail extends Component<Props, State> {
       !['OPEN', 'TBA'].includes(event.eventStatusType)
         ? {
             key: 'Frist for prikk',
+            keyNode: (
+              <Tooltip
+                content={
+                  <span>
+                    Lurer du på hvordan prikksystemet fungerer? Sjekk ut{' '}
+                    <Link to="/pages/arrangementer/26-arrangementsregler">
+                      arrangementsreglene
+                    </Link>
+                    .
+                  </span>
+                }
+              >
+                Frist for prikk <Icon name="help-circle-outline" size={16} />
+              </Tooltip>
+            ),
             value: (
               <FormatTime
                 format="dd DD. MMM HH:mm"
@@ -229,7 +243,7 @@ export default class EventDetail extends Component<Props, State> {
         : null,
     ];
 
-    const eventCreator: Array<?{ key: string, value: Node }> = [
+    const eventCreator = [
       event.responsibleGroup && {
         key: 'Arrangør',
         value: (
@@ -323,7 +337,7 @@ export default class EventDetail extends Component<Props, State> {
                     }
                   >
                     {' '}
-                    Vis kart
+                    {this.state.mapIsOpen ? 'Skjul kart' : 'Vis kart'}
                   </div>
                   {this.state.mapIsOpen && (
                     <MazemapEmbed mazemapPoi={event.mazemapPoi} />

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -17,11 +17,7 @@ import { FormatTime, FromToTime } from 'app/components/Time';
 import InfoList from 'app/components/InfoList';
 import { Flex } from 'app/components/Layout';
 import Tooltip from 'app/components/Tooltip';
-import {
-  colorForEvent,
-  unregistrationCloseTime,
-  penaltyHours,
-} from '../../utils';
+import { colorForEvent, penaltyHours } from '../../utils';
 import Admin from '../Admin';
 import RegistrationMeta from '../RegistrationMeta';
 import DisplayContent from 'app/components/DisplayContent';
@@ -50,6 +46,8 @@ import { MazemapEmbed } from 'app/components/MazemapEmbed';
 type InterestedButtonProps = {
   isInterested: boolean,
 };
+
+const Line = () => <div className={styles.line} />;
 
 const InterestedButton = ({ isInterested }: InterestedButtonProps) => {
   const icon = isInterested ? 'star' : 'star-outline';
@@ -197,7 +195,12 @@ export default class EventDetail extends Component<Props, State> {
       event.activationTime
         ? {
             key: 'Påmelding åpner',
-            value: <FormatTime time={eventRegistrationTime} />,
+            value: (
+              <FormatTime
+                format="dd DD. MMM HH:mm"
+                time={eventRegistrationTime}
+              />
+            ),
           }
         : null,
       event.heedPenalties &&
@@ -205,20 +208,23 @@ export default class EventDetail extends Component<Props, State> {
       !['OPEN', 'TBA'].includes(event.eventStatusType)
         ? {
             key: 'Frist for prikk',
-            value: <FormatTime time={event.unregistrationDeadline} />,
+            value: (
+              <FormatTime
+                format="dd DD. MMM HH:mm"
+                time={event.unregistrationDeadline}
+              />
+            ),
           }
         : null,
       event.paymentDueDate
         ? {
             key: 'Betalingsfrist',
-            value: <FormatTime time={event.paymentDueDate} />,
-          }
-        : null,
-      event.unregistrationDeadlineHours &&
-      !['OPEN', 'TBA'].includes(event.eventStatusType)
-        ? {
-            value: <FormatTime time={unregistrationCloseTime(event)} />,
-            key: 'Avregistrering stengt',
+            value: (
+              <FormatTime
+                format="dd DD. MMM HH:mm"
+                time={event.paymentDueDate}
+              />
+            ),
           }
         : null,
     ];
@@ -228,7 +234,11 @@ export default class EventDetail extends Component<Props, State> {
         key: 'Arrangør',
         value: (
           <span>
-            {event.responsibleGroup.name}{' '}
+            {event.responsibleGroup.type === 'komite' ? (
+              <Link to={`pages/komiteer/${event.responsibleGroup.id}`}></Link>
+            ) : (
+              event.responsibleGroup.name
+            )}{' '}
             {event.responsibleGroup.contactEmail && (
               <a href={`mailto:${event.responsibleGroup.contactEmail}`}>
                 {event.responsibleGroup.contactEmail}
@@ -279,11 +289,8 @@ export default class EventDetail extends Component<Props, State> {
             </ContentMain>
             <ContentSidebar>
               {event.company && (
-                <div>
-                  <Icon
-                    name="briefcase-outline"
-                    style={{ marginRight: '10px' }}
-                  />
+                <div className={styles.iconWithText}>
+                  <Icon name="briefcase-outline" className={styles.infoIcon} />
                   <strong>
                     <Link to={`/companies/${event.company.id}`}>
                       {event.company.name}
@@ -291,29 +298,24 @@ export default class EventDetail extends Component<Props, State> {
                   </strong>
                 </div>
               )}
-              <div>
-                <Icon name="time-outline" style={{ marginRight: 9 }} />
+              <div className={styles.iconWithText}>
+                <Icon name="time-outline" className={styles.infoIcon} />
                 <strong>
                   <FromToTime from={event.startTime} to={event.endTime} />
                 </strong>
               </div>
               {event.isPriced && (
-                <div style={{ marginLeft: 4, marginBottom: 7 }}>
-                  $
-                  <strong style={{ marginLeft: 12 }}>
-                    {event.priceMember / 100},-
-                  </strong>
+                <div className={styles.iconWithText}>
+                  <Icon name="cash-outline" className={styles.infoIcon} />
+                  <strong>{event.priceMember / 100},-</strong>
                 </div>
               )}
-              <div>
-                <Icon
-                  name="pin-outline"
-                  style={{ marginLeft: 2, marginRight: 8 }}
-                />
-                <strong>{' ' + event.location}</strong>
+              <div className={styles.iconWithText}>
+                <Icon name="pin-outline" className={styles.infoIcon} />
+                <strong>{event.location}</strong>
               </div>
               {event.mazemapPoi && (
-                <div>
+                <>
                   <div
                     className={styles.simulateLink}
                     onClick={() =>
@@ -326,13 +328,13 @@ export default class EventDetail extends Component<Props, State> {
                   {this.state.mapIsOpen && (
                     <MazemapEmbed mazemapPoi={event.mazemapPoi} />
                   )}
-                </div>
+                </>
               )}
               {['OPEN', 'TBA'].includes(event.eventStatusType) ? (
                 <JoinEventForm event={event} />
               ) : (
-                <Flex column>
-                  <h3 style={{ marginTop: 12 }}>Påmeldte</h3>
+                <Flex column className={styles.registeredBox}>
+                  <h3>Påmeldte</h3>
                   {registrations ? (
                     <Fragment>
                       <UserGrid
@@ -425,17 +427,16 @@ export default class EventDetail extends Component<Props, State> {
                   )}
                 </Flex>
               )}
-              <div className={styles.line} />
-              <InfoList style={{ marginBottom: '4px' }} items={deadlines} />
-              <div className={styles.line} />
-              <InfoList
-                style={{ paddingBottom: '24px' }}
-                items={eventCreator}
-              />
-              {(actionGrant.includes('edit') ||
-                actionGrant.includes('delete')) && (
-                <div className={styles.line} />
+              {deadlines.some((d) => d !== null) && (
+                <>
+                  <Line />
+                  <InfoList className={styles.infoList} items={deadlines} />
+                </>
               )}
+              <Line />
+              <InfoList items={eventCreator} className={styles.infoList} />
+              {(actionGrant.includes('edit') ||
+                actionGrant.includes('delete')) && <Line />}
               <Flex column>
                 <Admin
                   actionGrant={actionGrant}

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -71,7 +71,7 @@ button {
 }
 
 i {
-  display: inline;
+  display: inline-block;
 }
 
 table {

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -109,16 +109,16 @@ describe('Create meeting', () => {
     cy.contains('h1', 'Test meeting').should('be.visible');
     cy.contains('time', '10:00').should('be.visible');
     cy.contains(c('legoEditor_disabled'), 'Meeting plan').should('be.visible');
-    cy.contains('li', 'Når')
+    cy.contains('tr', 'Når')
       .should('contain.text', '10:00 - 13:37')
       .should('be.visible');
-    cy.contains('li', 'Sted')
+    cy.contains('tr', 'Sted')
       .should('contain.text', 'Test location')
       .should('be.visible');
-    cy.contains('li', 'Forfatter')
+    cy.contains('tr', 'Forfatter')
       .should('contain.text', 'webkom webkom')
       .should('be.visible');
-    cy.contains('li', 'Referent')
+    cy.contains('tr', 'Referent')
       .should('contain.text', 'bedkom bedkom')
       .should('be.visible');
 
@@ -224,16 +224,16 @@ describe('Create meeting', () => {
     cy.contains(c('legoEditor_disabled'), 'Meeting report').should(
       'be.visible'
     );
-    cy.contains('li', 'Når')
+    cy.contains('tr', 'Når')
       .should('contain.text', '17:15 - 20:00')
       .should('be.visible');
-    cy.contains('li', 'Sted')
+    cy.contains('tr', 'Sted')
       .should('contain.text', 'Abakus, Realfagbygget')
       .should('be.visible');
-    cy.contains('li', 'Forfatter')
+    cy.contains('tr', 'Forfatter')
       .should('contain.text', 'webkom webkom')
       .should('be.visible');
-    cy.contains('li', 'Referent')
+    cy.contains('tr', 'Referent')
       .should('contain.text', 'webkom webkom')
       .should('be.visible');
 


### PR DESCRIPTION
It has finally come! The redesign of the sidebar. 

It is rather simple, mostly rearranging of code.
Move some of the information and add some icons 'cause people like icons.
And move the name of the company and put the event type to the coloured bar under the header.
Also, the mazemap thing is now something that opens and close when hitting the link.

Before:
<img width="792" alt="image" src="https://user-images.githubusercontent.com/31897129/165397911-842331a1-97b5-4bf5-ab4b-c70f267f0a81.png">

After (the faces dont show, but now there is _one_ row of faces rather than two!):
![image](https://user-images.githubusercontent.com/31897129/165409203-16a2c641-bdb2-4556-9886-f8aa3f889d9a.png)



And with payment and mazemap:
![image](https://user-images.githubusercontent.com/31897129/165409169-b97a3418-569d-4b1c-8837-ef27eea36312.png)

