### PR TITLE
Remove useMazemap state from meeting and event editors

### DIFF
--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -86,6 +86,7 @@ const mapStateToProps = (state, props) => {
       useConsent: false,
       feedbackDescription: '',
       pools: [],
+      useMazemap: true,
       separateDeadlines: false,
       unregistrationDeadline: time({ hours: 12 }),
       registrationDeadlineHours: 2,

--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -56,6 +56,7 @@ const mapStateToProps = (state, props) => {
           valueSelector(state, 'unregistrationDeadlineHours'),
           'hours'
         ),
+      useMazemap: valueSelector(state, 'useMazemap'),
       mazemapPoi: valueSelector(state, 'mazemapPoi'),
       hasFeedbackQuestion: valueSelector(state, 'hasFeedbackQuestion'),
     },

--- a/app/routes/events/EventEditRoute.js
+++ b/app/routes/events/EventEditRoute.js
@@ -98,6 +98,7 @@ const mapStateToProps = (state, props) => {
           valueSelector(state, 'unregistrationDeadlineHours'),
           'hours'
         ),
+      useMazemap: valueSelector(state, 'useMazemap'),
       hasFeedbackQuestion: valueSelector(state, 'hasFeedbackQuestion'),
     },
     eventId,

--- a/app/routes/events/EventEditRoute.js
+++ b/app/routes/events/EventEditRoute.js
@@ -70,7 +70,7 @@ const mapStateToProps = (state, props) => {
       },
       separateDeadlines:
         event.registrationDeadlineHours !== event.unregistrationDeadlineHours,
-      useMazemap: event.mazemapPoi > 0,
+      useMazemap: event.eventStatusType === 'TBA' || event.mazemapPoi > 0,
       hasFeedbackQuestion: !!event.feedbackDescription,
     },
     actionGrant,

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -44,7 +44,6 @@ import { validYoutubeUrl } from 'app/utils/validation';
 import { FormatTime } from 'app/components/Time';
 import moment from 'moment-timezone';
 import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
-import { useEffect, useState } from 'react';
 
 type Props = {
   eventId: number,
@@ -86,16 +85,6 @@ function EventEditor({
   initialized,
 }: Props) {
   const isEditPage = eventId !== undefined;
-
-  const [useMazemap, setUseMazemap] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (initialized) {
-      setUseMazemap(event?.mazemapPoi?.value > 0);
-    }
-    // Should only run once when initialized to initialize useMazemap state
-    // eslint-disable-next-line react-hooks/exhaustive-deps, react-app/react-hooks/exhaustive-deps
-  }, [initialized]);
 
   if (isEditPage && !actionGrant.includes('edit')) {
     return null;
@@ -277,17 +266,13 @@ function EventEditor({
                 component={CheckBox.Field}
                 fieldClassName={styles.metaField}
                 className={styles.formField}
-                value={useMazemap}
-                onChange={(e) => {
-                  setUseMazemap(!useMazemap);
-                }}
                 normalize={(v) => !!v}
               />
             )}
             {['NORMAL', 'OPEN', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) &&
-              !useMazemap && (
+              (!event.useMazemap ? (
                 <Field
                   label="Sted"
                   name="location"
@@ -297,11 +282,7 @@ function EventEditor({
                   className={styles.formField}
                   warn={isTBA}
                 />
-              )}
-            {['NORMAL', 'OPEN', 'INFINITE'].includes(
-              event.eventStatusType && event.eventStatusType.value
-            ) &&
-              useMazemap && (
+              ) : (
                 <Flex alignItems="flex-end">
                   <Field
                     label="Mazemap-rom"
@@ -317,7 +298,7 @@ function EventEditor({
                     />
                   )}
                 </Flex>
-              )}
+              ))}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (

--- a/app/routes/meetings/MeetingCreateRoute.js
+++ b/app/routes/meetings/MeetingCreateRoute.js
@@ -23,6 +23,9 @@ const mapStateToProps = (state, props) => {
       endTime: time(20),
       report: '',
     },
+    meeting: {
+      useMazemap: valueSelector(state, 'useMazemap'),
+    },
     user: props.currentUser,
     invitingUsers: valueSelector(state, 'users') || [],
   };

--- a/app/routes/meetings/MeetingCreateRoute.js
+++ b/app/routes/meetings/MeetingCreateRoute.js
@@ -22,6 +22,7 @@ const mapStateToProps = (state, props) => {
       startTime: time(17, 15),
       endTime: time(20),
       report: '',
+      useMazemap: true,
     },
     meeting: {
       useMazemap: valueSelector(state, 'useMazemap'),

--- a/app/routes/meetings/MeetingEditRoute.js
+++ b/app/routes/meetings/MeetingEditRoute.js
@@ -55,6 +55,7 @@ const mapStateToProps = (state, props) => {
     invitingUsers: valueSelector(state, 'users') || [],
     meeting: {
       ...meeting,
+      useMazemap: valueSelector(state, 'useMazemap'),
       mazemapPoi: valueSelector(state, 'mazemapPoi'),
     },
     meetingId,

--- a/app/routes/meetings/components/MeetingEditor.js
+++ b/app/routes/meetings/components/MeetingEditor.js
@@ -22,7 +22,6 @@ import moment from 'moment-timezone';
 import config from 'app/config';
 import { unionBy } from 'lodash';
 import type { UserEntity } from 'app/reducers/users';
-import { useEffect, useState } from 'react';
 import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
 import { Flex } from 'app/components/Layout';
 
@@ -56,16 +55,6 @@ function MeetingEditor({
   initialized,
 }: Props) {
   const isEditPage = meetingId !== undefined;
-
-  const [useMazemap, setUseMazemap] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (initialized) {
-      setUseMazemap(meeting?.mazemapPoi?.value > 0);
-    }
-    // Should only run once when initialized to initialize useMazemap state
-    // eslint-disable-next-line react-hooks/exhaustive-deps, react-app/react-hooks/exhaustive-deps
-  }, [initialized]);
 
   if (isEditPage && !meeting) {
     return <LoadingIndicator loading />;
@@ -148,21 +137,16 @@ function MeetingEditor({
           component={CheckBox.Field}
           fieldClassName={styles.metaField}
           className={styles.formField}
-          value={useMazemap}
-          onChange={(e) => {
-            setUseMazemap(!useMazemap);
-          }}
           normalize={(v) => !!v}
         />
-        {!useMazemap && (
+        {!meeting.useMazemap ? (
           <Field
             name="location"
             label="Sted"
             placeholder="Sted for møte"
             component={TextInput.Field}
           />
-        )}
-        {useMazemap && (
+        ) : (
           <Flex alignItems="center">
             <Field
               label="Mazemap-rom"

--- a/cypress/integration/create_event_spec.js
+++ b/cypress/integration/create_event_spec.js
@@ -259,6 +259,7 @@ describe('Create event', () => {
     cy.focused().type('Vanlig{enter}', { force: true });
 
     // Set location
+    field('useMazemap').uncheck();
     cy.contains('Sted').click();
     cy.focused().type('R4');
 
@@ -329,6 +330,7 @@ describe('Create event', () => {
     cy.focused().type('Uten{enter}', { force: true });
 
     // Set location
+    field('useMazemap').uncheck();
     cy.contains('Sted').click();
     cy.focused().type('Kjellern');
 
@@ -361,6 +363,7 @@ describe('Create event', () => {
     cy.focused().type('Med på{enter}', { force: true });
 
     // Set location
+    field('useMazemap').uncheck();
     cy.contains('Sted').click();
     cy.focused().type('EL6');
 


### PR DESCRIPTION
It turns out we don't need the `useState` for `useMazemap` in the meeting or event editors as this is already saved in form state. 

I also set `useMazemap` to `true` by default in the hope that it will be used a bit more often.