### PR TITLE
Avoid loading zxcvbn unneccesarily

### DIFF
--- a/app/routes/users/components/ChangePassword.js
+++ b/app/routes/users/components/ChangePassword.js
@@ -8,6 +8,7 @@ import { createValidator, required, sameAs } from 'app/utils/validation';
 import { validPassword } from '../utils';
 import PasswordField from './PasswordField';
 import { type UserEntity } from 'app/reducers/users';
+import { createAsyncValidator } from 'app/utils/asyncValidator';
 
 type PasswordPayload = {
   newPassword: string,
@@ -57,16 +58,21 @@ const ChangePassword = ({
 
 const validate = createValidator({
   password: [required()],
-  newPassword: [required(), validPassword()],
+  newPassword: [required()],
   retypeNewPassword: [
     required(),
     sameAs('newPassword', 'Passordene er ikke like'),
   ],
 });
 
+const asyncValidate = createAsyncValidator({
+  newPassword: [validPassword()],
+});
+
 export default legoForm({
   form: 'changePassword',
   validate,
+  asyncValidate,
   onSubmit: (data, dispatch, { changePassword, push }: Props) =>
     changePassword(data).then(() => push('/users/me')),
 })(ChangePassword);

--- a/app/routes/users/components/PasswordStrengthMeter.js
+++ b/app/routes/users/components/PasswordStrengthMeter.js
@@ -1,9 +1,7 @@
 // @flow
 
-import { Component, Fragment } from 'react';
-import { pick } from 'lodash';
+import loadable from '@loadable/component';
 import moment from 'moment-timezone';
-import zxcvbn from 'zxcvbn';
 import Bar from '@webkom/react-meter-bar';
 import '@webkom/react-meter-bar/dist/Bar.css';
 import styles from './PasswordStrengthMeter.css';
@@ -19,60 +17,82 @@ type Props = {
   user: UserEntity,
 };
 
-class PasswordStrengthMeter extends Component<Props> {
-  render() {
-    const { password, user } = this.props;
-    const zxcvbnValue = zxcvbn(
-      password,
-      //$FlowFixMe[incompatible-call]
-      Object.values(pick(user, ['username', 'firstName', 'lastName']))
-    );
-    let tips = zxcvbnValue.feedback.suggestions;
-    tips.push(zxcvbnValue.feedback.warning);
-    tips = tips.map((tip) => passwordFeedbackMessages[tip]).filter(Boolean);
+const Zxcvbn = loadable.lib(() => import('zxcvbn'), { ssr: false });
 
-    const crackTimeSec = Number(
-      zxcvbnValue.crack_times_seconds.offline_slow_hashing_1e4_per_second
-    );
-    const crackTimeDuration = moment
-      .duration(crackTimeSec, 'seconds')
-      .humanize();
-    const crackTime =
-      crackTimeSec > 2 ? crackTimeDuration : crackTimeSec + ' sekunder';
+const PasswordStrengthMeter = ({ password, user }: Props) => {
+  return (
+    <Zxcvbn
+      fallback={
+        <>
+          <PasswordStrengthBar strengthScore={0} />
+          <span>
+            <strong>Kalkulerer passordstyrke</strong>
+          </span>
+        </>
+      }
+    >
+      {({ default: zxcvbn }) => {
+        const zxcvbnValue = zxcvbn(password, [
+          user.username,
+          user.firstName,
+          user.lastName,
+        ]);
 
-    return (
-      <Fragment>
-        <div className={styles.removeLabels}>
-          <Bar
-            labels={[1, 2, 3, 4, 5]}
-            labelColor="#000"
-            progress={zxcvbnValue.score * 25}
-            barColor={barColor[zxcvbnValue.score]}
-            seperatorColor="#fff"
-          />
-        </div>
-        {password && (
-          <Fragment>
-            <span>
-              <strong>Passordstyrke: </strong>{' '}
-              {passwordLabel[zxcvbnValue.score]}
-            </span>
-            <p>
-              Dette passordet hadde tatt en maskin {crackTime} å knekke @ 10^4
-              Hash/s.
-            </p>
-          </Fragment>
-        )}
-        {password && zxcvbnValue.score < 3 && (
-          <ul className={styles.tipsList}>
-            {tips.map((value, key) => {
-              return <li key={key}>{value}</li>;
-            })}
-          </ul>
-        )}
-      </Fragment>
-    );
-  }
-}
+        let tips = zxcvbnValue.feedback?.suggestions ?? [];
+        tips.push(zxcvbnValue.feedback?.warning);
+        tips = tips.map((tip) => passwordFeedbackMessages[tip]).filter(Boolean);
+
+        const crackTimeSec = Number(
+          zxcvbnValue.crack_times_seconds?.offline_slow_hashing_1e4_per_second
+        );
+        const crackTimeDuration = moment
+          .duration(crackTimeSec, 'seconds')
+          .humanize();
+
+        const crackTime =
+          crackTimeSec > 2 ? crackTimeDuration : crackTimeSec + ' sekunder';
+
+        return (
+          <>
+            <PasswordStrengthBar strengthScore={zxcvbnValue.score} />
+            {password && (
+              <>
+                <span>
+                  <strong>Passordstyrke: </strong>{' '}
+                  {passwordLabel[zxcvbnValue.score]}
+                </span>
+                <p>
+                  Dette passordet hadde tatt en maskin {crackTime} å knekke @
+                  10⁴ Hash/s.
+                </p>
+              </>
+            )}
+            {password && zxcvbnValue.score < 3 && (
+              <ul className={styles.tipsList}>
+                {tips.map((value, key) => {
+                  return <li key={key}>{value}</li>;
+                })}
+              </ul>
+            )}
+          </>
+        );
+      }}
+    </Zxcvbn>
+  );
+};
+
+const PasswordStrengthBar = ({ strengthScore }: { strengthScore: number }) => {
+  return (
+    <div className={styles.removeLabels}>
+      <Bar
+        labels={[1, 2, 3, 4, 5]}
+        labelColor="#000"
+        progress={strengthScore * 25}
+        barColor={barColor[strengthScore]}
+        seperatorColor="#fff"
+      />
+    </div>
+  );
+};
 
 export default PasswordStrengthMeter;

--- a/app/routes/users/components/UserConfirmation.js
+++ b/app/routes/users/components/UserConfirmation.js
@@ -17,6 +17,7 @@ import { createValidator, required, sameAs } from 'app/utils/validation';
 import { validPassword } from '../utils';
 import PasswordField from './PasswordField';
 import { type UserEntity } from 'app/reducers/users';
+import { createAsyncValidator } from 'app/utils/asyncValidator';
 
 type Props = {
   token: string,
@@ -151,9 +152,13 @@ const UserConfirmation = ({
 
 const validate = createValidator({
   username: [required()],
-  password: [required(), validPassword()],
+  password: [required()],
   retypePassword: [required(), sameAs('password', 'Passordene er ikke like')],
   gender: [required()],
+});
+
+const asyncValidate = createAsyncValidator({
+  password: [validPassword()],
 });
 
 const onSubmit = (data, dispatch, { token, createUser }) =>
@@ -162,5 +167,6 @@ const onSubmit = (data, dispatch, { token, createUser }) =>
 export default legoForm({
   form: 'ConfirmationForm',
   validate,
+  asyncValidate,
   onSubmit,
 })(UserConfirmation);

--- a/app/routes/users/components/UserResetPassword.js
+++ b/app/routes/users/components/UserResetPassword.js
@@ -7,6 +7,7 @@ import { Form, Button, TextInput } from 'app/components/Form';
 import { createValidator, required, sameAs } from 'app/utils/validation';
 import { validPassword } from '../utils';
 import PasswordField from './PasswordField';
+import { createAsyncValidator } from 'app/utils/asyncValidator';
 
 type Props = {
   token: string,
@@ -63,14 +64,19 @@ const UserResetPassword = ({
 };
 
 const validate = createValidator({
-  password: [required(), validPassword()],
+  password: [required()],
   retypeNewPassword: [
     required(),
     sameAs('password', 'Passordene er ikke like'),
   ],
 });
 
+const asyncValidate = createAsyncValidator({
+  password: [validPassword()],
+});
+
 export default reduxForm({
   form: 'ResetPassword',
   validate,
+  asyncValidate,
 })(UserResetPassword);

--- a/app/routes/users/utils.js
+++ b/app/routes/users/utils.js
@@ -1,14 +1,21 @@
-import zxcvbn from 'zxcvbn';
-import { pick } from 'lodash';
+// @flow
+
+type Data = {
+  username?: string,
+  firstName?: string,
+  lastName?: string,
+};
 
 export const validPassword =
-  (message = 'Passordet er for svakt. Minimum styrke er 3.') =>
-  (value, data) => {
+  (message: string = 'Passordet er for svakt. Minimum styrke er 3.') =>
+  async (value: string, data: Data) => {
     if (value === undefined) {
       return [true];
     }
-    const userValues = Object.values(
-      pick(data, ['username', 'firstName', 'lastName'])
+    const zxcvbn = (await import('zxcvbn')).default;
+
+    const userValues = [data.username, data.firstName, data.lastName].filter(
+      Boolean
     );
     const evalPass = zxcvbn(value, userValues);
     return [evalPass.score >= 3, message];

--- a/app/utils/__tests__/asyncValidator.spec.js
+++ b/app/utils/__tests__/asyncValidator.spec.js
@@ -1,0 +1,68 @@
+// @flow
+
+import { createAsyncValidator } from 'app/utils/asyncValidator';
+
+describe('asyncValidator', () => {
+  it('should validate a text field', async () => {
+    const asyncValidate = createAsyncValidator({
+      field1: [
+        (value) => {
+          return new Promise((resolve) => {
+            if (value === 'success') {
+              resolve([true]);
+            } else {
+              resolve([false, 'value was not success']);
+            }
+          });
+        },
+      ],
+    });
+
+    await expect(asyncValidate({ field1: 'success' })).resolves.toBeUndefined();
+    await expect(asyncValidate({ field1: 'failure' })).rejects.toStrictEqual({
+      field1: ['value was not success'],
+    });
+  });
+
+  it('should show errors on multiple fields', async () => {
+    const asyncValidate = createAsyncValidator({
+      field1: [
+        (value) => {
+          return new Promise((resolve) => {
+            if (value === 'success') {
+              resolve([true]);
+            } else {
+              resolve([false, 'value was not success']);
+            }
+          });
+        },
+      ],
+      field2: [
+        (value, formData) => {
+          return new Promise((resolve) => {
+            if (value === formData.field1) {
+              resolve([true]);
+            } else {
+              resolve([false, 'value was not equal to field1']);
+            }
+          });
+        },
+      ],
+    });
+
+    await expect(
+      asyncValidate({ field1: 'success', field2: 'success' })
+    ).resolves.toBeUndefined();
+    await expect(
+      asyncValidate({ field1: 'failure', field2: 'failure' })
+    ).rejects.toStrictEqual({
+      field1: ['value was not success'],
+    });
+    await expect(
+      asyncValidate({ field1: 'failure', field2: 'other' })
+    ).rejects.toStrictEqual({
+      field1: ['value was not success'],
+      field2: ['value was not equal to field1'],
+    });
+  });
+});

--- a/app/utils/asyncValidator.js
+++ b/app/utils/asyncValidator.js
@@ -1,0 +1,60 @@
+// @flow
+
+export type AsyncFieldValidator<T = any> = (
+  fieldValue: T,
+  formData: Object
+) => Promise<[true] | [boolean, string]>;
+
+type FieldValidators = {|
+  [field: string]: AsyncFieldValidator<>[],
+|};
+
+const getValidationErrors = async (
+  validators: AsyncFieldValidator<>[],
+  fieldData: any,
+  formData: Object
+): Promise<string[]> => {
+  const validationResults = await Promise.all(
+    validators.map((validator) => validator(fieldData, formData))
+  );
+
+  return (
+    validationResults
+      .filter(([isValid]) => !isValid)
+      // $FlowFixMe flow doesn't understand that the filter ensures that error message exists
+      .map(([, error]) => error)
+  );
+};
+
+const getFieldErrorArray = async (
+  fieldValidators: FieldValidators,
+  formData: Object
+): Promise<[string, string[]][]> => {
+  return (
+    await Promise.all(
+      Object.keys(fieldValidators).map(
+        async (field): Promise<[string, string[]]> => [
+          field,
+          await getValidationErrors(
+            fieldValidators[field],
+            formData[field],
+            formData
+          ),
+        ]
+      )
+    )
+  ).filter(([, fieldErrors]) => fieldErrors.length);
+};
+
+export const createAsyncValidator = (fieldValidators: FieldValidators) => {
+  return async (formData: Object) => {
+    const fieldErrorArray = await getFieldErrorArray(fieldValidators, formData);
+
+    if (fieldErrorArray.length) {
+      throw fieldErrorArray.reduce((errors, [field, fieldErrors]) => {
+        errors[field] = fieldErrors;
+        return errors;
+      }, {});
+    }
+  };
+};


### PR DESCRIPTION
We use `zxcvbn` for checking strength of new passwords in the frontend, and it's a pretty large package (400kb minified). It is currently loaded on all pages, and makes up about 20% of loaded javascript on the front page.

Luckily we have code-splitting and dynamic imports, so with some refactoring it is now only loaded once you actually need to use it 😁 

I've never used dynamic imports before, so please tell me if I'm doing something dumb or not following best practice. But it seems to work well.