### PR TITLE
Add randomly selected interestgroups to frontpage

### DIFF
--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -145,7 +145,7 @@ export const Group = {
   CREATE: (generateStatuses('Group.CREATE'): AAT),
   REMOVE: (generateStatuses('Group.REMOVE'): AAT),
   MEMBERSHIP_FETCH: (generateStatuses('Group.MEMBERSHIP_FETCH'): AAT),
-  FETCH_RADOM_INTERESTS: (generateStatuses(
+  FETCH_RANDOM_INTERESTS: (generateStatuses(
     'Group.FETCH_RANDOM_INTERESTS'
   ): AAT),
 };

--- a/app/actions/ActionTypes.js
+++ b/app/actions/ActionTypes.js
@@ -145,6 +145,9 @@ export const Group = {
   CREATE: (generateStatuses('Group.CREATE'): AAT),
   REMOVE: (generateStatuses('Group.REMOVE'): AAT),
   MEMBERSHIP_FETCH: (generateStatuses('Group.MEMBERSHIP_FETCH'): AAT),
+  FETCH_RADOM_INTERESTS: (generateStatuses(
+    'Group.FETCH_RANDOM_INTERESTS'
+  ): AAT),
 };
 
 export const CompanyInterestForm = {

--- a/app/actions/GroupActions.js
+++ b/app/actions/GroupActions.js
@@ -84,6 +84,19 @@ export function fetchAllWithType(type: string): Thunk<any> {
   });
 }
 
+export function fetchRandomInterestgroups(): Thunk<any> {
+  return callAPI({
+    types: Group.FETCH_RADOM_INTERESTS,
+    endpoint: '/groups/random_interests/',
+    method: 'GET',
+    meta: {
+      errorMessage: 'Henting av tilfeldige interessegrupper feilet',
+    },
+    useCache: false,
+    schema: [groupSchema],
+  });
+}
+
 export function editGroup(group: Object): Thunk<*> {
   return (dispatch) =>
     dispatch(

--- a/app/actions/GroupActions.js
+++ b/app/actions/GroupActions.js
@@ -86,7 +86,7 @@ export function fetchAllWithType(type: string): Thunk<any> {
 
 export function fetchRandomInterestgroups(): Thunk<any> {
   return callAPI({
-    types: Group.FETCH_RADOM_INTERESTS,
+    types: Group.FETCH_RANDOM_INTERESTS,
     endpoint: '/groups/random_interests/',
     method: 'GET',
     meta: {

--- a/app/actions/GroupActions.js
+++ b/app/actions/GroupActions.js
@@ -84,7 +84,7 @@ export function fetchAllWithType(type: string): Thunk<any> {
   });
 }
 
-export function fetchRandomInterestgroups(): Thunk<any> {
+export function fetchRandomInterestGroups(): Thunk<any> {
   return callAPI({
     types: Group.FETCH_RANDOM_INTERESTS,
     endpoint: '/groups/random_interests/',

--- a/app/reducers/frontpage.js
+++ b/app/reducers/frontpage.js
@@ -5,13 +5,15 @@ import { sortBy } from 'lodash';
 import { createSelector } from 'reselect';
 import { selectArticles } from './articles';
 import { selectEvents } from './events';
+import { selectRandomInterestgroups } from './groups';
 
 export default fetching(Frontpage.FETCH);
 
 export const selectFrontpage = createSelector(
   selectArticles,
   selectEvents,
-  (articles, events) => {
+  selectRandomInterestgroups,
+  (articles, events, interestGroups) => {
     articles = articles.map((article) => ({
       ...article,
       documentType: 'article',

--- a/app/reducers/frontpage.js
+++ b/app/reducers/frontpage.js
@@ -5,14 +5,14 @@ import { sortBy } from 'lodash';
 import { createSelector } from 'reselect';
 import { selectArticles } from './articles';
 import { selectEvents } from './events';
-import { selectRandomInterestgroups } from './groups';
+import { selectRandomInterestGroups } from './groups';
 
 export default fetching(Frontpage.FETCH);
 
 export const selectFrontpage = createSelector(
   selectArticles,
   selectEvents,
-  selectRandomInterestgroups,
+  selectRandomInterestGroups,
   (articles, events, interestGroups) => {
     articles = articles.map((article) => ({
       ...article,

--- a/app/reducers/groups.js
+++ b/app/reducers/groups.js
@@ -49,7 +49,7 @@ export default createEntityReducer({
         }
         break;
 
-      case Group.FETCH_RADOM_INTERESTS.SUCCESS:
+      case Group.FETCH_RANDOM_INTERESTS.SUCCESS:
         newState.randomInterestById = action.payload.result;
         break;
 

--- a/app/reducers/groups.js
+++ b/app/reducers/groups.js
@@ -49,6 +49,10 @@ export default createEntityReducer({
         }
         break;
 
+      case Group.FETCH_RADOM_INTERESTS.SUCCESS:
+        newState.randomInterestById = action.payload.result;
+        break;
+
       default:
         break;
     }
@@ -71,4 +75,13 @@ export const selectGroupsWithType = createSelector(
   (state, props) => selectGroups(state),
   (state, props) => props.groupType,
   (groups, groupType) => groups.filter((g) => g.type === groupType)
+);
+
+export const selectRandomInterestgroups = createSelector(
+  (state) => state.groups.byId,
+  (state) => state.groups.randomInterestById,
+  (groupsById, groupIds) => {
+    if (!groupsById || !groupIds) return [];
+    return groupIds.map((id) => groupsById[id]);
+  }
 );

--- a/app/reducers/groups.js
+++ b/app/reducers/groups.js
@@ -77,7 +77,7 @@ export const selectGroupsWithType = createSelector(
   (groups, groupType) => groups.filter((g) => g.type === groupType)
 );
 
-export const selectRandomInterestgroups = createSelector(
+export const selectRandomInterestGroups = createSelector(
   (state) => state.groups.byId,
   (state) => state.groups.randomInterestById,
   (groupsById, groupIds) => {

--- a/app/routes/overview/IndexRoute.js
+++ b/app/routes/overview/IndexRoute.js
@@ -17,11 +17,14 @@ import {
 } from 'app/reducers/feeds';
 import { selectPinnedPolls } from 'app/reducers/polls';
 import { votePoll } from 'app/actions/PollActions';
+import { fetchRandomInterestgroups } from 'app/actions/GroupActions';
+import { selectRandomInterestgroups } from 'app/reducers/groups';
 
 const mapStateToProps = (state) => ({
   frontpage: selectFrontpage(state),
   feed: selectFeedById(state, { feedId: 'personal' }),
   shouldFetchQuote: isEmpty(selectRandomQuote(state)),
+  shouldFetchInterestgroups: isEmpty(selectRandomInterestgroups(state)),
   feedItems: selectFeedActivitesByFeedId(state, {
     feedId: 'personal',
   }),
@@ -38,10 +41,13 @@ export default compose(
   // ),
   connect(mapStateToProps, mapDispatchToProps),
   prepare(
-    ({ shouldFetchQuote, loggedIn }, dispatch) =>
+    ({ shouldFetchQuote, shouldFetchInterestgroups, loggedIn }, dispatch) =>
       Promise.all([
         loggedIn && shouldFetchQuote && dispatch(fetchRandomQuote()),
         dispatch(fetchReadmes(loggedIn ? 4 : 1)),
+        loggedIn &&
+          shouldFetchInterestgroups &&
+          dispatch(fetchRandomInterestgroups()),
       ]),
     [],
     { awaitOnSsr: false }

--- a/app/routes/overview/IndexRoute.js
+++ b/app/routes/overview/IndexRoute.js
@@ -17,14 +17,14 @@ import {
 } from 'app/reducers/feeds';
 import { selectPinnedPolls } from 'app/reducers/polls';
 import { votePoll } from 'app/actions/PollActions';
-import { fetchRandomInterestgroups } from 'app/actions/GroupActions';
-import { selectRandomInterestgroups } from 'app/reducers/groups';
+import { fetchRandomInterestGroups } from 'app/actions/GroupActions';
+import { selectRandomInterestGroups } from 'app/reducers/groups';
 
 const mapStateToProps = (state) => ({
   frontpage: selectFrontpage(state),
   feed: selectFeedById(state, { feedId: 'personal' }),
   shouldFetchQuote: isEmpty(selectRandomQuote(state)),
-  shouldFetchInterestgroups: isEmpty(selectRandomInterestgroups(state)),
+  shouldFetchInterestGroups: isEmpty(selectRandomInterestGroups(state)),
   feedItems: selectFeedActivitesByFeedId(state, {
     feedId: 'personal',
   }),
@@ -41,13 +41,13 @@ export default compose(
   // ),
   connect(mapStateToProps, mapDispatchToProps),
   prepare(
-    ({ shouldFetchQuote, shouldFetchInterestgroups, loggedIn }, dispatch) =>
+    ({ shouldFetchQuote, shouldFetchInterestGroups, loggedIn }, dispatch) =>
       Promise.all([
         loggedIn && shouldFetchQuote && dispatch(fetchRandomQuote()),
         dispatch(fetchReadmes(loggedIn ? 4 : 1)),
         loggedIn &&
-          shouldFetchInterestgroups &&
-          dispatch(fetchRandomInterestgroups()),
+          shouldFetchInterestGroups &&
+          dispatch(fetchRandomInterestGroups()),
       ]),
     [],
     { awaitOnSsr: false }


### PR DESCRIPTION
This will be the first of many PRs into `new-frontpage-2022-release`, created to avoid my fellow webkomers to suffer the awful 3000 line PR :hot_face:  . More details about the project will be added once this is merged.

Add three randomly selected interestgroups to frontpage state. Achieved with the new endpoint in webkom/lego#2594. 

These will later be used to display some interestgroups on the frontpage, see #2311 for a preview^^