### PR TITLE
Made timeline and notifications show newlines and prevented timeline overflow

### DIFF
--- a/app/components/Feed/activity.css
+++ b/app/components/Feed/activity.css
@@ -5,6 +5,8 @@
   padding: 10px 20px;
   border-bottom: 1px solid
     rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 9%);
+  word-break: break-word;
+  white-space: pre-line;
 }
 
 .activityHeader {

--- a/app/components/HeaderNotifications/HeaderNotifications.css
+++ b/app/components/HeaderNotifications/HeaderNotifications.css
@@ -46,6 +46,7 @@ html[data-theme='dark'] .notifications {
   align-items: center;
   padding-right: 15px;
   word-break: break-word;
+  white-space: pre-line;
 }
 
 .unRead {


### PR DESCRIPTION
Added word-break to timeline to prevent horizontal overflow.

Also added white-space: pre-line; to display newlines, turning
![image](https://user-images.githubusercontent.com/13599770/170699174-1299b183-b252-4cbc-9bfc-b0fee379c266.png)
into
![image](https://user-images.githubusercontent.com/13599770/170699077-74225cf4-815a-48a4-9221-df840a3b4ac2.png)
