### PR TITLE
Prevent page overflow on mobile devices and small style changes

### DIFF
--- a/app/components/NavigationTab/NavigationTab.css
+++ b/app/components/NavigationTab/NavigationTab.css
@@ -17,11 +17,12 @@
   padding-right: 20px;
   text-transform: uppercase;
   flex-shrink: 99999;
+  word-break: break-word;
 }
 
 .navigator {
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
   align-items: center;
 }
 
@@ -29,7 +30,6 @@
   .container {
     flex-flow: column wrap;
     align-items: flex-end;
-    margin-right: -15px;
   }
 }
 

--- a/app/components/NavigationTab/index.js
+++ b/app/components/NavigationTab/index.js
@@ -22,7 +22,7 @@ type Props = {
 
 const NavigationTab = (props: Props) => {
   return (
-    <div>
+    <>
       {props.back && (
         <div>
           <NavigationLink to={props.back.path}>
@@ -38,7 +38,7 @@ const NavigationTab = (props: Props) => {
         <div className={styles.navigator}>{props.children}</div>
       </div>
       <div className={styles.details}>{props.details}</div>
-    </div>
+    </>
   );
 };
 

--- a/app/components/Tags/Tag.css
+++ b/app/components/Tags/Tag.css
@@ -31,7 +31,7 @@ html[data-theme='dark'] .tagLink {
   flex-wrap: wrap;
 }
 
-.link:hover {
+.link:active {
   background: #ba1414;
   color: var(--color-white);
   transition: 0.2s;

--- a/app/routes/articles/components/ArticleDetail.js
+++ b/app/routes/articles/components/ArticleDetail.js
@@ -80,7 +80,7 @@ const ArticleDetail = ({
 
       <Tags>
         {article.tags.map((tag) => (
-          <Tag tag={tag} key={tag} />
+          <Tag tag={tag} key={tag} link={'/articles/?tag=' + tag} />
         ))}
       </Tags>
 

--- a/app/routes/articles/components/Overview.js
+++ b/app/routes/articles/components/Overview.js
@@ -80,7 +80,7 @@ export default class Overview extends Component<Props> {
               <Tag
                 tag={tag.tag}
                 key={tag.tag}
-                color={isSelected ? 'cyan' : ''}
+                color={isSelected ? 'red' : ''}
                 link={isSelected ? '/articles/' : `/articles?tag=${tag.tag}`}
               />
             );

--- a/app/routes/meetings/components/MeetingList.js
+++ b/app/routes/meetings/components/MeetingList.js
@@ -68,7 +68,9 @@ const MeetingListView = ({
       </div>
     ))}
     {!sections.length && (
-      <h2 style={{ textAlign: 'center' }}> Ingen møter å vise</h2>
+      <h2 style={{ textAlign: 'center', marginBottom: 10 }}>
+        Ingen møter å vise
+      </h2>
     )}
   </div>
 );

--- a/app/routes/pages/components/PageDetail.css
+++ b/app/routes/pages/components/PageDetail.css
@@ -57,7 +57,6 @@
 }
 
 .mainTxt {
-  width: calc(100% - 5em);
   padding: 2.5em 0 4em 2em;
 }
 

--- a/app/routes/quotes/components/Quotes.css
+++ b/app/routes/quotes/components/Quotes.css
@@ -218,8 +218,7 @@
 
 @media (--small-viewport) {
   .quoteContainer {
-    margin: 0 15px;
-    width: 100%;
+    margin: 0;
     flex-direction: column;
   }
 

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -370,7 +370,7 @@ export default class UserProfile extends Component<Props, EventsProps> {
                 <GroupPill key={membership.id} group={membership.abakusGroup} />
               ))}
             </Flex>
-            <Flex>
+            <Flex wrap>
               {Object.keys(groupedMemberships).map((groupId) => (
                 <GroupBadge
                   memberships={groupedMemberships[groupId]}


### PR DESCRIPTION
* Add links to the tags in the bottom of articles to other articles with
the same tag.
* Flex-wrap and word-break in headers and profile badges
* Change color of active tag in /articles/ to the same color as hovered
tag, as it feels unintuitive to have them be different colors when it is
not a multi-select
* Change :hover to :active to prevent it displaying as if it were active
when disabling on mobile.