### PR TITLE
Route new announcement from event to detailed page view

### DIFF
--- a/app/components/AnnouncementInLine/index.js
+++ b/app/components/AnnouncementInLine/index.js
@@ -2,13 +2,13 @@
 import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import styles from './AnnouncementInLine.css';
-import type { ID } from 'app/models';
+import type { Group, Event } from 'app/models';
 import { useSelector } from 'react-redux';
 
 type Props = {
-  event?: ID,
-  meeting?: ID,
-  group?: ID,
+  event?: Event,
+  meeting?: Object,
+  group?: Group,
 };
 
 const AnnouncementInLine = ({ event, meeting, group }: Props) => {

--- a/app/components/AnnouncementInLine/index.js
+++ b/app/components/AnnouncementInLine/index.js
@@ -35,12 +35,6 @@ class AnnouncementInLine extends Component<Props, State> {
     sent: false,
   };
 
- 
-
-  handleOnClickAnnouncement = () => {
-
-  };
-
   render() {
     const {
       actionGrant,

--- a/app/components/AnnouncementInLine/index.js
+++ b/app/components/AnnouncementInLine/index.js
@@ -1,41 +1,37 @@
 // @flow
 import { Link } from 'react-router-dom';
-import { Component } from 'react';
 import Button from 'app/components/Button';
 import styles from './AnnouncementInLine.css';
 import type { ID } from 'app/models';
+import { useSelector } from 'react-redux';
 
 type Props = {
-  placeholder?: string,
   event?: ID,
   meeting?: ID,
   group?: ID,
-  createAnnouncement: (CreateAnnouncement) => Promise<*>,
-  handleSubmit: (Function) => void,
-  actionGrant: boolean,
-  hidden?: boolean,
-  button?: boolean,
-  className?: string,
 };
 
-class AnnouncementInLine extends Component<Props> {
-  render() {
-    const { actionGrant, event, meeting, group } = this.props;
+const AnnouncementInLine = ({ event, meeting, group }: Props) => {
+  const actionGrant = useSelector((state) => state.allowed.announcements);
 
-    return (
-      <div>
-        {actionGrant && (event || meeting || group) && (
-          <div>
-            <Link to={'/announcements'} state={{ event, meeting }}>
-              <Button className={styles.announcementButton}>
-                Ny kunngjøring
-              </Button>
-            </Link>
-          </div>
-        )}
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      {actionGrant && (event || meeting || group) && (
+        <div>
+          <Link
+            to={{
+              pathname: '/announcements',
+              state: { event, meeting, group },
+            }}
+          >
+            <Button className={styles.announcementButton}>
+              Ny kunngjøring
+            </Button>
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default AnnouncementInLine;

--- a/app/components/AnnouncementInLine/index.js
+++ b/app/components/AnnouncementInLine/index.js
@@ -15,22 +15,16 @@ const AnnouncementInLine = ({ event, meeting, group }: Props) => {
   const actionGrant = useSelector((state) => state.allowed.announcements);
 
   return (
-    <div>
-      {actionGrant && (event || meeting || group) && (
-        <div>
-          <Link
-            to={{
-              pathname: '/announcements',
-              state: { event, meeting, group },
-            }}
-          >
-            <Button className={styles.announcementButton}>
-              Ny kunngjøring
-            </Button>
-          </Link>
-        </div>
-      )}
-    </div>
+    actionGrant && (
+      <Link
+        to={{
+          pathname: '/announcements',
+          state: { event, meeting, group },
+        }}
+      >
+        <Button className={styles.announcementButton}>Ny kunngjøring</Button>
+      </Link>
+    )
   );
 };
 

--- a/app/components/AnnouncementInLine/index.js
+++ b/app/components/AnnouncementInLine/index.js
@@ -1,13 +1,7 @@
 // @flow
 import { Link } from 'react-router-dom';
-import { compose } from 'redux';
-import { connect } from 'react-redux';
-import cx from 'classnames';
 import { Component } from 'react';
 import Button from 'app/components/Button';
-import { Form, TextArea } from 'app/components/Form';
-import { reduxForm, Field, reset } from 'redux-form';
-import { createAnnouncement } from 'app/actions/AnnouncementsActions';
 import styles from './AnnouncementInLine.css';
 import type { ID } from 'app/models';
 
@@ -24,42 +18,19 @@ type Props = {
   className?: string,
 };
 
-type State = {
-  hidden: boolean,
-  sent: boolean,
-};
-
-class AnnouncementInLine extends Component<Props, State> {
-  state = {
-    hidden: true,
-    sent: false,
-  };
-
+class AnnouncementInLine extends Component<Props> {
   render() {
-    const {
-      actionGrant,
-      handleSubmit,
-      placeholder,
-      event,
-      meeting,
-      group,
-      button,
-      className,
-    } = this.props;
-
-    const showButton = button && this.state.hidden && !this.state.sent;
+    const { actionGrant, event, meeting, group } = this.props;
 
     return (
       <div>
         {actionGrant && (event || meeting || group) && (
           <div>
-            {showButton && (
-              <Link to={'/announcements'} state={{ event, meeting }}>
-                <Button className={styles.announcementButton}>
-                  Ny kunngjøring
-                </Button>
-              </Link>
-            )}
+            <Link to={'/announcements'} state={{ event, meeting }}>
+              <Button className={styles.announcementButton}>
+                Ny kunngjøring
+              </Button>
+            </Link>
           </div>
         )}
       </div>
@@ -67,27 +38,4 @@ class AnnouncementInLine extends Component<Props, State> {
   }
 }
 
-const resetForm = (result, dispatch) => {
-  dispatch(reset('announcementInline'));
-};
-
-const mapStateToProps = (state) => ({
-  actionGrant: state.allowed.announcements,
-});
-
-const mapDispatchToProps = { createAnnouncement };
-
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  reduxForm({
-    form: 'announcementInline',
-    onSubmitSuccess: resetForm,
-    validate(values) {
-      const errors = {};
-      if (!values.message) {
-        errors.message = 'Du må skrive en melding';
-      }
-      return errors;
-    },
-  })
-)(AnnouncementInLine);
+export default AnnouncementInLine;

--- a/app/components/AnnouncementInLine/index.js
+++ b/app/components/AnnouncementInLine/index.js
@@ -51,21 +51,18 @@ class AnnouncementInLine extends Component<Props, State> {
 
     return (
       <div>
-      {actionGrant && (event || meeting || group) && (
-        <div>
-          {showButton && (
-            <Link to={"/announcements"} state={{event}}>
-            <Button
-              onClick={this.handleOnClickAnnouncement}
-              className={styles.announcementButton}
-            >
-              Ny kunngjøring
-            </Button>
-            </Link>
-          )}
-        </div>
-      )}
-    </div>
+        {actionGrant && (event || meeting || group) && (
+          <div>
+            {showButton && (
+              <Link to={'/announcements'} state={{ event }}>
+                <Button className={styles.announcementButton}>
+                  Ny kunngjøring
+                </Button>
+              </Link>
+            )}
+          </div>
+        )}
+      </div>
     );
   }
 }

--- a/app/components/AnnouncementInLine/index.js
+++ b/app/components/AnnouncementInLine/index.js
@@ -1,5 +1,5 @@
 // @flow
-
+import { Link } from 'react-router-dom';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import cx from 'classnames';
@@ -9,7 +9,7 @@ import { Form, TextArea } from 'app/components/Form';
 import { reduxForm, Field, reset } from 'redux-form';
 import { createAnnouncement } from 'app/actions/AnnouncementsActions';
 import styles from './AnnouncementInLine.css';
-import type { CreateAnnouncement, ID } from 'app/models';
+import type { ID } from 'app/models';
 
 type Props = {
   placeholder?: string,
@@ -35,23 +35,10 @@ class AnnouncementInLine extends Component<Props, State> {
     sent: false,
   };
 
-  onSubmit = (announcement, event, meeting, group) => {
-    this.props.createAnnouncement({
-      ...announcement,
-      events: event ? [event] : [],
-      meetings: meeting ? [meeting] : [],
-      groups: group ? [group] : [],
-      send: true,
-    });
-    this.setState(() => ({
-      sent: true,
-    }));
-  };
+ 
 
-  handleHide = () => {
-    this.setState((prevState) => ({
-      hidden: !prevState.hidden,
-    }));
+  handleOnClickAnnouncement = () => {
+
   };
 
   render() {
@@ -67,55 +54,24 @@ class AnnouncementInLine extends Component<Props, State> {
     } = this.props;
 
     const showButton = button && this.state.hidden && !this.state.sent;
-    const showLabel = !button || !this.state.hidden || this.state.sent;
-    const showForm = !this.state.hidden && !this.state.sent;
 
     return (
       <div>
-        {actionGrant && (event || meeting || group) && (
-          <>
-            {showButton && (
-              <Button
-                onClick={this.handleHide}
-                className={styles.announcementButton}
-              >
-                Ny kunngjøring
-              </Button>
-            )}
-            {showLabel && (
-              <Button
-                flat
-                onClick={this.handleHide}
-                className={cx(
-                  button ? styles.labelButton : styles.label,
-                  className
-                )}
-              >
-                {!this.state.sent ? ' Ny kunngjøring ' : ' Kunngjøring sendt '}
-              </Button>
-            )}
-
-            {showForm && (
-              <Form
-                onSubmit={handleSubmit((values) =>
-                  this.onSubmit(values, event, meeting, group)
-                )}
-              >
-                <Field
-                  name="message"
-                  component={TextArea.Field}
-                  placeholder={placeholder || 'Skriv din kunngjøring her...'}
-                  fieldClassName={styles.field}
-                  className={styles.fieldText}
-                />
-                <Button submit size="small">
-                  Send
-                </Button>
-              </Form>
-            )}
-          </>
-        )}
-      </div>
+      {actionGrant && (event || meeting || group) && (
+        <div>
+          {showButton && (
+            <Link to={"/announcements"} state={{event}}>
+            <Button
+              onClick={this.handleOnClickAnnouncement}
+              className={styles.announcementButton}
+            >
+              Ny kunngjøring
+            </Button>
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
     );
   }
 }

--- a/app/components/AnnouncementInLine/index.js
+++ b/app/components/AnnouncementInLine/index.js
@@ -54,7 +54,7 @@ class AnnouncementInLine extends Component<Props, State> {
         {actionGrant && (event || meeting || group) && (
           <div>
             {showButton && (
-              <Link to={'/announcements'} state={{ event }}>
+              <Link to={'/announcements'} state={{ event, meeting }}>
                 <Button className={styles.announcementButton}>
                   Ny kunngjøring
                 </Button>

--- a/app/routes/announcements/components/AnnouncementsCreate.js
+++ b/app/routes/announcements/components/AnnouncementsCreate.js
@@ -30,10 +30,6 @@ const AnnouncementsCreate = ({
 
   const location = useLocation();
 
-  useEffect(() => {
-    l
-  })
-
   const onSubmit = (announcement, send = false) => {
     return createAnnouncement({
       ...announcement,

--- a/app/routes/announcements/components/AnnouncementsCreate.js
+++ b/app/routes/announcements/components/AnnouncementsCreate.js
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet-async';
 import Flex from 'app/components/Layout/Flex';
 import { Form, SelectInput, TextArea } from 'app/components/Form';
 import { reduxForm, Field, reset } from 'redux-form';
+import { useLocation } from 'react-router';
 import Button from 'app/components/Button';
 import { ContentMain } from 'app/components/Content';
 import type { ActionGrant, CreateAnnouncement } from 'app/models';
@@ -84,6 +85,7 @@ const AnnouncementsCreate = ({
                 component={SelectInput.AutocompleteField}
               />
               <Field
+                initialValues={location.state.meeting}
                 name="meetings"
                 placeholder="Møter"
                 filter={['meetings.meeting']}

--- a/app/routes/announcements/components/AnnouncementsCreate.js
+++ b/app/routes/announcements/components/AnnouncementsCreate.js
@@ -28,6 +28,12 @@ const AnnouncementsCreate = ({
 }: Props) => {
   const disabledButton = invalid || pristine || submitting;
 
+  const location = useLocation();
+
+  useEffect(() => {
+    l
+  })
+
   const onSubmit = (announcement, send = false) => {
     return createAnnouncement({
       ...announcement,
@@ -73,6 +79,7 @@ const AnnouncementsCreate = ({
             </Flex>
             <Flex className={styles.rowRec}>
               <Field
+                initialValues={location.state.event}
                 className={styles.recField}
                 name="events"
                 placeholder="Arrangementer"

--- a/app/routes/events/components/Admin.js
+++ b/app/routes/events/components/Admin.js
@@ -126,10 +126,7 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
             </li>
           )}
           <li>
-            <AnnouncementInLine
-              placeholder="Skriv en kunngjøring til alle påmeldte..."
-              event={event}
-            />
+            <AnnouncementInLine event={event} />
           </li>
         </ul>
       )}

--- a/app/routes/events/components/Admin.js
+++ b/app/routes/events/components/Admin.js
@@ -91,12 +91,6 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
             </li>
           )}
           <li>
-            <AnnouncementInLine
-              placeholder="Skriv en kunngjøring til alle påmeldte..."
-              event={event}
-            />
-          </li>
-          <li>
             {event.survey ? (
               <Link to={`/surveys/${event.survey}`}>
                 Gå til spørreundersøkelse
@@ -131,6 +125,12 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
               />
             </li>
           )}
+          <li>
+            <AnnouncementInLine
+              placeholder="Skriv en kunngjøring til alle påmeldte..."
+              event={event}
+            />
+          </li>
         </ul>
       )}
     </div>

--- a/app/routes/events/components/Admin.js
+++ b/app/routes/events/components/Admin.js
@@ -93,7 +93,7 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
           <li>
             <AnnouncementInLine
               placeholder="Skriv en kunngjøring til alle påmeldte..."
-              event={event.id}
+              event={event}
             />
           </li>
           <li>

--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -148,11 +148,7 @@ function InterestGroupDetail(props: Props) {
           />
           <Members group={group} members={group.memberships} />
           <Contact group={group} />
-          <AnnouncementInLine
-            placeholder="Skriv en kunngjøring til alle medlemmer..."
-            group={group}
-            button
-          />
+          <AnnouncementInLine group={group} />
         </ContentSidebar>
       </ContentSection>
     </Content>

--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -150,7 +150,7 @@ function InterestGroupDetail(props: Props) {
           <Contact group={group} />
           <AnnouncementInLine
             placeholder="Skriv en kunngjøring til alle medlemmer..."
-            group={group.id}
+            group={group}
             button
           />
         </ContentSidebar>

--- a/app/routes/meetings/components/MeetingDetail.js
+++ b/app/routes/meetings/components/MeetingDetail.js
@@ -194,7 +194,7 @@ class MeetingDetails extends Component<Props> {
                   <li>
                     <AnnouncementInLine
                       placeholder="Skriv en kunngjøring til alle inviterte..."
-                      meeting={meeting.id}
+                      meeting={meeting}
                       button
                     />
                   </li>

--- a/app/routes/meetings/components/MeetingDetail.js
+++ b/app/routes/meetings/components/MeetingDetail.js
@@ -192,11 +192,7 @@ class MeetingDetails extends Component<Props> {
                     <MazemapEmbed mazemapPoi={meeting.mazemapPoi} />
                   )}
                   <li>
-                    <AnnouncementInLine
-                      placeholder="Skriv en kunngjøring til alle inviterte..."
-                      meeting={meeting}
-                      button
-                    />
+                    <AnnouncementInLine meeting={meeting} />
                   </li>
                 </ul>
               </Card>


### PR DESCRIPTION
This was started in #2319 , but seemed to be abandoned.

Changes the "Ny kunngjøring" button on event, meeting and interest group pages to send you to the announcement creation form, instead of the inline form. Also fills in the correct group, meeting, or interest group automatically.

I fixed the prettier and flow issues, and some other issues that were left unsolved.