### PR TITLE
Add link to deployment in webkom/lego to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 [![open issues](https://badgen.net/github/open-issues/webkom/lego)](https://github.com/webkom/lego/issues)
 
+## Quick access
+
+1. [Quick Start](#quick-start)
+2. [Development](#development)
+3. [Deployment (webkom/lego#deployment)](https://github.com/webkom/lego#deployment)
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Add link to the deployment section in the webkom/lego README.md, and added a top-level table of contents for the README.md of this repo