### PR TITLE
Navigation cleanup

### DIFF
--- a/app/actions/GroupActions.js
+++ b/app/actions/GroupActions.js
@@ -107,7 +107,7 @@ export function editGroup(group: Object): Thunk<*> {
       })
     ).then(() =>
       group.type === 'interesse'
-        ? dispatch(push(`/interestgroups/${group.id}`))
+        ? dispatch(push(`/interest-groups/${group.id}`))
         : null
     );
 }
@@ -254,7 +254,7 @@ export function createGroup(group: Object): Thunk<*> {
         return;
       }
       const groupId = action.payload.result;
-      dispatch(push(`/interestgroups/${groupId}`));
+      dispatch(push(`/interest-groups/${groupId}`));
     });
   };
 }
@@ -278,5 +278,5 @@ export function removeGroup(id: string, group: Object): Thunk<*> {
               : 'Sletting av gruppe fullført',
         },
       })
-    ).then(() => dispatch(push('/interestgroups/')));
+    ).then(() => dispatch(push('/interest-groups/')));
 }

--- a/app/components/Feed/renders/group.js
+++ b/app/components/Feed/renders/group.js
@@ -61,7 +61,7 @@ export function getURL(aggregatedActivity: AggregatedActivity) {
   }
   switch (group.type) {
     case GroupTypeInterest:
-      return `/interestgroups/${group.id}`;
+      return `/interest-groups/${group.id}`;
     case GroupTypeCommittee:
       return `/pages/komiteer/${group.id}`;
     default:

--- a/app/components/NavigationTab/NavigationLink.css
+++ b/app/components/NavigationTab/NavigationLink.css
@@ -1,9 +1,14 @@
 .link {
-  display: inline-block;
+  display: inline;
   font-size: 20px;
   margin-right: 15px;
+  transition: all 125ms ease-in-out;
+
+  &:hover:not(.active) {
+    border-bottom: 2px solid var(--color-mono-gray-4);
+  }
 
   &.active {
-    font-weight: bold;
+    border-bottom: 2px solid var(--color-red-3);
   }
 }

--- a/app/components/NavigationTab/NavigationLink.js
+++ b/app/components/NavigationTab/NavigationLink.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Node } from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
 import styles from './NavigationLink.css';
 
@@ -13,14 +13,15 @@ type Props = {
 
 const NavigationLink = (props: Props) => {
   return (
-    <Link
+    <NavLink
+      exact
       to={props.to}
       onClick={props.onClick}
       className={styles.link}
       activeClassName={styles.active}
     >
       {props.children}
-    </Link>
+    </NavLink>
   );
 };
 

--- a/app/components/NavigationTab/NavigationTab.css
+++ b/app/components/NavigationTab/NavigationTab.css
@@ -2,9 +2,10 @@
 
 .container {
   display: flex;
+  flex-flow: row wrap;
+  align-items: center;
   justify-content: space-between;
   margin-bottom: 15px;
-  align-items: baseline;
 }
 
 .header {
@@ -26,27 +27,23 @@
   align-items: center;
 }
 
-@media (--mobile-device) {
-  .container {
-    flex-flow: column wrap;
-    align-items: flex-end;
-  }
+.back {
+  display: flex;
+  align-items: center;
+  width: fit-content;
 }
 
-@media (--small-viewport) {
-  .navigator {
-    flex-direction: row;
-    align-items: flex-end;
-  }
-}
-
-span.back {
+span.backLabel {
   font-weight: 600;
-  margin-left: 15px;
+  margin-left: 6px;
 }
 
 .backIcon {
-  vertical-align: middle;
+  transition: transform 150ms ease-in-out;
+}
+
+.back:hover > .backIcon {
+  transform: translateX(-3px);
 }
 
 .details {

--- a/app/components/NavigationTab/index.js
+++ b/app/components/NavigationTab/index.js
@@ -2,6 +2,7 @@
 
 import type { Node } from 'react';
 
+import { NavLink } from 'react-router-dom';
 import NavigationLink from './NavigationLink';
 import Icon from 'app/components/Icon';
 import styles from './NavigationTab.css';
@@ -20,27 +21,28 @@ type Props = {
   children?: Node,
 };
 
-const NavigationTab = (props: Props) => {
-  return (
-    <>
-      {props.back && (
-        <div>
-          <NavigationLink to={props.back.path}>
-            <Icon className={styles.backIcon} name="arrow-back" />
-            <span className={styles.back}>{props.back.label}</span>
-          </NavigationLink>
-        </div>
-      )}
-      <div className={cx(styles.container, props.className)}>
-        <h1 className={cx(styles.header, props.headerClassName)}>
-          {props.title}
-        </h1>
-        <div className={styles.navigator}>{props.children}</div>
-      </div>
-      <div className={styles.details}>{props.details}</div>
-    </>
-  );
-};
+const NavigationTab = (props: Props) => (
+  <>
+    {props.back && (
+      <NavLink to={props.back.path} className={styles.back}>
+        <Icon
+          size={19}
+          name="arrow-back"
+          prefix="ion-md-"
+          className={styles.backIcon}
+        />
+        <span className={styles.backLabel}>{props.back.label}</span>
+      </NavLink>
+    )}
+    <div className={cx(styles.container, props.className)}>
+      <h1 className={cx(styles.header, props.headerClassName)}>
+        {props.title}
+      </h1>
+      <div className={styles.navigator}>{props.children}</div>
+    </div>
+    <div className={styles.details}>{props.details}</div>
+  </>
+);
 
 export default NavigationTab;
 export { NavigationLink };

--- a/app/components/Search/utils.js
+++ b/app/components/Search/utils.js
@@ -45,9 +45,9 @@ const LINKS: Array<Link> = [
     url: 'https://readme.abakus.no',
   },
   {
-    key: 'interestGroups',
+    key: 'interest-groups',
     title: 'Interessegrupper',
-    url: '/interestgroups',
+    url: '/interest-groups',
   },
   {
     key: 'galleries',

--- a/app/reducers/groups.js
+++ b/app/reducers/groups.js
@@ -8,7 +8,7 @@ import { produce } from 'immer';
 export const resolveGroupLink = (group: { type: string, id: ID }) => {
   switch (group.type) {
     case GroupTypeInterest:
-      return `/interestgroups/${group.id}`;
+      return `/interest-groups/${group.id}`;
     case GroupTypeCommittee:
       return `/pages/komiteer/${group.id}`;
     default:

--- a/app/routes/app/AppRoute.js
+++ b/app/routes/app/AppRoute.js
@@ -156,7 +156,7 @@ class App extends PureComponent<AppProps> {
   }
 }
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
   const upcomingMeetings = Object.values(state.meetings.byId)
     .filter((meeting: any) => moment(meeting.endTime).isAfter(moment()))
     .sort((meetingA: any, meetingB: any) =>
@@ -175,7 +175,7 @@ function mapStateToProps(state) {
     upcomingMeeting: upcomingMeetings.length ? upcomingMeetings[0] : undefined,
     loading: state.frontpage.fetching,
   };
-}
+};
 
 const mapDispatchToProps = {
   toggleSearch,

--- a/app/routes/bdb/utils.js
+++ b/app/routes/bdb/utils.js
@@ -6,6 +6,7 @@ import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import type { Semester, CompanySemesterContactedStatus } from 'app/models';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
+import Button from 'app/components/Button';
 
 import { sortBy } from 'lodash';
 
@@ -179,17 +180,19 @@ export const DetailNavigation = ({
   companyId: number,
   deleteFunction: (number) => Promise<*>,
 }) => (
-  <NavigationTab title={title}>
-    <NavigationLink to="/bdb">Tilbake til liste</NavigationLink>
+  <NavigationTab
+    title={title}
+    back={{ label: 'Tilbake til liste', path: '/bdb' }}
+  >
     <NavigationLink to={`/bdb/${companyId}`}>Bedriftens side</NavigationLink>
-    <NavigationLink to="/bdb/add">Ny bedrift</NavigationLink>
-    <NavigationLink to={`/bdb/${companyId}/edit`}>Endre</NavigationLink>
+    <NavigationLink to={`/bdb/${companyId}/edit`}>Rediger</NavigationLink>
+    <NavigationLink to={'/bdb/add'}>Ny bedrift</NavigationLink>
     <ConfirmModalWithParent
       title="Slett bedrift"
       message="Er du sikker på at du vil slette denne bedriften?"
       onConfirm={() => deleteFunction(companyId)}
     >
-      <NavigationLink to="#">Slett</NavigationLink>
+      <Button danger>Slett</Button>
     </ConfirmModalWithParent>
   </NavigationTab>
 );

--- a/app/routes/company/components/CompanyDetail.js
+++ b/app/routes/company/components/CompanyDetail.js
@@ -9,7 +9,6 @@ import { Image } from 'app/components/Image';
 import InfoBubble from 'app/components/InfoBubble';
 import { Link } from 'react-router-dom';
 import NavigationTab from 'app/components/NavigationTab';
-import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import { jobType, Year } from 'app/routes/joblistings/components/Items';
 import Icon from 'app/components/Icon';
 import moment from 'moment-timezone';
@@ -178,9 +177,10 @@ const CompanyDetail = (props: Props) => {
         </div>
       )}
 
-      <NavigationTab title={company.name}>
-        <NavigationLink to="/companies">Tilbake til liste</NavigationLink>
-      </NavigationTab>
+      <NavigationTab
+        title={company.name}
+        back={{ label: 'Tilbake til liste', path: '/companies' }}
+      />
 
       <div className={styles.description}>
         <p>{company.description}</p>

--- a/app/routes/companyInterest/utils.js
+++ b/app/routes/companyInterest/utils.js
@@ -18,8 +18,10 @@ export const sortSemesterChronologically = (
 };
 
 export const SemesterNavigation = ({ title }: { title: Node }) => (
-  <NavigationTab title={title}>
-    <NavigationLink to="/companyInterest/">Tilbake til skjema</NavigationLink>
+  <NavigationTab
+    title={title}
+    back={{ label: 'Tilbake til skjema', path: '/companyInterest/' }}
+  >
     <NavigationLink to="/bdb">BDB</NavigationLink>
     <NavigationLink to="/bdb/add">Ny bedrift</NavigationLink>
   </NavigationTab>

--- a/app/routes/events/components/Toolbar.js
+++ b/app/routes/events/components/Toolbar.js
@@ -31,8 +31,8 @@ class Toolbar extends Component<Props, State> {
         </div>
 
         <NavLink
+          exact
           to="/events"
-          exact={true}
           activeClassName={styles.active}
           className={cx(styles.pickerItem, styles.list)}
         >
@@ -48,7 +48,7 @@ class Toolbar extends Component<Props, State> {
         </NavLink>
 
         <div className={styles.create}>
-          {actionGrant && actionGrant.includes('create') && (
+          {actionGrant?.includes('create') && (
             <Link to="/events/create">Lag nytt</Link>
           )}
         </div>

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -58,7 +58,7 @@ const AppWrapper = (props) => (
           <Route path="/events" component={Events} />
           <Route path="/companies" component={Companies} />
           <Route path={['/contact', '/kontakt']} component={Contact} />
-          <Route path="/interestgroups" component={InterestGroups} />
+          <Route path="/interest-groups" component={InterestGroups} />
           <Route path="/joblistings" component={Joblistings} />
           <Route path="/meetings" component={Meetings} />
           <Route path="/pages" component={Pages} />

--- a/app/routes/interestgroups/components/InterestGroup.js
+++ b/app/routes/interestgroups/components/InterestGroup.js
@@ -18,7 +18,7 @@ const InterestGroupComponent = ({ group, active }: Props) => {
   return (
     <Flex className={styles.listItem}>
       <Flex column className={styles.listItemContent} style={{ flex: '1' }}>
-        <Link to={`/interestgroups/${group.id}`} className={styles.link}>
+        <Link to={`/interest-groups/${group.id}`} className={styles.link}>
           <h2 style={!active ? { color: 'grey' } : {}}>{group.name}</h2>
         </Link>
         {active && (

--- a/app/routes/interestgroups/components/InterestGroupCreate.js
+++ b/app/routes/interestgroups/components/InterestGroupCreate.js
@@ -2,9 +2,8 @@
 import { Component } from 'react';
 import { Helmet } from 'react-helmet-async';
 import GroupForm from 'app/components/GroupForm';
-import { Flex } from 'app/components/Layout';
 import { Content } from 'app/components/Content';
-import { Link } from 'react-router-dom';
+import NavigationTab from 'app/components/NavigationTab';
 
 export default class InterestGroupEdit extends Component<{
   initialValues: Object,
@@ -18,17 +17,11 @@ export default class InterestGroupEdit extends Component<{
     return (
       <Content>
         <Helmet title="Opprett gruppe" />
-        <h2>
-          <Link to="/interestGroups/">
-            <i className="fa fa-angle-left" />
-            Tilbake
-          </Link>
-        </h2>
-        <Flex justifyContent="space-between" alignItems="baseline">
-          <div>
-            <h1>Opprett gruppe</h1>
-          </div>
-        </Flex>
+        <NavigationTab
+          title="Opprett Gruppe"
+          back={{ label: 'Tilbake', path: '/interest-groups' }}
+        />
+
         <GroupForm
           handleSubmitCallback={handleSubmitCallback}
           uploadFile={uploadFile}

--- a/app/routes/interestgroups/components/InterestGroupDetail.js
+++ b/app/routes/interestgroups/components/InterestGroupDetail.js
@@ -24,12 +24,14 @@ type TitleProps = {
 };
 
 const Title = ({ group: { name, id }, showEdit }: TitleProps) => (
-  <NavigationTab title={name}>
-    <NavigationLink to="/interestgroups/">
-      <i className="fa fa-angle-left" /> Tilbake
-    </NavigationLink>
+  <NavigationTab
+    title={name}
+    back={{ label: 'Tilbake', path: '/interest-groups' }}
+  >
     {showEdit && (
-      <NavigationLink to={`/interestgroups/${id}/edit`}>Rediger</NavigationLink>
+      <NavigationLink to={`/interest-groups/${id}/edit`}>
+        Rediger
+      </NavigationLink>
     )}
   </NavigationTab>
 );

--- a/app/routes/interestgroups/components/InterestGroupEdit.js
+++ b/app/routes/interestgroups/components/InterestGroupEdit.js
@@ -3,7 +3,7 @@ import { Component } from 'react';
 import { Helmet } from 'react-helmet-async';
 import GroupForm from 'app/components/GroupForm';
 import { Content } from 'app/components/Content';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 
 export default class InterestGroupEdit extends Component<{
   interestGroup: Object,
@@ -18,11 +18,13 @@ export default class InterestGroupEdit extends Component<{
     return (
       <Content>
         <Helmet title={`Redigerer: ${interestGroup.name}`} />
-        <NavigationTab title={`Redigerer: ${interestGroup.name}`}>
-          <NavigationLink to={`/interestGroups/${interestGroup.id}`}>
-            <i className="fa fa-angle-left" /> Tilbake
-          </NavigationLink>
-        </NavigationTab>
+        <NavigationTab
+          title={`Redigerer: ${interestGroup.name}`}
+          back={{
+            label: 'Tilbake',
+            path: `/interest-groups/${interestGroup.id}`,
+          }}
+        />
         <GroupForm
           handleSubmitCallback={handleSubmitCallback}
           group={interestGroup}

--- a/app/routes/interestgroups/components/InterestGroupList.js
+++ b/app/routes/interestgroups/components/InterestGroupList.js
@@ -6,7 +6,7 @@ import InterestGroupComponent from './InterestGroup';
 import Button from 'app/components/Button';
 import { Content } from 'app/components/Content';
 import { Link } from 'react-router-dom';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 import type { ActionGrant, Group } from 'app/models';
 
 export type Props = {
@@ -29,22 +29,19 @@ const InterestGroupList = ({ actionGrant, interestGroups }: Props) => {
     <Content>
       <Helmet title="Interessegrupper" />
       <div className={styles.section}>
-        <div>
-          <NavigationTab title="Interessegrupper">
-            <NavigationLink to="/">
-              <i className="fa fa-angle-left" /> Hjem
-            </NavigationLink>
-          </NavigationTab>
-          <p>
-            <Link to="/pages/generelt/39-praktisk-informasjon">Her</Link> finner
-            du all praktisk informasjon knyttet til våre interessegrupper.
-          </p>
-          {canCreate && (
-            <Link to="/interestgroups/create" className={styles.link}>
-              <Button>Lag ny interessegruppe</Button>
-            </Link>
-          )}
-        </div>
+        <NavigationTab
+          title="Interessegrupper"
+          back={{ label: 'Hjem', path: '/' }}
+        />
+        <p>
+          <Link to="/pages/generelt/39-praktisk-informasjon">Her</Link> finner
+          du all praktisk informasjon knyttet til våre interessegrupper.
+        </p>
+        {canCreate && (
+          <Link to="/interest-groups/create" className={styles.link}>
+            <Button>Lag ny interessegruppe</Button>
+          </Link>
+        )}
       </div>
       <div className="groups">
         {activeGroups.map((g) => (

--- a/app/routes/interestgroups/index.js
+++ b/app/routes/interestgroups/index.js
@@ -42,5 +42,5 @@ const interestGroupRoute = ({ match }: { match: { path: string } }) => (
 );
 
 export default function InterestGroups() {
-  return <Route path="/interestgroups" component={interestGroupRoute} />;
+  return <Route path="/interest-groups" component={interestGroupRoute} />;
 }

--- a/app/routes/meetings/MeetingDetailLoginRoute.js
+++ b/app/routes/meetings/MeetingDetailLoginRoute.js
@@ -4,7 +4,6 @@ import { push } from 'connected-react-router';
 import {
   fetchMeeting,
   setInvitationStatus,
-  deleteMeeting,
 } from 'app/actions/MeetingActions';
 import {
   selectMeetingById,
@@ -21,7 +20,6 @@ import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 
 const mapDispatchToProps = {
   setInvitationStatus,
-  deleteMeeting,
   fetchMeeting,
   push,
 };

--- a/app/routes/meetings/MeetingDetailLoginRoute.js
+++ b/app/routes/meetings/MeetingDetailLoginRoute.js
@@ -1,10 +1,7 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { push } from 'connected-react-router';
-import {
-  fetchMeeting,
-  setInvitationStatus,
-} from 'app/actions/MeetingActions';
+import { fetchMeeting, setInvitationStatus } from 'app/actions/MeetingActions';
 import {
   selectMeetingById,
   selectCommentsForMeeting,

--- a/app/routes/meetings/MeetingDetailRoute.js
+++ b/app/routes/meetings/MeetingDetailRoute.js
@@ -5,7 +5,6 @@ import { compose } from 'redux';
 import {
   fetchMeeting,
   setInvitationStatus,
-  deleteMeeting,
   answerMeetingInvitation,
   resetMeetingsToken,
 } from 'app/actions/MeetingActions';
@@ -92,7 +91,6 @@ const MeetingComponent = (props: Props) => {
 const mapDispatchToProps = {
   fetchMeeting,
   setInvitationStatus,
-  deleteMeeting,
   resetMeetingsToken,
   deleteComment,
 };

--- a/app/routes/meetings/MeetingEditRoute.js
+++ b/app/routes/meetings/MeetingEditRoute.js
@@ -8,6 +8,7 @@ import {
   editMeeting,
   fetchMeeting,
   inviteUsersAndGroups,
+  deleteMeeting,
 } from 'app/actions/MeetingActions';
 import { formValueSelector } from 'redux-form';
 import { selectMeetingById } from 'app/reducers/meetings';
@@ -21,6 +22,7 @@ const mapDispatchToProps = {
   fetchMeeting,
   inviteUsersAndGroups,
   push,
+  deleteMeeting,
 };
 
 const mapStateToProps = (state, props) => {

--- a/app/routes/meetings/components/MeetingDetail.css
+++ b/app/routes/meetings/components/MeetingDetail.css
@@ -1,5 +1,3 @@
-@import '~app/styles/variables.css';
-
 .root {
   composes: contentContainer from '~app/styles/utilities.css';
 }

--- a/app/routes/meetings/components/MeetingDetail.js
+++ b/app/routes/meetings/components/MeetingDetail.js
@@ -17,7 +17,6 @@ import DisplayContent from 'app/components/DisplayContent';
 import urlifyString from 'app/utils/urlifyString';
 import {
   Content,
-  ContentHeader,
   ContentSection,
   ContentSidebar,
   ContentMain,
@@ -125,7 +124,6 @@ class MeetingDetails extends Component<Props> {
 
     const actionGrant = meeting?.actionGrant;
 
-    const canDelete = actionGrant?.includes('delete');
     const canEdit = actionGrant?.includes('edit');
 
     const infoItems = [
@@ -155,28 +153,24 @@ class MeetingDetails extends Component<Props> {
       <div>
         <Helmet title={meeting.title} />
         <Content>
-          <ContentHeader className={styles.heading}>
-            <div style={{ flex: 1 }}>
-              <NavigationTab
-                title={meeting.title}
-                className={styles.detailTitle}
-                back={{ label: 'Mine møter', path: '/meetings' }}
-              >
-                {canEdit && (
-                  <NavigationLink to={`/meetings/${meeting.id}/edit`}>
-                    Rediger
-                  </NavigationLink>
-                )}
-              </NavigationTab>
-              <h3>
-                <Time
-                  style={{ color: 'grey' }}
-                  time={meeting.startTime}
-                  format="ll [-] HH:mm"
-                />
-              </h3>
-            </div>
-          </ContentHeader>
+          <NavigationTab
+            title={meeting.title}
+            className={styles.detailTitle}
+            details={
+              <Time
+                style={{ color: 'grey' }}
+                time={meeting.startTime}
+                format="ll [-] HH:mm"
+              />
+            }
+            back={{ label: 'Mine møter', path: '/meetings' }}
+          >
+            {canEdit && (
+              <NavigationLink to={`/meetings/${meeting.id}/edit`}>
+                Rediger
+              </NavigationLink>
+            )}
+          </NavigationTab>
 
           <ContentSection>
             <ContentMain>

--- a/app/routes/meetings/components/MeetingDetail.js
+++ b/app/routes/meetings/components/MeetingDetail.js
@@ -5,7 +5,6 @@ import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import Time, { FromToTime } from 'app/components/Time';
 import CommentView from 'app/components/Comments/CommentView';
-import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import styles from './MeetingDetail.css';
 import Card from 'app/components/Card';
 import Button from 'app/components/Button';
@@ -39,7 +38,6 @@ type Props = {
   currentUser: UserEntity,
   showAnswer: Boolean,
   meetingInvitations: Array<MeetingInvitationEntity>,
-  deleteMeeting: (number) => Promise<*>,
   setInvitationStatus: (
     meetingId: number,
     status: MeetingInvitationStatus,
@@ -108,11 +106,6 @@ class MeetingDetails extends Component<Props> {
       </li>
     );
 
-  onDeleteMeeting = () =>
-    this.props
-      .deleteMeeting(this.props.meeting.id)
-      .then(() => this.props.push('/meetings/'));
-
   render() {
     const {
       meeting,
@@ -128,12 +121,12 @@ class MeetingDetails extends Component<Props> {
     if (!meeting || !currentUser) {
       return <LoadingIndicator loading />;
     }
-    const statusMe = currentUserInvitation && currentUserInvitation.status;
+    const statusMe = currentUserInvitation?.status;
 
-    const actionGrant = meeting && meeting.actionGrant;
+    const actionGrant = meeting?.actionGrant;
 
-    const canDelete = actionGrant && actionGrant.includes('delete');
-    const canEdit = actionGrant && actionGrant.includes('edit');
+    const canDelete = actionGrant?.includes('delete');
+    const canEdit = actionGrant?.includes('edit');
 
     const infoItems = [
       {
@@ -167,23 +160,12 @@ class MeetingDetails extends Component<Props> {
               <NavigationTab
                 title={meeting.title}
                 className={styles.detailTitle}
+                back={{ label: 'Mine møter', path: '/meetings' }}
               >
-                <NavigationLink to="/meetings">
-                  <i className="fa fa-angle-left" /> Mine møter
-                </NavigationLink>
                 {canEdit && (
                   <NavigationLink to={`/meetings/${meeting.id}/edit`}>
-                    Endre møte
+                    Rediger
                   </NavigationLink>
-                )}
-                {canDelete && (
-                  <ConfirmModalWithParent
-                    title="Slett møte"
-                    message="Er du sikker på at du vil slette møtet?"
-                    onConfirm={this.onDeleteMeeting}
-                  >
-                    <NavigationLink to="#">Slett møte</NavigationLink>
-                  </ConfirmModalWithParent>
                 )}
               </NavigationTab>
               <h3>

--- a/app/routes/meetings/components/MeetingEditor.js
+++ b/app/routes/meetings/components/MeetingEditor.js
@@ -5,7 +5,7 @@ import styles from './MeetingEditor.css';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { Field } from 'redux-form';
 import { AttendanceStatus } from 'app/components/UserAttendance';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import { useHistory } from 'react-router-dom';
 
@@ -58,6 +58,8 @@ function MeetingEditor({
   initialized,
   deleteMeeting,
 }: Props) {
+  const history = useHistory();
+
   const isEditPage = meetingId !== undefined;
 
   if (isEditPage && !meeting) {
@@ -84,8 +86,6 @@ function MeetingEditor({
     invitingUsers,
     'value'
   );
-
-  const history = useHistory();
 
   const onDeleteMeeting = async () =>
     await deleteMeeting(meeting?.id).then(() => history.push('/meetings/'));

--- a/app/routes/meetings/components/MeetingEditor.js
+++ b/app/routes/meetings/components/MeetingEditor.js
@@ -6,6 +6,8 @@ import LoadingIndicator from 'app/components/LoadingIndicator';
 import { Field } from 'redux-form';
 import { AttendanceStatus } from 'app/components/UserAttendance';
 import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
+import { useHistory } from 'react-router-dom';
 
 import {
   Form,
@@ -39,6 +41,7 @@ type Props = {
   push: (string) => void,
   inviteUsersAndGroups: (Object) => Promise<*>,
   initialized: boolean,
+  deleteMeeting: (number) => Promise<*>,
 };
 
 function MeetingEditor({
@@ -53,6 +56,7 @@ function MeetingEditor({
   meetingInvitations,
   push,
   initialized,
+  deleteMeeting,
 }: Props) {
   const isEditPage = meetingId !== undefined;
 
@@ -81,6 +85,14 @@ function MeetingEditor({
     'value'
   );
 
+  const history = useHistory();
+
+  const onDeleteMeeting = async () =>
+    await deleteMeeting(meeting?.id).then(() => history.push('/meetings/'));
+
+  const actionGrant = meeting?.actionGrant;
+  const canDelete = actionGrant?.includes('delete');
+
   return (
     <div className={styles.root}>
       <Helmet
@@ -89,11 +101,8 @@ function MeetingEditor({
       <NavigationTab
         title={isEditPage ? `Redigerer: ${meeting.title}` : 'Nytt møte'}
         className={styles.detailTitle}
-      >
-        <NavigationLink to="/meetings/">
-          <i className="fa fa-angle-left" /> Mine møter
-        </NavigationLink>
-      </NavigationTab>
+        back={{ label: 'Mine møter', path: '/meetings' }}
+      />
       <Form onSubmit={handleSubmit}>
         <Field
           name="title"
@@ -210,6 +219,15 @@ function MeetingEditor({
         <Button success={isEditPage} disabled={pristine || submitting} submit>
           {isEditPage ? 'Lagre endringer' : 'Opprett møte'}
         </Button>
+        {isEditPage && canDelete && (
+          <ConfirmModalWithParent
+            title="Slett møte"
+            message="Er du sikker på at du vil slette møtet?"
+            onConfirm={onDeleteMeeting}
+          >
+            <Button danger>Slett møte</Button>
+          </ConfirmModalWithParent>
+        )}
       </Form>
     </div>
   );

--- a/app/routes/pages/components/PageEditor.js
+++ b/app/routes/pages/components/PageEditor.js
@@ -16,7 +16,7 @@ import {
   ObjectPermissions,
 } from 'app/components/Form';
 import ImageUpload from 'app/components/Upload/ImageUpload';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 import { Field, Fields } from 'redux-form';
 import { Content } from 'app/components/Content';
 import { get } from 'lodash';
@@ -130,11 +130,10 @@ export default class PageEditor extends Component<Props, State> {
 
     return (
       <Content>
-        <NavigationTab title={page.title}>
-          <NavigationLink to={backUrl}>
-            <i className="fa fa-angle-left" /> Tilbake
-          </NavigationLink>
-        </NavigationTab>
+        <NavigationTab
+          title={page.title}
+          back={{ label: 'Tilbake', path: backUrl }}
+        />
         <Form onSubmit={handleSubmit(withSubmissionError(this.onSubmit))}>
           <div className={styles.coverImage}>
             <ImageUpload

--- a/app/routes/photos/components/GalleryDetail.js
+++ b/app/routes/photos/components/GalleryDetail.js
@@ -148,7 +148,7 @@ export default class GalleryDetail extends Component<Props, State> {
           >
             <i className="fa fa-angle-left" /> Tilbake
           </NavigationLink>
-          {actionGrant && actionGrant.includes('edit') && (
+          {actionGrant?.includes('edit') && (
             <div>
               <NavigationLink to="#" onClick={() => this.toggleUpload()}>
                 Last opp bilder

--- a/app/routes/photos/components/GalleryEditor.js
+++ b/app/routes/photos/components/GalleryEditor.js
@@ -4,7 +4,7 @@ import { Component } from 'react';
 import { Helmet } from 'react-helmet-async';
 import cx from 'classnames';
 import moment from 'moment-timezone';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 import Button from 'app/components/Button';
 import {
   TextInput,
@@ -187,11 +187,8 @@ class GalleryEditor extends Component<Props, State> {
         />
         <NavigationTab
           title={gallery ? `Redigerer: ${gallery.title}` : 'Nytt album'}
-        >
-          <NavigationLink to="/photos">
-            <i className="fa fa-angle-left" /> Tilbake
-          </NavigationLink>
-        </NavigationTab>
+          back={{ label: 'Tilbake', path: '/photos' }}
+        />
         <Form onSubmit={handleSubmit}>
           <Field
             placeholder="Title"

--- a/app/routes/podcasts/components/PodcastEditor.js
+++ b/app/routes/podcasts/components/PodcastEditor.js
@@ -2,7 +2,7 @@
 
 import { Component } from 'react';
 import { Content } from 'app/components/Content';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 import Button from 'app/components/Button';
 import {
   TextInput,
@@ -45,9 +45,10 @@ class PodcastEditor extends Component<Props, *> {
 
     return (
       <Content>
-        <NavigationTab title={header}>
-          <NavigationLink to="/podcasts/">Tilbake</NavigationLink>
-        </NavigationTab>
+        <NavigationTab
+          title={header}
+          back={{ label: 'Tilbake', path: '/podcasts' }}
+        />
         <Form onSubmit={handleSubmit}>
           <Field
             name="source"

--- a/app/routes/polls/components/PollDetail.js
+++ b/app/routes/polls/components/PollDetail.js
@@ -3,9 +3,9 @@
 import { Component } from 'react';
 import { Content } from 'app/components/Content';
 import { Helmet } from 'react-helmet-async';
-import Button from 'app/components/Button';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 import Poll from 'app/components/Poll';
+import Button from 'app/components/Button';
 import PollEditor from './PollEditor';
 import { type PollEntity } from 'app/reducers/polls';
 import { type ActionGrant, type ID } from 'app/models';
@@ -39,8 +39,10 @@ class PollDetail extends Component<Props, State> {
     return (
       <Content>
         <Helmet title={this.props.poll.title} />
-        <NavigationTab title={this.props.poll.title}>
-          <NavigationLink to="/polls/">Tilbake</NavigationLink>
+        <NavigationTab
+          title={this.props.poll.title}
+          back={{ label: 'Tilbake', path: '/polls' }}
+        >
           {this.props.actionGrant.includes('edit') && (
             <Button onClick={this.toggleEdit}>
               {this.state.editing ? 'Avbryt' : 'Rediger'}

--- a/app/routes/polls/components/PollEditor.js
+++ b/app/routes/polls/components/PollEditor.js
@@ -5,11 +5,10 @@ import type { Node } from 'react';
 import { Component } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Content } from 'app/components/Content';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 import Button from 'app/components/Button';
 import Icon from 'app/components/Icon';
 import Tooltip from 'app/components/Tooltip';
-import { Link } from 'react-router-dom';
 import {
   typeof fieldArrayMetaPropTypes,
   typeof fieldArrayFieldsPropTypes,
@@ -102,9 +101,10 @@ class EditPollForm extends Component<Props, *> {
       <Content>
         <Helmet title={editing ? `Redigerer avstemning` : 'Ny avstemning'} />
         {!editing && (
-          <NavigationTab title="Ny avstemning">
-            <NavigationLink to="/polls">Tilbake</NavigationLink>
-          </NavigationTab>
+          <NavigationTab
+            title="Ny avstemning"
+            back={{ label: 'Tilbake', path: '/polls' }}
+          />
         )}
         <Form onSubmit={handleSubmit}>
           <Field

--- a/app/routes/quotes/utils.js
+++ b/app/routes/quotes/utils.js
@@ -7,7 +7,7 @@ export const navigation = (title: string, actionGrant: Array<string>) => (
     <NavigationLink to="/quotes/">Sitater</NavigationLink>
     {actionGrant.indexOf('approve') !== -1 && (
       <NavigationLink to="/quotes?approved=false">
-        Ikke godkjente sitater
+        Ikke-godkjente sitater
       </NavigationLink>
     )}
     <NavigationLink to="/quotes/add">Legg til sitat</NavigationLink>

--- a/app/routes/users/components/UserSettingsIndex.js
+++ b/app/routes/users/components/UserSettingsIndex.js
@@ -29,7 +29,7 @@ const UserSettingsIndex = (props: Props) => {
       <Helmet title="Innstillinger" />
       <NavigationTab title="Innstillinger">
         {props.isMe && (
-          <div>
+          <>
             <NavigationLink to={`${base}/profile`}>Profil</NavigationLink>
             <NavigationLink to={`${base}/notifications`}>
               Notifikasjoner
@@ -40,7 +40,7 @@ const UserSettingsIndex = (props: Props) => {
                 Verifiser studentstatus
               </NavigationLink>
             )}
-          </div>
+          </>
         )}
       </NavigationTab>
       {props.children &&

--- a/cypress/integration/router_spec.js
+++ b/cypress/integration/router_spec.js
@@ -176,7 +176,7 @@ describe('Create event', () => {
     cy.contains('Albumer');
 
     // Interestgroups
-    openMenuAndSelect('Interessegrupper', '/interestgroups');
+    openMenuAndSelect('Interessegrupper', '/interest-groups');
     cy.contains('Interessegrupper');
 
     // Joblistings


### PR DESCRIPTION
## I made some changes to the navigation
- Employ the generic `back` property of `NavigationTab` and do some general clean up of the navigation.
- Improve `NavigationLink` with active and hover effects. The active effect was no longer working due to it being removed from `Link`. I think the active effect will make the navigation tab more "visible", e.g. in the settings page, on which _Notifikasjoner_ and _OAuth2_ is quite hidden and unknown to many users.  
- Move meeting deletion to the edit page, as I find it more fitting.

### Showcase of the new `NavigationTab` style
![newNavigationTab](https://user-images.githubusercontent.com/69514187/171071337-c2b9f175-5332-454a-8c7d-932a62daf338.gif)

### The _back_ link also got a retouch
![newback](https://user-images.githubusercontent.com/69514187/171158141-f9449439-f357-4072-bbb3-18df3da2be8a.gif)