### PR TITLE
Fix quotes

### DIFF
--- a/app/components/NavigationTab/NavigationLink.js
+++ b/app/components/NavigationTab/NavigationLink.js
@@ -12,9 +12,16 @@ type Props = {
 };
 
 const NavigationLink = (props: Props) => {
+  // Custom isActive function as NavLink does not compare query params by default
+  const isActive = (match, location) => {
+    const regex = /\/+$/i; // Regex to remove trailing / for comparison
+    const comparePath = location.pathname + location.search;
+    return props.to.replace(regex, '') === comparePath.replace(regex, '');
+  };
   return (
     <NavLink
       exact
+      isActive={isActive}
       to={props.to}
       onClick={props.onClick}
       className={styles.link}

--- a/app/reducers/quotes.js
+++ b/app/reducers/quotes.js
@@ -84,7 +84,7 @@ export default createEntityReducer({
 export const selectQuotes = createSelector(
   (state) => state.quotes.byId,
   (state) => state.quotes.items,
-  (_, items, props) => props?.pagination,
+  (_, props) => props?.pagination,
   (quotesById, items, pagination) =>
     (pagination ? pagination.items : items).map(
       (quoteId) => quotesById[quoteId]

--- a/app/routes/quotes/QuotesRoute.js
+++ b/app/routes/quotes/QuotesRoute.js
@@ -29,7 +29,9 @@ const mapStateToProps = (state, props) => {
   })(state);
   const emojis = selectEmojis(state);
   return {
-    quotes: selectQuotes(state, { pagination }),
+    quotes: selectQuotes(state, {
+      pagination,
+    }),
     query: pagination.query,
     actionGrant: state.quotes.actionGrant,
     showFetchMore: pagination.hasMore,

--- a/app/routes/quotes/components/QuotePage.js
+++ b/app/routes/quotes/components/QuotePage.js
@@ -9,6 +9,7 @@ import Button from 'app/components/Button';
 import type { ActionGrant, ID } from 'app/models';
 import type { QuoteEntity } from 'app/reducers/quotes';
 import type { EmojiEntity } from 'app/reducers/emojis';
+import LoadingIndicator from 'app/components/LoadingIndicator';
 
 type Props = {
   reactions: Array<Object>,
@@ -28,6 +29,7 @@ type Props = {
     contentTarget: string,
   }) => Promise<*>,
   deleteReaction: ({ reactionId: ID, contentTarget: string }) => Promise<*>,
+  fetching: boolean,
   fetchEmojis: () => Promise<*>,
   fetchingEmojis: boolean,
   emojis: Array<EmojiEntity>,
@@ -48,11 +50,12 @@ export default function QuotePage({
   addReaction,
   deleteReaction,
   emojis,
+  fetching,
   fetchEmojis,
   fetchingEmojis,
 }: Props) {
   let errorMessage = undefined;
-  if (quotes.length === 0) {
+  if (quotes.length === 0 && !fetching) {
     errorMessage =
       query.approved === 'false'
         ? 'Ingen sitater venter på godkjenning.'
@@ -61,9 +64,7 @@ export default function QuotePage({
   return (
     <div className={cx(styles.root, styles.quoteContainer)}>
       <Helmet title="Overhørt" />
-
       {navigation('Overhørt', actionGrant)}
-
       {errorMessage || (
         <QuoteList
           approve={approve}
@@ -82,9 +83,11 @@ export default function QuotePage({
         />
       )}
       {showFetchMore && (
-        <Button onClick={() => fetchAll({ query, next: true })}>
-          Last inn flere
-        </Button>
+        <LoadingIndicator loading={fetching}>
+          <Button onClick={() => fetchAll({ query, next: true })}>
+            Last inn flere
+          </Button>
+        </LoadingIndicator>
       )}
     </div>
   );


### PR DESCRIPTION
This PR fixes a few things that has been bugging me about the quotes page. First and foremost this PR fixes the issue where the page would show all the quotes in the redux state, regardless of approved status. So approved quotes would be shown when viewing unapproved quotes, and vice versa.
This PR also fixes the NavLink component so that it takes query params into account. Why react-router does not do this by default is beyond me, but at this point I have come to believe that the maintainers of that repo makes changes just to mess with people. 
In addition it adds a loading indicator to the quotelist. 

I am not sure if I did the selector stuff correctly, so feel free to correct me if it is wrong.