### PR TITLE
Implement styling changes, particularly on the Joblistings page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
     'react-hooks',
     'react-redux',
   ],
+  ignorePatterns: ['mazemap/mazemap.min.*', '**/vendor/*.js'],
   rules: {
     'react/jsx-uses-react': 'off',
     'react/react-in-jsx-scope': 'off',

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ styleguide
 package-lock.json
 .idea
 report.*.json
+mazemap/mazemap.min.*
 
 
 # Certs

--- a/app/components/Button/Button.css
+++ b/app/components/Button/Button.css
@@ -20,10 +20,6 @@
   transition-property: color, background-color, border-color, box-shadow,
     opacity;
 
-  &:active {
-    transform: translateY(1px);
-  }
-
   &:focus-visible {
     box-shadow: 0 0 0 3px #9944;
   }
@@ -36,6 +32,10 @@
 
   + .button {
     margin-left: 16px;
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(1px);
   }
 
   > i {

--- a/app/components/Form/CheckBox.css
+++ b/app/components/Form/CheckBox.css
@@ -21,6 +21,7 @@
   z-index: 1;
   transform: scale(1.5);
   opacity: 0;
+  cursor: pointer;
 }
 
 .checked + label::after {
@@ -86,7 +87,7 @@
 .box {
   display: inline-block;
   width: 21px;
-  height: 18px;
+  height: 21px;
   margin-right: 10px;
   margin-bottom: -3px;
 }

--- a/app/routes/joblistings/components/JoblistingEditor.css
+++ b/app/routes/joblistings/components/JoblistingEditor.css
@@ -1,19 +1,3 @@
-@import '~app/styles/variables.css';
-
-.root {
-  composes: container from '~app/styles/utilities.css';
-  margin-top: 2rem;
-}
-
-.heading {
-  color: var(--color-dark-mono-gray-3);
-  letter-spacing: 2px;
-  text-transform: uppercase;
-  border-bottom: 1px solid var(--color-mono-gray-4);
-  font-weight: 400;
-  font-size: 24px;
-}
-
 .descriptionField,
 .textField {
   border: 1px;

--- a/app/routes/joblistings/components/JoblistingEditor.css
+++ b/app/routes/joblistings/components/JoblistingEditor.css
@@ -14,10 +14,6 @@
   font-size: 24px;
 }
 
-.submit {
-  width: 130px;
-}
-
 .descriptionField,
 .textField {
   border: 1px;

--- a/app/routes/joblistings/components/JoblistingEditor.js
+++ b/app/routes/joblistings/components/JoblistingEditor.js
@@ -24,6 +24,7 @@ import { places, jobTypes, yearValues } from '../constants';
 import { validYoutubeUrl } from 'app/utils/validation';
 
 import type { Joblisting, Workplace, ID } from 'app/models';
+import NavigationTab from 'app/components/NavigationTab';
 
 type SelectInputObject = {
   label: string,
@@ -122,9 +123,10 @@ class JoblistingEditor extends Component<Props, State> {
     return (
       <Content>
         <Helmet title={!isNew ? 'Rediger jobbannonse' : 'Ny jobbannonse'} />
-        <h1 className={styles.heading}>
-          {!isNew ? 'Rediger jobbannonse' : 'Legg til jobbannonse'}
-        </h1>
+        <NavigationTab
+          title={!isNew ? 'Rediger jobbannonse' : 'Ny jobbannonse'}
+          back={{ label: 'Tilbake', path: '/joblistings' }}
+        />
         <Form onSubmit={handleSubmit(this.onSubmit)}>
           <Field
             placeholder="Tittel"
@@ -260,12 +262,7 @@ class JoblistingEditor extends Component<Props, State> {
                 <Button danger>Slett</Button>
               </ConfirmModalWithParent>
             )}
-            <Button
-              success
-              disabled={invalid || submitting}
-              className={styles.submit}
-              submit
-            >
+            <Button success disabled={invalid || submitting} submit>
               Lagre
             </Button>
           </Flex>

--- a/app/routes/joblistings/components/JoblistingList.css
+++ b/app/routes/joblistings/components/JoblistingList.css
@@ -1,10 +1,5 @@
 @import '~app/styles/variables.css';
 
-.root {
-  composes: container from '~app/styles/utilities.css';
-  margin-top: 2rem;
-}
-
 .heading {
   color: var(--color-dark-mono-gray-3);
   letter-spacing: 2px;
@@ -25,7 +20,7 @@
 .headingDeadline {
   font-size: 16px;
 
-  @media (max-width: 900px) {
+  @media (--mobile-device) {
     display: none;
   }
 }
@@ -40,21 +35,23 @@
 }
 
 .joblistingItem {
-  margin-bottom: 12px;
-  padding-bottom: 5px;
+  display: flex;
+  align-items: center;
   margin-top: 3px;
+  margin-bottom: 12px;
+  padding: 15px;
   line-height: 1.3;
-  border-bottom: 1px solid var(--color-mono-gray-4);
   min-width: 280px;
-}
+  border-radius: 5px;
+  color: var(--lego-font-color);
+  transition: background-color 75ms ease-in-out;
 
-.companyLogoContainer {
-  width: 120px;
-  height: 80px;
-  margin-right: 20px;
+  &:hover {
+    background-color: rgba(255, 0, 0, 8%);
+  }
 
-  @media (max-width: 767px) {
-    display: none;
+  @media (--mobile-device) {
+    padding: 5px;
   }
 }
 
@@ -63,43 +60,36 @@
   height: 80px;
   min-width: 120px;
   object-fit: contain;
+  margin-right: 20px;
 }
 
 .listItem {
+  display: flex;
   flex: 1;
   justify-content: space-between;
+  font-size: 15px;
 
-  @media (max-width: 900px) {
+  @media (--mobile-device) {
     flex-direction: column;
   }
 }
 
 .joblistingItemTitle {
-  color: var(--color-black);
-  font-weight: 550;
-  margin: 0;
-  text-transform: uppercase;
-  font-size: 15px;
+  color: var(--color-dark-gray-1);
+  font-weight: 600;
+  font-size: 16px;
   letter-spacing: 2px;
-}
-
-.companyJobtype {
-  color: var(--color-dark-mono-gray-3);
+  margin-right: 5px;
+  margin-bottom: 10px;
 }
 
 .deadLine {
   display: flex;
-  align-self: center;
-  flex-direction: row;
+  align-items: center;
+  justify-content: end;
   min-width: 145px;
 
-  @media (max-width: 900px) {
-    align-self: flex-start;
-  }
-}
-
-.deadLineLabel {
-  @media (min-width: 900px) {
-    display: none;
+  @media (--mobile-device) {
+    justify-content: flex-start;
   }
 }

--- a/app/routes/joblistings/components/JoblistingList.js
+++ b/app/routes/joblistings/components/JoblistingList.js
@@ -13,62 +13,57 @@ type JobListingItemProps = {
   joblisting: /*TODO: JobListing*/ Object,
 };
 
-function JoblistingItem({ joblisting }: JobListingItemProps) {
-  return (
-    <Flex className={styles.joblistingItem}>
-      <Flex alignItems="center">
-        <Link to={`/joblistings/${joblisting.id}/`}>
-          <div className={styles.companyLogoContainer}>
-            {joblisting.company.logo && (
-              <Image
-                className={styles.companyLogo}
-                src={joblisting.company.logo}
-                placeholder={joblisting.company.logoPlaceholder}
-              />
-            )}
-          </div>
-        </Link>
-      </Flex>
-      <Flex className={styles.listItem}>
+const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
+  <Link to={`/joblistings/${joblisting.id}/`} className={styles.joblistingItem}>
+    {joblisting.company.logo && (
+      <Image
+        className={styles.companyLogo}
+        src={joblisting.company.logo}
+        placeholder={joblisting.company.logoPlaceholder}
+      />
+    )}
+    <div className={styles.listItem}>
+      <div>
+        <Flex wrap gap={4}>
+          {moment(joblisting.createdAt).isAfter(
+            moment().subtract(3, 'days')
+          ) && <Tag tag="NY" color="green" />}
+          <h3 className={styles.joblistingItemTitle}>{joblisting.title}</h3>
+        </Flex>
         <div>
-          <Link to={`/joblistings/${joblisting.id}/`}>
-            <Flex>
-              <h3 className={styles.joblistingItemTitle}>
-                {moment(joblisting.createdAt).isAfter(
-                  moment().subtract(3, 'days')
-                ) && <Tag tag="NY" color="green"></Tag>}
-                {joblisting.title}
-              </h3>
-            </Flex>
-          </Link>
-          <div className={styles.companyJobtype}>
-            {joblisting.company.name} • {jobType(joblisting.jobType)}
-          </div>
-          <Year joblisting={joblisting} /> •
-          <Workplaces places={joblisting.workplaces} />
+          {joblisting.company.name}
+          {joblisting.jobType && (
+            <>
+              <span> • </span>
+              {jobType(joblisting.jobType)}
+            </>
+          )}
         </div>
-        <div className={styles.deadLine}>
-          <span className={styles.deadLineLabel} style={{ marginRight: '5px' }}>
-            {'Frist  • '}
-          </span>
-          <span>
-            <Time
-              time={joblisting.deadline}
-              style={{ width: '135px' }}
-              format="ll HH:mm"
-            />
-          </span>
+        <div>
+          <Year joblisting={joblisting} />
+          {joblisting.workplaces && (
+            <>
+              <span> • </span>
+              <Workplaces places={joblisting.workplaces} />
+            </>
+          )}
         </div>
-      </Flex>
-    </Flex>
-  );
-}
+      </div>
+      <Time
+        time={joblisting.deadline}
+        style={{ width: '135px' }}
+        format="ll HH:mm"
+        className={styles.deadLine}
+      />
+    </div>
+  </Link>
+);
 
-type JobListingsItemProps = {
+type JobListingsListProps = {
   joblistings: /*TODO: JobListings*/ Array<Object>,
 };
 
-const JoblistingsList = ({ joblistings }: JobListingsItemProps) => (
+const JoblistingsList = ({ joblistings }: JobListingsListProps) => (
   <Flex column className={styles.joblistingList}>
     <Flex className={styles.heading}>
       <h2 className={styles.headingText}>Jobbannonser</h2>

--- a/app/routes/joblistings/components/JoblistingPage.css
+++ b/app/routes/joblistings/components/JoblistingPage.css
@@ -8,7 +8,7 @@
   margin-top: 2rem;
   justify-content: space-around;
 
-  @media (max-width: 630px) {
+  @media (--small-viewport) {
     flex-direction: column-reverse;
   }
 }

--- a/app/routes/joblistings/components/JoblistingPage.js
+++ b/app/routes/joblistings/components/JoblistingPage.js
@@ -6,11 +6,12 @@ import LoadingIndicator from 'app/components/LoadingIndicator/';
 import JoblistingsList from './JoblistingList';
 import JoblistingsRightNav from './JoblistingRightNav';
 import { Flex } from 'app/components/Layout';
+import type { ActionGrant } from 'app/models';
 
 type Props = {
   joblistings: Array</*TODO: JobListing*/ any>,
   search: Object,
-  actionGrant: /*TODO: ActionGrant */ any,
+  actionGrant: ActionGrant,
   history: Object,
 };
 

--- a/app/routes/joblistings/components/JoblistingRightNav.css
+++ b/app/routes/joblistings/components/JoblistingRightNav.css
@@ -105,3 +105,13 @@
     margin-right: 10px;
   }
 }
+
+/* Caret */
+.box h2 i {
+  margin-left: 5px;
+  transition: transform 200ms ease-in-out;
+}
+
+.rotateCaret {
+  transform: rotate(-90deg);
+}

--- a/app/routes/joblistings/components/JoblistingRightNav.css
+++ b/app/routes/joblistings/components/JoblistingRightNav.css
@@ -1,7 +1,8 @@
 @import '~app/styles/variables.css';
 
-.box {
+.joblistingRightNav {
   display: flex;
+  flex-direction: column;
   justify-content: flex-start;
   min-height: 350px;
   border-left: 1px solid var(--color-mono-gray-4);
@@ -14,13 +15,13 @@
   min-width: 225px;
   max-width: 250px;
 
-  @media (max-width: 630px) {
+  @media (--small-viewport) {
     align-items: center;
     justify-content: space-around;
     max-width: none;
     min-height: 0;
     margin-left: 0;
-    margin-bottom: 5px;
+    margin-bottom: 20px;
     padding-bottom: 0;
   }
 }
@@ -35,15 +36,19 @@
   align-items: center;
   padding: 0.5rem;
 
-  @media (max-width: 630px) {
-    margin-bottom: 0;
-    margin-left: 10px;
-    margin-right: 10px;
-  }
-
   &:hover {
     cursor: pointer;
   }
+}
+
+/* Caret */
+.optionsTitle i {
+  margin-left: 5px;
+  transition: transform 200ms ease-in-out;
+}
+
+.rotateCaret {
+  transform: rotate(-90deg);
 }
 
 .optionsTitle h2 {
@@ -54,27 +59,15 @@
 .options {
   margin-top: 20px;
 
-  @media (max-width: 630px) {
+  @media (--small-viewport) {
     width: 100%;
   }
 }
 
-.filters {
-  @media (max-width: 630px) {
-    flex-flow: row wrap;
-  }
-}
-
-.filters > div {
-  margin: 10px;
-}
-
-.sortNav {
-  @media (max-width: 630px) {
-    flex-wrap: wrap;
-    margin-left: 10px;
-    margin-right: 10px;
-  }
+.filterLink {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .rightHeader {
@@ -86,32 +79,4 @@
   margin-bottom: 2%;
   margin-top: 8%;
   padding-left: 0;
-}
-
-.sortHeader {
-  @media (max-width: 630px) {
-    margin-left: 10px;
-    margin-right: 10px;
-  }
-}
-
-.createButton {
-  flex: 1;
-  align-self: center;
-  justify-content: center;
-
-  @media (max-width: 630px) {
-    margin-left: 10px;
-    margin-right: 10px;
-  }
-}
-
-/* Caret */
-.box h2 i {
-  margin-left: 5px;
-  transition: transform 200ms ease-in-out;
-}
-
-.rotateCaret {
-  transform: rotate(-90deg);
 }

--- a/app/routes/joblistings/components/JoblistingRightNav.js
+++ b/app/routes/joblistings/components/JoblistingRightNav.js
@@ -140,12 +140,13 @@ export default class JoblistingsRightNav extends Component<Props, State> {
           className={styles.optionsTitle}
         >
           <h2>
-            <span>Valg</span>
-            {this.state.displayOptions ? (
-              <i style={{ marginLeft: '5px' }} className="fa fa-caret-down" />
-            ) : (
-              <i style={{ marginLeft: '5px' }} className="fa fa-caret-right" />
-            )}
+            Valg
+            <i
+              className={cx(
+                'fa fa-caret-down',
+                !this.state.displayOptions && styles.rotateCaret
+              )}
+            />
           </h2>
         </Button>
         <Flex

--- a/app/routes/joblistings/components/JoblistingRightNav.js
+++ b/app/routes/joblistings/components/JoblistingRightNav.js
@@ -1,7 +1,7 @@
 // @flow
 
 import styles from './JoblistingRightNav.css';
-import { Component } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CheckBox, RadioButton } from 'app/components/Form/';
 import Button from 'app/components/Button';
@@ -45,7 +45,6 @@ const FilterLink = ({ type, label, value, filters }: Object) => (
     className={styles.filterLink}
   >
     <CheckBox id={label} value={filters[type].includes(value)} readOnly />
-
     {label}
   </Link>
 );
@@ -54,6 +53,12 @@ type Filter = {
   grades: Array<string>,
   jobTypes: Array<string>,
   workplaces: Array<string>,
+};
+
+type Order = {
+  deadline: boolean,
+  company: boolean,
+  createdAt: boolean,
 };
 
 type Props = {
@@ -67,61 +72,40 @@ type Props = {
   history: any,
 };
 
-type State = {
-  filters: Filter,
-  order: {
-    deadline: boolean,
-    company: boolean,
-    createdAt: boolean,
-  },
-  displayOptions: boolean,
-};
-
-export default class JoblistingsRightNav extends Component<Props, State> {
-  state = {
-    filters: {
-      grades: [],
-      jobTypes: [],
-      workplaces: [],
-    },
-    order: {
-      deadline: true,
-      company: false,
-      createdAt: false,
-    },
-    displayOptions: true,
-  };
-
-  updateDisplayOptions = () => {
-    this.setState({
-      displayOptions: !this.state.displayOptions,
-    });
-  };
-
-  toggleDisplay = (display: boolean) => ({
-    display: display ? 'block' : 'none',
+const JoblistingsRightNav = (props: Props) => {
+  const [filters, setFilters] = useState<Filter>({
+    grades: [],
+    jobTypes: [],
+    workplaces: [],
   });
+  const [order, setOrder] = useState<Order>({
+    deadline: true,
+    company: false,
+    createdAt: false,
+  });
+  const [displayOptions, setDisplayOptions] = useState<boolean>(true);
 
-  // eslint-disable-next-line
-  componentWillReceiveProps = (nextProps: Props) => {
-    const query = nextProps.query;
-    this.setState({
-      filters: {
-        grades: query.grades ? query.grades.split(',') : [],
-        jobTypes: query.jobTypes ? query.jobTypes.split(',') : [],
-        workplaces: query.workplaces ? query.workplaces.split(',') : [],
-      },
-      order: {
-        deadline:
-          query.order === 'deadline' || !Object.keys(query).includes('order'),
-        company: query.order === 'company',
-        createdAt: query.order === 'createdAt',
-      },
+  useEffect(() => {
+    const query = props.query;
+    setFilters({
+      grades: query.grades ? query.grades.split(',') : [],
+      jobTypes: query.jobTypes ? query.jobTypes.split(',') : [],
+      workplaces: query.workplaces ? query.workplaces.split(',') : [],
     });
-  };
+    setOrder({
+      deadline:
+        query.order === 'deadline' || !Object.keys(query).includes('order'),
+      company: query.order === 'company',
+      createdAt: query.order === 'createdAt',
+    });
+  }, [props.query]);
 
-  handleQuery = (type: string, value: string, remove: boolean = false) => {
-    const query = { ...this.props.query };
+  const handleQuery = (
+    type: string,
+    value: string,
+    remove: boolean = false
+  ) => {
+    const query = { ...props.query };
     if (remove) {
       delete query[type];
     } else {
@@ -130,137 +114,137 @@ export default class JoblistingsRightNav extends Component<Props, State> {
     return query;
   };
 
-  render() {
-    return (
-      <div className={styles.joblistingRightNav}>
-        <Button
-          flat
-          onClick={this.updateDisplayOptions}
-          className={styles.optionsTitle}
-        >
-          <h2>
-            Valg
-            <i
-              className={cx(
-                'fa fa-caret-down',
-                !this.state.displayOptions && styles.rotateCaret
-              )}
-            />
-          </h2>
-        </Button>
-
-        <div
-          className={styles.options}
-          style={{ display: this.state.displayOptions ? 'block' : 'none' }}
-        >
-          {this.props.actionGrant.includes('create') && (
-            <Link to="/joblistings/create">
-              <Button className={styles.createButton}>Ny jobbannonse</Button>
-            </Link>
-          )}
-
-          <h3 className={styles.rightHeader}>Sorter etter:</h3>
-          <label htmlFor="deadline" style={{ cursor: 'pointer' }}>
-            <RadioButton
-              name="sort"
-              id="deadline"
-              inputValue={true}
-              value={this.state.order.deadline}
-              onChange={() => {
-                this.props.history.push({
-                  pathname: '/joblistings',
-                  search: qs.stringify(this.handleQuery('order', 'deadline')),
-                });
-              }}
-            />
-            Frist
-          </label>
-          <label htmlFor="company" style={{ cursor: 'pointer' }}>
-            <RadioButton
-              name="sort"
-              id="company"
-              inputValue={true}
-              value={this.state.order.company}
-              onChange={() => {
-                this.props.history.push({
-                  pathname: '/joblistings',
-                  search: qs.stringify(this.handleQuery('order', 'company')),
-                });
-              }}
-            />
-            Bedrift
-          </label>
-          <label htmlFor="createdAt" style={{ cursor: 'pointer' }}>
-            <RadioButton
-              name="sort"
-              id="createdAt"
-              inputValue={true}
-              value={this.state.order.createdAt}
-              onChange={() => {
-                this.props.history.push({
-                  pathname: '/joblistings',
-                  search: qs.stringify(this.handleQuery('order', 'createdAt')),
-                });
-              }}
-            />
-            Publisert
-          </label>
-
-          <h3 className={styles.rightHeader}>Klassetrinn:</h3>
-          {['1', '2', '3', '4', '5'].map((element) => (
-            <FilterLink
-              key={element}
-              type="grades"
-              label={`${element}. klasse`}
-              value={element}
-              filters={this.state.filters}
-            />
-          ))}
-
-          <h3 className={styles.rightHeader}>Jobbtype:</h3>
-          <FilterLink
-            type="jobTypes"
-            label="Sommerjobb"
-            value="summer_job"
-            filters={this.state.filters}
+  return (
+    <div className={styles.joblistingRightNav}>
+      <Button
+        flat
+        onClick={() => setDisplayOptions(!displayOptions)}
+        className={styles.optionsTitle}
+      >
+        <h2>
+          Valg
+          <i
+            className={cx(
+              'fa fa-caret-down',
+              !displayOptions && styles.rotateCaret
+            )}
           />
-          <FilterLink
-            type="jobTypes"
-            value="part_time"
-            label="Deltid"
-            filters={this.state.filters}
-          />
-          <FilterLink
-            type="jobTypes"
-            value="full_time"
-            label="Fulltid"
-            filters={this.state.filters}
-          />
-          <FilterLink
-            type="jobTypes"
-            value="master_thesis"
-            label="Masteroppgave"
-            filters={this.state.filters}
-          />
-          <FilterLink
-            type="jobTypes"
-            value="other"
-            label="Annet"
-            filters={this.state.filters}
-          />
+        </h2>
+      </Button>
 
-          <h3 className={styles.rightHeader}>Sted:</h3>
-          {['Oslo', 'Trondheim', 'Bergen', 'Tromsø', 'Annet'].map((element) => (
-            <FilterLink
-              type="workplaces"
-              key={element}
-              value={element}
-              label={element}
-              filters={this.state.filters}
-            />
-          ))}
-        </div>
+      <div
+        className={styles.options}
+        style={{ display: displayOptions ? 'block' : 'none' }}
+      >
+        {props.actionGrant.includes('create') && (
+          <Link to="/joblistings/create">
+            <Button className={styles.createButton}>Ny jobbannonse</Button>
+          </Link>
+        )}
+
+        <h3 className={styles.rightHeader}>Sorter etter:</h3>
+        <label htmlFor="deadline" style={{ cursor: 'pointer' }}>
+          <RadioButton
+            name="sort"
+            id="deadline"
+            inputValue={true}
+            value={order.deadline}
+            onChange={() => {
+              props.history.push({
+                pathname: '/joblistings',
+                search: qs.stringify(handleQuery('order', 'deadline')),
+              });
+            }}
+          />
+          Frist
+        </label>
+        <label htmlFor="company" style={{ cursor: 'pointer' }}>
+          <RadioButton
+            name="sort"
+            id="company"
+            inputValue={true}
+            value={order.company}
+            onChange={() => {
+              props.history.push({
+                pathname: '/joblistings',
+                search: qs.stringify(handleQuery('order', 'company')),
+              });
+            }}
+          />
+          Bedrift
+        </label>
+        <label htmlFor="createdAt" style={{ cursor: 'pointer' }}>
+          <RadioButton
+            name="sort"
+            id="createdAt"
+            inputValue={true}
+            value={order.createdAt}
+            onChange={() => {
+              props.history.push({
+                pathname: '/joblistings',
+                search: qs.stringify(handleQuery('order', 'createdAt')),
+              });
+            }}
+          />
+          Publisert
+        </label>
+
+        <h3 className={styles.rightHeader}>Klassetrinn:</h3>
+        {['1', '2', '3', '4', '5'].map((element) => (
+          <FilterLink
+            key={element}
+            type="grades"
+            label={`${element}. klasse`}
+            value={element}
+            filters={filters}
+          />
+        ))}
+
+        <h3 className={styles.rightHeader}>Jobbtype:</h3>
+        <FilterLink
+          type="jobTypes"
+          label="Sommerjobb"
+          value="summer_job"
+          filters={filters}
+        />
+        <FilterLink
+          type="jobTypes"
+          value="part_time"
+          label="Deltid"
+          filters={filters}
+        />
+        <FilterLink
+          type="jobTypes"
+          value="full_time"
+          label="Fulltid"
+          filters={filters}
+        />
+        <FilterLink
+          type="jobTypes"
+          value="master_thesis"
+          label="Masteroppgave"
+          filters={filters}
+        />
+        <FilterLink
+          type="jobTypes"
+          value="other"
+          label="Annet"
+          filters={filters}
+        />
+
+        <h3 className={styles.rightHeader}>Sted:</h3>
+        {['Oslo', 'Trondheim', 'Bergen', 'Tromsø', 'Annet'].map((element) => (
+          <FilterLink
+            type="workplaces"
+            key={element}
+            value={element}
+            label={element}
+            filters={filters}
+          />
+        ))}
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+export default JoblistingsRightNav;

--- a/app/routes/joblistings/components/JoblistingRightNav.js
+++ b/app/routes/joblistings/components/JoblistingRightNav.js
@@ -3,7 +3,6 @@
 import styles from './JoblistingRightNav.css';
 import { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Flex } from 'app/components/Layout';
 import { CheckBox, RadioButton } from 'app/components/Form/';
 import Button from 'app/components/Button';
 import cx from 'classnames';
@@ -43,11 +42,11 @@ const FilterLink = ({ type, label, value, filters }: Object) => (
       pathname: '/joblistings',
       search: qs.stringify(updateFilters(type, value, filters)),
     }}
-    style={{ display: 'flex', flex: 1, alignItems: 'center' }}
+    className={styles.filterLink}
   >
     <CheckBox id={label} value={filters[type].includes(value)} readOnly />
 
-    <span>{label}</span>
+    {label}
   </Link>
 );
 
@@ -133,7 +132,7 @@ export default class JoblistingsRightNav extends Component<Props, State> {
 
   render() {
     return (
-      <Flex column className={styles.box}>
+      <div className={styles.joblistingRightNav}>
         <Button
           flat
           onClick={this.updateDisplayOptions}
@@ -149,8 +148,8 @@ export default class JoblistingsRightNav extends Component<Props, State> {
             />
           </h2>
         </Button>
-        <Flex
-          column
+
+        <div
           className={styles.options}
           style={{ display: this.state.displayOptions ? 'block' : 'none' }}
         >
@@ -159,143 +158,109 @@ export default class JoblistingsRightNav extends Component<Props, State> {
               <Button className={styles.createButton}>Ny jobbannonse</Button>
             </Link>
           )}
-          <h3 className={cx(styles.rightHeader, styles.sortHeader)}>
-            Sorter etter:
-          </h3>
-          <Flex justifyContent="flex-start" className={styles.sortNav}>
-            <Flex>
-              <label
-                htmlFor="deadline"
-                style={{ marginRight: '10px', cursor: 'pointer' }}
-              >
-                <RadioButton
-                  name="sort"
-                  id="deadline"
-                  inputValue={true}
-                  value={this.state.order.deadline}
-                  onChange={() => {
-                    this.props.history.push({
-                      pathname: '/joblistings',
-                      search: qs.stringify(
-                        this.handleQuery('order', 'deadline')
-                      ),
-                    });
-                  }}
-                />
-                Frist
-              </label>
-            </Flex>
-            <Flex>
-              <label htmlFor="company" style={{ cursor: 'pointer' }}>
-                <RadioButton
-                  name="sort"
-                  id="company"
-                  inputValue={true}
-                  value={this.state.order.company}
-                  onChange={() => {
-                    this.props.history.push({
-                      pathname: '/joblistings',
-                      search: qs.stringify(
-                        this.handleQuery('order', 'company')
-                      ),
-                    });
-                  }}
-                />
-                Bedrift
-              </label>
-            </Flex>
-            <Flex>
-              <label htmlFor="createdAt" style={{ cursor: 'pointer' }}>
-                <RadioButton
-                  name="sort"
-                  id="createdAt"
-                  inputValue={true}
-                  value={this.state.order.createdAt}
-                  onChange={() => {
-                    this.props.history.push({
-                      pathname: '/joblistings',
-                      search: qs.stringify(
-                        this.handleQuery('order', 'createdAt')
-                      ),
-                    });
-                  }}
-                />
-                Publisert
-              </label>
-            </Flex>
-          </Flex>
-          <Flex column className={styles.filters}>
-            <Flex
-              column
-              style={{ display: this.state.displayOptions ? 'block' : 'flex' }}
-            >
-              <h3 className={styles.rightHeader}>Klassetrinn:</h3>
-              {['1', '2', '3', '4', '5'].map((element) => (
-                <FilterLink
-                  key={element}
-                  type="grades"
-                  label={`${element}. klasse`}
-                  value={element}
-                  filters={this.state.filters}
-                />
-              ))}
-            </Flex>
-            <Flex
-              column
-              style={{ display: this.state.displayOptions ? 'block' : 'flex' }}
-            >
-              <h3 className={styles.rightHeader}>Jobbtype:</h3>
-              <FilterLink
-                type="jobTypes"
-                label="Sommerjobb"
-                value="summer_job"
-                filters={this.state.filters}
-              />
-              <FilterLink
-                type="jobTypes"
-                value="part_time"
-                label="Deltid"
-                filters={this.state.filters}
-              />
-              <FilterLink
-                type="jobTypes"
-                value="full_time"
-                label="Fulltid"
-                filters={this.state.filters}
-              />
-              <FilterLink
-                type="jobTypes"
-                value="master_thesis"
-                label="Masteroppgave"
-                filters={this.state.filters}
-              />
-              <FilterLink
-                type="jobTypes"
-                value="other"
-                label="Annet"
-                filters={this.state.filters}
-              />
-            </Flex>
-            <Flex
-              column
-              style={{ display: this.state.displayOptions ? 'block' : 'flex' }}
-            >
-              <h3 className={styles.rightHeader}>Sted:</h3>
-              {['Oslo', 'Trondheim', 'Bergen', 'Tromsø', 'Annet'].map(
-                (element) => (
-                  <FilterLink
-                    type="workplaces"
-                    key={element}
-                    value={element}
-                    label={element}
-                    filters={this.state.filters}
-                  />
-                )
-              )}
-            </Flex>
-          </Flex>
-        </Flex>
-      </Flex>
+
+          <h3 className={styles.rightHeader}>Sorter etter:</h3>
+          <label htmlFor="deadline" style={{ cursor: 'pointer' }}>
+            <RadioButton
+              name="sort"
+              id="deadline"
+              inputValue={true}
+              value={this.state.order.deadline}
+              onChange={() => {
+                this.props.history.push({
+                  pathname: '/joblistings',
+                  search: qs.stringify(this.handleQuery('order', 'deadline')),
+                });
+              }}
+            />
+            Frist
+          </label>
+          <label htmlFor="company" style={{ cursor: 'pointer' }}>
+            <RadioButton
+              name="sort"
+              id="company"
+              inputValue={true}
+              value={this.state.order.company}
+              onChange={() => {
+                this.props.history.push({
+                  pathname: '/joblistings',
+                  search: qs.stringify(this.handleQuery('order', 'company')),
+                });
+              }}
+            />
+            Bedrift
+          </label>
+          <label htmlFor="createdAt" style={{ cursor: 'pointer' }}>
+            <RadioButton
+              name="sort"
+              id="createdAt"
+              inputValue={true}
+              value={this.state.order.createdAt}
+              onChange={() => {
+                this.props.history.push({
+                  pathname: '/joblistings',
+                  search: qs.stringify(this.handleQuery('order', 'createdAt')),
+                });
+              }}
+            />
+            Publisert
+          </label>
+
+          <h3 className={styles.rightHeader}>Klassetrinn:</h3>
+          {['1', '2', '3', '4', '5'].map((element) => (
+            <FilterLink
+              key={element}
+              type="grades"
+              label={`${element}. klasse`}
+              value={element}
+              filters={this.state.filters}
+            />
+          ))}
+
+          <h3 className={styles.rightHeader}>Jobbtype:</h3>
+          <FilterLink
+            type="jobTypes"
+            label="Sommerjobb"
+            value="summer_job"
+            filters={this.state.filters}
+          />
+          <FilterLink
+            type="jobTypes"
+            value="part_time"
+            label="Deltid"
+            filters={this.state.filters}
+          />
+          <FilterLink
+            type="jobTypes"
+            value="full_time"
+            label="Fulltid"
+            filters={this.state.filters}
+          />
+          <FilterLink
+            type="jobTypes"
+            value="master_thesis"
+            label="Masteroppgave"
+            filters={this.state.filters}
+          />
+          <FilterLink
+            type="jobTypes"
+            value="other"
+            label="Annet"
+            filters={this.state.filters}
+          />
+
+          <h3 className={styles.rightHeader}>Sted:</h3>
+          {['Oslo', 'Trondheim', 'Bergen', 'Tromsø', 'Annet'].map((element) => (
+            <FilterLink
+              type="workplaces"
+              key={element}
+              value={element}
+              label={element}
+              filters={this.state.filters}
+            />
+          ))}
+        </div>
+      </div>
     );
   }
 }


### PR DESCRIPTION
- Replace JoblistingEditor header with `NavigationTab`
- Add a rotation animation to the dropdown caret in `JoblistingRightNav`
- Clean up `JoblistingRightNav`
- Rewrite `JoblistingsRightNav` to a functional component
- Prevent active effect on Button when disabled
- Redesign `JoblistingList`. Notice that the entire item functions as a link, as opposed to the current situation in which the link is only accessible on the title and the image.
- Untrack mazemap.min.* files and ignore them when running eslint

## The new look
![showcase](https://user-images.githubusercontent.com/69514187/172068143-508e445d-94e8-4de5-97c4-b81699add282.gif)