### PR TITLE
Refactor comment form (migrate to react-final-form)

### DIFF
--- a/app/actions/CommentActions.js
+++ b/app/actions/CommentActions.js
@@ -9,7 +9,7 @@ import { type ID } from 'app/models';
 export type CommentEntity = {
   text: string,
   contentTarget: string,
-  parent: number,
+  parent?: number,
 };
 
 export function addComment({

--- a/app/actions/CommentActions.js
+++ b/app/actions/CommentActions.js
@@ -28,7 +28,7 @@ export function addComment({
     },
     meta: {
       contentTarget,
-      errorMessage: 'Legg til kommentar feilet',
+      errorMessage: 'Kommentering feilet',
     },
     schema: commentSchema,
   });

--- a/app/actions/CommentActions.js
+++ b/app/actions/CommentActions.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { startSubmit, stopSubmit, initialize } from 'redux-form';
 import { commentSchema } from 'app/reducers';
 import callAPI from 'app/actions/callAPI';
 import { Comment } from './ActionTypes';
@@ -17,41 +16,22 @@ export function addComment({
   text,
   contentTarget,
   parent,
-}: CommentEntity): Thunk<*> {
-  return (dispatch) => {
-    dispatch(startSubmit('comment'));
-
-    return dispatch(
-      callAPI({
-        types: Comment.ADD,
-        endpoint: '/comments/',
-        method: 'POST',
-        body: {
-          text,
-          content_target: contentTarget,
-          ...(parent ? { parent } : {}),
-        },
-        meta: {
-          contentTarget,
-          errorMessage: 'Legg til kommentar feilet',
-        },
-        schema: commentSchema,
-      })
-    )
-      .then(() => {
-        dispatch(stopSubmit('comment'));
-        let formName = `comment.${contentTarget}`;
-        if (parent) {
-          formName += `-${parent}`;
-        }
-
-        dispatch(initialize(formName, { text: '' }));
-      })
-      .catch((action) => {
-        const errors = { ...action.payload.response.jsonData };
-        dispatch(stopSubmit('comment', errors));
-      });
-  };
+}: CommentEntity): Thunk<Promise<?Object>> {
+  return callAPI({
+    types: Comment.ADD,
+    endpoint: '/comments/',
+    method: 'POST',
+    body: {
+      text,
+      content_target: contentTarget,
+      ...(parent ? { parent } : {}),
+    },
+    meta: {
+      contentTarget,
+      errorMessage: 'Legg til kommentar feilet',
+    },
+    schema: commentSchema,
+  });
 }
 
 export function deleteComment(

--- a/app/components/CommentForm/index.js
+++ b/app/components/CommentForm/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import cx from 'classnames';
 import { EditorField } from 'app/components/Form';
@@ -39,11 +39,13 @@ const CommentForm = ({
   parent,
 }: Props) => {
   const dispatch = useDispatch();
-  const [disabled, setDisabled] = useState(!__CLIENT__);
+  // editor must be disabled while server-side rendering
+  const [editorSsrDisabled, setEditorSsrDisabled] = useState(true);
 
-  const enableForm = (e) => {
-    setDisabled(false);
-  };
+  useEffect(() => {
+    // Workaround to make sure we re-render editor in enabled state on client after ssr
+    setEditorSsrDisabled(false);
+  }, []);
 
   const className = inlineMode ? styles.inlineForm : styles.form;
 
@@ -82,14 +84,8 @@ const CommentForm = ({
 
               {isOpen && <div className={styles.author}>{user.fullName}</div>}
             </div>
-
-            <div
-              className={cx(styles.fields, isOpen && styles.activeFields)}
-              onMouseOver={enableForm}
-              onScroll={enableForm}
-              onPointerDown={enableForm}
-            >
-              {disabled ? (
+            <div className={cx(styles.fields, isOpen && styles.activeFields)}>
+              {editorSsrDisabled ? (
                 <DisplayContent
                   id="comment-text"
                   className={styles.text}

--- a/app/components/CommentForm/index.js
+++ b/app/components/CommentForm/index.js
@@ -19,11 +19,10 @@ type Props = {
   contentTarget: string,
   user: Object,
   loggedIn: boolean,
-  parent: number,
-  submitText: string,
-  inlineMode: boolean,
-  autoFocus: boolean,
-  isOpen: boolean,
+  submitText?: string,
+  inlineMode?: boolean,
+  autoFocus?: boolean,
+  parent?: number,
 };
 
 const validate = createValidator({
@@ -31,12 +30,12 @@ const validate = createValidator({
 });
 
 const CommentForm = ({
+  contentTarget,
   user,
   loggedIn,
   submitText = 'Kommenter',
-  inlineMode,
+  inlineMode = false,
   autoFocus = false,
-  contentTarget,
   parent,
 }: Props) => {
   const dispatch = useDispatch();

--- a/app/components/Comments/Comment.js
+++ b/app/components/Comments/Comment.js
@@ -15,11 +15,11 @@ import Button from '../Button';
 
 type Props = {
   comment: CommentEntity,
-  commentFormProps: {
+  commentFormProps: {|
     contentTarget: string,
     user: UserEntity,
     loggedIn: boolean,
-  },
+  |},
   deleteComment: (id: ID, contentTarget: string) => Promise<*>,
   user: UserEntity,
   contentTarget: string,
@@ -93,12 +93,11 @@ export default class Comment extends Component<Props, State> {
 
         {replyOpen && (
           <CommentForm
-            form={`comment.${commentFormProps.contentTarget}-${comment.id}`}
-            parent={comment.id}
+            {...commentFormProps}
             submitText="Send svar"
             inlineMode
             autoFocus
-            {...(commentFormProps: Object)}
+            parent={comment.id}
           />
         )}
       </div>

--- a/app/components/Comments/CommentTree.js
+++ b/app/components/Comments/CommentTree.js
@@ -10,11 +10,11 @@ import { type ID } from 'app/models';
 type Props = {
   comments: Array<CommentEntity>,
   isChild?: boolean,
-  commentFormProps: {
+  commentFormProps: {|
     contentTarget: string,
     user: UserEntity,
     loggedIn: boolean,
-  },
+  |},
   level?: number,
   deleteComment: (id: ID, contentTarget: string) => Promise<*>,
   user: UserEntity,

--- a/app/components/Comments/CommentView.js
+++ b/app/components/Comments/CommentView.js
@@ -62,10 +62,7 @@ const CommentView = (props: Props) => {
 
         {!formDisabled && (
           <div>
-            <CommentForm
-              form={`comment.${commentFormProps.contentTarget}`}
-              {...commentFormProps}
-            />
+            <CommentForm {...commentFormProps} />
           </div>
         )}
       </Flex>

--- a/app/components/Form/EditorField.js
+++ b/app/components/Form/EditorField.js
@@ -1,5 +1,5 @@
 // @flow
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import cx from 'classnames';
 import Editor from '@webkom/lego-editor';
 import '@webkom/lego-editor/dist/style.css';
@@ -15,7 +15,6 @@ type Props = {
   meta: any,
   name: string,
   initialized: boolean,
-  uploadFile: (file: Blob) => Promise<*>,
 };
 
 class NoSSRError {
@@ -25,30 +24,23 @@ class NoSSRError {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    uploadFile: async (file) => {
-      const response = await dispatch(uploadFile({ file, isPublic: true }));
-      return { fileKey: response.meta.fileKey };
-    },
-  };
-};
-
 /*
  * The reason for the initialized prop is an issue(https://github.com/redux-form/redux-form/issues/621) in redux form that causes all fields to be initially rendered with an empty string as value,
  * due to the form not being initialized. Because the editor state is immutable, the editor field does not update once it is passed the correct initial value on the second render.
  * The initialized prop "solves" the issue by enabling the editor field to only render once the form has been initialized.
  */
-const EditorFieldComponent = ({
-  className,
-  name,
-  initialized,
-  uploadFile,
-  ...props
-}: Props) => {
+const EditorField = ({ className, name, initialized, ...props }: Props) => {
   if (!__CLIENT__) {
     throw new NoSSRError('Cannot SSR editor');
   }
+
+  const dispatch = useDispatch();
+
+  const imageUpload = async (file: File) => {
+    const response = await dispatch(uploadFile({ file, isPublic: true }));
+    return { fileKey: response.meta.fileKey };
+  };
+
   return (
     <div name={name}>
       {initialized && (
@@ -57,25 +49,19 @@ const EditorFieldComponent = ({
           {...props}
           {...props.input}
           {...props.meta}
-          imageUpload={uploadFile}
+          imageUpload={imageUpload}
         />
       )}
     </div>
   );
 };
 
-const EditorField = connect(null, mapDispatchToProps)(EditorFieldComponent);
-
 EditorField.AutoInitialized = (props) =>
-  EditorFieldComponent({
+  EditorField({
     initialized: !!(props.value || props.input?.value),
     ...props,
   });
 
-// $FlowFixMe
-EditorField.Field = connect(
-  null,
-  mapDispatchToProps
-)(createField(EditorField.AutoInitialized, { noLabel: true }));
+EditorField.Field = createField(EditorField.AutoInitialized, { noLabel: true });
 
 export default EditorField;

--- a/app/components/Form/EditorField.js
+++ b/app/components/Form/EditorField.js
@@ -36,9 +36,8 @@ const mapDispatchToProps = (dispatch) => {
 
 /*
  * The reason for the initialized prop is an issue(https://github.com/redux-form/redux-form/issues/621) in redux form that causes all fields to be initially rendered with an empty string as value,
- * due to the form not being initialized. Because the editorstate is immutable, the editorfield does not update once it is passed the correct initialvalue on the second render.
- * The initialized prop "solves" the issue by enabling the editorfield to only render once the form has been initialized.
- * The initialized prop is passed to the form by the redux-form HoC, see the redux form docs for more info. The "solution" is a hack, yet i could find no better way to solve this.
+ * due to the form not being initialized. Because the editor state is immutable, the editor field does not update once it is passed the correct initial value on the second render.
+ * The initialized prop "solves" the issue by enabling the editor field to only render once the form has been initialized.
  */
 const EditorFieldComponent = ({
   className,
@@ -67,15 +66,16 @@ const EditorFieldComponent = ({
 
 const EditorField = connect(null, mapDispatchToProps)(EditorFieldComponent);
 
+EditorField.AutoInitialized = (props) =>
+  EditorFieldComponent({
+    initialized: !!(props.value || props.input?.value),
+    ...props,
+  });
+
 // $FlowFixMe
 EditorField.Field = connect(
   null,
   mapDispatchToProps
-)(
-  createField(
-    (props) => EditorFieldComponent({ initialized: !!props.value, ...props }),
-    { noLabel: true }
-  )
-);
+)(createField(EditorField.AutoInitialized, { noLabel: true }));
 
 export default EditorField;

--- a/app/components/Form/LegoFinalForm.js
+++ b/app/components/Form/LegoFinalForm.js
@@ -6,7 +6,7 @@ import { Form } from 'react-final-form';
 import createFocusOnErrorDecorator from 'final-form-focus';
 import * as Sentry from '@sentry/browser';
 import { handleSubmissionErrorFinalForm } from 'app/components/Form/utils';
-import { isEqual } from 'lodash-es';
+import { isEqual } from 'lodash';
 
 const focusOnError = createFocusOnErrorDecorator();
 

--- a/app/components/Form/SubmissionError.js
+++ b/app/components/Form/SubmissionError.js
@@ -1,0 +1,7 @@
+import { spyFormError } from 'app/utils/formSpyUtils';
+import { RenderErrorMessage } from 'app/components/Form/Field';
+
+const SubmissionError = () =>
+  spyFormError((error) => <>{error && <RenderErrorMessage error={error} />}</>);
+
+export default SubmissionError;

--- a/app/routes/meetings/components/MeetingEditor.js
+++ b/app/routes/meetings/components/MeetingEditor.js
@@ -25,12 +25,7 @@ import { Flex } from 'app/components/Layout';
 import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
 import { unionBy } from 'lodash';
 import { AttendanceStatus } from 'app/components/UserAttendance';
-import {
-  spyFormError,
-  spySubmittable,
-  spyValues,
-} from 'app/utils/formSpyUtils';
-import { RenderErrorMessage } from 'app/components/Form/Field';
+import { spySubmittable, spyValues } from 'app/utils/formSpyUtils';
 import {
   createValidator,
   ifField,
@@ -39,6 +34,7 @@ import {
   required,
   timeIsAfter,
 } from 'app/utils/validation';
+import SubmissionError from 'app/components/Form/SubmissionError';
 
 type Values = {
   title?: string,
@@ -269,9 +265,7 @@ const MeetingEditor = ({
                   </div>
                 </>
               )}
-              {spyFormError((error) => (
-                <>{error && <RenderErrorMessage error={error} />}</>
-              ))}
+              <SubmissionError />
               <Flex wrap>
                 <Button onClick={() => push(`/meetings/${meeting.id}`)}>
                   Avbryt

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -202,6 +202,7 @@ describe('Create meeting', () => {
     selectFromSelectField('users', 'bedkom bedkom (bedkom)', 'bedkom');
 
     selectEditor().type('{enter}{enter}Meeting report');
+    cy.wait(100); // wait for lego-editor debounce
 
     fieldError('title').should('not.exist');
     fieldError('report').should('not.exist');

--- a/cypress/e2e/event_visit_spec.js
+++ b/cypress/e2e/event_visit_spec.js
@@ -51,18 +51,11 @@ describe('View event', () => {
 
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
       .last()
-      .as('form')
-      .click();
-    cy.wait(500);
-    // We have to click twice due to our ssr hack. This is not needed in a real setting, as a
-    // mouseover should fix this issue. That does not seem to work as good here.
-    cy.get(c('CommentForm') + ' [data-slate-editor="true"]').click({
-      force: true,
-    });
-    cy.contains('button', 'Kommenter').as('button').should('not.be.disabled');
+      .click()
+      .wait(100);
+    cy.contains('button', 'Kommenter').should('be.disabled');
     cy.focused().type('This event will be awesome');
-    cy.wait(700);
-    cy.contains('button', 'Kommenter').click();
+    cy.contains('button', 'Kommenter').should('not.be.disabled').click();
 
     // We should see the comment and be able to delete it
     cy.get(c('Comment__comment')).within(($c) => {
@@ -81,25 +74,18 @@ describe('View event', () => {
     cy.reload();
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
       .last()
-      .click();
-    cy.wait(100);
-    cy.get(c('CommentForm') + ' [data-slate-editor="true"]').click({
-      force: true,
-    });
+      .wait(500)
+      .click()
+      .wait(100);
+    cy.contains('button', 'Kommenter').should('be.disabled');
     cy.focused().type('This is the top comment');
-    cy.wait(500);
-    cy.contains('button', 'Kommenter').click();
+    cy.contains('button', 'Kommenter').should('not.be.disabled').click();
 
     cy.get(c('Comment__comment')).last().contains('This is the top comment');
     cy.contains('button', 'Svar').click();
-    cy.contains('button', 'Send svar').should('exist').and('be.disabled');
 
-    cy.wait(500);
-
-    // With out custom methods for interacting with the editor, we need to fire events on some
-    // other elements first.
-    cy.contains('Kommentarer').click();
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
+      .should('have.lengthOf', 2)
       .first()
       .click()
       .wait(100);


### PR DESCRIPTION
While converting the comment form to use `react-final-form` I did some cleanup and refactoring.
- Converted `CommentForm` to a function-component
- For connecting the `CommentForm` and `EditorField` to redux state, I have replaced `connect` with `useDispatch` and `useSelector`. This makes the code a lot more readable imo. and works better with flow.
- Replaced `redux-form` with `react-final-form` in `CommentForm`. Most of what I changed is related to this, as it changes the way we read the form-state and also required some changes to `CommentActions`. I also made use of `LegoFinalForm` to handle errors from the API which further simplified
`CommentActions`.
- Changed the workaround to make ssr work with the editor. I haven't quite figured out why it works like this, but the editor needs to be disabled during ssr, and it needs an explicit re-render to become enabled on the client. This used to be done by having various event-listeners that would enable it, but it seems to work fine to just do it in a `useEffect`, so I've changed it to that.
- Cleaned up the cypress test. (it included some old workarounds that are no longer needed)

As far as I'm aware, I have only made two changes to the functionality of the form.
- The submit-button is now disabled until something is typed (the fact that it wasn't disabled was likely a bug).
- It will now show submission errors in the UI in addition to the little toast in the corner. 