### PR TITLE
bug fix: don't require meeting "location" if useMazemap is selected

### DIFF
--- a/app/routes/meetings/components/MeetingEditor.js
+++ b/app/routes/meetings/components/MeetingEditor.js
@@ -33,6 +33,7 @@ import { RenderErrorMessage } from 'app/components/Form/Field';
 import {
   createValidator,
   ifField,
+  ifNotField,
   legoEditorRequired,
   required,
   timeIsAfter,
@@ -65,7 +66,9 @@ type Props = {
 const validate = createValidator({
   title: [required('Du må gi møtet en tittel')],
   report: [legoEditorRequired('Referatet kan ikke være tomt')],
-  location: [required('Du må gi møtet en lokasjon')],
+  location: [
+    ifNotField('useMazemap', required('Sted eller Mazemap-rom er påkrevd')),
+  ],
   mazemapPoi: [
     ifField('useMazemap', required('Sted eller Mazemap-rom er påkrevd')),
   ],

--- a/app/utils/validation.js
+++ b/app/utils/validation.js
@@ -55,6 +55,9 @@ export const timeIsAfter = (otherField, message) => (value, context) => {
 export const ifField = (field, validator) => (value, context) =>
   context[field] ? validator(value, context) : [true];
 
+export const ifNotField = (field, validator) => (value, context) =>
+  context[field] ? [true] : validator(value, context);
+
 export function createValidator(fieldValidators, rawValidator) {
   return function validate(input) {
     const rawValidatorErrors = rawValidator ? rawValidator(input) : {};


### PR DESCRIPTION
Fix a bug in the meeting editor where new meetings cannot be created without filling in the "location"-field, even if a mazemap location is entered. 