### PR TITLE
Change color of front page banner

### DIFF
--- a/app/components/Banner/Banner.css
+++ b/app/components/Banner/Banner.css
@@ -7,7 +7,7 @@
   box-shadow: 0 1px 4px
     rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 50%);
   border: 1px solid rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 10%);
-  border-radius: 3px;
+  border-radius: 5px;
   animation-name: wiggle;
   animation-duration: 4s;
   animation-iteration-count: infinite;
@@ -40,6 +40,11 @@
 .itdageneBlue {
   background-color: #0778bc;
   color: var(--color-white);
+}
+
+.buddyweek2022 {
+  background-color: #dd6e4b;
+  color: white;
 }
 
 @keyframes wiggle {

--- a/app/components/Banner/index.js
+++ b/app/components/Banner/index.js
@@ -11,6 +11,7 @@ export const COLORS = {
   gray: styles.gray,
   lightBlue: styles.lightBlue,
   itdageneBlue: styles.itdageneBlue,
+  buddyweek2022: styles.buddyweek2022,
 };
 
 type Color = $Keys<typeof COLORS>;

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -196,7 +196,7 @@ class Overview extends Component<Props, State> {
           header="Velkommen til fadderperioden 2022!"
           subHeader="Trykk her for mer informasjon"
           link="articles/414"
-          color={COLORS.red}
+          color={COLORS.buddyweek2022}
           internal
         />
         <Flex className={styles.desktopContainer}>


### PR DESCRIPTION
As requested by the PR committee, the banner on the front page should employ the same background-color as the chosen "buddy week" color for 2022.

<img src="https://user-images.githubusercontent.com/69514187/176993940-4952bc8d-3748-45b5-961d-99f9365f9b51.png" width="500" />
