### PR TITLE
Update path to find eventId of event to copy

### DIFF
--- a/app/routes/events/EventCreateRoute.js
+++ b/app/routes/events/EventCreateRoute.js
@@ -25,7 +25,7 @@ import moment from 'moment-timezone';
 const mapStateToProps = (state, props) => {
   const actionGrant = state.events.actionGrant;
   const valueSelector = formValueSelector('eventEditor');
-  const eventId = props.match.params.id;
+  const eventId = props.location.state?.id;
 
   const eventTemplate = selectEventById(state, { eventId });
   const poolsTemplate = selectPoolsWithRegistrationsForEvent(state, {

--- a/app/routes/events/components/Admin.js
+++ b/app/routes/events/components/Admin.js
@@ -105,7 +105,7 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
             <Link
               to={{
                 pathname: `/events/create`,
-                query: { id: event.id },
+                state: { id: event.id },
               }}
             >
               Lag kopi av arrangement


### PR DESCRIPTION
Resolves https://github.com/webkom/lego/issues/2380

Apparently it seems the location of where props are passed through react-router-dom have changed. I didn't find the changelog for exactly when the change occured, but in my search for answers I found [this StackOverflow answer](https://stackoverflow.com/questions/38085893/react-router-link-pass-in-params) that used `match.params` for react-router-dom v2, and the other sources I visited (e.g. [this guide](https://ui.dev/react-router-v5-pass-props-to-link)) used `location.state` for v5 which we currently use.