### PR TITLE
Change HTTP auth scheme from JWT to Bearer

### DIFF
--- a/app/actions/callAPI.js
+++ b/app/actions/callAPI.js
@@ -117,7 +117,7 @@ export default function callAPI({
 
     const jwt = state.auth.token;
     if (jwt && requiresAuthentication) {
-      requestOptions.headers.Authorization = `JWT ${jwt}`;
+      requestOptions.headers.Authorization = `Bearer ${jwt}`;
     }
 
     function normalizeJsonResponse(

--- a/app/routes/surveys/SubmissionsRoute.js
+++ b/app/routes/surveys/SubmissionsRoute.js
@@ -46,7 +46,7 @@ const mapStateToProps = (state, props) => {
     isSummary,
     exportSurvey: async (surveyId) => {
       const blob = await fetch(getCsvUrl(surveyId), {
-        headers: { Authorization: `JWT ${state.auth.token}` },
+        headers: { Authorization: `Bearer ${state.auth.token}` },
       }).then((response) => response.blob());
       return {
         url: URL.createObjectURL(blob),

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -97,7 +97,7 @@ Cypress.Commands.add('apiRequest', (options, username = 'webkom') => {
     ...options,
     url: apiBaseUrl + options.url,
     headers: {
-      authorization: `JWT ${token}`,
+      authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
       ...options.headers,
     },


### PR DESCRIPTION
This is related to https://github.com/webkom/lego/pull/2801.

[`drf-jwt`](https://styria-digital.github.io/django-rest-framework-jwt/#usage) requires Bearer, instead of `djangorestframework-jwt`'s JWT scheme.

I've spent the last week contemplating and trying to figure out why the JWT auth was not behaving correctly ...... 😣 Check your header schemes kids

**This must be merged together with https://github.com/webkom/lego/pull/2801.**