### PR TITLE
Fix event detail crashing

### DIFF
--- a/app/reducers/followers.js
+++ b/app/reducers/followers.js
@@ -24,7 +24,7 @@ export const selectFollowers = createSelector(
     followers.byId[
       followers.items.find(
         (item) =>
-          followers.byId[item].follower.toString() === follower.toString() &&
+          followers.byId[item].follower.toString() === follower?.toString() &&
           followers.byId[item].target.toString() === target.toString()
       )
     ]


### PR DESCRIPTION
This fixes an issue where the event detail page would crash for some events that you follow.

Now quite sure why this was happening, and I couldn't find when `follower` was undefined when
debugging.

Anyways, this seems to fix the issue :shrug:.
