### PR TITLE
Update create new email form to autofill the new email

### DIFF
--- a/app/routes/admin/email/components/EmailUserEditor.js
+++ b/app/routes/admin/email/components/EmailUserEditor.js
@@ -11,6 +11,11 @@ export type Props = {
   handleSubmit: (Function) => void,
   push: (string) => void,
   mutateFunction: (Object) => Promise<*>,
+  change: (string, Object) => void,
+};
+
+type AutocompleteUserValue = {
+  title: string,
 };
 
 const EmailUserEditor = ({
@@ -19,7 +24,23 @@ const EmailUserEditor = ({
   submitting,
   push,
   handleSubmit,
+  change,
 }: Props) => {
+  const onUserChange = (data: AutocompleteUserValue) => {
+    const nameSplit = data.title.toLowerCase().split(' ');
+    if (nameSplit.length < 2) return;
+    let email = nameSplit[0] + '.' + nameSplit[nameSplit.length - 1];
+    // Replace predefined characters
+    const illegalChars = { å: 'aa', æ: 'ae', ø: 'oe' };
+    Object.keys(illegalChars).forEach(
+      (char) =>
+        (email = email.replace(new RegExp(char, 'g'), illegalChars[char]))
+    );
+    // Remove any other non-a-z characters
+    email = email.replace(/[^a-z0-9.-]/gi, '');
+    change('internalEmail', email);
+  };
+
   const onSubmit = (data) => {
     mutateFunction({
       ...data,
@@ -42,6 +63,7 @@ const EmailUserEditor = ({
         placeholder="Velg bruker"
         filter={['users.user']}
         component={SelectInput.AutocompleteField}
+        onChange={(data) => onUserChange(((data: any): AutocompleteUserValue))}
       />
       <Field
         required


### PR DESCRIPTION
Recruitment-season do be closing in, and as it's not unheard of to write the wrong name when creating new emails I decided it could be nice to give a helping hand.

Set æøå to be replaced by ae, oe and aa. Seemed to be kinda standard, but if anyone has any objections I'll do it.  
Set to remove any characters except a-z, 0-9, - and . after the three above are replaced.

![image](https://user-images.githubusercontent.com/13599770/184415529-81324563-7246-45a2-9735-56b3c990a9d8.png)
![image](https://user-images.githubusercontent.com/13599770/184415582-2e3d6540-6661-4265-a95d-43fd2c30f66c.png)
![image](https://user-images.githubusercontent.com/13599770/184415616-26fa58f0-ecd3-472f-a943-d90b9362b64d.png)
