### PR TITLE
Fix event-detail title overflow, make participants-list fit content

### DIFF
--- a/app/components/Content/ContentHeader.css
+++ b/app/components/Content/ContentHeader.css
@@ -5,4 +5,11 @@
   border-bottom-width: 2px;
   border-bottom-style: solid;
   margin-bottom: 1em;
+  flex-wrap: wrap;
+}
+
+.eventType {
+  display: flex;
+  justify-content: flex-end;
+  flex-grow: 1;
 }

--- a/app/components/Content/ContentHeader.js
+++ b/app/components/Content/ContentHeader.js
@@ -35,7 +35,7 @@ function ContentHeader({
     >
       <h2>{children}</h2>
       {event && (
-        <strong style={{ color: borderColor }}>
+        <strong style={{ color: borderColor }} className={styles.eventType}>
           {eventTypeToString(event.eventType)}
         </strong>
       )}

--- a/app/components/UserGrid/index.js
+++ b/app/components/UserGrid/index.js
@@ -25,7 +25,7 @@ const UserGrid = ({
       gridTemplateColumns: `repeat(auto-fill, minmax(${
         size + padding
       }px, 1fr))`,
-      gridTemplateRows: size + padding,
+      gridTemplateRows: users.length === 0 ? 0 : size + padding,
       overflow: 'hidden',
       minHeight: minRows * size + (minRows - 1) * padding,
       maxHeight: maxRows * size + (maxRows - 1) * padding,

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -352,7 +352,7 @@ export default class EventDetail extends Component<Props, State> {
                   {registrations ? (
                     <Fragment>
                       <UserGrid
-                        minRows={2}
+                        minRows={0}
                         maxRows={2}
                         users={registrations
                           .slice(0, 14)


### PR DESCRIPTION

## ~Full-width
Only change here is that the list of participants has no height if there are no participants.
### Before
![image](https://user-images.githubusercontent.com/13599770/184863803-207d01e6-62e0-4ae2-bb3a-89ac93d6a0f3.png)

### After
![image](https://user-images.githubusercontent.com/13599770/184863629-6a96844a-8f81-4888-8a3b-d9de680dfb20.png)

## Smaller width
List of participants has no height if there are no participants  
Title and event-type wraps so none overflow and the title gets to use the entire width
### Before
![image](https://user-images.githubusercontent.com/13599770/184864521-ba2098b8-a65b-4b67-bed4-eb0e933a69f2.png)

### After
![image](https://user-images.githubusercontent.com/13599770/184864692-db2829b7-65ed-4cea-b92f-d6c7e5a511e4.png)
