### PR TITLE
Upgrade Ionicons to version 5

### DIFF
--- a/app/components/Button/Button.css
+++ b/app/components/Button/Button.css
@@ -38,7 +38,8 @@
     transform: translateY(1px);
   }
 
-  > i {
+  > i,
+  > ion-icon {
     margin-right: 7px;
   }
 

--- a/app/components/EmptyState/index.js
+++ b/app/components/EmptyState/index.js
@@ -20,7 +20,7 @@ type Props = {
  */
 const EmptyState = ({ icon, size = 88, className, children }: Props) => (
   <div className={cx(styles.container, icon && styles.centered, className)}>
-    {icon && <Icon className={styles.icon} size={size} name={icon} />}
+    {icon && <Icon name={icon} className={styles.icon} size={size} />}
     {children}
   </div>
 );

--- a/app/components/Feed/renders/announcement.js
+++ b/app/components/Feed/renders/announcement.js
@@ -35,7 +35,7 @@ export function activityContent() {
 }
 
 export function icon() {
-  return <Icon name="chatboxes" />;
+  return <Icon name="chatbubbles" />;
 }
 
 export function getURL(aggregatedActivity: AggregatedActivity) {

--- a/app/components/Feed/renders/comment.js
+++ b/app/components/Feed/renders/comment.js
@@ -41,7 +41,7 @@ export function activityContent(activity: Activity) {
 }
 
 export function icon() {
-  return <Icon name="text" />;
+  return <Icon name="chatbubble" />;
 }
 
 export function getURL(aggregatedActivity: AggregatedActivity) {

--- a/app/components/Feed/renders/comment_reply.js
+++ b/app/components/Feed/renders/comment_reply.js
@@ -41,7 +41,7 @@ export function activityContent(activity: Activity) {
 }
 
 export function icon() {
-  return <Icon name="text" />;
+  return <Icon name="chatbubble" />;
 }
 
 export function getURL(aggregatedActivity: AggregatedActivity) {

--- a/app/components/Feed/renders/event_register.js
+++ b/app/components/Feed/renders/event_register.js
@@ -40,7 +40,7 @@ export function activityContent(activity: Activity) {
 }
 
 export function icon() {
-  return <Icon name="text" />;
+  return <Icon name="chatbubble" />;
 }
 
 export function getURL(aggregatedActivity: AggregatedActivity) {

--- a/app/components/Form/DatePicker.css
+++ b/app/components/Form/DatePicker.css
@@ -20,21 +20,9 @@
 }
 
 .header {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 20px;
+  font-size: 1.3em;
   text-align: center;
   padding: 10px;
-
-  > h3 {
-    flex: 3;
-  }
-
-  > * {
-    flex: 1;
-  }
 }
 
 .calendarItem {

--- a/app/components/Form/DatePicker.js
+++ b/app/components/Form/DatePicker.js
@@ -4,13 +4,13 @@ import { Component } from 'react';
 import moment from 'moment-timezone';
 import cx from 'classnames';
 import Dropdown from 'app/components/Dropdown';
-import Icon from 'app/components/Icon';
 import createMonthlyCalendar from 'app/utils/createMonthlyCalendar';
 import { createField } from './Field';
 import TextInput from './TextInput';
 import TimePicker from './TimePicker';
 import styles from './DatePicker.css';
 import parseDateValue from 'app/utils/parseDateValue';
+import Flex from 'app/components/Layout/Flex';
 
 type Props = {
   onChange: (string) => void,
@@ -116,15 +116,19 @@ class DatePicker extends Component<Props, State> {
         style={{ flex: 1 }}
       >
         <div className={styles.datePicker} onClick={(e) => e.stopPropagation()}>
-          <div className={styles.header}>
+          <Flex
+            justifyContent="space-between"
+            alignItems="center"
+            className={styles.header}
+          >
             <button onClick={this.onPrev} className={styles.arrowIcon}>
-              <Icon name="arrow-back" />
+              <i className="fa fa-long-arrow-left" />
             </button>
-            <h3>{date.format('MMMM YYYY')}</h3>
+            <span>{date.format('MMMM YYYY')}</span>
             <button onClick={this.onNext} className={styles.arrowIcon}>
-              <Icon name="arrow-forward" />
+              <i className="fa fa-long-arrow-right" />
             </button>
-          </div>
+          </Flex>
 
           <div className={styles.calendar}>
             {createMonthlyCalendar(date).map((dateProps, i) => (

--- a/app/components/Form/TimePicker.js
+++ b/app/components/Form/TimePicker.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { Component } from 'react';
-import Icon from 'app/components/Icon';
 import TextInput from './TextInput';
 import { createField } from './Field';
 import styles from './TimePicker.css';
@@ -11,11 +10,11 @@ function TimePickerInput({ onNext, onPrev, ...props }: any) {
   return (
     <div className={styles.timePickerInput}>
       <button type="button" onClick={onNext} className={styles.arrowIcon}>
-        <Icon name="arrow-up" />
+        <i className="fa fa-angle-up" />
       </button>
       <TextInput {...props} />
       <button type="button" onClick={onPrev} className={styles.arrowIcon}>
-        <Icon name="arrow-down" />
+        <i className="fa fa-angle-down" />
       </button>
     </div>
   );

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -67,20 +67,20 @@ function AccountDropdownItems({
           style={{ color: 'var(--lego-color-gray)' }}
         >
           <strong>{username}</strong>
-          <Icon name="contact" size={24} />
+          <Icon name="person-circle-outline" size={24} />
         </NavLink>
       </Dropdown.ListItem>
       <Dropdown.Divider />
       <Dropdown.ListItem>
         <Link to="/users/me/settings/profile" onClick={onClose}>
           Innstillinger
-          <Icon name="cog" size={24} />
+          <Icon name="settings-outline" size={24} />
         </Link>
       </Dropdown.ListItem>
       <Dropdown.ListItem>
         <Link to="/meetings/" onClick={onClose}>
           Møteinnkallinger
-          <Icon name="calendar" size={24} />
+          <Icon name="calendar-outline" size={24} />
         </Link>
       </Dropdown.ListItem>
       <Dropdown.Divider />
@@ -93,7 +93,7 @@ function AccountDropdownItems({
           }}
         >
           Logg ut
-          <Icon name="log-out" size={24} />
+          <Icon name="log-out-outline" size={24} />
         </Button>
       </Dropdown.ListItem>
     </Dropdown.List>
@@ -236,7 +236,7 @@ class Header extends Component<Props, State> {
                   closeOnContentClick
                   triggerComponent={
                     <ProfilePicture
-                      size={30}
+                      size={24}
                       alt="user"
                       user={this.props.currentUser}
                       style={{ verticalAlign: 'middle' }}
@@ -265,7 +265,7 @@ class Header extends Component<Props, State> {
                     this.state.shake ? 'animated shake' : '',
                     styles.dropdown
                   )}
-                  triggerComponent={<Icon name="contact" size={30} />}
+                  triggerComponent={<Icon name="person-circle-outline" />}
                 >
                   <div style={{ padding: 10 }}>
                     <Flex
@@ -309,7 +309,7 @@ class Header extends Component<Props, State> {
               )}
 
               <button onClick={this.props.toggleSearch}>
-                <Icon name="menu" size={30} className={styles.searchIcon} />
+                <Icon name="menu" className={styles.searchIcon} />
               </button>
             </div>
           </div>

--- a/app/components/HeaderNotifications/index.js
+++ b/app/components/HeaderNotifications/index.js
@@ -95,7 +95,6 @@ export default class NotificationsDropdown extends Component<Props, State> {
         triggerComponent={
           <Icon.Badge
             name="notifications"
-            size={30}
             className={styles.notificationBell}
             badgeCount={this.state.notificationsOpen ? 0 : unreadCount}
           />

--- a/app/components/Icon/index.js
+++ b/app/components/Icon/index.js
@@ -1,49 +1,46 @@
 // @flow
 
-import cx from 'classnames';
 import styles from './Icon.css';
 
 type Props = {
   /** Name of the icon can be found on the webpage*/
   name: string,
-  /** Name of the icon can be found on the webpage*/
   scaleOnHover?: boolean,
-  /** Name of the icon can be found on the webpage*/
   className?: string,
-  /** Name of the icon can be found on the webpage*/
   size?: number,
-  /** Name of the icon can be found on the webpage*/
-  prefix?: string,
-  /** Icon prefix. defaults to "ion-ios-" */
   style?: Object,
 };
 
 /**
- * Render an Icon
+ * Render an Icon like this with the name of your icon:
  *
- * <Icon name="add" > </Icon>
+ * <Icon name="add" />
  *
- * Just like this...
+ * Names can be found here:
+ * https://ionic.io/ionicons
  *
- * https://infinitered.github.io/ionicons-version-3-search/
  */
-function Icon({
+const Icon = ({
   name = 'star',
-  prefix = 'ion-ios-',
   scaleOnHover = false,
   className,
   style = {},
   size = 24,
   ...props
-}: Props) {
+}: Props) => {
   return (
-    <i
-      className={cx(`${prefix}${name}`, styles.icon, className)}
-      style={{ fontSize: `${size.toString()}px`, lineHeight: 1, ...style }}
+    <ion-icon
+      name={name}
+      class={className}
+      style={{
+        fontSize: `${size.toString()}px`,
+        lineHeight: 2,
+        ...style,
+      }}
       {...(props: Object)}
-    />
+    ></ion-icon>
   );
-}
+};
 
 Icon.Badge = ({ badgeCount, ...props }: Props & { badgeCount: number }) => {
   const icon = <Icon {...props} />;

--- a/app/components/NavigationTab/index.js
+++ b/app/components/NavigationTab/index.js
@@ -25,12 +25,7 @@ const NavigationTab = (props: Props) => (
   <>
     {props.back && (
       <NavLink to={props.back.path} className={styles.back}>
-        <Icon
-          size={19}
-          name="arrow-back"
-          prefix="ion-md-"
-          className={styles.backIcon}
-        />
+        <Icon name="arrow-back" size={19} className={styles.backIcon} />
         <span className={styles.backLabel}>{props.back.label}</span>
       </NavLink>
     )}

--- a/app/components/PhotoUploadStatus/index.js
+++ b/app/components/PhotoUploadStatus/index.js
@@ -50,7 +50,6 @@ const UploadStatusCard = ({
       <div align="right">
         <Icon
           style={{ cursor: 'pointer' }}
-          size={24}
           onClick={hideUploadStatus}
           name="close"
         />

--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -2,6 +2,7 @@
 
 .optionWrapper {
   justify-content: center;
+  margin-top: 4px;
   min-height: 120px;
   position: relative;
 }
@@ -84,10 +85,6 @@ html[data-theme='dark'] .pollGraph {
 }
 
 .pollHeader {
-  border-radius: 8px;
-  margin-bottom: 20px;
-  margin-left: 20px;
-  font-size: 16px;
   color: var(--lego-font-color);
 }
 

--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -107,9 +107,7 @@ html[data-theme='dark'] .pollGraph {
   cursor: pointer;
 
   &:hover {
-    transform: scale(1.5);
     color: var(--color-red-3);
-    transition: transform 0.2s;
   }
 }
 

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -118,7 +118,7 @@ class Poll extends Component<Props, State> {
       <div className={cx(styles.poll, backgroundLight ? styles.pollLight : '')}>
         <Flex>
           <Link to={`/polls/${id}`} style={{ flex: 1 }}>
-            <Icon name="stats" />
+            <Icon name="stats-chart" />
             <span className={styles.pollHeader}>{title}</span>
           </Link>
           <Tooltip content="Avstemningen er anonym." renderDirection="left">
@@ -197,9 +197,9 @@ class Poll extends Component<Props, State> {
                   Klikk her for å se alle alternativene.
                 </p>
                 <Icon
-                  className={cx(styles.blurOverlay, styles.blurArrow)}
+                  name={expanded ? 'chevron-up' : 'chevron-down'}
                   size={60}
-                  name={expanded ? 'arrow-up' : 'arrow-down'}
+                  className={cx(styles.blurOverlay, styles.blurArrow)}
                 />
               </Flex>
             )}
@@ -232,9 +232,9 @@ class Poll extends Component<Props, State> {
                 <div className={styles.alignItems}>
                   <Icon
                     onClick={this.toggleTruncate}
-                    className={styles.arrow}
+                    name={expanded ? 'chevron-up' : 'chevron-down'}
                     size={20}
-                    name={expanded ? 'arrow-up' : 'arrow-down'}
+                    className={styles.arrow}
                   />
                 </div>
               )}

--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -116,17 +116,21 @@ class Poll extends Component<Props, State> {
 
     return (
       <div className={cx(styles.poll, backgroundLight ? styles.pollLight : '')}>
-        <Flex>
-          <Link to={`/polls/${id}`} style={{ flex: 1 }}>
-            <Icon name="stats-chart" />
-            <span className={styles.pollHeader}>{title}</span>
+        <Flex wrap justifyContent="space-between" alignItems="center">
+          <Link to={`/polls/${id}`}>
+            <Flex gap={10}>
+              <Icon name="stats-chart" />
+              <span className={styles.pollHeader}>{title}</span>
+            </Flex>
           </Link>
           <Tooltip content="Avstemningen er anonym." renderDirection="left">
-            <Icon
-              name="information-circle-outline"
-              size={20}
-              style={{ cursor: 'pointer' }}
-            />
+            <Flex>
+              <Icon
+                name="information-circle-outline"
+                size={20}
+                style={{ cursor: 'pointer' }}
+              />
+            </Flex>
           </Tooltip>
         </Flex>
         {details && (

--- a/app/components/Search/SearchPageResults.js
+++ b/app/components/Search/SearchPageResults.js
@@ -56,8 +56,8 @@ function SearchResult({ result, onSelect, isSelected }: SearchResultProps) {
               />
             ) : (
               <Icon
-                className={styles.searchResultItemIcon}
                 name={result.icon}
+                className={styles.searchResultItemIcon}
               />
             )}
           </h3>

--- a/app/components/Search/SearchResults.js
+++ b/app/components/Search/SearchResults.js
@@ -30,9 +30,9 @@ const SearchResultItem = ({
       )}
       {!result.profilePicture && result.icon && (
         <Icon
-          className={styles.searchResultItemIcon}
           name={result.icon}
           size={28}
+          className={styles.searchResultItemIcon}
         />
       )}
       <ul>

--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -214,12 +214,9 @@ export default class Table extends Component<Props, State> {
         <div className={styles.tableHeader}>
           {sorter && (
             <div className={styles.sorter}>
-              <Icon
+              <i
                 onClick={() => this.onSortInput(dataIndex, sorter)}
-                name={sortIconName}
-                prefix="fa fa-"
-                size={18}
-                className={styles.icon}
+                className={`fa fa-${sortIconName}`}
               />
             </div>
           )}
@@ -232,6 +229,7 @@ export default class Table extends Component<Props, State> {
                 triggerComponent={
                   <Icon
                     name="search"
+                    size={21}
                     className={cx(
                       (filters[dataIndex] && filters[dataIndex].length) ||
                         isShown[dataIndex]

--- a/app/components/Upload/ImageUpload.js
+++ b/app/components/Upload/ImageUpload.js
@@ -76,10 +76,9 @@ const FilePreview = ({ file, onRemove }: FilePreviewProps) => {
         </div>
       </div>
       <Icon
-        size={32}
-        name="trash"
-        prefix="ion-md-"
         onClick={onRemove}
+        name="trash"
+        size={32}
         className={styles.removeIcon}
       />
     </Flex>
@@ -111,7 +110,7 @@ const UploadArea = ({ multiple, onDrop, image }: UploadAreaProps) => {
       <div {...getRootProps({ className: styles.dropArea })}>
         <div className={styles.placeholderContainer}>
           <Icon size={82} name="image" />
-          <h2 className={styles.placeholdeTitle}>
+          <h2 className={styles.placeholderTitle}>
             {`Dropp ${word} her eller trykk for å velge fra fil`}
           </h2>
         </div>

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -50,7 +50,7 @@ html[data-theme='dark'] .dropArea {
   position: absolute;
 }
 
-.placeholdeTitle {
+.placeholderTitle {
   background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 80%);
   border-radius: 5px;
   padding: 0 20px;

--- a/app/routes/company/components/CompaniesPage.css
+++ b/app/routes/company/components/CompaniesPage.css
@@ -124,14 +124,6 @@ html[data-theme='dark'] .companyItem {
   width: 100%;
 }
 
-.briefcaseCount {
-  margin-right: 5px;
-}
-
-.calendarCount {
-  margin-right: 5px;
-}
-
 .iconInfo {
   margin-left: 10px;
   margin-bottom: 10px;

--- a/app/routes/company/components/CompaniesPage.js
+++ b/app/routes/company/components/CompaniesPage.js
@@ -142,15 +142,15 @@ class CompaniesPage extends Component<Props, State> {
           </div>
         </div>
         <div className={styles.iconInfoPlacement}>
-          <Flex row>
+          <Flex>
             <Icon name="briefcase" size={25} />
             <span className={styles.iconInfo}> Aktive jobbannonser</span>
           </Flex>
-          <Flex row>
+          <Flex>
             <Icon name="at-circle" size={25} />
             <span className={styles.iconInfo}> Nettside</span>
           </Flex>
-          <Flex row>
+          <Flex>
             <Icon name="calendar-clear" size={25} />
             <span className={styles.iconInfo}> Kommende arrangementer</span>
           </Flex>

--- a/app/routes/company/components/CompaniesPage.js
+++ b/app/routes/company/components/CompaniesPage.js
@@ -40,11 +40,9 @@ const CompanyItem = ({ company }: Company) => {
           </Link>
         </div>
         <Flex className={styles.companyInfo}>
-          <Flex column>
-            <Icon name="md-briefcase" prefix="ion-" size={20} />
-            <span className={styles.briefcaseCount}>
-              {company.joblistingCount}
-            </span>
+          <Flex column alignItems="center">
+            <Icon name="briefcase" size={20} />
+            <span>{company.joblistingCount}</span>
           </Flex>
           {company.website && (
             <div className={styles.iconLink}>
@@ -53,21 +51,20 @@ const CompanyItem = ({ company }: Company) => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Flex column>
+                <Flex column alignItems="center">
                   <Icon
-                    name="at"
+                    name="at-circle"
                     size={20}
                     style={{ color: 'var(--lego-link-color)' }}
                   />
-                  <span />
-                  Link her
+                  <span>Link her</span>
                 </Flex>
               </a>
             </div>
           )}
-          <Flex column>
-            <Icon name="md-calendar" prefix="ion-" size={20} />
-            <span className={styles.calendarCount}>{company.eventCount}</span>
+          <Flex column alignItems="center">
+            <Icon name="calendar-clear" size={20} />
+            <span>{company.eventCount}</span>
           </Flex>
         </Flex>
       </div>
@@ -146,15 +143,15 @@ class CompaniesPage extends Component<Props, State> {
         </div>
         <div className={styles.iconInfoPlacement}>
           <Flex row>
-            <Icon name="md-briefcase" prefix="ion-" size={25} />
+            <Icon name="briefcase" size={25} />
             <span className={styles.iconInfo}> Aktive jobbannonser</span>
           </Flex>
           <Flex row>
-            <Icon name="at" size={25} />
+            <Icon name="at-circle" size={25} />
             <span className={styles.iconInfo}> Nettside</span>
           </Flex>
           <Flex row>
-            <Icon name="md-calendar" prefix="ion-" size={25} />
+            <Icon name="calendar-clear" size={25} />
             <span className={styles.iconInfo}> Kommende arrangementer</span>
           </Flex>
         </div>

--- a/app/routes/company/components/CompanyDetail.js
+++ b/app/routes/company/components/CompanyDetail.js
@@ -120,7 +120,7 @@ class CompanyEvents extends Component<EventProps, *> {
             }}
           >
             <Icon
-              name="arrow-dropdown"
+              name="chevron-down-circle-outline"
               size={35}
               onClick={fetchMoreEvents}
               style={{ cursor: 'pointer' }}

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -1,7 +1,7 @@
 @import '../Event.css';
 
 .star {
-  color: var(--color-event-red);
+  color: var(--color-orange-5);
   margin-right: 10px;
 }
 

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -219,7 +219,10 @@ export default class EventDetail extends Component<Props, State> {
                   </span>
                 }
               >
-                Frist for prikk <Icon name="help-circle-outline" size={16} />
+                <Flex alignItems="center" gap={4}>
+                  Frist for prikk
+                  <Icon name="help-circle-outline" size={16} />
+                </Flex>
               </Tooltip>
             ),
             value: (

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -56,11 +56,11 @@ const InterestedButton = ({ isInterested }: InterestedButtonProps) => {
         style={{ lineHeight: '1.3rem' }}
         content={
           <span style={{ fontSize: '1rem', fontWeight: '100', padding: '0' }}>
-            Favoritt
+            Følg arrangementet, og få e-post når påmelding nærmer seg!
           </span>
         }
       >
-        <Icon className={styles.star} name={icon} />
+        <Icon name={icon} className={styles.star} />
       </Tooltip>
     </div>
   );
@@ -325,7 +325,7 @@ export default class EventDetail extends Component<Props, State> {
                 </div>
               )}
               <div className={styles.iconWithText}>
-                <Icon name="pin-outline" className={styles.infoIcon} />
+                <Icon name="location-outline" className={styles.infoIcon} />
                 <strong>{event.location}</strong>
               </div>
               {event.mazemapPoi && (

--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -223,8 +223,8 @@ class EventList extends Component<EventListProps, State> {
             </label>
           </div>
           <Icon
-            size={25}
             name="funnel-outline"
+            size={25}
             style={{ marginRight: '5px', marginLeft: '10px' }}
           />
           <Select

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -105,7 +105,7 @@ const SubmitButton = ({
       }}
     >
       <Button className={styles.registrationBtn} danger disabled={disabled}>
-        <Icon name="remove" prefix="ion-md-" />
+        <Icon name="person-remove" size={19} />
         {title}
       </Button>
     </ConfirmModalWithParent>

--- a/app/routes/overview/components/NextEvent.js
+++ b/app/routes/overview/components/NextEvent.js
@@ -90,7 +90,7 @@ class EventItem extends Component<Props, State> {
 // Component when there is no events
 const Filler = () => (
   <Flex column className={styles.filler}>
-    <Icon size={40} name="eye-off-outline" style={{ marginRight: '5px' }} />
+    <Icon name="eye-off-outline" size={40} style={{ marginRight: '5px' }} />
     <span>Ingen påmeldinger de neste 3 dagene </span>
   </Flex>
 );

--- a/app/routes/overview/components/Overview.js
+++ b/app/routes/overview/components/Overview.js
@@ -227,7 +227,11 @@ class Overview extends Component<Props, State> {
         </section>
         {frontpage.length > 8 && (
           <div className={styles.showMore}>
-            <Icon onClick={this.showMore} size={40} name="arrow-dropdown" />
+            <Icon
+              onClick={this.showMore}
+              name="chevron-down-circle-outline"
+              size={40}
+            />
           </div>
         )}
       </Container>

--- a/app/routes/pages/components/LandingPage.js
+++ b/app/routes/pages/components/LandingPage.js
@@ -132,7 +132,7 @@ const LandingPage = ({
           </div>
           <Flex wrap className={styles.committeeEmails}>
             <div className={styles.socialMediaType}>
-              <Icon name="logo-facebook" size={40} prefix="ion-" />
+              <Icon name="logo-facebook" size={40} />
               <div className={styles.socialMediaTypeLinks}>
                 {socialMedia.facebook.map((page, index) => (
                   <a
@@ -154,7 +154,7 @@ const LandingPage = ({
               </div>
             </div>
             <div className={styles.socialMediaType}>
-              <Icon name="logo-instagram" size={40} prefix="ion-" />
+              <Icon name="logo-instagram" size={40} />
               <div className={styles.socialMediaTypeLinks}>
                 {socialMedia.instagram.map((page, index) => (
                   <a
@@ -171,7 +171,6 @@ const LandingPage = ({
               <Icon
                 name="logo-snapchat"
                 size={40}
-                prefix="ion-"
                 className={styles.snapchatIcon}
               />
               <div className={styles.socialMediaTypeLinks}>

--- a/app/routes/pages/components/PageDetail.js
+++ b/app/routes/pages/components/PageDetail.js
@@ -77,7 +77,7 @@ class PageDetail extends Component<Props, State> {
         <Helmet title={selectedPageInfo.title} />
         <div className={styles.main}>
           <button className={styles.sidebarOpenBtn} onClick={this.openSidebar}>
-            <Icon size={30} name="arrow-forward" />
+            <Icon name="arrow-forward" size={30} />
           </button>
           <Flex className={styles.page}>
             <Sidebar

--- a/app/routes/pages/components/PageHierarchy.js
+++ b/app/routes/pages/components/PageHierarchy.js
@@ -110,9 +110,9 @@ class AccordionContainer extends Component<AccordionProps, AccordionState> {
         <button className={styles.dropdownBtn} onClick={this.handleClick}>
           {title}{' '}
           {this.state.isOpen ? (
-            <Icon className={styles.dropdownIcon} name="arrow-down" />
+            <Icon name="arrow-down" className={styles.dropdownIcon} />
           ) : (
-            <Icon className={styles.dropdownIcon} name="arrow-forward" />
+            <Icon name="arrow-forward" className={styles.dropdownIcon} />
           )}
         </button>{' '}
         {this.state.isOpen ? <div>{children}</div> : null}

--- a/app/routes/pages/components/Sidebar.js
+++ b/app/routes/pages/components/Sidebar.js
@@ -48,7 +48,7 @@ class Sidebar extends Component<Props, State> {
           <aside className={styles.sidebar}>
             <div className={styles.sidebarTop}>
               <button className={styles.sidebarCloseBtn} onClick={handleClose}>
-                <Icon size={50} name="close" />
+                <Icon name="close" size={50} />
               </button>
               <h3 className={styles.sidebarHeader}>Om Abakus</h3>
               <h4 className={styles.sidebarSubtitle}>

--- a/app/routes/photos/components/GalleryEditor.js
+++ b/app/routes/photos/components/GalleryEditor.js
@@ -66,12 +66,12 @@ const photoOverlay = (photo: Object, selected: Array<number>) => (
     )}
   >
     <Icon
+      name="checkmark-circle-outline"
+      size={32}
       className={cx(
         styles.icon,
         selected.includes(photo.id) && styles.iconSelected
       )}
-      name="checkmark-circle-outline"
-      size={32}
     />
   </div>
 );

--- a/app/routes/photos/components/GalleryPictureModal.js
+++ b/app/routes/photos/components/GalleryPictureModal.js
@@ -256,7 +256,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
                 closeOnContentClick
                 className={styles.dropdown}
                 contentClassName={styles.dropdownContent}
-                iconName="more"
+                iconName="options-outline"
               >
                 <Dropdown.List>
                   <Dropdown.ListItem>
@@ -279,7 +279,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
                           style={{ color: 'var(--lego-color-gray)' }}
                         >
                           <strong>Rediger</strong>
-                          <Icon name="gear" size={24} />
+                          <Icon name="create-outline" size={24} />
                         </Link>
                       </Dropdown.ListItem>,
                       <Dropdown.ListItem key="cover">
@@ -289,7 +289,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
                           style={{ color: 'var(--lego-color-gray)' }}
                         >
                           <strong>Sett som album cover</strong>
-                          <Icon name="image" size={24} />
+                          <Icon name="image-outline" size={24} />
                         </Link>
                       </Dropdown.ListItem>,
                       <Dropdown.Divider key="divider" />,
@@ -326,12 +326,12 @@ export default class GalleryPictureModal extends Component<Props, State> {
                   onClick={this.previousGalleryPicture}
                   style={{ marginRight: '50px' }}
                 >
-                  <Icon name="arrow-dropleft" size={64} />
+                  <Icon name="arrow-back-circle-outline" size={64} />
                 </Link>
               )}
               {this.state.hasNext && (
                 <Link to="#" onClick={this.nextGalleryPicture}>
-                  <Icon name="arrow-dropright" size={64} />
+                  <Icon name="arrow-forward-circle-outline" size={64} />
                 </Link>
               )}
             </Flex>

--- a/app/routes/podcasts/components/Podcast.js
+++ b/app/routes/podcasts/components/Podcast.js
@@ -103,16 +103,16 @@ class Podcast extends Component<Props, State> {
           {this.state.extended ? (
             <Icon
               onClick={this.showMore}
-              className={styles.arrow}
-              size={20}
               name="arrow-up"
+              size={20}
+              className={styles.arrow}
             />
           ) : (
             <Icon
               onClick={this.showMore}
-              className={styles.arrow}
-              size={20}
               name="arrow-down"
+              size={20}
+              className={styles.arrow}
             />
           )}
         </Button>

--- a/app/routes/podcasts/components/PodcastList.js
+++ b/app/routes/podcasts/components/PodcastList.js
@@ -47,7 +47,11 @@ class PodcastList extends Component<Props, State> {
         {elements}
         {podcasts.length > this.state.items && (
           <div className={styles.showMore}>
-            <Icon onClick={this.showMore} size={40} name="arrow-dropdown" />
+            <Icon
+              name="chevron-down-circle-outline"
+              size={40}
+              onClick={this.showMore}
+            />
           </div>
         )}
       </Content>

--- a/app/routes/podcasts/components/PodcastPlayer.js
+++ b/app/routes/podcasts/components/PodcastPlayer.js
@@ -42,7 +42,11 @@ class LegoSoundCloudPlayer extends Component<Props, *> {
               to={`/podcasts/${id}/edit`}
               style={{ marginRight: '10px', whiteSpace: 'nowrap' }}
             >
-              <Icon size={17} name="options" style={{ marginRight: '5px' }} />
+              <Icon
+                size={17}
+                name="options-outline"
+                style={{ marginRight: '5px' }}
+              />
               Det er noe feil med linken til denne podcasten, trykk her for å
               endre den
             </Link>
@@ -57,8 +61,8 @@ class LegoSoundCloudPlayer extends Component<Props, *> {
         <div className={styles.header}>
           <span>
             <Icon
-              size={15}
               name="musical-notes"
+              size={15}
               style={{ marginRight: '5px' }}
             />
             <span className={styles.title}>{track ? track.title : ''}</span>
@@ -68,7 +72,11 @@ class LegoSoundCloudPlayer extends Component<Props, *> {
               to={`/podcasts/${id}/edit`}
               style={{ marginRight: '10px', whiteSpace: 'nowrap' }}
             >
-              <Icon size={17} name="options" style={{ marginRight: '5px' }} />
+              <Icon
+                name="options-outline"
+                size={17}
+                style={{ marginRight: '5px' }}
+              />
               Edit
             </Link>
           )}
@@ -98,12 +106,12 @@ class LegoSoundCloudPlayer extends Component<Props, *> {
           />
           <Flex className={styles.extra}>
             <span>
-              <Icon size={15} name="time" style={{ margin: '0 5px' }} />
+              <Icon name="time" size={15} style={{ margin: '0 5px' }} />
               {moment(date, 'YYYY/MM/DD').format('Do MMM YYYY')}
             </span>
             <span>
               Lyttere
-              <Icon size={15} name="podium" style={{ margin: '0 5px' }} />
+              <Icon name="stats-chart" size={15} style={{ margin: '0 5px' }} />
               {track.playback_count}
             </span>
           </Flex>

--- a/app/routes/polls/components/PollEditor.js
+++ b/app/routes/polls/components/PollEditor.js
@@ -74,11 +74,7 @@ const renderOptions = ({
             className={styles.deleteOption}
           >
             <Tooltip content="Fjern">
-              <Icon
-                name="trash"
-                prefix="ion-md-"
-                className={styles.deleteOption}
-              />
+              <Icon name="trash" className={styles.deleteOption} />
             </Tooltip>
           </ConfirmModalWithParent>
         </li>
@@ -86,7 +82,7 @@ const renderOptions = ({
     </ul>
 
     <Button onClick={() => fields.push({})}>
-      <Icon name="add" prefix="ion-md-" size={25} />
+      <Icon name="add" size={25} />
       Legg til alternativ
     </Button>
   </div>

--- a/app/routes/polls/components/PollsList.css
+++ b/app/routes/polls/components/PollsList.css
@@ -26,7 +26,3 @@
 .heading {
   margin-left: 15px;
 }
-
-.answeredText {
-  float: right;
-}

--- a/app/routes/polls/components/PollsList.js
+++ b/app/routes/polls/components/PollsList.js
@@ -53,7 +53,7 @@ const PollsList = ({
           >
             <div className={styles.pollListItem}>
               <Flex>
-                <Icon className={styles.icon} name="stats" size={40} />
+                <Icon name="stats" size={40} className={styles.icon} />
                 <h3 className={styles.heading}>{poll.title}</h3>
               </Flex>
               <span>{`Antall stemmer: ${poll.totalVotes}`}</span>

--- a/app/routes/polls/components/PollsList.js
+++ b/app/routes/polls/components/PollsList.js
@@ -53,32 +53,36 @@ const PollsList = ({
           >
             <div className={styles.pollListItem}>
               <Flex>
-                <Icon name="stats" size={40} className={styles.icon} />
+                <Icon name="stats-chart" size={35} className={styles.icon} />
                 <h3 className={styles.heading}>{poll.title}</h3>
               </Flex>
-              <span>{`Antall stemmer: ${poll.totalVotes}`}</span>
-              {poll.hasAnswered ? (
-                <span className={styles.answeredText}>
-                  Svart
-                  <Icon
-                    name="checkmark-circle-outline"
-                    size={20}
-                    style={{ marginLeft: '10px', color: 'green' }}
-                  />
-                </span>
-              ) : (
-                <span className={styles.answeredText}>
-                  Ikke svart
-                  <Icon
-                    name="close-circle"
-                    size={20}
-                    style={{
-                      marginLeft: '10px',
-                      color: 'var(--lego-link-color)',
-                    }}
-                  />
-                </span>
-              )}
+
+              <Flex wrap justifyContent="space-between">
+                <span>{`Antall stemmer: ${poll.totalVotes}`}</span>
+                <Flex alignItems="center" gap={2}>
+                  {poll.hasAnswered ? (
+                    <>
+                      Svart
+                      <Icon
+                        name="checkmark-circle-outline"
+                        size={20}
+                        style={{ color: 'var(--color-green-4)' }}
+                      />
+                    </>
+                  ) : (
+                    <>
+                      Ikke svart
+                      <Icon
+                        name="close-circle-outline"
+                        size={20}
+                        style={{
+                          color: 'var(--lego-link-color)',
+                        }}
+                      />
+                    </>
+                  )}
+                </Flex>
+              </Flex>
             </div>
           </Link>
         ))}

--- a/app/routes/quotes/components/Quote.js
+++ b/app/routes/quotes/components/Quote.js
@@ -137,7 +137,7 @@ export default class Quote extends Component<Props, State> {
                     contentClassName="adminDropdown2"
                     triggerComponent={
                       <Icon
-                        name="arrow-dropdown"
+                        name="chevron-down-circle-outline"
                         className={styles.dropdownIcon}
                       />
                     }

--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -83,8 +83,7 @@ class AdminSideBar extends Component<Props, State> {
                   className={cx(this.state.copied && styles.copied)}
                 >
                   <Icon
-                    name={this.state.copied ? 'checkmark' : 'copy'}
-                    prefix="ion-md-"
+                    name={this.state.copied ? 'checkmark' : 'copy-outline'}
                   />
                   {this.state.copied ? 'Kopiert!' : 'Kopier delbar link'}
                 </Button>

--- a/app/routes/surveys/components/Submissions/Results.js
+++ b/app/routes/surveys/components/Submissions/Results.js
@@ -281,7 +281,6 @@ const Results = ({
                             return (
                               <QuestionTypeOption
                                 iconName={graphTypeToIcon[value]}
-                                prefix="fa fa-"
                                 {...props}
                               />
                             );
@@ -291,7 +290,6 @@ const Results = ({
                             return (
                               <QuestionTypeValue
                                 iconName={graphTypeToIcon[value]}
-                                prefix="fa fa-"
                                 {...props}
                               />
                             );

--- a/app/routes/surveys/components/SurveyEditor/Question.js
+++ b/app/routes/surveys/components/SurveyEditor/Question.js
@@ -36,7 +36,7 @@ type Props = {
 const questionTypeToIcon = {
   single_choice: 'radio-button-on',
   multiple_choice: 'checkbox',
-  text_field: 'more',
+  text_field: 'text',
 };
 
 const questionIndexMappings = (indexNumbers: number) =>
@@ -127,22 +127,10 @@ const Question = ({
               options={indexOptions}
               components={{
                 Option: (props: any) => {
-                  return (
-                    <QuestionTypeOption
-                      iconName={'sort'}
-                      prefix="fa fa-"
-                      {...props}
-                    />
-                  );
+                  return <QuestionTypeOption iconName="list" {...props} />;
                 },
                 SingleValue: (props: any) => {
-                  return (
-                    <QuestionTypeValue
-                      iconName={'sort'}
-                      prefix="fa fa-"
-                      {...props}
-                    />
-                  );
+                  return <QuestionTypeValue iconName="list" {...props} />;
                 },
               }}
               onChange={(user) =>

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -114,12 +114,7 @@ export const CHART_COLORS = [
 export const getCsvUrl = (surveyId: string) =>
   `${config.serverUrl}/surveys/${surveyId}/csv/`;
 
-export const QuestionTypeOption = ({
-  iconName,
-  prefix,
-  option,
-  ...props
-}: any) => (
+export const QuestionTypeOption = ({ iconName, option, ...props }: any) => (
   <div
     style={{
       cursor: 'pointer',
@@ -142,18 +137,13 @@ export const QuestionTypeOption = ({
     {...props.innerProps}
   >
     <span className={styles.dropdownColor}>
-      <Icon name={iconName} style={{ marginRight: '15px' }} prefix={prefix} />
+      <Icon name={iconName} style={{ marginRight: '15px' }} />
       {props.children}
     </span>
   </div>
 );
 
-export const QuestionTypeValue = ({
-  iconName,
-  prefix,
-  option,
-  ...props
-}: any) => (
+export const QuestionTypeValue = ({ iconName, option, ...props }: any) => (
   <div
     className={cx(styles.dropdownSelected, styles.dropdown)}
     onMouseDown={(event) => {
@@ -170,7 +160,7 @@ export const QuestionTypeValue = ({
     {...props.innerProps}
   >
     <span className={cx('Select-value-label', styles.dropdownColor)}>
-      <Icon name={iconName} style={{ marginRight: '15px' }} prefix={prefix} />
+      <Icon name={iconName} style={{ marginRight: '15px' }} />
       {props.children}
     </span>
   </div>

--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -27,8 +27,8 @@ export const QuestionTypes = (choice: string) => {
 
 export const PresentableQuestionType = (choice: string) => {
   const questionTypeToString = {
-    single_choice: 'Multiple Choice',
-    multiple_choice: 'Sjekkboks',
+    single_choice: 'Enkeltvalg',
+    multiple_choice: 'Avkrysningsbokser',
     text_field: 'Fritekst',
   };
   return questionTypeToString[choice] || questionTypeToString[0];

--- a/app/routes/users/components/RemovePicture.js
+++ b/app/routes/users/components/RemovePicture.js
@@ -38,7 +38,7 @@ export default class RemovePicture extends Component<Props, State> {
           <Button onClick={this.toggleSelected}>Avbryt</Button>
         ) : (
           <Button danger onClick={this.toggleSelected}>
-            <Icon name="trash" prefix="ion-md-" size={20} />
+            <Icon name="trash" size={20} />
             Slett profilbildet
           </Button>
         )}

--- a/app/routes/users/components/UserSettingsOAuth2.js
+++ b/app/routes/users/components/UserSettingsOAuth2.js
@@ -121,7 +121,7 @@ const UserSettingsOAuth2 = (props: Props) => {
                     onClick={() => props.deleteOAuth2Grant(grant.id)}
                     style={{ marginTop: '-5px' }}
                   >
-                    <Icon size={28} name="trash" prefix="ion-md-" />
+                    <Icon name="trash" size={28} />
                   </Tooltip>
                 </td>
               </tr>

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -16,7 +16,9 @@ describe('Create event', () => {
   const uploadHeader = () => {
     // Upload file
     cy.upload_file(
-      c('ImageUploadField__coverImage') + ' ' + c('UploadImage__dropArea'),
+      c('ImageUploadField__coverImage') +
+        ' ' +
+        c('UploadImage__placeholderTitle'),
       'images/screenshot.png'
     );
     cy.get('.cropper-move').click();
@@ -145,7 +147,9 @@ describe('Create event', () => {
 
     // Fill rest of form
     cy.upload_file(
-      c('ImageUploadField__coverImage') + ' ' + c('UploadImage__dropArea'),
+      c('ImageUploadField__coverImage') +
+        ' ' +
+        c('UploadImage__placeholderTitle'),
       'images/screenshot.png'
     );
     cy.get('.cropper-move').click();

--- a/cypress/e2e/event_editor_spec.js
+++ b/cypress/e2e/event_editor_spec.js
@@ -86,7 +86,9 @@ describe('Editor', () => {
 
     // Fill rest of form
     cy.upload_file(
-      c('ImageUploadField__coverImage') + ' ' + c('UploadImage__dropArea'),
+      c('ImageUploadField__coverImage') +
+        ' ' +
+        c('UploadImage__placeholderTitle'),
       'images/screenshot.png'
     );
     cy.get('.cropper-move').click();

--- a/cypress/e2e/event_payment_spec.js
+++ b/cypress/e2e/event_payment_spec.js
@@ -25,7 +25,9 @@ describe('Event registration & payment', () => {
     const uploadHeader = () => {
       // Upload file
       cy.upload_file(
-        c('ImageUploadField__coverImage') + ' ' + c('UploadImage__dropArea'),
+        c('ImageUploadField__coverImage') +
+          ' ' +
+          c('UploadImage__placeholderTitle'),
         'images/screenshot.png'
       );
       cy.get('.cropper-move').click();

--- a/cypress/e2e/home_page_spec.js
+++ b/cypress/e2e/home_page_spec.js
@@ -64,7 +64,7 @@ describe('The Home Page and Login', () => {
     cy.contains('h2', 'Deloitte AS');
     cy.contains('h2', 'Mesan');
     cy.contains('h2', 'Sikkerhet og Sårbarhet').should('not.exist');
-    cy.get(c('ion-ios-arrow-dropdown')).click();
+    cy.get('ion-icon[name="chevron-down-circle-outline"]').click();
     cy.contains('h2', 'Sikkerhet og Sårbarhet');
     cy.contains('a', 'Artikkel med youtube cover');
   });

--- a/server/pageRenderer.js
+++ b/server/pageRenderer.js
@@ -110,9 +110,9 @@ export default function pageRenderer({
         <meta name="apple-mobile-web-app-title" content="Abakus"/>
 
         <link href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" rel="stylesheet">
-        <link href="https://unpkg.com/ionicons@3.0.0/dist/css/ionicons.min.css" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css?family=Open+Sans:700|Raleway|Roboto" rel="stylesheet">
         ${links}
+
         ${helmet ? helmet.meta.toString() : ''}
 
         ${styles}
@@ -139,6 +139,8 @@ export default function pageRenderer({
            window.__PRELOADED_STATE__ = ${serialize(state, { isJSON: true })};
            window.__IS_SSR__ = ${isSSR};
         </script>
+        <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+        <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
         ${dllPlugin}
         ${scripts}
       </body>


### PR DESCRIPTION
## About time ...
The new version is very similar in looks, but is in my opinion much better, less _edgy_. 

Most notably though, icons are now SVGs, instead of being a font. This is clever, as the icon font would require us to bundle several megabytes of font data, even if we didn't use all the icons. Now with this, we only include the icons we actually need to use in our app.

I went through and checked every single use of `<Icon />` in our webapp, and they all work with the new version.

## Example

**Before**
<img src="https://user-images.githubusercontent.com/69514187/185219494-f9c59d18-2037-4ca1-aa5a-44fcb7b567d9.png" width="300" />

**After**
<img src="https://user-images.githubusercontent.com/69514187/185219539-a49a9ced-bce7-4dbf-b222-dda6a2bdfd4e.png" width="300" />

-----

**Before**
<img width="300" src="https://user-images.githubusercontent.com/69514187/185219213-968b58da-b17b-45a2-966e-8457e39cf280.png" />

**After**
<img width="300" src="https://user-images.githubusercontent.com/69514187/185219066-3af14475-5fc2-4b26-b53c-e5cf85f2ff37.png" />

