### PR TITLE
Convert prikkfrist from datetime to time from now

### DIFF
--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -185,10 +185,12 @@ export default class EventDetail extends Component<Props, State> {
       ? () => unfollow(currentUserFollowing.id, event.id)
       : () => follow(currentUser.id, event.id);
 
+    const currentMoment = moment();
     const eventRegistrationTime = moment(event.activationTime).subtract(
       penaltyHours(penalties),
       'hours'
     );
+    const unregistrationDeadlineMoment = moment(event.unregistrationDeadline);
 
     const deadlines = [
       event.activationTime
@@ -222,12 +224,24 @@ export default class EventDetail extends Component<Props, State> {
                 Frist for prikk <Icon name="help-circle-outline" size={16} />
               </Tooltip>
             ),
-            value: (
-              <FormatTime
-                format="dd DD. MMM HH:mm"
-                time={event.unregistrationDeadline}
-              />
-            ),
+            value:
+              unregistrationDeadlineMoment.diff(currentMoment, 'hours') > 12 ? (
+                <FormatTime
+                  format="dd DD. MMM HH:mm"
+                  time={event.unregistrationDeadline}
+                />
+              ) : (
+                <Tooltip
+                  content={
+                    <FormatTime
+                      format="dd DD. MMM HH:mm"
+                      time={event.unregistrationDeadline}
+                    />
+                  }
+                >
+                  {unregistrationDeadlineMoment.fromNow()}
+                </Tooltip>
+              ),
           }
         : null,
       event.paymentDueDate
@@ -384,7 +398,7 @@ export default class EventDetail extends Component<Props, State> {
                   {loggedIn && (
                     <RegistrationMeta
                       useConsent={event.useConsent}
-                      hasEnded={moment(event.endTime).isBefore(moment())}
+                      hasEnded={moment(event.endTime).isBefore(currentMoment)}
                       registration={currentRegistration}
                       isPriced={event.isPriced}
                       registrationIndex={currentRegistrationIndex}


### PR DESCRIPTION
The only interesting part about the prikkfrist is when it is going to happen in relation to the current time, and as such I'd like it to show exactly that.

Although I think the feature would be nice, I'm torn about whether it would be confusing or not that it is currently not rerendering as the time from now changes. That could either be done manually with a timeout which would add more rerenders to the page, or with the react-moment library as suggested [here](https://stackoverflow.com/a/61947050) which would add yet another dependency. Or not at all.

Thoughts?

Preview:
![image](https://user-images.githubusercontent.com/13599770/185604477-c6cb0d62-6f7e-4f69-86bb-c1245a80238d.png)

![image](https://user-images.githubusercontent.com/13599770/185604590-b27e3f03-ebc2-4799-8c11-c040a17727a5.png)

![image](https://user-images.githubusercontent.com/13599770/185604730-656b4e68-5a7b-41a3-bc30-dd97f07f4ad6.png)
