### PR TITLE
Convert registration-start to registration-end after registrations open

### DIFF
--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -16,7 +16,11 @@ import { FormatTime, FromToTime } from 'app/components/Time';
 import InfoList from 'app/components/InfoList';
 import { Flex } from 'app/components/Layout';
 import Tooltip from 'app/components/Tooltip';
-import { colorForEvent, penaltyHours } from '../../utils';
+import {
+  colorForEvent,
+  penaltyHours,
+  registrationCloseTime,
+} from '../../utils';
 import Admin from '../Admin';
 import RegistrationMeta from '../RegistrationMeta';
 import DisplayContent from 'app/components/DisplayContent';
@@ -185,13 +189,16 @@ export default class EventDetail extends Component<Props, State> {
       ? () => unfollow(currentUserFollowing.id, event.id)
       : () => follow(currentUser.id, event.id);
 
-    const eventRegistrationTime = moment(event.activationTime).subtract(
+    const currentMoment = moment();
+    const activationTimeMoment = moment(event.activationTime);
+    const eventRegistrationTime = activationTimeMoment.subtract(
       penaltyHours(penalties),
       'hours'
     );
+    const registrationCloseTimeMoment = registrationCloseTime(event);
 
     const deadlines = [
-      event.activationTime
+      event.activationTime && currentMoment.isBefore(activationTimeMoment)
         ? {
             key: 'Påmelding åpner',
             value: (
@@ -226,6 +233,34 @@ export default class EventDetail extends Component<Props, State> {
               <FormatTime
                 format="dd DD. MMM HH:mm"
                 time={event.unregistrationDeadline}
+              />
+            ),
+          }
+        : null,
+      activationTimeMoment.isBefore(currentMoment)
+        ? {
+            key: 'Frist for av/påmelding',
+            keyNode: (
+              <Tooltip
+                content={
+                  <span>
+                    Etter påmeldingen stenger er det hverken mulig å melde seg
+                    på eller av arrangementet.
+                  </span>
+                }
+              >
+                <Flex alignItems="center" gap={4}>
+                  {currentMoment.isBefore(registrationCloseTimeMoment)
+                    ? 'Påmelding stenger'
+                    : 'Påmelding stengte'}{' '}
+                  <Icon name="help-circle-outline" size={16} />
+                </Flex>
+              </Tooltip>
+            ),
+            value: (
+              <FormatTime
+                format="dd DD. MMM HH:mm"
+                time={registrationCloseTimeMoment}
               />
             ),
           }
@@ -384,7 +419,7 @@ export default class EventDetail extends Component<Props, State> {
                   {loggedIn && (
                     <RegistrationMeta
                       useConsent={event.useConsent}
-                      hasEnded={moment(event.endTime).isBefore(moment())}
+                      hasEnded={moment(event.endTime).isBefore(currentMoment)}
                       registration={currentRegistration}
                       isPriced={event.isPriced}
                       registrationIndex={currentRegistrationIndex}

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -254,6 +254,30 @@ describe('Create event', () => {
     selectField('eventType').click();
     cy.focused().type('be{enter}', { force: true });
 
+    // Always select one day into the future to avoid test issues with "Påmelding åpner/stenger" variants changing
+    const dateObject = new Date();
+    const todayDay = dateObject.getDate();
+    dateObject.setDate(dateObject.getDate() + 1);
+    const tomorrowDay = dateObject.getDate();
+    field('startTime').click();
+    if (tomorrowDay < todayDay) {
+      // End of month
+      cy.get(c('DatePicker__arrowIcon'))
+        .eq(1)
+        .should('not.be.disabled')
+        .click();
+    }
+    cy.get('button').contains(tomorrowDay).click();
+    field('endTime').click();
+    if (tomorrowDay < todayDay) {
+      // End of month
+      cy.get(c('DatePicker__arrowIcon'))
+        .eq(1)
+        .should('not.be.disabled')
+        .click();
+    }
+    cy.get('button').contains(tomorrowDay).click();
+
     // Select regitrationType
     selectField('eventStatusType').click();
     cy.focused().type('Vanlig{enter}', { force: true });

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -309,7 +309,7 @@ describe('Create event', () => {
     cy.contains('WebkomPool');
     cy.contains('BedkomPool');
     cy.contains('R4');
-    cy.contains('Påmelding åpner');
+    cy.contains('Påmelding stenger');
   });
 
   it('should be possible to create OPEN event', () => {


### PR DESCRIPTION
During the redesign it was concluded to remove the unregistre/register deadline, on the grounds that it would be confusing to have both "avregistreringsfrist" and "avregistrering stenger".

I argue that these premisses have changed, as we no longer have "avregistreringsfrist", but "frist for prikk" - which in my opinion has a different meaning.  
In addition, "påmelding åpner" makes no sense after the registration has already opened.  
We also have some events that close the day before before to be able to order food, and it would be nice to show that as everyone might not realize that before it is too late to unregister.  
Aaand not all events use the prikk-system, but they still have times where the registration closes.


Preview:
![image](https://user-images.githubusercontent.com/13599770/185615146-f4e94504-0377-4cee-acff-43e3976fcc91.png)

![image](https://user-images.githubusercontent.com/13599770/185615269-8262fc1a-1bb4-420b-a915-c211431cc456.png)

![image](https://user-images.githubusercontent.com/13599770/185615400-7cb0c7e2-7fc3-4417-b40f-ad8c4a1a4f6c.png)

![image](https://user-images.githubusercontent.com/13599770/185615579-c5ef9570-542b-4b66-b418-488aec242dba.png)
