### PR TITLE
Show ical and google calendar integration on mobile

### DIFF
--- a/app/routes/events/components/EventFooter.css
+++ b/app/routes/events/components/EventFooter.css
@@ -1,3 +1,5 @@
+@import '~app/styles/variables.css';
+
 .eventFooter {
   width: 100%;
   padding-top: 20px;
@@ -11,6 +13,10 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+
+  @media (--small-viewport) {
+    flex-direction: column;
+  }
 }
 
 .section {

--- a/app/routes/events/components/EventFooter.js
+++ b/app/routes/events/components/EventFooter.js
@@ -1,8 +1,6 @@
 //@flow
 import { Link } from 'react-router-dom';
 import styles from './EventFooter.css';
-import utilityStyles from 'app/styles/utilities.css';
-import cx from 'classnames';
 
 import { eventTypeToString, colorForEvent, EVENT_CONSTANTS } from '../utils';
 
@@ -29,7 +27,7 @@ type Props = {
 const EventFooter = ({ icalToken }: Props) => (
   <div className={styles.eventFooter}>
     {icalToken && (
-      <p className={cx(styles.section, utilityStyles.hiddenOnMobile)}>
+      <p className={styles.section}>
         Her kan du importere arrangementer og møter til din favorittkalender!
         For innstillinger se
         <Link to="/users/me/settings"> her</Link>.
@@ -37,7 +35,7 @@ const EventFooter = ({ icalToken }: Props) => (
     )}
     <div className={styles.eventFooterSections}>
       {icalToken && (
-        <div className={cx(styles.section, utilityStyles.hiddenOnMobile)}>
+        <div className={styles.section}>
           <h3>Google kalender</h3>
           <ul>
             {icalTypes.map((type, key) => (
@@ -51,7 +49,7 @@ const EventFooter = ({ icalToken }: Props) => (
         </div>
       )}
       {icalToken && (
-        <div className={cx(styles.section, utilityStyles.hiddenOnMobile)}>
+        <div className={styles.section}>
           <h3>iCalendar</h3>
           <ul>
             {icalTypes.map((type, key) => (


### PR DESCRIPTION
We should probably do more to ensure people know this exists, but this a bare minimum. I honestly don't understand why it was hidden on mobile at all.

Before: 
![Screenshot 2022-08-22 at 13 48 27](https://user-images.githubusercontent.com/8343002/185914334-e3a41b70-3a6e-4a8a-8f43-b46fa367ca25.png)
After:
![Screenshot 2022-08-22 at 13 46 03](https://user-images.githubusercontent.com/8343002/185914353-7e5c4102-d727-47a4-9771-f674e85a8110.png)

