### PR TITLE
use white background behind company and event images

### DIFF
--- a/app/components/Content/Content.css
+++ b/app/components/Content/Content.css
@@ -36,6 +36,7 @@
   img {
     object-fit: cover;
     display: block;
+    background: white;
   }
 }
 

--- a/app/components/EventItem/styles.css
+++ b/app/components/EventItem/styles.css
@@ -27,6 +27,7 @@
 
 .companyLogo img {
   min-width: 120px;
-  height: 80px;
+  max-height: 80px;
   object-fit: contain;
+  background: white;
 }

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -62,6 +62,7 @@ html[data-theme='dark'] .dropArea {
   height: inherit;
   width: 100%;
   object-fit: cover;
+  background: white;
 }
 
 .cropper {

--- a/app/routes/articles/components/Overview.css
+++ b/app/routes/articles/components/Overview.css
@@ -51,6 +51,10 @@
   width: 100%;
 }
 
+.imageLink img {
+  background: white;
+}
+
 .normal {
   grid-template-columns: repeat(3, minmax(100px, 1fr));
 

--- a/app/routes/company/components/CompaniesPage.css
+++ b/app/routes/company/components/CompaniesPage.css
@@ -116,7 +116,8 @@ html[data-theme='dark'] .companyItem {
 .companyLogo img {
   object-fit: contain;
   display: block;
-  height: 88px;
+  max-height: 88px;
+  background: white;
 }
 
 .companyLogoDetail {

--- a/app/routes/joblistings/components/JoblistingList.css
+++ b/app/routes/joblistings/components/JoblistingList.css
@@ -57,10 +57,11 @@
 
 .companyLogo {
   width: 120px;
-  height: 80px;
+  max-height: 80px;
   min-width: 120px;
   object-fit: contain;
   margin-right: 20px;
+  background: white;
 }
 
 .listItem {

--- a/app/routes/overview/components/ArticleItem.css
+++ b/app/routes/overview/components/ArticleItem.css
@@ -18,6 +18,7 @@
   object-fit: cover;
   width: 100%;
   height: auto;
+  background: white;
 }
 
 .articleTitle {

--- a/app/routes/overview/components/EventItem.css
+++ b/app/routes/overview/components/EventItem.css
@@ -27,7 +27,7 @@
 
 .imageFrontpage {
   object-fit: cover;
-  background: var(--color-white);
+  background: white;
   height: 80px;
   width: 270px;
 

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -57,8 +57,9 @@
 
 .companyLogo img {
   min-width: 120px;
-  height: 80px;
+  max-height: 80px;
   object-fit: contain;
+  background: white;
 }
 
 .questions {


### PR DESCRIPTION
Makes it easier to see dark logos with transparency in dark mode. In light mode it is invisible as all the backgrounds were already white.

I also changed `height` to `max-height` a few places, this was to avoid unneccesary white background around the images. The only layout change i noticed was that job-listings became slightly thinner.

## Events
before:
<img width="1116" alt="Screenshot 2022-08-22 at 20 47 14" src="https://user-images.githubusercontent.com/8343002/186000761-ca2d04f9-c5c1-4476-bbae-13b7333bb014.png">
<img width="1172" alt="Screenshot 2022-08-22 at 21 05 13" src="https://user-images.githubusercontent.com/8343002/186000958-2aea7743-58f1-470e-8824-b3208f4eb5d2.png">

after:
<img width="1116" alt="Screenshot 2022-08-22 at 20 47 04" src="https://user-images.githubusercontent.com/8343002/186000751-5ce5e657-415d-473b-9b90-b50c2d0d18e7.png">
<img width="1172" alt="Screenshot 2022-08-22 at 21 05 05" src="https://user-images.githubusercontent.com/8343002/186000978-08ffb588-c203-43b3-845d-a49e8f6aae55.png">

## Front page
before:
<img width="722" alt="Screenshot 2022-08-22 at 21 10 18" src="https://user-images.githubusercontent.com/8343002/186001078-ac2ec12e-1f00-4d4e-86a6-1de40c9f0f2b.png">
after:
<img width="722" alt="Screenshot 2022-08-22 at 21 10 12" src="https://user-images.githubusercontent.com/8343002/186001100-a2ce2dc4-adb9-43a3-8aae-c55d44d72948.png">

## Job listings
before:
<img width="806" alt="Screenshot 2022-08-22 at 20 52 55" src="https://user-images.githubusercontent.com/8343002/186001202-33785c74-e138-4a85-a8af-1e298a7612d5.png">
after:
<img width="806" alt="Screenshot 2022-08-22 at 20 53 06" src="https://user-images.githubusercontent.com/8343002/186001218-28336d3c-cd18-4bb8-b175-46b2f64e19b7.png">