### PR TITLE
remove white space from event details

### DIFF
--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -63,10 +63,6 @@
   }
 }
 
-.join {
-  flex: 2;
-}
-
 .joinHeader {
   margin-top: 20px;
   font-size: 20px;

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -334,7 +334,7 @@ const JoinEventForm = (props: Props) => {
   return (
     <>
       <div className={styles.joinHeader}>Påmelding</div>
-      <Flex column className={styles.join}>
+      <Flex column>
         {['OPEN', 'TBA'].includes(event.eventStatusType) ? (
           registrationMessage(event)
         ) : (


### PR DESCRIPTION
Co-authored-by: @EliHaugu.

The white space is now removed from the event pages.

Resolves [#2865 ](https://github.com/webkom/lego/issues/2865)


before fix:
![Screenshot 2022-08-23 at 21 56 47](https://user-images.githubusercontent.com/90712892/186254512-70488ec7-e38d-41fd-af0f-0903e96b703a.png)


after fix:
![Screenshot 2022-08-23 at 21 58 00](https://user-images.githubusercontent.com/90712892/186254619-f3682a0c-428c-444c-8e2c-ac64a90b187c.png)
