### PR TITLE
Set survey default activation time to noon the day after

### DIFF
--- a/app/routes/surveys/utils.js
+++ b/app/routes/surveys/utils.js
@@ -97,7 +97,7 @@ export const TokenNavigation = ({
 );
 
 export const defaultActiveFrom = (hours: number, minutes: number) =>
-  moment().startOf('day').add({ hours, minutes }).toISOString();
+  moment().startOf('day').add({ day: 1, hours, minutes }).toISOString();
 
 export const CHART_COLORS = [
   'var(--lego-red)',


### PR DESCRIPTION
Small fix to do what is described here: https://github.com/webkom/lego/issues/1998

> It is currently the time that you make the survey. We should set it to something like 24h in the future, so that people don't accidentally create it and send it out immediately, when it is not ready.

