### PR TITLE
Improve event page and event editor

### DIFF
--- a/app/components/UserAttendance/AttendanceStatus.css
+++ b/app/components/UserAttendance/AttendanceStatus.css
@@ -3,20 +3,23 @@
   flex-flow: row wrap;
   justify-content: flex-start;
   width: 100%;
+  height: 100%;
   text-align: center;
+  border-radius: 0.3rem;
+  margin: 10px 0;
+  overflow: hidden;
 }
 
 .poolBox {
   display: flex;
   flex: 1;
-  background-color: rgba(200, 200, 200, 50%);
+  background-color: rgba(200, 200, 200, 30%);
   max-width: 100%;
   min-width: 25%;
   flex-direction: column;
   align-items: center;
-  margin: 10px 0;
 }
 
 html[data-theme='dark'] .poolBox {
-  background-color: rgba(50, 50, 50, 50%);
+  background-color: rgba(50, 50, 50, 30%);
 }

--- a/app/routes/events/EventEditRoute.js
+++ b/app/routes/events/EventEditRoute.js
@@ -26,6 +26,7 @@ import time from 'app/utils/time';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import moment from 'moment-timezone';
+import { push } from 'connected-react-router';
 
 const mapStateToProps = (state, props) => {
   const eventId = props.match.params.eventId;
@@ -122,6 +123,7 @@ const mapDispatchToProps = {
   handleSubmitCallback: (event) => editEvent(transformEvent(event, true)),
   uploadFile,
   setCoverPhoto,
+  push,
 };
 
 export default compose(

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -422,6 +422,9 @@ export default class EventDetail extends Component<Props, State> {
                   {loggedIn && (
                     <RegistrationMeta
                       useConsent={event.useConsent}
+                      hasOpened={moment(event.activationTime).isBefore(
+                        currentMoment
+                      )}
                       hasEnded={moment(event.endTime).isBefore(currentMoment)}
                       registration={currentRegistration}
                       isPriced={event.isPriced}

--- a/app/routes/events/components/EventDetail/index.js
+++ b/app/routes/events/components/EventDetail/index.js
@@ -287,7 +287,9 @@ export default class EventDetail extends Component<Props, State> {
         value: (
           <span>
             {event.responsibleGroup.type === 'komite' ? (
-              <Link to={`pages/komiteer/${event.responsibleGroup.id}`}></Link>
+              <Link to={`pages/komiteer/${event.responsibleGroup.id}`}>
+                {event.responsibleGroup.name}
+              </Link>
             ) : (
               event.responsibleGroup.name
             )}{' '}
@@ -356,16 +358,16 @@ export default class EventDetail extends Component<Props, State> {
                   <FromToTime from={event.startTime} to={event.endTime} />
                 </strong>
               </div>
+              <div className={styles.iconWithText}>
+                <Icon name="location-outline" className={styles.infoIcon} />
+                <strong>{event.location}</strong>
+              </div>
               {event.isPriced && (
                 <div className={styles.iconWithText}>
                   <Icon name="cash-outline" className={styles.infoIcon} />
                   <strong>{event.priceMember / 100},-</strong>
                 </div>
               )}
-              <div className={styles.iconWithText}>
-                <Icon name="location-outline" className={styles.infoIcon} />
-                <strong>{event.location}</strong>
-              </div>
               {event.mazemapPoi && (
                 <>
                   <div

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -2,7 +2,6 @@
 
 import { Helmet } from 'react-helmet-async';
 import styles from './EventEditor.css';
-import { Link } from 'react-router-dom';
 import renderPools, { validatePools } from './renderPools';
 import {
   AttendanceStatus,
@@ -44,6 +43,7 @@ import { validYoutubeUrl } from 'app/utils/validation';
 import { FormatTime } from 'app/components/Time';
 import moment from 'moment-timezone';
 import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
+import NavigationTab from 'app/components/NavigationTab';
 
 type Props = {
   eventId: number,
@@ -64,6 +64,7 @@ type Props = {
   submitting: boolean,
   pristine: boolean,
   initialized: boolean,
+  push: (string) => void,
 };
 
 function EventEditor({
@@ -83,6 +84,7 @@ function EventEditor({
   submitting,
   pristine,
   initialized,
+  push,
 }: Props) {
   const isEditPage = eventId !== undefined;
 
@@ -109,21 +111,20 @@ function EventEditor({
   const tooLow = (value) =>
     value && value <= 3 ? `Summen må være større enn 3 kr` : undefined;
 
-  const color = colorForEvent(event.eventType);
+  const color = colorForEvent(event.eventType?.value);
 
   return (
     <Content>
       <Helmet
         title={isEditPage ? `Redigerer: ${event.title}` : 'Nytt arrangement'}
       />
-      {isEditPage && (
-        <h2>
-          <Link to={`/events/${eventId}`}>
-            <i className="fa fa-angle-left" />
-            {` ${event.title}`}
-          </Link>
-        </h2>
-      )}
+      <NavigationTab
+        title={isEditPage ? `Redigerer: ${event.title}` : 'Nytt arrangement'}
+        back={{
+          label: 'Tilbake',
+          path: isEditPage ? `/events/${event.id}` : '/events',
+        }}
+      />
       <Form onSubmit={handleSubmit}>
         <Field
           name="cover"
@@ -568,16 +569,14 @@ function EventEditor({
           </ContentSidebar>
         </ContentSection>
 
-        <div>
+        <Flex wrap>
           {isEditPage && (
-            <Link to={`/events/${event.id}`}>
-              <Button style={{ marginRight: '20px' }}>Tilbake</Button>
-            </Link>
+            <Button onClick={() => push(`/events/${event.id}`)}>Avbryt</Button>
           )}
           <Button success={isEditPage} disabled={pristine || submitting} submit>
             {isEditPage ? 'Lagre endringer' : 'Opprett'}
           </Button>
-        </div>
+        </Flex>
       </Form>
     </Content>
   );

--- a/app/routes/events/components/JoinEventForm.js
+++ b/app/routes/events/components/JoinEventForm.js
@@ -450,7 +450,7 @@ const JoinEventForm = (props: Props) => {
                   <Flex style={{ marginBottom: '20px' }}>
                     <Field
                       id={feedbackName}
-                      placeholder="Melding til arrangører"
+                      placeholder="Melding til arrangør"
                       name={feedbackName}
                       component={TextInput.Field}
                       labelClassName={styles.feedbackLabel}

--- a/app/routes/events/components/RegistrationMeta.js
+++ b/app/routes/events/components/RegistrationMeta.js
@@ -20,6 +20,7 @@ type Props = {
   registrationIndex: number,
   hasSimpleWaitingList: boolean,
   useConsent: boolean,
+  hasOpened: boolean,
   hasEnded: boolean,
 };
 
@@ -70,23 +71,23 @@ const PresenceStatus = ({
   switch (presence) {
     case 'NOT_PRESENT':
       return (
-        <>
+        <div>
           <i className="fa fa-exclamation-circle" /> Du møtte ikke opp på
           arrangementet
-        </>
+        </div>
       );
     case 'PRESENT':
       return (
-        <>
+        <div>
           <i className="fa fa-check-circle" /> Du møtte opp på arrangementet
-        </>
+        </div>
       );
     case 'UNKNOWN':
       if (!hasEnded) return null;
       return (
-        <>
+        <div>
           <i className="fa fa-check-circle" /> Oppmøte ble ikke sjekket
-        </>
+        </div>
       );
     default:
       return null;
@@ -117,10 +118,10 @@ const PaymentStatus = ({
       );
     case paymentCardDeclined:
       return (
-        <>
+        <div>
           <i className="fa fa-exclamation-circle" /> Du har ikke betalt. Kortet
           du prøvde å betale med ble ikke godtatt.
-        </>
+        </div>
       );
     case paymentCardExpired:
       return (
@@ -140,32 +141,39 @@ const PaymentStatus = ({
 
 const RegistrationMeta = ({
   registration,
+  hasOpened,
   hasEnded,
   useConsent,
   isPriced,
   registrationIndex,
   hasSimpleWaitingList,
 }: Props) => (
-  <div>
-    {!registration && (
+  <>
+    {!registration && hasOpened && (
       <div>
-        <i className="fa fa-exclamation-circle" /> Du er ikke påmeldt
+        <i className="fa fa-times-circle" /> Du {hasEnded ? 'var' : 'er'} ikke
+        påmeldt
       </div>
     )}
     {registration && (
-      <div>
+      <>
         {registration.pool ? (
-          <div>
-            <i className="fa fa-check-circle" /> Du er påmeldt
-          </div>
+          <>
+            {!hasEnded && (
+              <div>
+                <i className="fa fa-check-circle" /> Du er påmeldt
+              </div>
+            )}
+          </>
         ) : hasSimpleWaitingList ? (
           <div>
-            <i className="fa fa-pause-circle" /> Din plass i venteliste{' '}
+            <i className="fa fa-pause-circle" /> Din plass i ventelisten:{' '}
             <strong>{registrationIndex + 1}</strong>
           </div>
         ) : (
           <div>
-            <i className="fa fa-pause-circle" /> Du er i venteliste
+            <i className="fa fa-pause-circle" /> Du {hasEnded ? 'stod' : 'står'}{' '}
+            på venteliste
           </div>
         )}
         <PresenceStatus presence={registration.presence} hasEnded={hasEnded} />
@@ -180,9 +188,9 @@ const RegistrationMeta = ({
           isPriced={isPriced}
           paymentStatus={registration.paymentStatus}
         />
-      </div>
+      </>
     )}
-  </div>
+  </>
 );
 
 export default RegistrationMeta;


### PR DESCRIPTION
### Some minor improvements here and there.

- [Clean up registration meta info](https://github.com/webkom/lego-webapp/commit/59f745a0e3be3dc5456985de3e4812f1993f17e4)
  - Don't show "Du er ikke påmeldt" when registration has not yet opened (but if you're admin registered before, it will show that you're registered).
  - Don't show "Du er påmeldt" when event has ended.
  - Fix alignment of icons and text whenever the text overflows.
- [Small improvements to the event page and event editor](https://github.com/webkom/lego-webapp/commit/75ebf3e5da08dea72dcf7455c1e2d46fa1c16d0c)
  - Fix responsible group link (see https://github.com/webkom/lego/pull/2886).
  - Fix the showing of event type color in the editor (and thus also the event creator)
  - Relocate price field to come after location, as it will usually be a shorter value.
  - Add a `NavigationTab` to the event editor, making it match the other pages better (related to https://github.com/webkom/lego/issues/2866).

### Result

**Before**
Event has ended. Notice the grammar, styling and icon changes.

<img src="https://user-images.githubusercontent.com/69514187/187081317-66856310-6739-454c-8f37-092bcc984aa1.png" width="400" />

**After**
<img src="https://user-images.githubusercontent.com/69514187/187081302-085390a1-1f6e-4b12-81da-dc33dd882f19.png" width="400" />

---

**Before**
Event has ended, therefore making "Du er påmeldt" unnecessary.  
<img src="https://user-images.githubusercontent.com/69514187/187081416-f081bac6-245c-4fd8-8dc9-7f244ec03016.png" width="400" />

**After**
<img src="https://user-images.githubusercontent.com/69514187/187081401-9a8c5214-cf82-44a2-a750-b221b0320b47.png" width="400" />

---

**Before**
Notice the `NavigationTab` and the event type color under the title.
<img src="https://user-images.githubusercontent.com/69514187/187081579-b30b36a6-2195-4411-8807-315fc7c26949.png" width="400" />

**After**
<img src="https://user-images.githubusercontent.com/69514187/187081598-13d189fb-c66c-41c1-b2e3-dcdd9a3942f9.png" width="400" />