### PR TITLE
fix bug where opening a modal scrolls to bottom of page

### DIFF
--- a/app/components/Modal/index.js
+++ b/app/components/Modal/index.js
@@ -33,6 +33,7 @@ const Modal = ({
   backdropClassName,
 }: Props) => (
   <ReactModal
+    className={cx(styles.content, contentClassName)}
     show={show}
     backdrop={backdrop}
     onHide={onHide}
@@ -45,7 +46,7 @@ const Modal = ({
       />
     )}
   >
-    <div className={cx(styles.content, contentClassName)}>
+    <div>
       <button onClick={onHide} className={styles.closeButton}>
         <Icon name="close" />
       </button>


### PR DESCRIPTION
😡😠😠 This took waaaaay too long to debug

The styling needs to be on the modal-element, not on the div inside it...

fixes https://github.com/webkom/lego/issues/2841