### PR TITLE
fix bug where comment form would not clear after submit

### DIFF
--- a/app/components/CommentForm/index.js
+++ b/app/components/CommentForm/index.js
@@ -57,6 +57,7 @@ const CommentForm = ({
     <LegoFinalForm
       initialValues={{
         text: EDITOR_EMPTY,
+        commentKey: Math.random(),
       }}
       validate={validate}
       onSubmit={({ text }) => {
@@ -69,7 +70,14 @@ const CommentForm = ({
         );
       }}
     >
-      {({ handleSubmit, pristine, submitting, form }) => {
+      {({
+        handleSubmit,
+        pristine,
+        submitting,
+        form,
+        // $FlowFixMe
+        values,
+      }) => {
         const textValue = form.getFieldState('text')?.value;
         const fieldActive = form.getFieldState('text')?.active;
         const isOpen = fieldActive || (textValue && textValue !== EDITOR_EMPTY);
@@ -94,6 +102,7 @@ const CommentForm = ({
                 />
               ) : (
                 <Field
+                  key={values.commentKey}
                   autoFocus={autoFocus}
                   name="text"
                   placeholder="Skriv en kommentar"


### PR DESCRIPTION
LegoEditor is uncontrolled, so we cannot set the editor text from our code. What we can do though, is make sure that each separate comment uses a separate editor-instance by setting a unique key. As each new editor is intially empty, this will clear the comment form whenever the form changes to a new comment.

For the key i just used Math.random(), as we don't have a UUID library. I assume this will be good enough.

Fixes https://github.com/webkom/lego/issues/1464