### PR TITLE
fix: add a z-index to Tooltip

### DIFF
--- a/app/components/Tooltip/Tooltip.css
+++ b/app/components/Tooltip/Tooltip.css
@@ -10,6 +10,7 @@
   color: var(--color-white);
   border-radius: 5px;
   padding: 5px 15px;
+  z-index: 1;
 }
 
 .baseTooltipHover::after {


### PR DESCRIPTION
Resolves webkom/lego#2941

<img width="438" alt="image" src="https://user-images.githubusercontent.com/27623888/191075012-defe2ad1-41ff-4ca3-a4c5-f7fedc1707e0.png">
