### PR TITLE
ABA-31: Add validation so payment due date is minimum 24 hours after unregistration deadline

### DIFF
--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -634,11 +634,16 @@ const validate = (data) => {
   if (!isInteger(data.unregistrationDeadlineHours)) {
     errors.unregistrationDeadlineHours = 'Kun hele timer';
   }
-  if (!moment(data.startTime).isBefore(data.endTime)) {
+  if (moment(data.startTime).isSameOrAfter(data.endTime)) {
     errors.endTime = 'Starttidspunkt må være før sluttidspunkt';
   }
-  if (!moment(data.unregistrationDeadline).add(1, 'days').isSameOrBefore(moment(data.paymentDueDate))) {
-    errors.paymentDueDate = 'Betalingsfristen må være minst 24 timer etter avmeldingsfristen';
+  if (
+    moment(data.unregistrationDeadline)
+      .add(1, 'days')
+      .isAfter(moment(data.paymentDueDate))
+  ) {
+    errors.paymentDueDate =
+      'Betalingsfristen må være minst 24 timer etter avmeldingsfristen';
   }
 
   const mergeTimeError =

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -637,6 +637,10 @@ const validate = (data) => {
   if (!moment(data.startTime).isBefore(data.endTime)) {
     errors.endTime = 'Starttidspunkt må være før sluttidspunkt';
   }
+  if (!moment(data.unregistrationDeadline).add(1, 'days').isSameOrBefore(moment(data.paymentDueDate))) {
+    errors.paymentDueDate = 'Betalingsfristen må være minst 24 timer etter avmeldingsfristen';
+  }
+
   const mergeTimeError =
     data.pools &&
     data.pools


### PR DESCRIPTION
As requested from Arrkom it is now not possible to have the payment deadline within the first 24 hours after the unregistration deadline for events using prikker.

Invalid payment deadline:
![Screenshot from 2022-09-20 18-32-48](https://user-images.githubusercontent.com/43182025/191314822-1ec99e70-b207-4756-b1f8-a0d93ca8106c.png)

Valid payment deadline:
![Screenshot from 2022-09-20 18-33-34](https://user-images.githubusercontent.com/43182025/191314853-f30fdaf8-f740-451e-8f59-7e34c7848107.png)
