### PR TITLE
Add safeguard to disable reading of assumed existing key

### DIFF
--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -59,7 +59,7 @@ const GradeRenderer = (group: { name: string }) =>
     </Tooltip>
   );
 
-const hasWebkomGroup = (user) => user.abakusGroups.includes(WEBKOM_GROUP_ID);
+const hasWebkomGroup = (user) => user.abakusGroups?.includes(WEBKOM_GROUP_ID);
 
 const getPoolName = (pools, poolId) => {
   const pool = pools.find((pool) => pool.id === poolId);


### PR DESCRIPTION
Loong description, but I want the background for this bug to make sense(:

Lately there has been a problem where the admin-view for events crashes for some users.

After doing some debugging in the prod browser (editing the JS files that the browser caches, awesome way to test frontend changes in prod in your local environment with bugs that are hard to reproduce in dev/staging), as I wasn't able to reproduce in staging, it seems that in https://github.com/webkom/lego-webapp/blob/master/app/routes/events/components/EventAdministrate/RegistrationTables.js#L79 there are certain cases where the user object contains all it's properties, except `abakusGroups` (which is used by `hasWebkomGroup`).

Exactly why this happens I'm not sure, but it might be related to the following;  
When the list of registrations is fetched from `https://lego.abakus.no/api/v1/events/3250/administrate/`, the abakusGroup property and the others are passed along with the users information. But the creator of the registration is only passed by id.

That would mean that for the `createdBy` object in the frontend to be an object and not an integer (the id), somewhere in the code it has to be mapped, and for the reason that abakusGroups is missing, I assume that data source does not include that property.

&nbsp;

Pretty sure I figured out why the `abakusGroups` property is missing (I think);
- When users are loaded they are saved to the redux state (I assume)
- When that user is later referenced by id, the redux state is checked before the user details are fetched remotely (I assume)

^ this could cause this problem because @juniwbjerde had admin-registered users without being registered to the event herself. In addition, she is invited to meetings along with all the other committee leaders. This would mean that when the other committee leaders tried to view the list of participants, her user data would be prefetched from the meetings api and not updated through the event-admin api.  
The crucial difference here is that the meetings API doesn't fetch the `abakusGroups` property, and event-admin requires it for the Webkom-registration feature..


Soo while this fix breaks the webkom-registration feature for users that have future meetings in common, it's a nice safeguard that makes sure the page won't crash and only harms a very non-critical feature.  
To make webkom-registrations work for users with meetings in common, make sure the events serializer/view returns every users abakusGroups.