### PR TITLE
Make Past Events on Profile Page Extra Compact

### DIFF
--- a/app/components/EventItem/index.js
+++ b/app/components/EventItem/index.js
@@ -18,6 +18,8 @@ type AttendanceProps = {
   event: Event,
 };
 
+export type EventStyle = 'default' | 'extra-compact';
+
 const Attendance = ({ event }: AttendanceProps) => {
   const attendance = eventAttendance(event);
   return (
@@ -57,6 +59,7 @@ type EventItemProps = {
   field?: EventTimeType,
   showTags?: boolean,
   loggedIn: boolean,
+  eventStyle?: EventStyle,
 };
 
 const EventItem = ({
@@ -64,38 +67,64 @@ const EventItem = ({
   field = EVENTFIELDS.start,
   showTags = true,
   loggedIn = false,
-}: EventItemProps): Node => (
-  <div
-    style={{ borderColor: colorForEvent(event.eventType) }}
-    className={styles.eventItem}
-  >
-    <div>
-      <Link to={`/events/${event.id}`}>
-        <h3 className={styles.eventItemTitle}>{event.title}</h3>
-        {event.totalCapacity > 0 && (
-          <Attendance
-            registrationCount={event.registrationCount}
-            totalCapacity={event.totalCapacity}
-            event={event}
-          />
-        )}
-      </Link>
-      <TimeStamp event={event} field={field} loggedIn={loggedIn} />
-      {showTags && (
-        <Flex wrap>
-          {event.tags.map((tag, index) => (
-            <Tag key={index} tag={tag} />
-          ))}
-        </Flex>
-      )}
-    </div>
+  eventStyle,
+}: EventItemProps): Node => {
+  switch (eventStyle) {
+    case 'extra-compact':
+      return (
+        <div
+          style={{ borderColor: colorForEvent(event.eventType) }}
+          className={styles.eventItem}
+        >
+          <div>
+            <Link to={`/events/${event.id}`}>
+              <h4 className={styles.eventItemTitle}>{event.title}</h4>
+            </Link>
+            <Time time={event.startTime} format="ll - HH:mm" />
+          </div>
+          <Flex className={styles.companyLogoExtraCompact}>
+            {event.cover && (
+              <Image src={event.cover} placeholder={event.coverPlaceholder} />
+            )}
+          </Flex>
+        </div>
+      );
 
-    <div className={styles.companyLogo}>
-      {event.cover && (
-        <Image src={event.cover} placeholder={event.coverPlaceholder} />
-      )}
-    </div>
-  </div>
-);
+    default:
+      return (
+        <div
+          style={{ borderColor: colorForEvent(event.eventType) }}
+          className={styles.eventItem}
+        >
+          <div>
+            <Link to={`/events/${event.id}`}>
+              <h3 className={styles.eventItemTitle}>{event.title}</h3>
+              {event.totalCapacity > 0 && (
+                <Attendance
+                  registrationCount={event.registrationCount}
+                  totalCapacity={event.totalCapacity}
+                  event={event}
+                />
+              )}
+            </Link>
+            <TimeStamp event={event} field={field} loggedIn={loggedIn} />
+            {showTags && (
+              <Flex wrap>
+                {event.tags.map((tag, index) => (
+                  <Tag key={index} tag={tag} />
+                ))}
+              </Flex>
+            )}
+          </div>
+
+          <Flex className={styles.companyLogo}>
+            {event.cover && (
+              <Image src={event.cover} placeholder={event.coverPlaceholder} />
+            )}
+          </Flex>
+        </div>
+      );
+  }
+};
 
 export default EventItem;

--- a/app/components/EventItem/styles.css
+++ b/app/components/EventItem/styles.css
@@ -25,9 +25,21 @@
   flex-direction: row;
 }
 
+.companyLogoExtraCompact {
+  composes: companyLogo;
+  width: 90px;
+}
+
 .companyLogo img {
   min-width: 120px;
   max-height: 80px;
+  object-fit: contain;
+  background: white;
+}
+
+.companyLogoExtraCompact img {
+  min-width: 90px;
+  height: 30px;
   object-fit: contain;
   background: white;
 }

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -29,6 +29,7 @@ import EventItem from 'app/components/EventItem';
 import EmptyState from 'app/components/EmptyState';
 import moment from 'moment-timezone';
 import frame from 'app/assets/frame.png';
+import type { EventStyle } from 'app/components/EventItem';
 
 const fieldTranslations = {
   username: 'Brukernavn',
@@ -85,6 +86,7 @@ type EventsProps = {
   events: Array<Event>,
   noEventsMessage: string,
   loggedIn: boolean,
+  eventStyle?: EventStyle,
 };
 
 const GroupPill = ({ group }: { group: Group }) =>
@@ -156,7 +158,12 @@ const GroupBadge = ({ memberships }: { memberships: Array<Object> }) => {
   );
 };
 
-const ListEvents = ({ events, noEventsMessage, loggedIn }: EventsProps) => (
+const ListEvents = ({
+  events,
+  noEventsMessage,
+  loggedIn,
+  eventStyle,
+}: EventsProps) => (
   <div>
     {events && events.length ? (
       <Flex column wrap>
@@ -166,6 +173,7 @@ const ListEvents = ({ events, noEventsMessage, loggedIn }: EventsProps) => (
             event={event}
             showTags={false}
             loggedIn={loggedIn}
+            eventStyle={eventStyle}
           />
         ))}
       </Flex>
@@ -686,6 +694,7 @@ export default class UserProfile extends Component<Props, EventsProps> {
                     }
                     noEventsMessage="Du har ingen tidligere arrangementer"
                     loggedIn={loggedIn}
+                    eventStyle="extra-compact"
                   />
                 )}
               </div>


### PR DESCRIPTION
Just making the components for previous events more compact.
Planning on using pagination in a later PR 

![ExtraCompactOldEvents](https://user-images.githubusercontent.com/55885035/191868005-72a16881-0b09-4683-9c3c-29bbed780acd.png)
