### PR TITLE
Fix poll info icon & remove tooltip with icon names

### DIFF
--- a/app/components/Poll/index.js
+++ b/app/components/Poll/index.js
@@ -117,7 +117,7 @@ class Poll extends Component<Props, State> {
 
     return (
       <div className={cx(styles.poll, backgroundLight ? styles.pollLight : '')}>
-        <Flex wrap justifyContent="space-between" alignItems="center">
+        <Flex justifyContent="space-between">
           <Link to={`/polls/${id}`}>
             <Flex gap={10}>
               <Icon name="stats-chart" />


### PR DESCRIPTION
The name attribute would make it so the default tooltip whenever you
hovered over an ion-icon element.


Before:
![image](https://user-images.githubusercontent.com/42850232/192868913-d7a42f64-b685-4e6b-9de8-048b69615963.png)



After:
![image](https://user-images.githubusercontent.com/42850232/192868867-c741d1c7-1572-45e9-8d3c-f8c05bab1fca.png)

