### PR TITLE
Remove noreferrer from job listing links

### DIFF
--- a/app/routes/company/components/CompanyDetail.js
+++ b/app/routes/company/components/CompanyDetail.js
@@ -160,6 +160,7 @@ const CompanyDetail = (props: Props) => {
             <a
               href={joblisting.applicationUrl}
               target="_blank"
+              rel="noopener"
             >
               <strong>SØK HER</strong>
             </a>

--- a/app/routes/company/components/CompanyDetail.js
+++ b/app/routes/company/components/CompanyDetail.js
@@ -160,7 +160,6 @@ const CompanyDetail = (props: Props) => {
             <a
               href={joblisting.applicationUrl}
               target="_blank"
-              rel="noreferrer"
             >
               <strong>SØK HER</strong>
             </a>

--- a/app/routes/joblistings/components/JoblistingDetail.js
+++ b/app/routes/joblistings/components/JoblistingDetail.js
@@ -88,6 +88,7 @@ const JoblistingDetail = ({
               href={joblisting.applicationUrl}
               style={{ marginTop: '10px' }}
               target="_blank"
+              rel="noopener"
             >
               <strong>SØK HER</strong>
             </a>

--- a/app/routes/joblistings/components/JoblistingDetail.js
+++ b/app/routes/joblistings/components/JoblistingDetail.js
@@ -88,7 +88,6 @@ const JoblistingDetail = ({
               href={joblisting.applicationUrl}
               style={{ marginTop: '10px' }}
               target="_blank"
-              rel="noreferrer"
             >
               <strong>SØK HER</strong>
             </a>


### PR DESCRIPTION
Removes `rel="noreferrer"` from job listing links to allow businesses to see where the traffic is coming from.
This will incentivize businesses to post more job listings because they can see how the listing performs.