### PR TITLE
Fix typos in tooltip and validation in the event editor

### DIFF
--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -643,7 +643,7 @@ const validate = (data) => {
       .isAfter(moment(data.paymentDueDate))
   ) {
     errors.paymentDueDate =
-      'Betalingsfristen må være minst 24 timer etter avmeldingsfristen';
+      'Betalingsfristen må være minst 24 timer etter avregistreringsfristen';
   }
 
   const mergeTimeError =

--- a/app/routes/events/components/EventEditor/index.js
+++ b/app/routes/events/components/EventEditor/index.js
@@ -325,7 +325,7 @@ function EventEditor({
             )}
             {event.isPriced && (
               <div className={styles.subSection}>
-                <Tooltip content="Manuell betaling kan også av i etterkant">
+                <Tooltip content="Manuell betaling kan også godkjennes av oss i etterkant">
                   <Field
                     label="Betaling via Abakus.no"
                     name="useStripe"


### PR DESCRIPTION
The first typo, "Manuell betaling kan også av i etterkant" does not really make sense, and the second one is using the wrong term "avmelding" instead of "avregistrering".

![image](https://user-images.githubusercontent.com/43182025/194142175-48e9dfdc-218f-4a93-9156-bd1f27d5f498.png)
