### PR TITLE
Fix cypress tests by finding the correct date

### DIFF
--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -271,7 +271,9 @@ describe('Create event', () => {
         .should('not.be.disabled')
         .click();
     }
-    cy.get('button').contains(tomorrowDay).click();
+    cy.get('button')
+      .contains(new RegExp('^' + tomorrowDay + '$', 'g'))
+      .click();
     field('endTime').click();
     if (tomorrowDay < todayDay) {
       // End of month
@@ -280,7 +282,9 @@ describe('Create event', () => {
         .should('not.be.disabled')
         .click();
     }
-    cy.get('button').contains(tomorrowDay).click();
+    cy.get('button')
+      .contains(new RegExp('^' + tomorrowDay + '$', 'g'))
+      .click();
 
     // Select regitrationType
     selectField('eventStatusType').click();


### PR DESCRIPTION
When `tomorrowDate` would for example be "8", cypress would falsely try to click on "28" (from the previous month) because this comes before "8" in the DOM. The dates from the previous month would, for obvious reasons, be disabled and thus cause the tests to fail.

This was solved by simply utilizing a regex.