### PR TITLE
Improve layout and design of sidebar

### DIFF
--- a/app/routes/pages/components/PageDetail.css
+++ b/app/routes/pages/components/PageDetail.css
@@ -14,7 +14,8 @@
 }
 
 .page {
-  margin: -20px 0px 0px 0px;
+  margin: 0;
+  margin-top: -20px;
   width: 100%;
 }
 

--- a/app/routes/pages/components/PageDetail.css
+++ b/app/routes/pages/components/PageDetail.css
@@ -14,7 +14,7 @@
 }
 
 .page {
-  margin: 0;
+  margin: -20px 0px 0px 0px;
   width: 100%;
 }
 

--- a/app/routes/pages/components/PageHierarchy.css
+++ b/app/routes/pages/components/PageHierarchy.css
@@ -11,25 +11,28 @@
 
 .pageList {
   text-align: left;
-  line-height: 18px;
-  width: 220px;
+  line-height: 28px;
+  width: 100%;
 }
 
 .pageList a {
-  font-size: 18px;
+  font-size: 17px;
+  color: var(--lego-text-gray);
 }
 
 .dropdownBtn {
   text-transform: uppercase;
+  width: 100%;
   letter-spacing: 1.5px;
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: space-between;
   font-size: var(--font-size-large);
   font-family: Raleway, sans-serif;
   font-weight: bold;
   color: var(--lego-text-gray);
-  margin-bottom: 0.8em;
+  margin-top: 1.4em;
 }
 
 .back > i {
@@ -40,6 +43,12 @@
 .links {
   margin: 8px 0 10px 8px;
 }
+.links:first-child {
+  margin-top: 15px;
+}
+.links:last-child {
+  margin-bottom: -5px;
+}
 
 .nonSelected {
   font-weight: normal;
@@ -47,11 +56,12 @@
 
 .selected {
   font-weight: bold;
-  margin-left: -16px;
 }
 
 .selected::before {
   content: '\25CF ';
+  color: var(--lego-red);
+  margin-right: 5px;
 }
 
 .dropdownContainer {
@@ -59,5 +69,13 @@
 }
 
 .dropdownIcon {
-  padding-left: 8px;
+  align-self: flex-end;
+  transform: scale(0.9);
+  transition: transform .2s ease-in-out; 
+}
+
+@media (--mobile-device) {
+  .pageList {
+    width: 90%;
+  }
 }

--- a/app/routes/pages/components/PageHierarchy.css
+++ b/app/routes/pages/components/PageHierarchy.css
@@ -17,7 +17,10 @@
 
 .pageList a {
   font-size: 17px;
-  color: var(--lego-text-gray);
+}
+
+.pageList a:hover {
+  color: var(--lego-link-color);
 }
 
 .dropdownBtn {
@@ -42,6 +45,9 @@
 
 .links {
   margin: 8px 0 10px 8px;
+  padding-bottom: 6px;  
+  padding-top: 6px;
+  border-bottom: 2px solid var(--border-gray);
 }
 
 .links:first-child {
@@ -53,10 +59,12 @@
 }
 
 .nonSelected {
+  color: var(--lego-text-gray);
   font-weight: normal;
 }
 
 .selected {
+  color: var(--lego-link-color);
   font-weight: bold;
 }
 
@@ -64,6 +72,7 @@
   content: '\25CF ';
   color: var(--lego-red);
   margin-right: 5px;
+  margin-left: -15.5px;
 }
 
 .dropdownContainer {

--- a/app/routes/pages/components/PageHierarchy.css
+++ b/app/routes/pages/components/PageHierarchy.css
@@ -43,9 +43,11 @@
 .links {
   margin: 8px 0 10px 8px;
 }
+
 .links:first-child {
   margin-top: 15px;
 }
+
 .links:last-child {
   margin-bottom: -5px;
 }
@@ -71,7 +73,7 @@
 .dropdownIcon {
   align-self: flex-end;
   transform: scale(0.9);
-  transition: transform .2s ease-in-out; 
+  transition: transform 0.2s ease-in-out;
 }
 
 @media (--mobile-device) {

--- a/app/routes/pages/components/PageHierarchy.js
+++ b/app/routes/pages/components/PageHierarchy.js
@@ -109,11 +109,15 @@ class AccordionContainer extends Component<AccordionProps, AccordionState> {
       <div>
         <button className={styles.dropdownBtn} onClick={this.handleClick}>
           {title}{' '}
-          {this.state.isOpen ? (
-            <Icon name="arrow-down" className={styles.dropdownIcon} />
-          ) : (
-            <Icon name="arrow-forward" className={styles.dropdownIcon} />
-          )}
+          <Icon
+            name="chevron-up-outline"
+            className={styles.dropdownIcon}
+            style={
+              this.state.isOpen
+                ? { transform: 'rotateX(0deg)' }
+                : { transform: 'rotateX(180deg)' }
+            }
+          />
         </button>{' '}
         {this.state.isOpen ? <div>{children}</div> : null}
       </div>

--- a/app/routes/pages/components/Sidebar.css
+++ b/app/routes/pages/components/Sidebar.css
@@ -12,7 +12,7 @@
 }
 
 .sidebar {
-  width: 80%; 
+  width: 80%;
   padding-top: 25px;
   display: flex;
   flex-direction: column;

--- a/app/routes/pages/components/Sidebar.css
+++ b/app/routes/pages/components/Sidebar.css
@@ -5,16 +5,15 @@
   display: flex;
   justify-content: center;
   box-sizing: border-box;
-  border-right: 2px solid var(--lego-red);
-  margin-bottom: 5em;
-  width: 270px;
+  background-color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 2%);
+  padding-top: 20px;
+  padding-bottom: 80px;
+  width: 315px;
 }
 
 .sidebar {
-  min-width: 150px;
-  max-width: 230px;
-  margin: 0 1.5em;
-  padding-top: 20px;
+  width: 80%; 
+  padding-top: 25px;
   display: flex;
   flex-direction: column;
 
@@ -25,19 +24,12 @@
 
 .sidebarHeader {
   letter-spacing: 1.5px;
-  font-size: 2em;
-  font-weight: 900;
-  margin-bottom: -10px;
+  font-size: 28px;
+  font-weight: 800;
+  margin-bottom: -25px;
+  margin-left: 2.5px;
   font-family: RalewayBold, sans-serif;
-}
-
-.sidebarSubtitle {
-  margin-top: 0;
-  padding-top: 0;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 15px;
-  font-weight: bold;
+  align-self: center;
 }
 
 .sidebarPicture {
@@ -79,6 +71,9 @@
 .sidebarCloseBtn {
   width: 40px;
   height: 25px;
+  margin-top: 53px;
+  margin-right: 30px;
+  transform: scale(0.6);
   display: none;
   align-items: right;
   justify-content: flex-end;
@@ -100,19 +95,29 @@
     display: none;
   }
 
+  .side {
+    padding-top: 30px;
+    background-color: var(--color-white);
+  }
+
+  .sidebarHeader {
+    align-self: flex-start;
+    margin-left: 30px;
+  }
+
   .side.isOpen {
     display: block;
     position: absolute;
     z-index: 11;
     width: 90%;
-    box-shadow: 10px 10px 27px -15px rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 75%);
+    box-shadow: 10px 10px 27px -15px rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 25%);
     height: 100%;
   }
 
   .sidebar {
     width: 100%;
     max-width: 100%;
-    background-color: #f6f6f6;
+    background-color: var(--color-white);
     height: 100%;
   }
 
@@ -120,7 +125,6 @@
     width: 100%;
     position: absolute;
     height: 100%;
-    background-color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 7%);
     z-index: 10;
   }
 }

--- a/app/routes/pages/components/Sidebar.js
+++ b/app/routes/pages/components/Sidebar.js
@@ -51,9 +51,10 @@ class Sidebar extends Component<Props, State> {
                 <Icon name="close" size={50} />
               </button>
               <h3 className={styles.sidebarHeader}>Om Abakus</h3>
+              {/*
               <h4 className={styles.sidebarSubtitle}>
                 {categorySelected ? categorySelected : 'Generelt'}
-              </h4>
+              </h4>*/}
               {/* <div className={styles.sidebarPicture}>
                 <h4 className={styles.pictureHeader}> {"Abakus' Fortid"}</h4>
                 <a href="https://abakus.no/">


### PR DESCRIPTION
First change of the planned improvements of the /pages/ route layout. 

This PR includes:
- Improved alignment of list items
- New icon for dropdown buttons
- Flip animation/transition for icon
- Cleaner design with small tint of background instead of right border/divider
- Links are gray while the "abakule" circle is kept red
- Mobile look is vastly improved (although not perfect)

Light mode:
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/37273026/195339350-2145a697-cd17-42a8-8ec7-5a07676e6f49.png">

Dark mode:
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/37273026/195339408-af194cec-19ee-4461-b4ad-c9d1b77b8860.png">

