### PR TITLE
Fix attendees stats bug on admin page

### DIFF
--- a/app/routes/events/components/EventAdministrate/Attendees.js
+++ b/app/routes/events/components/EventAdministrate/Attendees.js
@@ -102,7 +102,9 @@ export default class Attendees extends Component<Props, State> {
     ).length;
 
     const paidCount = registered.filter(
-      (reg) => reg.paymentStatus === 'succeeded' && reg.pool
+      (reg) =>
+        (reg.paymentStatus === 'succeeded' || reg.paymentStatus === 'manual') &&
+        reg.pool
     ).length;
 
     if (loading) {
@@ -177,13 +179,13 @@ export default class Attendees extends Component<Props, State> {
           <div>
             <strong>Påmeldte:</strong>
             <div className={styles.attendees}>
-              {`${registerCount}/${event.totalCapacity} har møtt opp`}
+              {`${registerCount}/${event.registrationCount} har møtt opp`}
             </div>
             <div className={styles.adminRegistrations}>
-              {`${adminRegisterCount}/${event.totalCapacity} er adminpåmeldt`}
+              {`${adminRegisterCount}/${event.registrationCount} er adminpåmeldt`}
             </div>
             <div className={styles.adminRegistrations}>
-              {`${paidCount}/${event.totalCapacity} har betalt`}
+              {`${paidCount}/${event.registrationCount} har betalt`}
             </div>
           </div>
           {registered.length === 0 && <li>Ingen påmeldte</li>}


### PR DESCRIPTION
Introduced in #3107.

People that had paid "manual" were not taken into account, and instead of comparing the stats to capacity it should be compared to registration count.