### PR TITLE
Add analytics snippet

### DIFF
--- a/server/pageRenderer.js
+++ b/server/pageRenderer.js
@@ -68,6 +68,14 @@ const readyHtml = (app) => {
   }
 };
 
+const analytics = __DEV__
+  ? ''
+  : // The .replace() remove the protocol (https://) part of the url, leaving just the domain
+    `<script defer data-domain=${config.webUrl.replace(
+      /(^\w+:|^)\/\//,
+      ''
+    )} src="https://analytics.webkom.dev/js/plausible.js"></script>`;
+
 export default function pageRenderer({
   app = undefined,
   state = {},
@@ -108,6 +116,8 @@ export default function pageRenderer({
         <meta name="apple-mobile-web-app-capable" content="yes"/>
         <meta name="mobile-web-app-capable" content="yes"/>
         <meta name="apple-mobile-web-app-title" content="Abakus"/>
+
+        ${analytics}
 
         <link href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css?family=Open+Sans:700|Raleway|Roboto" rel="stylesheet">


### PR DESCRIPTION
This adds an analytics snippet to start tracking some analytics again!

This points to our self-hosted plausible instance, so all data is stored in the same method as our
other data.

Additionally, this analytics snippet is GDPR-compliant and does _not_ store any cookies, saving us
from the dreaded cookie-popup hell.

Fixes ABA-93