### PR TITLE
Fix bug where icons disappear after interacting with them

### DIFF
--- a/app/components/Icon/index.js
+++ b/app/components/Icon/index.js
@@ -29,16 +29,16 @@ const Icon = ({
   ...props
 }: Props) => {
   return (
-    <ion-icon
-      name={name}
-      class={className}
+    <div
+      className={className}
       style={{
         fontSize: `${size.toString()}px`,
-        lineHeight: 2,
         ...style,
       }}
       {...(props: Object)}
-    ></ion-icon>
+    >
+      <ion-icon name={name}></ion-icon>
+    </div>
   );
 };
 


### PR DESCRIPTION
When clicking icons in Tables the icon would become invisible. Turns out this is because ion-icons sets classnames on itself when initializing, that would then be overwritten when we change the className in react.

I fixed it by wrapping each icon in a div, and applying style to that instead. This however caused some icons to take up too much vertical space, so I removed "lineHeight: 2" from the style, which seems to have fixed it. Not sure why that was there in the first place, as I have looked around a bit and not found any icons that look different from before.