### PR TITLE
Aligned Select And Filtericon With Filterbuttons

### DIFF
--- a/app/routes/events/components/EventList.css
+++ b/app/routes/events/components/EventList.css
@@ -38,14 +38,18 @@
   justify-content: flex-end;
   margin-bottom: -36px;
   margin-right: -2px;
+
+  @media (--mobile-device) {
+    margin-bottom: 0;
+  }
+}
+
+.filter ion-icon {
+  flex-shrink: 0;
 }
 
 .select {
   width: 200px;
-
-  @media (--mobile-device) {
-    width: 100px;
-  }
 }
 
 .checkbox {
@@ -56,10 +60,6 @@
 .filterButtons {
   display: flex;
   flex-wrap: wrap;
-
-  @media (--mobile-device) {
-    margin-bottom: 40px;
-  }
 }
 
 .filterButtons label {


### PR DESCRIPTION
This looks better on mobile or when zooming.

Also removed the width change on mobile from 200px to 100px, now its always 200px. Since 100px makes it very short and difficult to read, and it is space enough for 200px anyways

Changed from:
<img width="1709" alt="Skjermbilde 2022-10-19 kl  21 16 40" src="https://user-images.githubusercontent.com/45620425/196783688-8aedffd3-fef1-48cb-b127-5400a112913d.png">
To:
<img width="1720" alt="Skjermbilde 2022-10-19 kl  21 17 40" src="https://user-images.githubusercontent.com/45620425/196783884-a49f24d1-13d0-42db-9da2-7514361f413d.png">

Last changes:
<img width="1717" alt="Skjermbilde 2022-10-19 kl  22 11 22" src="https://user-images.githubusercontent.com/45620425/196794056-55961619-55dc-48ba-98fa-3b195620abe1.png">

