### PR TITLE
Add the Abakus Revue to pages

### DIFF
--- a/app/models.js
+++ b/app/models.js
@@ -68,6 +68,7 @@ export type Tags = string;
 
 export const GroupTypeCommittee = 'komite';
 export const GroupTypeBoard = 'styre';
+export const GroupTypeRevue = 'revy';
 export const GroupTypeInterest = 'interesse';
 export const GroupTypeSub = 'under';
 export const GroupTypeGrade = 'klasse';

--- a/app/reducers/pages.js
+++ b/app/reducers/pages.js
@@ -88,6 +88,8 @@ export const selectCommitteeForHierarchy = createGroupSelector(
   'komiteer'
 );
 
+export const selectRevueForHierarchy = createGroupSelector('revy', 'revy');
+
 export const selectBoardsForHierarchy = createGroupSelector('styre', 'styrer');
 
 export const selectPageHierarchy = createSelector(

--- a/app/routes/pages/PageDetailRoute.js
+++ b/app/routes/pages/PageDetailRoute.js
@@ -20,10 +20,11 @@ import PageDetail, {
   GroupRenderer,
 } from './components/PageDetail';
 import LandingPage from './components/LandingPage';
-import { GroupTypeCommittee, GroupTypeBoard } from 'app/models';
+import { GroupTypeCommittee, GroupTypeBoard, GroupTypeRevue } from 'app/models';
 import {
   selectPagesForHierarchy,
   selectCommitteeForHierarchy,
+  selectRevueForHierarchy,
   selectBoardsForHierarchy,
   selectPageHierarchy,
   selectCommitteeForPages,
@@ -99,6 +100,18 @@ const sections: {|
     hierarchySectionSelector: selectCommitteeForHierarchy,
     PageRenderer: GroupRenderer,
     fetchAll: () => fetchAllWithType(GroupTypeCommittee),
+    fetchItemActions: [
+      fetchGroup,
+      (groupId: number) => fetchAllMemberships(groupId, true),
+    ],
+  },
+  revy: {
+    title: 'Revy',
+    section: 'revy',
+    pageSelector: selectCommitteeForPages,
+    hierarchySectionSelector: selectRevueForHierarchy,
+    PageRenderer: GroupRenderer,
+    fetchAll: () => fetchAllWithType(GroupTypeRevue),
     fetchItemActions: [
       fetchGroup,
       (groupId: number) => fetchAllMemberships(groupId, true),


### PR DESCRIPTION
To better showcase the Abakus Revue it will now be displayed in its own tab, in the same way as the committees.

Depends on: https://github.com/webkom/lego/pull/3010