### PR TITLE
Improve Badge Order

### DIFF
--- a/app/routes/users/components/UserProfile.tsx
+++ b/app/routes/users/components/UserProfile.tsx
@@ -289,7 +289,11 @@ const UserProfile = (props: Props) => {
       filteredPastMembershipsAsBadges.concat(membershipsAsBadges),
       'abakusGroup.id'
     ),
-    (memberships) => !memberships.some((membership) => membership.isActive)
+    [
+      (memberships) => !memberships.some((membership) => membership.isActive),
+      (memberships) => memberships[0].abakusGroup.type === 'interesse',
+      (memberships) => memberships[0].abakusGroup.type !== 'styre',
+    ]
   );
   const tree = {};
 
@@ -436,11 +440,8 @@ const UserProfile = (props: Props) => {
             ))}
           </Flex>
           <Flex wrap>
-            {Object.keys(groupedMemberships).map((groupId) => (
-              <GroupBadge
-                memberships={groupedMemberships[groupId]}
-                key={groupId}
-              />
+            {groupedMemberships.map((memberships) => (
+              <GroupBadge memberships={memberships} key={memberships[0].id} />
             ))}
           </Flex>
         </Flex>


### PR DESCRIPTION
Currently, the badges on my profile are ordered like this:
![image](https://user-images.githubusercontent.com/66320400/197355599-3dd6d96e-e48f-4af7-a335-6a4f22117261.png)

In my opinion, it would look better if the red badges were grouped together (i.e. the revy badge is next to the webkom badge). This PR will change the order to the following (from most prioritized to least):
1. Styrer (e.g. Hovedstyret and Fondsstyret)
2. Committee, Revue (i.e. the rest of the red badges)
3. Interest groups (i.e. yellow badges)
4. Inactive groups (i.e. gray badges)

I'm open for any feedback/changes :)