### PR TITLE
Make `allConsentsAnswered` => false for empty array

### DIFF
--- a/app/routes/events/utils.js
+++ b/app/routes/events/utils.js
@@ -296,7 +296,7 @@ export const allConsentsAnswered = (
 ): boolean =>
   photoConsents?.reduce(
     (all_bool, pc) => all_bool && typeof pc.isConsenting === 'boolean',
-    true
+    photoConsents.length > 0
   );
 
 export const toReadableSemester = (


### PR DESCRIPTION
Another teeny tiny bug here.

The reduce function would return true if we passed in an empty array,
which does not make sense when there are no consents that could have
been answered.
