### PR TITLE
Refetch me-user when viewing profile page

### DIFF
--- a/app/routes/users/UserProfileRoute.js
+++ b/app/routes/users/UserProfileRoute.js
@@ -39,7 +39,7 @@ const loadData = (
     dispatch(fetchAllWithType(GroupTypeGrade)),
     isMe && dispatch(fetchPrevious()),
     isMe && dispatch(fetchUpcoming()),
-    isMe || dispatch(fetchUser(username)),
+    dispatch(fetchUser(username)),
   ]);
 // TODO: re-enable when the user feed is fixed:
 // .then(action =>


### PR DESCRIPTION
This is to make the "Åre"-photo consent experience better. When viewing an event with photo-consent for an upcoming semester, the photo-consent objects are created in backend, but not updated in frontend. By refetching user when viewing the profile page the new objects will be fetched.

Without this you would need to reload the page in order to register photo-consent.