### PR TITLE
Fix cypress bug where it selects wrong date at end of month

### DIFF
--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -5,6 +5,7 @@ import {
   selectField,
   selectFieldDropdown,
   selectEditor,
+  setDatePickerDate,
 } from '../support/utils.js';
 
 describe('Create event', () => {
@@ -263,28 +264,9 @@ describe('Create event', () => {
     const todayDay = dateObject.getDate();
     dateObject.setDate(dateObject.getDate() + 1);
     const tomorrowDay = dateObject.getDate();
-    field('startTime').click();
-    if (tomorrowDay < todayDay) {
-      // End of month
-      cy.get(c('DatePicker__arrowIcon'))
-        .eq(1)
-        .should('not.be.disabled')
-        .click();
-    }
-    cy.get('button')
-      .contains(new RegExp('^' + tomorrowDay + '$', 'g'))
-      .click();
-    field('endTime').click();
-    if (tomorrowDay < todayDay) {
-      // End of month
-      cy.get(c('DatePicker__arrowIcon'))
-        .eq(1)
-        .should('not.be.disabled')
-        .click();
-    }
-    cy.get('button')
-      .contains(new RegExp('^' + tomorrowDay + '$', 'g'))
-      .click();
+
+    setDatePickerDate('startTime', tomorrowDay, tomorrowDay < todayDay);
+    setDatePickerDate('endTime', tomorrowDay, tomorrowDay < todayDay);
 
     // Select regitrationType
     selectField('eventStatusType').click();

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -71,7 +71,7 @@ export const setDatePickerDate = (name, date, isNextMonth = false) => {
     cy.get(c('DatePicker__arrowIcon')).eq(1).should('not.be.disabled').click();
   }
 
-  cy.get('button')
+  cy.get('button:not(:disabled)')
     .contains(new RegExp('^' + date + '$', 'g'))
     .click();
 };

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -64,6 +64,18 @@ export const setDatePickerTime = (name, hours, minutes) => {
   field(name).click();
 };
 
+export const setDatePickerDate = (name, date, isNextMonth = false) => {
+  field(name).click();
+
+  if (isNextMonth) {
+    cy.get(c('DatePicker__arrowIcon')).eq(1).should('not.be.disabled').click();
+  }
+
+  cy.get('button')
+    .contains(new RegExp('^' + date + '$', 'g'))
+    .click();
+};
+
 // Used to either confirm or deny the 3D secure pop-up from Stripe.
 export const confirm3DSecureDialog = (confirm = true) => {
   const target = confirm


### PR DESCRIPTION
At the end of the month, the cypress tests selected the date from the previous month instead of the date tomorrow, if it was visible. I added ":not(:disabled)" to the selector, which works because the previous month's dates are all disabled.
<img width="210" alt="Screenshot 2022-10-26 at 17 46 29" src="https://user-images.githubusercontent.com/8343002/198073297-1984abfb-c85e-4910-b382-b0fb95a6f6e3.png">

I also moved the date picking code into a function as it was duplicated.