### PR TITLE
Fix mobile page overflow with long words in articles

### DIFF
--- a/app/routes/overview/components/ArticleItem.css
+++ b/app/routes/overview/components/ArticleItem.css
@@ -27,7 +27,7 @@
   font-size: 1.2rem;
   letter-spacing: 2px;
   text-transform: uppercase;
-  word-break: normal;
+  word-break: break-word;
 }
 
 .articleMeta {


### PR DESCRIPTION
Before:
<img width="395" alt="Screenshot 2022-10-26 at 19 28 09" src="https://user-images.githubusercontent.com/8343002/198095331-34b236b6-da3d-48d0-a862-d9200628fef6.png">
After:
<img width="395" alt="Screenshot 2022-10-26 at 19 23 50" src="https://user-images.githubusercontent.com/8343002/198095103-059365f3-08cf-48df-8ef0-2a8f799100d5.png">

It doesn't look great to break words without a hyphen, but that is surprisingly hard with only css.

closes ABA-103