### PR TITLE
[ABA-109] Add sorting option for payment status on attendees page

### DIFF
--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -284,7 +284,7 @@ export class RegisteredTable extends Component<Props> {
       {
         title: 'Betaling',
         dataIndex: 'paymentStatus',
-        visible: !!event.isPriced,
+        visible: event.isPriced,
         center: true,
         render: (paymentStatus, registration) => (
           <StripeStatus
@@ -294,9 +294,9 @@ export class RegisteredTable extends Component<Props> {
           />
         ),
         sorter: (a, b) => {
-          a.paymentStatus ??= 'failed';
-          b.paymentStatus ??= 'failed';
-          return a.paymentStatus > b.paymentStatus ? 1 : -1;
+          const paymentStatusA = a.paymentStatus ?? 'failed';
+          const paymentStatusB = b.paymentStatus ?? 'failed';
+          return paymentStatusA > paymentStatusB ? 1 : -1;
         },
       },
       {

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -294,11 +294,9 @@ export class RegisteredTable extends Component<Props> {
           />
         ),
         sorter: (a, b) => {
-          const paymentStatusA = a.paymentStatus ?? 'failed';
-          const paymentStatusB = b.paymentStatus ?? 'failed';
-
-          if (paymentStatusA > paymentStatusB) return 1;
-          else return -1;
+          a.paymentStatus ??= 'failed';
+          b.paymentStatus ??= 'failed';
+          return a.paymentStatus > b.paymentStatus ? 1 : -1;
         },
       },
       {
@@ -311,9 +309,7 @@ export class RegisteredTable extends Component<Props> {
             {`Matallergier: ${registration.user.allergies || '-'}`}
           </span>
         ),
-        sorter: (a, b) => {
-          return a.feedback.localeCompare(b.feedback);
-        },
+        sorter: (a, b) => a.feedback.localeCompare(b.feedback),
       },
       {
         title: 'Administrer',

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.js
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.js
@@ -284,7 +284,7 @@ export class RegisteredTable extends Component<Props> {
       {
         title: 'Betaling',
         dataIndex: 'paymentStatus',
-        visible: event.isPriced,
+        visible: !!event.isPriced,
         center: true,
         render: (paymentStatus, registration) => (
           <StripeStatus
@@ -293,6 +293,13 @@ export class RegisteredTable extends Component<Props> {
             handlePayment={handlePayment}
           />
         ),
+        sorter: (a, b) => {
+          const paymentStatusA = a.paymentStatus ?? 'failed';
+          const paymentStatusB = b.paymentStatus ?? 'failed';
+
+          if (paymentStatusA > paymentStatusB) return 1;
+          else return -1;
+        },
       },
       {
         title: 'Tilbakemelding',
@@ -305,8 +312,7 @@ export class RegisteredTable extends Component<Props> {
           </span>
         ),
         sorter: (a, b) => {
-          if (a.feedback > b.feedback) return 1;
-          else return -1;
+          return a.feedback.localeCompare(b.feedback);
         },
       },
       {


### PR DESCRIPTION
Two things are fixed:

* It is now possible to sort attendees based on payment status.
* The sorting of feedback is done with localeCompare so that the sorting is done alphabetically instead of based on ASCII values.

[Sorting in action :nerd_face:](https://user-images.githubusercontent.com/43182025/198133744-9bb917d5-8d07-4f37-b327-2c40aad7c277.webm)