### PR TITLE
Fix Turnstile theme discrepany

### DIFF
--- a/app/components/Form/Captcha.js
+++ b/app/components/Form/Captcha.js
@@ -7,6 +7,7 @@ import { createField } from './Field';
 import Turnstile from 'react-turnstile';
 import styles from './Captcha.css';
 import cx from 'classnames';
+import { getTheme } from 'app/utils/themeUtils';
 
 type Props = {
   className?: string,
@@ -40,6 +41,7 @@ class Captcha extends Component<Props> {
           }}
           sitekey={config.captchaKey}
           onVerify={onChange}
+          theme={getTheme()}
         />
       </div>
     );


### PR DESCRIPTION
Couple of minor issues: 
* The light version seems to be loaded before being replaced when running with csr (not an issue with ssr).
* When switching themes, the Turnstile widget remains the old theme (I don't know how to cascade this🤷).

Closes https://github.com/webkom/lego/issues/3036