### PR TITLE
fix(UserProfile): FRAME styling

### DIFF
--- a/app/routes/users/components/UserProfile.css
+++ b/app/routes/users/components/UserProfile.css
@@ -49,18 +49,10 @@ html[data-theme='dark'] .emptyState {
 }
 
 .frameMargin {
-  margin-top: 6.5rem;
-}
-
-.picture {
-  flex-direction: column;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  margin-top: 2rem;
 }
 
 .sidebar {
-  flex: 1;
   min-width: 320px;
   position: relative;
 }

--- a/app/routes/users/components/UserProfile.js
+++ b/app/routes/users/components/UserProfile.js
@@ -392,9 +392,11 @@ const UserProfile = (props: Props) => {
       </Modal>
 
       <Flex wrap className={styles.header}>
-        <div className={cx(styles.sidebar, styles.picture)}>
-          {hasFrame && <Image className={styles.frame} src={frame} />}
-          <ProfilePicture user={user} size={150} />
+        <Flex column alignItems="center" className={styles.sidebar}>
+          <Flex alignItems="center" justifyContent="center">
+            {hasFrame && <Image className={styles.frame} src={frame} />}
+            <ProfilePicture user={user} size={150} />
+          </Flex>
           {isMe && (
             <Button
               className={
@@ -410,7 +412,7 @@ const UserProfile = (props: Props) => {
               Vis ABA-ID
             </Button>
           )}
-        </div>
+        </Flex>
         <Flex column className={styles.rightContent}>
           <h2>{user.fullName}</h2>
           <Flex wrap>


### PR DESCRIPTION
The FRAME has some whack styling that caused this visual mishap. Did not spot this in the original PR, since profile pictures are not loaded in the staging environment. 

In my LEGO PR [#3041](https://github.com/webkom/lego/pull/3041) I made it so that the default (placeholder) profile picture is always used in staging. This makes it easier to spot these kind of issues.

## Before and After
<img width="318" alt="image" src="https://user-images.githubusercontent.com/26925695/198580901-6615b5cb-d5ee-4fe8-a04a-b04c218f9149.png"><img width="318" alt="image" src="https://user-images.githubusercontent.com/26925695/198580989-2a0b01ab-c298-4aa0-b172-c16655989f0f.png">
