### PR TITLE
Set end time explicitly in cypress meeting test

### DIFF
--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -197,6 +197,7 @@ describe('Create meeting', () => {
     cy.get(c('Modal__closeButton')).click();
 
     setDatePickerTime('startTime', '17', '15');
+    setDatePickerTime('endTime', '20', '00');
     field('useMazemap').click();
     selectFromSelectField('mazemapPoi', 'Abakus, Realfagbygget', 'a');
     selectFromSelectField('users', 'bedkom bedkom (bedkom)', 'bedkom');


### PR DESCRIPTION
The test fails on the two days a year we set the time because of daylight savings, because the default values of the form will be an hour off. Setting the time explicitly in the test fixes it, and I don't really see a need to test the default values.

ABA-115