### PR TITLE
Dark mode fixes

### DIFF
--- a/app/components/Modal/Modal.css
+++ b/app/components/Modal/Modal.css
@@ -17,6 +17,10 @@
   z-index: 3;
 }
 
+html[data-theme='dark'] .backdrop {
+  background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 80%);
+}
+
 .content {
   position: fixed;
   max-width: 680px;

--- a/app/routes/users/components/PhotoConsents.js
+++ b/app/routes/users/components/PhotoConsents.js
@@ -14,6 +14,8 @@ import {
 } from 'app/routes/events/utils';
 import styles from './PhotoConsents.css';
 
+import { selectStyles, selectTheme } from 'app/components/Form/SelectInput';
+
 const ConsentManager = ({
   consent,
   updateConsent,
@@ -136,6 +138,8 @@ const PhotoConsents = ({
         onChange={({ value }) =>
           setSelectedSemesterOption({ label: toReadableSemester(value), value })
         }
+        theme={selectTheme}
+        styles={selectStyles}
       />
       <ConsentManager
         consent={getConsent(


### PR DESCRIPTION
##  Fix the ugly white modal backdrop in dark mode
### Before
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/26925695/199229392-a352cc2a-36d2-4a1f-ace1-8a6a2b89c10b.png">

### After
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/26925695/199229433-503f4f35-0f43-487e-a051-23cb939fdd3d.png">

## Apply default styling to the select element in ConsentManager

### Before & After
<img width="375" alt="image" src="https://user-images.githubusercontent.com/26925695/199229973-0e876865-d69d-450c-a9f3-562e5d2304a1.png"><img width="375" alt="image" src="https://user-images.githubusercontent.com/26925695/199230013-e4d9425a-5f39-40c4-9391-003cc1daf884.png">
