### PR TITLE
Fix clicking links on /search page

### DIFF
--- a/app/components/Search/SearchPage.js
+++ b/app/components/Search/SearchPage.js
@@ -14,7 +14,7 @@ type Props = {
   onQueryChanged: (string) => void,
   placeholder?: string,
   results: Array<SearchResult>,
-  handleSelect: (string) => Promise<*>,
+  handleSelect: (SearchResult) => Promise<*>,
 };
 
 const SearchPage = (props: Props) => {
@@ -59,7 +59,7 @@ const SearchPage = (props: Props) => {
   const handleSelect = (result: SearchResult) => {
     setQuery('');
     setSelectedIndex(0);
-    props.handleSelect(result.username ?? '');
+    props.handleSelect(result);
   };
 
   const handleQueryChange = ({

--- a/app/components/UserValidator/index.js
+++ b/app/components/UserValidator/index.js
@@ -15,7 +15,7 @@ import { QrReader } from 'react-qr-reader';
 import Icon from 'app/components/Icon';
 type Props = {
   clearSearch: () => void,
-  handleSelect: (string) => Promise<void>,
+  handleSelect: (SearchResult) => Promise<void>,
   location: Object,
   onQueryChanged: (string) => void,
   results: Array<SearchResult>,
@@ -36,7 +36,7 @@ const Validator = (props: Props) => {
   };
 
   const onSelect = useCallback(
-    (result: string) => {
+    (result: SearchResult) => {
       clearSearch();
       return handleSelect(result)
         .then(
@@ -69,7 +69,18 @@ const Validator = (props: Props) => {
 
   useEffect(() => {
     if (scannerResult.length > 0 && !completed) {
-      onSelect(scannerResult);
+      onSelect({
+        username: scannerResult,
+        result: '',
+        color: '',
+        content: '',
+        icon: '',
+        label: '',
+        link: '',
+        path: '',
+        picture: '',
+        value: '',
+      });
     }
   }, [completed, onSelect, scannerResult]);
 

--- a/app/routes/events/components/EventAdministrate/Abacard.js
+++ b/app/routes/events/components/EventAdministrate/Abacard.js
@@ -30,7 +30,7 @@ const Abacard = (props: Props) => {
     (reg) => reg.presence === 'PRESENT' && reg.pool
   ).length;
 
-  const handleSelect = (username: string) =>
+  const handleSelect = ({ username = '' }: { username?: string }) =>
     markUsernamePresent(id.toString(), username).then(async (result) => {
       const payload = get(result, 'payload.response.jsonData');
       if (payload && payload.error) return result;


### PR DESCRIPTION
[This](https://github.com/webkom/lego-webapp/pull/3017/commits/0053f16b4360d5cc00b6463ba5af5e34a6dc42da) commit from https://github.com/webkom/lego-webapp/pull/3017, accidentally broke all `handleSelect`-calls when searching for other things than users, making links unclickable in the search-page.

If only we had working type-checking...