### PR TITLE
Change group leader name to editor for readme

### DIFF
--- a/app/components/GroupMember/index.js
+++ b/app/components/GroupMember/index.js
@@ -10,9 +10,12 @@ type Props = {
   user: User,
   leader?: boolean,
   co_leader?: boolean,
+  groupName?: string,
 };
 
-const GroupMember = ({ user, leader, co_leader }: Props) => {
+const GroupMember = ({ user, leader, co_leader, groupName }: Props) => {
+  const isReadme = groupName === 'readme';
+
   return (
     <Link to={`/users/${user.username}`}>
       <div
@@ -27,7 +30,9 @@ const GroupMember = ({ user, leader, co_leader }: Props) => {
           src={user.profilePicture}
           placeholder={user.profilePicturePlaceholder}
         />
-        {leader && <div className={styles.title}>LEDER</div>}
+        {leader && (
+          <div className={styles.title}> {isReadme ? 'REDAKTØR' : 'LEDER'}</div>
+        )}
         {co_leader && <div className={styles.title}>NESTLEDER</div>}
         <div className={styles.name}>{user.fullName}</div>
       </div>

--- a/app/routes/pages/components/PageDetail.js
+++ b/app/routes/pages/components/PageDetail.js
@@ -161,7 +161,7 @@ export const FlatpageRenderer = ({ page }: { page: PageEntity }) => (
 );
 
 export const GroupRenderer = ({ page }: { page: Object }) => {
-  const { membershipsByRole, text } = page;
+  const { membershipsByRole, text, name } = page;
 
   const {
     leader: leaders = [],
@@ -178,7 +178,7 @@ export const GroupRenderer = ({ page }: { page: Object }) => {
       <div className={styles.membersSection}>
         <div className={styles.leaderBoard}>
           {leaders.map(({ user }, key) => (
-            <GroupMember user={user} key={user.id} leader />
+            <GroupMember user={user} key={user.id} leader groupName={name} />
           ))}
           {co_leaders.map(({ user }, key) => (
             <GroupMember user={user} key={user.id} co_leader />


### PR DESCRIPTION
As the leader of readme is called editor ("Redaktør") and not leader, this is now updated on the flatpages.

![image](https://user-images.githubusercontent.com/43182025/199581947-39d5f7b9-7502-4d70-8bfe-d7c36aa96ba6.png)

Fixes ABA-132