### PR TITLE
Improve Checkbox component

### DIFF
--- a/app/components/Form/CheckBox.css
+++ b/app/components/Form/CheckBox.css
@@ -1,108 +1,106 @@
 @import '~app/styles/variables.css';
 
+.checkbox {
+  --background: inherit;
+  --border: var(--color-mono-gray-2);
+  --border-hover: var(--color-mono-gray-1);
+  --border-active: var(--lego-red);
+  --tick: white;
+
+  position: relative;
+}
+
+.checkbox input,
+.checkbox svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  display: block;
+}
+
 .label {
   cursor: pointer;
+  user-select: none;
+}
+
+.checkbox input {
+  appearance: none;
   position: relative;
-  padding-left: 25px;
-  margin-right: 15px;
-  font-size: 13px;
-}
-
-.label:hover::before {
-  border: 1px solid var(--color-dark-mono-gray-5) !important;
-  transition: border 0.5s;
-}
-
-.checked,
-.unchecked {
-  position: absolute;
-  margin-top: 4px;
-  margin-left: 2px;
-  z-index: 1;
-  transform: scale(1.5);
-  opacity: 0;
+  outline: none;
+  background: var(--background);
+  border: none;
+  margin: 0;
+  padding: 0;
   cursor: pointer;
+  border-radius: 4px;
+  transition: box-shadow 0.2s;
+  box-shadow: inset 0 0 0 var(--s, 1px) var(--b, var(--border));
 }
 
-.checked + label::after {
-  content: '\2713';
+.checkbox input:hover {
+  --s: 2px;
+  --b: var(--border-hover);
+}
+
+.checkbox input:checked {
+  --b: var(--border-active);
+}
+
+.checkbox svg {
+  pointer-events: none;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke: var(--stroke, var(--border-active));
   position: absolute;
-  top: 4px;
-  left: 3px;
-  font-size: 16px;
-  line-height: 80%;
-  color: var(--color-white);
-  transition: all 0.2s;
-  opacity: 1;
-  transform: scale(1);
-}
-
-.unchecked + label::before {
-  background: var(--color-almost-white-2);
-}
-
-.unchecked + label::after {
-  opacity: 0;
-  transform: scale(0);
-}
-
-.checked + label::before {
-  background: var(--lego-link-color);
-  border-color: var(--lego-link-color);
-}
-
-.checked + label::before,
-.unchecked + label::before {
-  content: '';
-  position: absolute;
+  top: 0;
   left: 0;
-  top: 1px;
-  width: 17px;
-  height: 17px;
-  border: 1px solid var(--color-mono-gray-1);
-  border-radius: 3px;
+  transform: scale(var(--scale, 1)) translateZ(0);
 }
 
-/* CheckBox uses label for its clickable square, so these values are tuned for
-  checkboxes */
-.checkboxField > label label::before {
-  top: 6px;
+.checkbox.path input:checked {
+  --s: 2px;
+
+  transition-delay: 0.3s;
 }
 
-.checkboxField > label label::after {
-  top: 9px;
+.checkbox.path svg {
+  stroke-dasharray: var(--a, 86.12);
+  stroke-dashoffset: var(--o, 86.12);
+  transition: stroke-dasharray 0.6s, stroke-dashoffset 0.6s;
 }
 
-.checked:focus + label::before,
-.unchecked:focus + label::before {
-  cursor: pointer;
+.checkbox.bounce svg {
+  --scale: 0;
 }
 
-.unchecked + label,
-.checked + label {
-  position: relative;
-  cursor: pointer;
+.checkbox.path input:checked + svg {
+  --a: 16.1 86.12;
+  --o: 102.22;
 }
 
-.box {
-  display: inline-block;
-  width: 21px;
-  height: 21px;
-  margin-right: 10px;
-  margin-bottom: -3px;
+.checkbox.bounce {
+  --stroke: var(--tick);
 }
 
-.box input:disabled + label::before {
-  background: var(--color-mono-gray-4);
-  border: 1px solid var(--color-mono-gray-2);
+.checkbox.bounce input:checked {
+  --s: 11px;
 }
 
-.box input:disabled + label::after {
-  color: var(--color-dark-mono-gray-4);
+.checkbox.bounce input:checked + svg {
+  animation: bounce 0.4s linear forwards 0.2s;
 }
 
-.checkboxField > label {
-  display: flex;
-  flex-direction: row-reverse;
-  justify-content: flex-end;
+@keyframes bounce {
+  50% {
+    transform: scale(1.2);
+  }
+
+  75% {
+    transform: scale(0.9);
+  }
+
+  100% {
+    transform: scale(1);
+  }
 }

--- a/app/components/Form/CheckBox.js
+++ b/app/components/Form/CheckBox.js
@@ -4,12 +4,12 @@ import { createField } from './Field';
 import type { FormProps } from './Field';
 import styles from './CheckBox.css';
 import cx from 'classnames';
+import { Flex } from '../Layout';
 
 type Props = {
   id?: string,
   type?: string,
   label?: string,
-  labelStyle?: string,
   value?: boolean,
   checked?: boolean,
   inverted?: boolean,
@@ -17,38 +17,35 @@ type Props = {
 };
 
 /*
-
 When using this component as a Field in form, you have to include
 type="checkbox", so that react-final-form knows to send the "checked" prop.
-
 */
 
-function CheckBox({
-  inverted,
+const CheckBox = ({
   id,
   label,
   value, // TODO: remove "value" once migration to react-final-form is complete
   checked,
-  labelStyle,
+  inverted,
   className,
   ...props
-}: Props) {
+}: Props) => {
   checked = checked ?? value;
   const normalizedValue = inverted ? !checked : checked;
   return (
-    <div className={cx(styles.box, className)}>
-      <input
-        {...props}
-        checked={checked}
-        className={cx(normalizedValue ? styles.checked : styles.unchecked)}
-        type="checkbox"
-      />
-      <label htmlFor={id} style={labelStyle} className={styles.label}>
+    <Flex wrap alignItems="center" gap={5}>
+      <div className={cx(styles.checkbox, styles.bounce, className)}>
+        <input {...props} id={id} checked={normalizedValue} type="checkbox" />
+        <svg viewBox="0 0 21 21">
+          <polyline points="5 10.75 8.5 14.25 16 6" />
+        </svg>
+      </div>
+      <label htmlFor={id} className={styles.label}>
         {label}
       </label>
-    </div>
+    </Flex>
   );
-}
+};
 
 const RawField = createField(CheckBox);
 const StyledField = ({ fieldClassName, ...props }: FormProps) => (

--- a/app/routes/bdb/components/OptionsBox.js
+++ b/app/routes/bdb/components/OptionsBox.js
@@ -73,14 +73,13 @@ export default class OptionsBox extends Component<Props, State> {
 
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           <div className={styles.section} style={{ order: 0 }}>
-            <label>
-              <CheckBox
-                value={this.state.active}
-                name="active"
-                onChange={() => this.toggleSection('active')}
-              />
-              <span>Er aktiv</span>
-            </label>
+            <CheckBox
+              id="isActive"
+              value={this.state.active}
+              name="active"
+              label="Er aktiv"
+              onChange={() => this.toggleSection('active')}
+            />
 
             <div
               className={styles.options}
@@ -108,14 +107,13 @@ export default class OptionsBox extends Component<Props, State> {
               </label>
             </div>
 
-            <label>
-              <CheckBox
-                value={this.state.studentContact}
-                name="studentContact"
-                onChange={() => this.toggleSection('studentContact')}
-              />
-              <span>Har studentkontakt...</span>
-            </label>
+            <CheckBox
+              id="hasStudentContact"
+              value={this.state.studentContact}
+              name="studentContact"
+              label="Har studentkontakt ..."
+              onChange={() => this.toggleSection('studentContact')}
+            />
 
             <div
               className={styles.options}

--- a/app/routes/events/components/EventList.css
+++ b/app/routes/events/components/EventList.css
@@ -59,7 +59,8 @@
 
 .filterButtons {
   display: flex;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
+  gap: 15px;
 }
 
 .filterButtons label {

--- a/app/routes/events/components/EventList.js
+++ b/app/routes/events/components/EventList.js
@@ -192,44 +192,32 @@ class EventList extends Component<EventListProps, State> {
         <Toolbar actionGrant={this.props.actionGrant} />
         <div className={styles.filter}>
           <div className={styles.filterButtons}>
-            <label>
-              <CheckBox
-                id="companyPresentation"
-                value={showCompanyPresentation}
-                onChange={() =>
-                  this.handleFilterEventTypeChange('showCompanyPresentation')
-                }
-                className={styles.checkbox}
-              />
-              <span>Bedpres</span>
-            </label>
-            <label>
-              <CheckBox
-                id="course"
-                value={showCourse}
-                onChange={() => this.handleFilterEventTypeChange('showCourse')}
-                className={styles.checkbox}
-              />
-              <span>Kurs</span>
-            </label>
-            <label>
-              <CheckBox
-                id="social"
-                value={showSocial}
-                onChange={() => this.handleFilterEventTypeChange('showSocial')}
-                className={styles.checkbox}
-              />
-              <span>Sosialt</span>
-            </label>
-            <label>
-              <CheckBox
-                id="other"
-                value={showOther}
-                onChange={() => this.handleFilterEventTypeChange('showOther')}
-                className={styles.checkbox}
-              />
-              <span>Annet</span>
-            </label>
+            <CheckBox
+              id="companyPresentation"
+              label="Bedpres"
+              value={showCompanyPresentation}
+              onChange={() =>
+                this.handleFilterEventTypeChange('showCompanyPresentation')
+              }
+            />
+            <CheckBox
+              id="course"
+              label="Kurs"
+              value={showCourse}
+              onChange={() => this.handleFilterEventTypeChange('showCourse')}
+            />
+            <CheckBox
+              id="social"
+              label="Sosialt"
+              value={showSocial}
+              onChange={() => this.handleFilterEventTypeChange('showSocial')}
+            />
+            <CheckBox
+              id="other"
+              label="Annet"
+              value={showOther}
+              onChange={() => this.handleFilterEventTypeChange('showOther')}
+            />
           </div>
           <Icon
             name="funnel-outline"

--- a/app/routes/joblistings/components/JoblistingRightNav.css
+++ b/app/routes/joblistings/components/JoblistingRightNav.css
@@ -64,12 +64,6 @@
   }
 }
 
-.filterLink {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
 .rightHeader {
   text-transform: uppercase;
   font-weight: 400;

--- a/app/routes/joblistings/components/JoblistingRightNav.js
+++ b/app/routes/joblistings/components/JoblistingRightNav.js
@@ -8,6 +8,7 @@ import Button from 'app/components/Button';
 import cx from 'classnames';
 import type { ActionGrant } from 'app/models';
 import qs from 'qs';
+import { jobTypes } from '../constants';
 
 const updateFilters = (type, value, filters) => {
   const newFilter = {
@@ -36,18 +37,25 @@ const updateFilters = (type, value, filters) => {
   };
 };
 
-const FilterLink = ({ type, label, value, filters }: Object) => (
-  <Link
-    to={{
+const FilterLink = ({ type, label, value, filters, history }: Object) => {
+  const handleChange = () => {
+    const location = {
       pathname: '/joblistings',
       search: qs.stringify(updateFilters(type, value, filters)),
-    }}
-    className={styles.filterLink}
-  >
-    <CheckBox id={label} value={filters[type].includes(value)} readOnly />
-    {label}
-  </Link>
-);
+    };
+    history.push(location);
+  };
+
+  return (
+    <CheckBox
+      id={label}
+      label={label}
+      value={filters[type].includes(value)}
+      onChange={handleChange}
+      readOnly
+    />
+  );
+};
 
 type Filter = {
   grades: Array<string>,
@@ -141,7 +149,6 @@ const JoblistingsRightNav = (props: Props) => {
             <Button className={styles.createButton}>Ny jobbannonse</Button>
           </Link>
         )}
-
         <h3 className={styles.rightHeader}>Sorter etter:</h3>
         <label htmlFor="deadline" style={{ cursor: 'pointer' }}>
           <RadioButton
@@ -197,49 +204,33 @@ const JoblistingsRightNav = (props: Props) => {
             label={`${element}. klasse`}
             value={element}
             filters={filters}
+            history={props.history}
           />
         ))}
 
         <h3 className={styles.rightHeader}>Jobbtype:</h3>
-        <FilterLink
-          type="jobTypes"
-          label="Sommerjobb"
-          value="summer_job"
-          filters={filters}
-        />
-        <FilterLink
-          type="jobTypes"
-          value="part_time"
-          label="Deltid"
-          filters={filters}
-        />
-        <FilterLink
-          type="jobTypes"
-          value="full_time"
-          label="Fulltid"
-          filters={filters}
-        />
-        <FilterLink
-          type="jobTypes"
-          value="master_thesis"
-          label="Masteroppgave"
-          filters={filters}
-        />
-        <FilterLink
-          type="jobTypes"
-          value="other"
-          label="Annet"
-          filters={filters}
-        />
+        {jobTypes.map((el) => {
+          return (
+            <FilterLink
+              key={el.value}
+              type="jobTypes"
+              value={el.value}
+              label={el.label}
+              filters={filters}
+              history={props.history}
+            />
+          );
+        })}
 
         <h3 className={styles.rightHeader}>Sted:</h3>
         {['Oslo', 'Trondheim', 'Bergen', 'Tromsø', 'Annet'].map((element) => (
           <FilterLink
-            type="workplaces"
             key={element}
+            type="workplaces"
             value={element}
             label={element}
             filters={filters}
+            history={props.history}
           />
         ))}
       </div>

--- a/app/routes/surveys/components/AdminSideBar.js
+++ b/app/routes/surveys/components/AdminSideBar.js
@@ -61,15 +61,14 @@ class AdminSideBar extends Component<Props, State> {
               <Link to={`/surveys/${surveyId}/edit`}>Endre undersøkelsen</Link>
             </li>
             {actionGrant && actionGrant.includes('edit') && shareSurvey && (
-              <div>
-                <CheckBox
-                  onChange={() =>
-                    token ? hideSurvey(surveyId) : shareSurvey(surveyId)
-                  }
-                  value={!!token}
-                />
-                Del spørreundersøkelsen
-              </div>
+              <CheckBox
+                id="shareSurvey"
+                label="Del spørreundersøkelsen"
+                onChange={() =>
+                  token ? hideSurvey(surveyId) : shareSurvey(surveyId)
+                }
+                value={!!token}
+              />
             )}
             {token && (
               <li>


### PR DESCRIPTION
The `<Checkbox />` component is in great need of an improvement. It now also looks much better in dark mode.

It now works to pass a `label` into the component as a prop, making it align to the checkbox. It is now also clickable, but only if an `id` is given.  

The CSS is completely rewritten, so no need to compare the diffs.

## Result
Keep in mind that the .gif is laggy, causing the transitions to seem slow and less smooth. 

![checkbox](https://user-images.githubusercontent.com/69514187/199578392-347e1612-130c-4cc0-b3b7-285866b0468c.gif)

Closes ABA-133
