### PR TITLE
Support interest group links on events

### DIFF
--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -45,6 +45,7 @@ import type {
 import type { CommentEntity } from 'app/reducers/comments';
 import type { UserEntity } from 'app/reducers/users';
 import { MazemapEmbed } from 'app/components/MazemapEmbed';
+import { resolveGroupLink } from 'app/reducers/groups';
 type InterestedButtonProps = {
   isInterested: boolean;
 };
@@ -297,15 +298,16 @@ export default class EventDetail extends Component<Props, State> {
           }
         : null,
     ];
+
+    const groupLink =
+      event.responsibleGroup && resolveGroupLink(event.responsibleGroup);
     const eventCreator = [
       event.responsibleGroup && {
         key: 'Arrangør',
         value: (
           <span>
-            {event.responsibleGroup.type === 'komite' ? (
-              <Link to={`/pages/komiteer/${event.responsibleGroup.id}`}>
-                {event.responsibleGroup.name}
-              </Link>
+            {groupLink ? (
+              <Link to={groupLink}>{event.responsibleGroup.name}</Link>
             ) : (
               event.responsibleGroup.name
             )}{' '}
@@ -331,6 +333,7 @@ export default class EventDetail extends Component<Props, State> {
             value: 'Anonym',
           },
     ];
+
     return (
       <div>
         <Content


### PR DESCRIPTION
Now that interest groups are more regularly creating events, I think it's fitting to link to their page.

## Result

**Before**
![image](https://user-images.githubusercontent.com/69514187/200052890-ba6437ea-e0a2-447f-a622-b0b0a4fc4b53.png)

**After**
![image](https://user-images.githubusercontent.com/69514187/200052965-115db604-a193-4b74-8abd-ced254819231.png)


---

To help in review, this is what `resolveGroupLink` does:
```tsx
export const resolveGroupLink = (group: { type: string; id: ID }) => {
  switch (group.type) {
    case GroupTypeInterest:
      return `/interest-groups/${group.id}`;

    case GroupTypeCommittee:
      return `/pages/komiteer/${group.id}`;

    default:
      return null;
  }
};
```

---

Closes ABA-136