### PR TITLE
Fix back link on joblisting edit page

### DIFF
--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -126,7 +126,7 @@ class JoblistingEditor extends Component<Props, State> {
           back={{
             label: 'Tilbake',
             path: !isNew
-              ? `/joblistings${this.props.joblisting.id}`
+              ? `/joblistings/${this.props.joblisting.id}`
               : '/joblistings',
           }}
         />


### PR DESCRIPTION
It was missing a "/"