### PR TITLE
Fix registration selector when user is missing

### DIFF
--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -309,8 +309,9 @@ export const selectAllRegistrationsForEvent = createSelector(
   (state, props) => props.eventId,
   (registrationsById, registrationItems, usersById, eventId) =>
     registrationItems
-      .map((regId, i) => {
-        const registration = registrationsById[regId];
+      .map((regId) => registrationsById[regId])
+      .filter((registration) => registration.event === Number(eventId))
+      .map((registration) => {
         const user = registration.user.id
           ? registration.user
           : usersById[registration.user];
@@ -331,7 +332,6 @@ export const selectAllRegistrationsForEvent = createSelector(
           updatedBy,
         });
       })
-      .filter((reg) => reg.event === Number(eventId))
 );
 export const selectWaitingRegistrationsForEvent = createSelector(
   selectEventById,


### PR DESCRIPTION
When a user does not have perms to register on an event, websocket registration messages in the `Event.SOCKET_REGISTRATION.SUCCESS` action will use the `RegistrationAnonymizedReadSerializer` containing the fields `("id", "pool", "status")`. This is done to make those user able to watch registrations real time, without seeing who the users are.

For those events, we don't hit this code path, since it will only use counters. However, if the user has normal access to an event and can see the registrations, the frontend will currently crash if one such websocket event (for another event without access) has occurred.

We could in theory handle the case here as well, but it will currently not be hit unless other code is refactored; and in that case even more code has to support it.

Fixes https://github.com/webkom/lego/pull/1929