### PR TITLE
Fix Link For Revue Badges

### DIFF
--- a/app/reducers/groups.ts
+++ b/app/reducers/groups.ts
@@ -2,7 +2,11 @@ import { createSelector } from 'reselect';
 import { Group, Membership } from '../actions/ActionTypes';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import type { ID } from 'app/models';
-import { GroupTypeInterest, GroupTypeCommittee } from 'app/models';
+import {
+  GroupTypeInterest,
+  GroupTypeCommittee,
+  GroupTypeRevue,
+} from 'app/models';
 import { produce } from 'immer';
 export const resolveGroupLink = (group: { type: string; id: ID }) => {
   switch (group.type) {
@@ -11,6 +15,9 @@ export const resolveGroupLink = (group: { type: string; id: ID }) => {
 
     case GroupTypeCommittee:
       return `/pages/komiteer/${group.id}`;
+
+    case GroupTypeRevue:
+      return `/pages/revy/${group.id}`;
 
     default:
       return null;


### PR DESCRIPTION
Thanks to #3152, every group in the revue has its own page on abakus.no. That means that we now can link the revue badges on your profile to their respective page, like what we've done for committees and interest groups. This PR adds that feature.

For example, I have a Teknikk-badge on my profile. Previously, nothing would happen if you clicked on it, but now it will route you to the Teknikk-page under Revy.