### PR TITLE
Implement a registration skeleton on event page

### DIFF
--- a/app/components/Image/CircularPicture.tsx
+++ b/app/components/Image/CircularPicture.tsx
@@ -10,6 +10,7 @@ const CircularPicture = ({
   placeholder,
   alt,
   size = 100,
+  className,
   style,
   ...props
 }: Props) => (
@@ -17,8 +18,7 @@ const CircularPicture = ({
     src={src}
     placeholder={placeholder}
     alt={alt}
-    width={size}
-    height={size}
+    className={className}
     style={{ ...style, borderRadius: size / 2, width: size, height: size }}
     {...props}
   />

--- a/app/components/Image/Image.tsx
+++ b/app/components/Image/Image.tsx
@@ -22,11 +22,15 @@ const ImageComponent = (props: Props) => {
   const [imageError, setImageError] = useState<boolean>(false);
   const [loadStart, setLoadStart] = useState<number>(0);
   const [loadEnd, setLoadEnd] = useState<number>(0);
+
   const { src, className, alt = 'image', style, ...rest } = props;
+
   const isProgressive = !!props.placeholder;
+
   useEffect(() => {
     setProgressiveSrc(props.placeholder || EMPTY_IMAGE);
   }, [props.placeholder]);
+
   useEffect(() => {
     if (isProgressive) {
       setImageLoaded(false);
@@ -47,6 +51,7 @@ const ImageComponent = (props: Props) => {
       setImageError(true);
     };
   }, [isProgressive, src]);
+
   const defaultClass = cx(styles.image, className);
   // Skip the transition effect if the image loads very quick.
   // F.ex. when high bandwith or cached
@@ -57,7 +62,9 @@ const ImageComponent = (props: Props) => {
     className,
     !imageLoaded && !imageError && isProgressive && styles.blur
   );
+
   if (!src) return <div className={finalClass} style={style} {...rest} />;
+
   return (
     <img
       className={isProgressive ? finalClass : defaultClass}

--- a/app/components/Image/ProfilePicture.tsx
+++ b/app/components/Image/ProfilePicture.tsx
@@ -6,16 +6,24 @@ type Props = Omit<
   {
     user: UserEntity;
     size: number;
+    className?: string;
   } & ComponentProps<typeof CircularPicture>,
   'placeholder' | 'src' | 'alt'
 >;
 
-const ProfilePicture = ({ user, size = 100, style, ...props }: Props) => (
+const ProfilePicture = ({
+  user,
+  size = 100,
+  className,
+  style,
+  ...props
+}: Props) => (
   <CircularPicture
-    alt={`${user.username} profile picture`}
+    alt={`${user.username}'s profile picture`}
     src={user.profilePicture}
     placeholder={user.profilePicturePlaceholder}
     size={size}
+    className={className}
     style={style}
     {...props}
   />

--- a/app/components/UserAttendance/AttendanceStatus.css
+++ b/app/components/UserAttendance/AttendanceStatus.css
@@ -13,13 +13,13 @@
 .poolBox {
   display: flex;
   flex: 1;
-  background-color: rgba(200, 200, 200, 30%);
   max-width: 100%;
   min-width: 25%;
   flex-direction: column;
   align-items: center;
+  background-color: rgba(200, 200, 200, 30%);
 }
 
 html[data-theme='dark'] .poolBox {
-  background-color: rgba(50, 50, 50, 30%);
+  background-color: rgba(80, 80, 80, 30%);
 }

--- a/app/components/UserGrid/UserGrid.css
+++ b/app/components/UserGrid/UserGrid.css
@@ -1,0 +1,18 @@
+.cell {
+  margin: 0 auto;
+
+  /* 3.3 pixels are added to the minimum height of the outer grid */
+  margin-bottom: 3.3px;
+}
+
+.skeletonCell {
+  /* The same dimensions as the profile pictures  */
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-color: var(--color-mono-gray-2);
+}
+
+html[data-theme='dark'] .skeletonCell {
+  background-color: var(--color-mono-gray-1);
+}

--- a/app/components/UserGrid/index.tsx
+++ b/app/components/UserGrid/index.tsx
@@ -1,7 +1,9 @@
+import cx from 'classnames';
 import { Link } from 'react-router-dom';
 import { ProfilePicture } from 'app/components/Image';
 import Tooltip from 'app/components/Tooltip';
 import type { User } from 'app/models';
+import styles from './UserGrid.css';
 
 const UserGrid = ({
   users,
@@ -10,7 +12,7 @@ const UserGrid = ({
   minRows = 0,
   padding = 3,
 }: {
-  users: Array<User>;
+  users: User[];
 
   /* profile picture size */
   size?: number;
@@ -26,17 +28,23 @@ const UserGrid = ({
       }px, 1fr))`,
       gridTemplateRows: users.length === 0 ? 0 : size + padding,
       overflow: 'hidden',
-      minHeight: minRows * size + (minRows - 1) * padding,
-      maxHeight: maxRows * size + (maxRows - 1) * padding,
+      minHeight: minRows * size + (minRows - 1) * padding + 3.3,
+      maxHeight: maxRows * size + (maxRows - 1) * padding + 3.3,
     }}
   >
     {users.map((user) => (
-      <RegisteredCell key={user.id} user={user} />
+      <RegisteredUserCell key={user.id} user={user} />
     ))}
+
+    {/* Only 15 users are passed into the users prop */}
+    {minRows > 0 &&
+      Array.from({ length: 15 - users.length }, (_, index) => (
+        <SkeletonUserCell key={index} />
+      ))}
   </div>
 );
 
-export const RegisteredCell = ({ user }: { user: User }) => (
+const RegisteredUserCell = ({ user }: { user: User }) => (
   <Tooltip
     style={{
       marginTop: '-7px',
@@ -45,14 +53,17 @@ export const RegisteredCell = ({ user }: { user: User }) => (
   >
     <Link to={`/users/${user.username}`}>
       <ProfilePicture
+        alt={`${user.username}'s profile picture`}
         size={56}
         user={user}
-        style={{
-          margin: '0 auto',
-          display: 'block',
-        }}
+        className={styles.cell}
       />
     </Link>
   </Tooltip>
 );
+
+const SkeletonUserCell = () => (
+  <div className={cx(styles.skeletonCell, styles.cell)} />
+);
+
 export default UserGrid;

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -51,6 +51,9 @@ type InterestedButtonProps = {
   isInterested: boolean;
 };
 
+const MIN_USER_GRID_ROWS = 2;
+const MAX_USER_GRID_ROWS = 2;
+
 const Line = () => <div className={styles.line} />;
 
 const InterestedButton = ({ isInterested }: InterestedButtonProps) => {
@@ -206,16 +209,29 @@ export default class EventDetail extends Component<Props, State> {
     }
 
     const color = colorForEvent(event.eventType);
+
     const onRegisterClick = currentUserFollowing
       ? () => unfollow(currentUserFollowing.id, event.id)
       : () => follow(currentUser.id, event.id);
+
     const currentMoment = moment();
+
     const activationTimeMoment = moment(event.activationTime);
+
     const eventRegistrationTime = activationTimeMoment.subtract(
       penaltyHours(penalties),
       'hours'
     );
+
     const registrationCloseTimeMoment = registrationCloseTime(event);
+
+    // The UserGrid is expanded when there's less than 5 minutes till activation
+    const minUserGridRows = currentMoment.isAfter(
+      activationTimeMoment.subtract(5, 'minutes')
+    )
+      ? MIN_USER_GRID_ROWS
+      : 0;
+
     const deadlines = [
       event.activationTime && currentMoment.isBefore(activationTimeMoment)
         ? {
@@ -302,6 +318,7 @@ export default class EventDetail extends Component<Props, State> {
 
     const groupLink =
       event.responsibleGroup && resolveGroupLink(event.responsibleGroup);
+
     const eventCreator = [
       event.responsibleGroup && {
         key: 'Arrangør',
@@ -418,8 +435,8 @@ export default class EventDetail extends Component<Props, State> {
                   {registrations ? (
                     <Fragment>
                       <UserGrid
-                        minRows={0}
-                        maxRows={2}
+                        minRows={minUserGridRows}
+                        maxRows={MAX_USER_GRID_ROWS}
                         users={registrations
                           .slice(0, 14)
                           .map((reg) => reg.user)}


### PR DESCRIPTION
To prevent the register button from moving once people start registering (which we've recieved a ton of feedback on). The skeleton will, however, only be visible once there's less than 5 minutes until activation.

## Result

### When there's more than 5 minutes until activation:
<img src="https://user-images.githubusercontent.com/69514187/201540761-4b646ea1-3c71-49ca-83c1-366de94e33b2.png" width="400" />

### When there's less than 5 minutes until activation:
<img src="https://user-images.githubusercontent.com/69514187/201542597-5dbc3478-92f4-4908-a727-2750e9d01a99.png" width="400" />

### When someone has registered:
<img src="https://user-images.githubusercontent.com/69514187/201539891-833439a8-84c6-4cce-a205-f342a6630a45.png" width="400" />

---

Closes https://github.com/webkom/lego/issues/3004 and closes ABA-122