### PR TITLE
Fix Unregistration With Unanswered Survey

### DIFF
--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -494,7 +494,8 @@ export default class EventDetail extends Component<Props, State> {
                     </div>
                   )}
                   {event.unansweredSurveys &&
-                  event.unansweredSurveys.length > 0 ? (
+                  event.unansweredSurveys.length > 0 &&
+                  !event.isAdmitted ? (
                     <div className={sharedStyles.eventWarning}>
                       <p>
                         Du kan ikke melde deg på dette arrangementet fordi du


### PR DESCRIPTION
Previously if you had an unanswered survey you could not unregister from an event.

Added so that if you are registered for the event it will show the unregister button and not the warning that you have unanswered surveys.

