### PR TITLE
Update react-prepare to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@stripe/stripe-js": "^1.44.1",
     "@webkom/lego-editor": "^2.0.3",
     "@webkom/react-meter-bar": "^1.0.3",
-    "@webkom/react-prepare": "^0.10.3",
+    "@webkom/react-prepare": "^1.0.0",
     "animate.css": "^4.1.1",
     "buffer": "^6.0.3",
     "bunyan": "^1.8.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,15 +1725,6 @@
     "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/core@7.21.1":
-  version "7.21.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.21.1.tgz#d0423282d90875625802dfe380f9657e9242b72b"
-  integrity sha512-Og5wEEsy24fNvT/T7IKjcV4EvVK5ryY2kxbJzKY6GU2eX+i+aBl+n/vp7U0Es351C/AlTkS+0NOUsp2TQQFxZA==
-  dependencies:
-    "@sentry/types" "7.21.1"
-    "@sentry/utils" "7.21.1"
-    tslib "^1.9.3"
-
 "@sentry/core@7.22.0":
   version "7.22.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.22.0.tgz#8e50f288e5e8fcaa2774daffd2487e042a392893"
@@ -1789,11 +1780,6 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
   integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
 
-"@sentry/types@7.21.1":
-  version "7.21.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.21.1.tgz#408a7b95a66ddc30c4359979594e03bee8f9fbdc"
-  integrity sha512-3/IKnd52Ol21amQvI+kz+WB76s8/LR5YvFJzMgIoI2S8d82smIr253zGijRXxHPEif8kMLX4Yt+36VzrLxg6+A==
-
 "@sentry/types@7.22.0":
   version "7.22.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.22.0.tgz#58e4ce77b523048e0f31e2ea4b597946d76f6079"
@@ -1805,14 +1791,6 @@
   integrity sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==
   dependencies:
     "@sentry/types" "6.19.7"
-    tslib "^1.9.3"
-
-"@sentry/utils@7.21.1":
-  version "7.21.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.21.1.tgz#96582345178015fd32fe9159c25c44ccf2f99d2a"
-  integrity sha512-F0W0AAi8tgtTx6ApZRI2S9HbXEA9ENX1phTZgdNNWcMFm1BNbc21XEwLqwXBNjub5nlA6CE8xnjXRgdZKx4kzQ==
-  dependencies:
-    "@sentry/types" "7.21.1"
     tslib "^1.9.3"
 
 "@sentry/utils@7.22.0":
@@ -2565,10 +2543,10 @@
     react "^16.4.0"
     react-dom "^16.4.0"
 
-"@webkom/react-prepare@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@webkom/react-prepare/-/react-prepare-0.10.3.tgz#291158200f92949112b60af1b310fa16f1d22d3c"
-  integrity sha512-XE9XGej7vDyt6eTZNJw5SLs3x76FORypwHWXd/ssAnQsFTKPgbhlc195NEYclEyl/uoIYWGfpUGERJfZnZqv2Q==
+"@webkom/react-prepare@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@webkom/react-prepare/-/react-prepare-1.0.0.tgz#c5512b084012157e3506b677352d7622fa1e1381"
+  integrity sha512-s05Aks3g7ZSZlPt/k53SSrrcwOJXSXnDRzaJ7hxLSBLk9O+uHFusmY8BA3rQ8MQk/R/4wqhaYBZNUBjrzeCM9w==
 
 "@webpack-cli/configtest@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
The only change is that code for the deprecated `prepared` and `dispatched` functions was removed. We don't use them anymore so it should be fine. I have tested a little bit, and everything seems to work well.