### PR TITLE
Improve the table component

### DIFF
--- a/app/components/Button/Button.css
+++ b/app/components/Button/Button.css
@@ -1,5 +1,52 @@
 @import url('~app/styles/variables.css');
 
+:root {
+  --button-color: var(--color-white);
+  --button-box-shadow: 0 1px 0 rgba(27, 31, 36, 10%),
+    inset 0 1px 0 rgba(255, 255, 255, 3%);
+  --button-background: var(--color-light-gray-4);
+  --button-background-hover: var(--color-light-gray-3);
+  --button-border: #30404d77;
+  --button-border-hover: #394b59aa;
+
+  --button-dark-background: var(--color-red-2);
+  --button-dark-background-hover: var(--color-red-1);
+  --button-dark-border: #bfccd633;
+  --button-dark-border-hover: #ced9e044;
+  --button-dark-box-shadow-focus: #db373744;
+
+  --button-danger-box-shadow-focus: #db373744;
+
+  --button-success-background: var(--color-green-7);
+  --button-success-background-hover: var(--color-green-6);
+  --button-success-border: #a7b6c233;
+  --button-success-border-hover: #bfccd644;
+  --button-success-box-shadow-focus: #2c974b44;
+}
+
+[data-theme='dark'] {
+  --button-color: var(--color-black);
+  --button-box-shadow: 0 0 transparent, inset 0 0 transparent;
+  --button-background: var(--color-mono-gray-2);
+  --button-background-hover: var(--color-mono-gray-4);
+  --button-border: #a7b6c277;
+  --button-border-hover: #bfccd6aa;
+
+  --button-dark-background: var(--color-red-1);
+  --button-dark-background-hover: var(--color-red-2);
+  --button-dark-border: #a7b6c233;
+  --button-dark-border-hover: #bfccd644;
+  --button-dark-box-shadow-focus: #ff737344;
+
+  --button-danger-box-shadow-focus: #ff737344;
+
+  --button-success-background: var(--color-green-4);
+  --button-success-background-hover: var(--color-green-3);
+  --button-success-border: #bfccd633;
+  --button-success-border-hover: #ced9e044;
+  --button-success-box-shadow-focus: #2da44e44;
+}
+
 .button {
   display: inline-flex;
   align-items: center;

--- a/app/components/Chart/utils.tsx
+++ b/app/components/Chart/utils.tsx
@@ -6,8 +6,8 @@ export interface DistributionDataPoint {
 export const CHART_COLORS = [
   'var(--lego-red)',
   'var(--color-blue-4)',
-  'var(--color-orange-3)',
-  'var(--color-green-5)',
+  'var(--color-orange-7)',
+  'var(--color-green-8)',
   'var(--lego-chart-purple)',
   'var(--lego-chart-yellow)',
   '#ff87eb',

--- a/app/components/Dropdown/Dropdown.css
+++ b/app/components/Dropdown/Dropdown.css
@@ -7,7 +7,7 @@
 
 html[data-theme='dark'] .dropdownList > li > a:hover,
 html[data-theme='dark'] .dropdownList > li > button:hover {
-  background: var(--color-gray-2);
+  background: var(--color-gray-8);
 }
 
 .divider {

--- a/app/components/Form/DatePicker.css
+++ b/app/components/Form/DatePicker.css
@@ -51,7 +51,7 @@ html[data-theme='dark'] .calendarItem {
   color: var(--lego-font-color);
 
   &:hover {
-    background: var(--color-gray-2);
+    background: var(--color-gray-7);
   }
 }
 

--- a/app/components/Header/toggleTheme.css
+++ b/app/components/Header/toggleTheme.css
@@ -11,7 +11,7 @@
 
 .sun {
   @media (--mobile-device) {
-    color: var(--color-orange-4);
+    color: var(--color-orange-6);
   }
 }
 
@@ -20,5 +20,5 @@
 }
 
 .sun:hover {
-  color: var(--color-orange-4);
+  color: var(--color-orange-6);
 }

--- a/app/components/NavigationTab/NavigationLink.css
+++ b/app/components/NavigationTab/NavigationLink.css
@@ -10,6 +10,6 @@
   }
 
   &.active {
-    border-bottom: 2px solid var(--color-red-3);
+    border-bottom: 2px solid var(--color-red-2);
   }
 }

--- a/app/components/PhotoUploadStatus/PhotoUploadStatus.css
+++ b/app/components/PhotoUploadStatus/PhotoUploadStatus.css
@@ -15,5 +15,5 @@
 }
 
 .successMessage {
-  color: var(--color-green-3);
+  color: var(--color-green-8);
 }

--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -47,7 +47,7 @@
 .pollGraph {
   animation: graph 1.2s cubic-bezier(41%, 80%, 40%, 94%);
   background-color: var(--lego-red-color);
-  padding-left: 8px;
+  padding: 5px;
   border-radius: 0 2px 2px 0;
   font-style: italic;
   font-weight: 300;

--- a/app/components/Poll/index.tsx
+++ b/app/components/Poll/index.tsx
@@ -183,6 +183,7 @@ class Poll extends Component<Props, State> {
                             {ratio < 18 && (
                               <span
                                 style={{
+                                  padding: '5px',
                                   marginLeft: '2px',
                                 }}
                               >

--- a/app/components/Search/Search.css
+++ b/app/components/Search/Search.css
@@ -144,7 +144,7 @@ html[data-theme='dark'] .quickLinks {
 }
 
 html[data-theme='dark'] .quickLinks a:hover {
-  background-color: var(--color-gray-2);
+  background-color: var(--color-gray-8);
 }
 
 .results {

--- a/app/components/Table/Table.css
+++ b/app/components/Table/Table.css
@@ -1,53 +1,27 @@
 @import url('~app/styles/variables.css');
 
-.tableDiv {
+.wrapper {
   overflow-x: scroll;
 }
 
-.table {
+table {
   width: 100%;
 }
 
-.tableHeader {
-  display: flex;
-  padding: 0 10px;
+thead button {
+  padding: 0;
 }
 
-.sorter {
-  display: inline-block;
-  margin-right: 5px;
-  margin-top: 5px;
-  vertical-align: middle;
-  line-height: 1;
+thead i {
   cursor: pointer;
-  position: relative;
 }
 
-.searchIcon {
-  display: inline-block;
-  margin-left: 5px;
-  vertical-align: middle;
-  line-height: 1;
-  cursor: pointer;
-  position: relative;
+tr:nth-child(even) {
+  background-color: var(--color-light-gray-5);
 }
 
-.filterIcon {
-  display: inline-block;
-  margin-right: 5px;
-  vertical-align: middle;
-  line-height: 1;
-  cursor: pointer;
-  position: relative;
-}
-
-.arrowDownIcon {
-  display: inline-block;
-  margin-left: 5px;
-  vertical-align: middle;
-  line-height: 1;
-  cursor: pointer;
-  position: relative;
+html[data-theme='dark'] tr:nth-child(even) {
+  background-color: var(--color-gray-8);
 }
 
 .checkbox {
@@ -56,7 +30,7 @@
   padding: 8px;
 }
 
-.checkbox div {
+.checkbox > div {
   margin-bottom: 10px;
 }
 
@@ -74,9 +48,9 @@
 }
 
 .icon {
-  color: var(--lego-font-color);
+  color: var(--color-gray-2);
 }
 
 .iconActive {
-  color: var(--lego-link-color);
+  color: var(--color-red-4);
 }

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -2,11 +2,12 @@ import cx from 'classnames';
 import { debounce, isEmpty, get } from 'lodash';
 import { Component } from 'react';
 import InfiniteScroll from 'react-infinite-scroller';
+import Button from 'app/components/Button';
 import Dropdown from 'app/components/Dropdown';
 import { TextInput, CheckBox, RadioButton } from 'app/components/Form';
 import Icon from 'app/components/Icon';
+import Flex from 'app/components/Layout/Flex';
 import LoadingIndicator from 'app/components/LoadingIndicator';
-import Button from '../Button';
 import styles from './Table.css';
 import type { ReactNode, ChangeEvent } from 'react';
 
@@ -15,10 +16,12 @@ type sortProps = {
   dataIndex?: string;
   sorter?: boolean | ((arg0: any, arg1: any) => number);
 };
+
 type checkFilter = {
   label: string;
   value: any;
 };
+
 type columnProps = {
   dataIndex: string;
   title?: string;
@@ -37,11 +40,12 @@ type columnProps = {
   render?: (arg0: any, arg1: Record<string, any>) => ReactNode;
   // Should column be rendered. Will render when not set
   visible?: boolean;
-  center?: boolean;
+  centered?: boolean;
   inlineFiltering?: boolean;
   filterMessage?: string;
   columnChoices?: Array<columnProps>;
 };
+
 type Props = {
   rowKey?: string;
   columns: Array<columnProps>;
@@ -52,6 +56,7 @@ type Props = {
   onLoad?: (filters: Record<string, any>, sort: sortProps) => void;
   filters?: Record<string, any>;
 };
+
 type State = {
   filters: Record<string, any>;
   isShown: Record<string, any>;
@@ -168,13 +173,13 @@ export default class Table extends Component<Props, State> {
     const {
       render = (cellData, data) => cellData,
       dataIndex,
-      center = false,
+      centered = true,
     } = column;
     return (
       <td
         key={`${dataIndex}-${index}-${data.id}`}
         style={
-          center
+          centered
             ? {
                 textAlign: 'center',
               }
@@ -195,7 +200,7 @@ export default class Table extends Component<Props, State> {
       chosenProps = { ...props, ...props.columnChoices[columnIndex] };
     }
 
-    const { dataIndex, title, sorter, filter, search, center, filterMessage } =
+    const { dataIndex, title, sorter, filter, search, filterMessage } =
       chosenProps;
     const sortIconName =
       this.state.sort.dataIndex === dataIndex
@@ -204,153 +209,140 @@ export default class Table extends Component<Props, State> {
           : 'sort-desc'
         : 'sort';
     const { filters, isShown } = this.state;
+
     return (
-      <th
-        key={`${dataIndex}-${index}`}
-        style={
-          center
-            ? {
-                textAlign: 'center',
-              }
-            : {}
-        }
-      >
-        <div className={styles.tableHeader}>
+      <th key={`${dataIndex}-${index}`}>
+        <Flex alignItems="center" justifyContent="center" gap={4.5}>
           {sorter && (
-            <div className={styles.sorter}>
-              <i
-                onClick={() => this.onSortInput(dataIndex, sorter)}
-                className={`fa fa-${sortIconName}`}
-              />
-            </div>
+            <i
+              onClick={() => this.onSortInput(dataIndex, sorter)}
+              className={`fa fa-${sortIconName}`}
+            />
           )}
           {title}
           {search && (
-            <div className={styles.searchIcon}>
-              <Dropdown
-                show={isShown[dataIndex]}
-                toggle={() => this.toggleSearch(dataIndex)}
-                triggerComponent={
-                  <Icon
-                    name="search"
-                    size={21}
-                    className={cx(
-                      (filters[dataIndex] && filters[dataIndex].length) ||
-                        isShown[dataIndex]
-                        ? styles.iconActive
-                        : styles.icon
-                    )}
-                  />
-                }
-                contentClassName={styles.overlay}
-                rootClose
-              >
-                <TextInput
-                  autoFocus
-                  placeholder={filterMessage}
-                  value={filters[dataIndex]}
-                  onChange={(e) => this.onSearchInput(e, dataIndex)}
-                  onKeyDown={({ keyCode }) => {
-                    if (keyCode === 13) {
-                      this.toggleSearch(dataIndex);
-                    }
-                  }}
+            <Dropdown
+              show={isShown[dataIndex]}
+              toggle={() => this.toggleSearch(dataIndex)}
+              triggerComponent={
+                <Icon
+                  name="search"
+                  size={16}
+                  className={cx(
+                    (filters[dataIndex] && filters[dataIndex].length) ||
+                      isShown[dataIndex]
+                      ? styles.iconActive
+                      : styles.icon
+                  )}
                 />
-              </Dropdown>
-            </div>
+              }
+              contentClassName={styles.overlay}
+              rootClose
+            >
+              <TextInput
+                autoFocus
+                placeholder={filterMessage}
+                value={filters[dataIndex]}
+                onChange={(e) => this.onSearchInput(e, dataIndex)}
+                onKeyDown={({ keyCode }) => {
+                  if (keyCode === 13) {
+                    this.toggleSearch(dataIndex);
+                  }
+                }}
+              />
+            </Dropdown>
           )}
           {filter && (
-            <div className={styles.filterIcon}>
-              <Dropdown
-                show={isShown[dataIndex]}
-                toggle={() => this.toggleFilter(dataIndex)}
-                triggerComponent={
-                  <Icon
-                    name="funnel"
-                    className={cx(
-                      filters[dataIndex] !== undefined || isShown[dataIndex]
-                        ? styles.iconActive
-                        : styles.icon
-                    )}
-                  />
-                }
-                contentClassName={styles.checkbox}
-                rootClose
-              >
-                {filter.map(({ label, value }) => (
-                  <div
-                    key={label}
-                    onClick={() =>
-                      this.onFilterInput(
-                        this.state.filters[dataIndex] === value
-                          ? undefined
-                          : value,
-                        dataIndex
-                      )
-                    }
-                  >
-                    <p key={label}>
-                      <CheckBox
-                        label={label}
-                        value={value === this.state.filters[dataIndex]}
-                      />
-                    </p>
-                  </div>
-                ))}
-                <Button
-                  flat
+            <Dropdown
+              show={isShown[dataIndex]}
+              toggle={() => this.toggleFilter(dataIndex)}
+              triggerComponent={
+                <Icon
+                  name="funnel"
+                  size={16}
+                  className={cx(
+                    filters[dataIndex] !== undefined || isShown[dataIndex]
+                      ? styles.iconActive
+                      : styles.icon
+                  )}
+                />
+              }
+              contentClassName={styles.checkbox}
+              rootClose
+            >
+              {filter.map(({ label, value }) => (
+                <div
+                  key={label}
                   onClick={() =>
-                    this.setState(
-                      (state) => ({
-                        filters: { ...state.filters, [dataIndex]: undefined },
-                      }),
-                      () => {
-                        this.toggleFilter(dataIndex);
-                        this.onChange();
-                      }
+                    this.onFilterInput(
+                      this.state.filters[dataIndex] === value
+                        ? undefined
+                        : value,
+                      dataIndex
                     )
                   }
                 >
-                  Nullstill
-                </Button>
-              </Dropdown>
-            </div>
+                  <CheckBox
+                    label={label}
+                    value={value === this.state.filters[dataIndex]}
+                  />
+                </div>
+              ))}
+              <Button
+                flat
+                onClick={() =>
+                  this.setState(
+                    (state) => ({
+                      filters: { ...state.filters, [dataIndex]: undefined },
+                    }),
+                    () => {
+                      this.toggleFilter(dataIndex);
+                      this.onChange();
+                    }
+                  )
+                }
+              >
+                Nullstill
+              </Button>
+            </Dropdown>
           )}
           {columnChoices && (
-            <div className={styles.arrowDownIcon}>
-              <Dropdown
-                show={isShown[dataIndex]}
-                toggle={() => this.toggleChooseColumn(dataIndex)}
-                triggerComponent={
-                  <Icon name="arrow-down" className={styles.icon} />
-                }
-                contentClassName={styles.overlay}
-                rootClose
-              >
-                {columnChoices.map(({ title }, index) => (
-                  <div
-                    key={title}
-                    onClick={() =>
-                      this.onChooseColumnInput(index, dataIndexColumnChoices)
-                    }
-                  >
-                    <p key={title}>
-                      <RadioButton
-                        id={dataIndexColumnChoices}
-                        name={dataIndexColumnChoices}
-                        inputValue={
-                          this.state.showColumn[dataIndexColumnChoices]
-                        }
-                        value={index}
-                        label={title}
-                      />
-                    </p>
-                  </div>
-                ))}
-              </Dropdown>
-            </div>
+            <Dropdown
+              show={isShown[dataIndex]}
+              toggle={() => this.toggleChooseColumn(dataIndex)}
+              triggerComponent={
+                <Icon
+                  name="options"
+                  size={16}
+                  className={cx(
+                    filters[dataIndex] !== undefined || isShown[dataIndex]
+                      ? styles.iconActive
+                      : styles.icon
+                  )}
+                />
+              }
+              contentClassName={styles.overlay}
+              rootClose
+            >
+              {columnChoices.map(({ title }, index) => (
+                <div
+                  key={title}
+                  onClick={() => {
+                    this.onChooseColumnInput(index, dataIndexColumnChoices);
+                  }}
+                >
+                  <RadioButton
+                    id={dataIndexColumnChoices}
+                    name={dataIndexColumnChoices}
+                    inputValue={this.state.showColumn[dataIndexColumnChoices]}
+                    value={index}
+                    label={title}
+                  />
+                </div>
+              ))}
+            </Dropdown>
           )}
-        </div>
+        </Flex>
       </th>
     );
   };
@@ -406,40 +398,39 @@ export default class Table extends Component<Props, State> {
       sorter !== undefined && typeof sorter !== 'boolean' ? sorter(a, b) : 0
     );
     if (direction === 'desc') sortedData.reverse();
+
     return (
-      <div>
-        <div className={styles.tableDiv}>
-          <table className={styles.table}>
-            <thead>
-              <tr>
+      <div className={styles.wrapper}>
+        <table>
+          <thead>
+            <tr>
+              {columns
+                .filter(isVisible)
+                .map((column, index) => this.renderHeadCell(column, index))}
+            </tr>
+          </thead>
+          <InfiniteScroll
+            element="tbody"
+            hasMore={hasMore && !loading}
+            loadMore={this.loadMore}
+            threshold={50}
+          >
+            {sortedData.filter(this.filter).map((item) => (
+              <tr key={item[rowKey]}>
                 {columns
                   .filter(isVisible)
-                  .map((column, index) => this.renderHeadCell(column, index))}
+                  .map((column, index) => this.renderCell(column, item, index))}
               </tr>
-            </thead>
-            <InfiniteScroll
-              element="tbody"
-              hasMore={hasMore && !loading}
-              loadMore={this.loadMore}
-              threshold={50}
-            >
-              {sortedData.filter(this.filter).map((item, index) => (
-                <tr key={item[rowKey]}>
-                  {columns
-                    .filter(isVisible)
-                    .map((column, index) =>
-                      this.renderCell(column, item, index)
-                    )}
-                </tr>
-              ))}
+            ))}
+            {loading && (
               <tr>
                 <td className={styles.loader} colSpan={columns.length}>
                   <LoadingIndicator loading={loading} />
                 </td>
               </tr>
-            </InfiniteScroll>
-          </table>
-        </div>
+            )}
+          </InfiniteScroll>
+        </table>
       </div>
     );
   }

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -50,29 +50,26 @@ const GroupMembersList = ({
   const GroupMembersListColumns = (fullName, membership) => {
     const { user, abakusGroup } = membership;
     return (
-      true && (
-        <>
-          <ConfirmModalWithParent
-            title="Bekreft utmelding"
-            message={`Er du sikker på at du vil melde ut "${user.fullName}" fra gruppen "${groupsById[abakusGroup].name}?"`}
-            onConfirm={() => removeMember(membership)}
-          >
-            <i key="icon" className={`fa fa-times ${styles.removeIcon}`} />
-          </ConfirmModalWithParent>
-          <Link key="link" to={`/users/${user.username}`}>
-            {user.fullName} ({user.username})
-          </Link>
-        </>
-      )
+      <>
+        <ConfirmModalWithParent
+          title="Bekreft utmelding"
+          message={`Er du sikker på at du vil melde ut "${user.fullName}" fra gruppen "${groupsById[abakusGroup].name}?"`}
+          onConfirm={() => removeMember(membership)}
+        >
+          <i key="icon" className={`fa fa-times ${styles.removeIcon}`} />
+        </ConfirmModalWithParent>
+        <Link key="link" to={`/users/${user.username}`}>
+          {user.fullName} ({user.username})
+        </Link>
+      </>
     );
   };
 
-  const GroupLinkRender = (abakusGroup) =>
-    true && (
-      <Link to={`/admin/groups/${abakusGroup}/members?descendants=false`}>
-        {groupsById[abakusGroup] && groupsById[abakusGroup].name}
-      </Link>
-    );
+  const GroupLinkRender = (abakusGroup) => (
+    <Link to={`/admin/groups/${abakusGroup}/members?descendants=false`}>
+      {groupsById[abakusGroup] && groupsById[abakusGroup].name}
+    </Link>
+  );
 
   const RoleRender = (role: string) =>
     role !== 'member' && <i>{ROLES[role] || role} </i>;
@@ -83,6 +80,7 @@ const GroupMembersList = ({
       dataIndex: 'user.fullName',
       search: true,
       inlineFiltering: false,
+      centered: false,
       render: GroupMembersListColumns,
     },
     showDescendants
@@ -108,10 +106,10 @@ const GroupMembersList = ({
       render: RoleRender,
     },
   ].filter(Boolean);
+
   return (
     <>
       <Table
-        infiniteScroll
         onChange={(filters, sort) => {
           push({
             pathname,

--- a/app/routes/events/components/EventAdministrate/Administrate.css
+++ b/app/routes/events/components/EventAdministrate/Administrate.css
@@ -24,33 +24,71 @@
   grid-template-columns: repeat(5, 20%);
 }
 
-.webkomIcon {
-  font-size: 1.1em;
-  background: #e20d13;
-  color: var(--color-white);
+.pill {
+  margin: 0 auto;
   display: inline-block;
-  border-radius: 60px;
-  padding: 0.1em 0.2em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.7rem;
+  font-weight: bold;
+  border-radius: 1rem;
+  letter-spacing: 0.6px;
+  line-height: 1;
+  box-shadow: rgb(0, 0, 0 / 5%) 1px 2px 5px 0;
+  align-items: center;
+  align-self: center;
+}
+
+.webkomPill {
+  background: linear-gradient(
+    90deg,
+    rgba(255, 0, 0, 100%) 0%,
+    rgba(255, 154, 0, 100%) 10%,
+    rgba(208, 222, 33, 100%) 20%,
+    rgba(79, 220, 74, 100%) 30%,
+    rgba(63, 218, 216, 100%) 40%,
+    rgba(47, 201, 226, 100%) 50%,
+    rgba(28, 127, 238, 100%) 60%,
+    rgba(95, 21, 242, 100%) 70%,
+    rgba(186, 12, 248, 100%) 80%,
+    rgba(251, 7, 217, 100%) 90%,
+    rgba(255, 0, 0, 100%) 100%
+  );
+  color: white;
+}
+
+.greenPill {
+  background-color: var(--color-green-2);
+  color: var(--color-green-7);
 }
 
 .greenIcon {
-  font-size: 1.5em;
-  color: green;
+  font-size: 1.4em;
+  color: var(--color-green-6);
 }
 
-.orangeIcon {
-  font-size: 1.5em;
-  color: var(--color-orange-3);
+.orangePill {
+  background-color: var(--color-orange-2);
+  color: var(--color-orange-7);
 }
 
 .questionIcon {
-  font-size: 1.5em;
-  color: var(--color-blue-1);
+  font-size: 1.4em;
+  color: var(--color-blue-6);
+}
+
+.bluePill {
+  background-color: var(--color-blue-2);
+  color: var(--color-blue-6);
 }
 
 .redIcon {
-  font-size: 1.5em;
-  color: '#C24538';
+  font-size: 1.4em;
+  color: var(--color-red-3);
+}
+
+.consentIcon {
+  font-size: 1.15em;
 }
 
 .center {
@@ -77,18 +115,13 @@ a.transparent:hover {
   border-bottom: 1px solid var(--color-mono-gray-3);
 }
 
-.presenceIcons {
-  display: flex;
-  flex-direction: row;
-  align-content: space-around;
-  margin: 5px;
-}
-
-.cell {
-  margin: 2px;
-}
-
 .consents {
   display: flex;
   justify-content: center;
+}
+
+.unregisterIcon {
+  justify-content: center;
+  cursor: pointer;
+  color: var(--color-red-3);
 }

--- a/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
+++ b/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
@@ -1,9 +1,12 @@
 import cx from 'classnames';
 import Button from 'app/components/Button';
+import Icon from 'app/components/Icon';
 import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
+import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import Tooltip from 'app/components/Tooltip';
 import type {
+  EventRegistration,
   EventRegistrationPaymentStatus,
   EventRegistrationPresence,
   ID,
@@ -23,9 +26,8 @@ type PresenceProps = {
 };
 type UnregisterProps = {
   fetching: boolean;
-  handleUnregister: (arg0: ID) => void;
-  id: ID;
-  clickedUnregister: ID;
+  handleUnregister: (arg0: ID) => Promise<void>;
+  registration: EventRegistration;
 };
 type StripeStatusProps = {
   id: ID;
@@ -35,6 +37,7 @@ type StripeStatusProps = {
   ) => Promise<any>;
   paymentStatus: EventRegistrationPaymentStatus;
 };
+
 export const TooltipIcon = ({
   onClick,
   content,
@@ -42,7 +45,7 @@ export const TooltipIcon = ({
   iconClass,
 }: TooltipIconProps) => {
   return (
-    <Tooltip className={styles.cell} content={content}>
+    <Tooltip content={content}>
       <Button
         flat
         className={cx(transparent && styles.transparent)}
@@ -53,13 +56,14 @@ export const TooltipIcon = ({
     </Tooltip>
   );
 };
+
 export const PresenceIcons = ({
   handlePresence,
   presence,
   id,
 }: PresenceProps) => {
   return (
-    <Flex className={styles.presenceIcons}>
+    <Flex justifyContent="center" gap={5}>
       <TooltipIcon
         content="Til stede"
         iconClass={cx('fa fa-check', styles.greenIcon)}
@@ -81,12 +85,13 @@ export const PresenceIcons = ({
     </Flex>
   );
 };
+
 export const StripeStatus = ({
   id,
   handlePayment,
   paymentStatus,
 }: StripeStatusProps) => (
-  <Flex className={styles.presenceIcons}>
+  <Flex justifyContent="center" gap={5}>
     <TooltipIcon
       content="Betalt stripe"
       iconClass={cx('fa fa-cc-stripe', styles.greenIcon)}
@@ -106,28 +111,32 @@ export const StripeStatus = ({
     />
   </Flex>
 );
+
 export const Unregister = ({
   fetching,
   handleUnregister,
-  id,
-  clickedUnregister,
+  registration,
 }: UnregisterProps) => {
   return (
-    <div>
+    <>
       {fetching ? (
-        <LoadingIndicator loading={true} small />
+        <LoadingIndicator loading small />
       ) : (
-        <Button flat onClick={() => handleUnregister(id)}>
-          <i
-            className="fa fa-minus-circle"
-            style={{
-              color: '#C24538',
-              marginRight: '5px',
-            }}
-          />
-          {clickedUnregister === id ? 'Er du sikker?' : 'Meld av'}
-        </Button>
+        <ConfirmModalWithParent
+          title="Bekreft utmelding"
+          message={`Er du sikker på at du vil melde av "${registration.user.fullName}"?`}
+          onConfirm={() => handleUnregister(registration.id)}
+          closeOnCancel
+        >
+          <Tooltip content="Meld av bruker" style={{ marginTop: '-7px' }}>
+            <Icon
+              name="person-remove-outline"
+              size={18}
+              className={styles.unregisterIcon}
+            />
+          </Tooltip>
+        </ConfirmModalWithParent>
       )}
-    </div>
+    </>
   );
 };

--- a/app/routes/events/components/EventAdministrate/Attendees.tsx
+++ b/app/routes/events/components/EventAdministrate/Attendees.tsx
@@ -35,7 +35,7 @@ export type Props = {
     eventId: ID;
     registrationId: ID;
     admin: boolean;
-  }) => Promise<any>;
+  }) => Promise<void>;
   updatePresence: (arg0: number, arg1: number, arg2: string) => Promise<any>;
   updatePayment: (
     arg0: ID,
@@ -48,31 +48,19 @@ export type Props = {
   searching: boolean;
 };
 type State = {
-  clickedUnregister: number;
   generatedCsvUrl?: string;
 };
 export default class Attendees extends Component<Props, State> {
   state = {
-    clickedUnregister: 0,
     generatedCsvUrl: '',
   };
-  handleUnregister = (registrationId: number) => {
+  handleUnregister = async (registrationId: number) => {
     const { unregister, eventId } = this.props;
-
-    if (this.state.clickedUnregister === registrationId) {
-      unregister({
-        eventId,
-        registrationId,
-        admin: true,
-      });
-      this.setState({
-        clickedUnregister: 0,
-      });
-    } else {
-      this.setState({
-        clickedUnregister: registrationId,
-      });
-    }
+    await unregister({
+      eventId,
+      registrationId,
+      admin: true,
+    });
   };
   handlePresence = (registrationId: ID, presence: EventRegistrationPresence) =>
     this.props.updatePresence(this.props.eventId, registrationId, presence);
@@ -113,6 +101,11 @@ export default class Attendees extends Component<Props, State> {
       return <div>{error.message}</div>;
     }
 
+    // Not showing the presence column until 1 day before start or if someone has been given set to presence
+    const showPresence =
+      moment().isAfter(moment(event.startTime).subtract(1, 'day')) ||
+      registerCount > 0;
+
     const showUnregister = // Show unregister button until 1 day after event has ended,
       // or until reg/unreg has ended if that is more than 1 day
       // after event end
@@ -150,7 +143,7 @@ export default class Attendees extends Component<Props, State> {
 
     return (
       <div>
-        <Flex row justifyContent="space-between">
+        <Flex justifyContent="space-between">
           <h2>
             <Link to={`/events/${eventId}`}>
               <i className="fa fa-angle-left" />
@@ -197,7 +190,7 @@ export default class Attendees extends Component<Props, State> {
             handlePresence={this.handlePresence}
             handlePayment={this.handlePayment}
             handleUnregister={this.handleUnregister}
-            clickedUnregister={this.state.clickedUnregister}
+            showPresence={showPresence}
             showUnregister={showUnregister}
             pools={pools}
           />

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -1,7 +1,7 @@
 @import url('../Event.css');
 
 .star {
-  color: var(--color-orange-5);
+  color: var(--color-orange-6);
   margin-right: 10px;
 }
 

--- a/app/routes/polls/components/PollsList.tsx
+++ b/app/routes/polls/components/PollsList.tsx
@@ -65,7 +65,7 @@ const PollsList = ({
                         name="checkmark-circle-outline"
                         size={20}
                         style={{
-                          color: 'var(--color-green-4)',
+                          color: 'var(--color-green-8)',
                         }}
                       />
                     </>

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -391,11 +391,11 @@
 }
 
 .copied {
-  border-color: var(--color-green-3);
-  color: var(--color-green-3);
-  outline-color: var(--color-green-3);
+  border-color: var(--color-green-8);
+  color: var(--color-green-8);
+  outline-color: var(--color-green-8);
 
   &:hover:not(:disabled) {
-    border-color: var(--color-green-3);
+    border-color: var(--color-green-8);
   }
 }

--- a/app/routes/users/components/UserSettingsNotifications.css
+++ b/app/routes/users/components/UserSettingsNotifications.css
@@ -5,3 +5,8 @@
 .table thead {
   text-transform: capitalize;
 }
+
+/* Override the Checkbox alignment from flex-start to center */
+td div {
+  justify-content: center !important;
+}

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -76,27 +76,30 @@ i {
 }
 
 table {
+  line-height: 1.3;
   border-collapse: collapse;
 }
 
-th {
-  padding: 5px 0;
-  border-top: 1px solid var(--color-mono-gray-1);
-  border-bottom: 1px solid var(--color-mono-gray-1) !important;
+thead {
+  background-color: var(--color-gray-9);
+  color: var(--color-gray-2);
+  font-size: 0.9rem;
+  font-weight: bold;
 }
 
 th,
 td {
-  padding-left: 7px;
+  padding: 10px;
   width: 140px;
-  border-bottom: 1px dashed var(--color-mono-gray-1);
-  text-align: left;
   display: table-cell;
 }
 
-thead {
-  font-weight: bold;
-  background-color: var(--lego-color-gray-light);
+th:first-child {
+  border-radius: 2em 0 0 2em;
+}
+
+th:last-child {
+  border-radius: 0 2em 2em 0;
 }
 
 h1 {

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -52,11 +52,15 @@
   --color-dark-gray-4: #30404d;
   --color-dark-gray-5: #394b59;
 
-  --color-gray-1: #5c7080;
-  --color-gray-2: #738694;
-  --color-gray-3: #8a9ba8;
-  --color-gray-4: #a7b6c2;
-  --color-gray-5: #bfccd6;
+  --color-gray-1: #11181c;
+  --color-gray-2: #687076;
+  --color-gray-3: #7e868c;
+  --color-gray-4: #889096;
+  --color-gray-5: #c1c8cd;
+  --color-gray-6: #d7dbdf;
+  --color-gray-7: #dfe3e6;
+  --color-gray-8: #e6e8eb;
+  --color-gray-9: #f1f3f5;
 
   --color-light-gray-1: #ced9e0;
   --color-light-gray-2: #d8e1e8;
@@ -76,29 +80,42 @@
   --color-mono-gray-4: #ddd;
   --color-mono-gray-5: #eee;
 
-  --color-blue-1: #0e5a8a;
-  --color-blue-2: #106ba3;
-  --color-blue-3: #137cbd;
-  --color-blue-4: #2b95d6;
-  --color-blue-5: #48aff0;
+  --color-blue-1: #e6f1ff;
+  --color-blue-2: #cee4fe;
+  --color-blue-3: #b7d5f8;
+  --color-blue-4: #96c1f2;
+  --color-blue-5: #5ea2ef;
+  --color-blue-6: #0072f5;
+  --color-blue-7: #005fcc;
+  --color-blue-8: #004799;
+  --color-blue-9: #00254d;
 
-  --color-orange-1: #a66321;
-  --color-orange-2: #bf7326;
-  --color-orange-3: #d9822b;
-  --color-orange-4: #f29d49;
-  --color-orange-5: #ffb366;
+  --color-orange-1: #fef5e7;
+  --color-orange-2: #fdefd8;
+  --color-orange-3: #fce7c5;
+  --color-orange-4: #fbdba7;
+  --color-orange-5: #f9cb80;
+  --color-orange-6: #f5a524;
+  --color-orange-7: #b97509;
+  --color-orange-8: #925d07;
+  --color-orange-9: #4e3104;
 
-  --color-green-1: #2d6931;
-  --color-green-2: #347d39;
-  --color-green-3: #2c974b;
-  --color-green-4: #46954a;
-  --color-green-5: #2da44e;
+  --color-green-1: #e8fcf1;
+  --color-green-2: #dafbe8;
+  --color-green-3: #c8f9dd;
+  --color-green-4: #adf5cc;
+  --color-green-5: #88f1b6;
+  --color-green-6: #17c964;
+  --color-green-7: #13a452;
+  --color-green-8: #108944;
+  --color-green-9: #06371b;
 
+  --color-red-0: #fcc5d8;
   --color-red-1: #a82a2a;
   --color-red-2: #c23030;
-  --color-red-3: #db3737;
-  --color-red-4: #f55656;
-  --color-red-5: #ff7373;
+  --color-red-3: #f31260;
+  --color-red-4: #f4256d;
+  --color-red-5: #fcc5d8;
 
   --color-select-hover: rgb(178, 212, 255);
   --color-select-multi-bg: rgb(230, 230, 230);
@@ -108,28 +125,6 @@
   --font-size: 16px;
   --font-size-small: 12px;
   --font-size-large: 18px;
-
-  --button-color: var(--color-white);
-  --button-box-shadow: 0 1px 0 rgba(27, 31, 36, 10%),
-    inset 0 1px 0 rgba(255, 255, 255, 3%);
-  --button-background: var(--color-light-gray-4);
-  --button-background-hover: var(--color-light-gray-3);
-  --button-border: #30404d77;
-  --button-border-hover: #394b59aa;
-
-  --button-dark-background: var(--color-red-2);
-  --button-dark-background-hover: var(--color-red-1);
-  --button-dark-border: #bfccd633;
-  --button-dark-border-hover: #ced9e044;
-  --button-dark-box-shadow-focus: #db373744;
-
-  --button-danger-box-shadow-focus: #db373744;
-
-  --button-success-background: var(--color-green-5);
-  --button-success-background-hover: var(--color-green-3);
-  --button-success-border: #a7b6c233;
-  --button-success-border-hover: #bfccd644;
-  --button-success-box-shadow-focus: #2c974b44;
 }
 
 [data-theme='dark'] {
@@ -175,11 +170,15 @@
   --rgb-max: 0;
   --rgb-min: 255;
 
-  --color-gray-1: #181818;
-  --color-gray-2: #1e1e1e;
-  --color-gray-3: #242424;
-  --color-gray-4: #323232;
-  --color-gray-5: #393939;
+  --color-gray-9: #1f2123;
+  --color-gray-8: #2b2f31;
+  --color-gray-7: #313538;
+  --color-gray-6: #3a3f42;
+  --color-gray-5: #4c5155;
+  --color-gray-4: #697177;
+  --color-gray-3: #787f85;
+  --color-gray-2: #9ba1a6;
+  --color-gray-1: #ecedee;
 
   --color-light-gray-1: #5c7080;
   --color-light-gray-2: #738694;
@@ -205,29 +204,42 @@
   --color-dark-mono-gray-4: #ddd;
   --color-dark-mono-gray-5: #eee;
 
-  --color-blue-1: #0e5a8a;
-  --color-blue-2: #106ba3;
-  --color-blue-3: #137cbd;
-  --color-blue-4: #2b95d6;
-  --color-blue-5: #48aff0;
+  --color-blue-1: #102a47;
+  --color-blue-2: #0f3158;
+  --color-blue-3: #0d3868;
+  --color-blue-4: #0a4281;
+  --color-blue-5: #0952a5;
+  --color-blue-6: #0072f5;
+  --color-blue-7: #3694ff;
+  --color-blue-8: #3694ff;
+  --color-blue-9: #eaf4ff;
 
-  --color-orange-1: #a66321;
-  --color-orange-2: #bf7326;
-  --color-orange-3: #d9822b;
-  --color-orange-4: #f29d49;
-  --color-orange-5: #ffb366;
+  --color-orange-1: #402803;
+  --color-orange-2: #583804;
+  --color-orange-3: #704705;
+  --color-orange-4: #845306;
+  --color-orange-5: #a66908;
+  --color-orange-6: #f5a524;
+  --color-orange-7: #f6ad37;
+  --color-orange-8: #f8c572;
+  --color-orange-9: #fef7ec;
 
-  --color-green-1: #2d6931;
-  --color-green-2: #347d39;
-  --color-green-3: #2c974b;
-  --color-green-4: #46954a;
-  --color-green-5: #2da44e;
+  --color-green-1: #06381b;
+  --color-green-2: #074a24;
+  --color-green-3: #0a6130;
+  --color-green-4: #0b7439;
+  --color-green-5: #0f9549;
+  --color-green-6: #17c964;
+  --color-green-7: #41ec8b;
+  --color-green-8: #78f2ad;
+  --color-green-9: #ecfdf4;
 
+  --color-red-0: #300313;
   --color-red-1: #a82a2a;
   --color-red-2: #c23030;
-  --color-red-3: #db3737;
+  --color-red-3: #f4256d;
   --color-red-4: #f55656;
-  --color-red-5: #ff7373;
+  --color-red-5: #fcc5d8;
 
   --color-select-hover: var(--color-gray-4);
   --color-select-multi-bg: var(--color-gray-5);
@@ -237,25 +249,4 @@
   --font-size: 16px;
   --font-size-small: 12px;
   --font-size-large: 18px;
-
-  --button-color: var(--color-black);
-  --button-box-shadow: 0 0 transparent, inset 0 0 transparent;
-  --button-background: var(--color-mono-gray-2);
-  --button-background-hover: var(--color-mono-gray-4);
-  --button-border: #a7b6c277;
-  --button-border-hover: #bfccd6aa;
-
-  --button-dark-background: var(--color-red-1);
-  --button-dark-background-hover: var(--color-red-2);
-  --button-dark-border: #a7b6c233;
-  --button-dark-border-hover: #bfccd644;
-  --button-dark-box-shadow-focus: #ff737344;
-
-  --button-danger-box-shadow-focus: #ff737344;
-
-  --button-success-background: var(--color-green-2);
-  --button-success-background-hover: var(--color-green-4);
-  --button-success-border: #bfccd633;
-  --button-success-border-hover: #ced9e044;
-  --button-success-box-shadow-focus: #2da44e44;
 }


### PR DESCRIPTION
I believe it was in great need of a retouch.

---

[Improve color palette](https://github.com/webkom/lego-webapp/commit/922c8ead20dfeda10b02ba8a934e830c04f3b82d)

I think we should support far more shades of each color. I'm going to change the other colors as well and go more thoroughly through our webapp, but that should be a seperate PR. Here I've only changed colors used by the event table (gray, red, green, blue and orange).

---

[Give the table component a retouch](https://github.com/webkom/lego-webapp/commit/07ec000d6d9354373aac3f49a1e131d6f0fc08d9) 

This is mostly in regard to the table used on the event details page.

- Fix issue with `event.isPriced` being undefined and causing the "paid column" to vanish. 
   See https://github.com/webkom/lego/pull/3155
- Align cells in the body and header. However, not all cells should be centered imo.,
  e.g. cells with text such as the usernames or feedbacks/allergies column as I
  believe those need all the space they can get.
- Remove the "Klassetrinn" and "Status" column from the "Avmeldte" table.
  "Klassetrinn" was not showing and "status" is not needed.
- Replace "Meld av" button with an icon, and utilize a confirm modal.
  Saves space.
- Status pills in the "Status" column instead of icons. Does not save
  space, but looks good.
- Remove the ability to sort on the users' names as I believe that's not
  needed and saves us precious space.
- Remove the ability to sort on pools when there's only 1 pool.
- Align checkboxes to their labels in the filter dropdown.
- Do not show presence status when there's more than a day until event start or
  if someone has been set to present.
- General styling here and there. I've tried to cut down on space where I can.

I didn't really touch the "feedbacks/allergies" column because I'm planning on tackling that whole thing in a separate PR.

## Result

### Before
<img width="1160" alt="Screenshot 2023-01-04 at 21 22 21" src="https://user-images.githubusercontent.com/69514187/210642976-a247593e-5999-4e8d-b106-984983d286f3.png">

### After
Notice that the dropdown to sort on pools is removed, since there's only one pool.

<img width="1068" alt="Screenshot 2023-01-06 at 14 17 00" src="https://user-images.githubusercontent.com/69514187/211019617-cb764800-badc-48da-af00-5009d4eedb4a.png">

<img width="1068" alt="Screenshot 2023-01-06 at 14 15 40" src="https://user-images.githubusercontent.com/69514187/211019590-49df2d1f-6d1b-4d09-9cc2-b5005dc69675.png">

### Before
<img width="612" alt="Screenshot 2023-01-07 at 23 31 36" src="https://user-images.githubusercontent.com/69514187/211172744-b66101f3-7980-4bc4-a649-8a9d27597092.png">

### After
Notice that the user column has been explicitly set to not be centered. It looks bad because the name + username combo here is shorter than it usually is. Might not look too bad centered here though, so I might change that later. I'm going to tackle this specific table soon (gonna add an edit button), so I'll do it then.
<img width="562" alt="Screenshot 2023-01-07 at 23 34 07" src="https://user-images.githubusercontent.com/69514187/211172795-6e0e213d-7b01-408c-bcbb-d67331d067af.png">

### Before
<img width="861" alt="Screenshot 2023-01-07 at 23 26 18" src="https://user-images.githubusercontent.com/69514187/211172587-9b1eca7e-b4b4-4fa8-9acd-94075e4cc72b.png">

### After
Notice here that the table does not use the `<Table />` component, but is still somewhat affected by the global cascading table conf. Will do a seperate PR and clean up stuff like this.
<img width="861" alt="Screenshot 2023-01-07 at 23 23 31" src="https://user-images.githubusercontent.com/69514187/211172507-62c10f83-3d75-4495-a14e-9f7fd6e3c029.png">

---

Resolves ABA-197