### PR TITLE
Introduce a `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Format all TS files with prettier
+00f32c3f7560243d22dfd6209c8cebecbfc2fbf6
+
+# Convert all flow to TS with flow-to-ts
+cb6303655b635c8a59b424aa6dcedce511c116c4


### PR DESCRIPTION
I religiously use `git blame`, and the recent bulk changes in regards to our transition to Typescript has made it awful. But [this](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt) makes everything better! `git blame --ignore-revs-file .git-blame-ignore-revs` will now output a useful `git blame`. The flag must always be passed, so I recommend setting a config for this;
`git config blame.ignoreRevsFile .git-blame-ignore-revs`. Note that this needs to be set per-project, as `git blame` will raise an error if it cannot find the file.

This also works if you use `GitLens` (but you still need to configure it the same way).

This is entirely optional to use, but I've now used it a couple of days and it does wonders!