### PR TITLE
Improve all modals

### DIFF
--- a/app/components/Modal/ConfirmModal.css
+++ b/app/components/Modal/ConfirmModal.css
@@ -1,39 +1,11 @@
-.modal {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-  right: 0;
+.warningIcon {
+  color: var(--color-orange-6);
 }
 
-.backdrop {
-  position: fixed;
-  background: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 80%);
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+.dangerTitle {
+  color: var(--color-red-2);
 }
 
-.content {
-  position: fixed;
-  max-width: 680px;
-  top: 100px;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
-  background: var(--color-white);
-  border-radius: 5px;
-  padding: 40px;
-  outline: none;
-  max-height: 80vh;
-  overflow-y: auto;
-}
-
-.closeButton {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  font-size: 20px;
+.errorMessage {
+  color: var(--color-red-2);
 }

--- a/app/components/Modal/ConfirmModal.tsx
+++ b/app/components/Modal/ConfirmModal.tsx
@@ -1,7 +1,9 @@
 import { get } from 'lodash';
 import { Component, Children, cloneElement } from 'react';
+import Button from 'app/components/Button';
+import Icon from 'app/components/Icon';
+import Flex from 'app/components/Layout/Flex';
 import Modal from 'app/components/Modal';
-import Button from '../Button';
 import styles from './ConfirmModal.css';
 import type { ComponentType, ReactElement, ReactNode } from 'react';
 
@@ -14,8 +16,9 @@ type ConfirmModalProps = {
   errorMessage?: string;
   cancelText?: string;
   confirmText?: string;
-  safeConfirm?: boolean;
+  danger?: boolean;
 };
+
 export const ConfirmModal = ({
   message,
   onConfirm,
@@ -25,30 +28,26 @@ export const ConfirmModal = ({
   errorMessage = '',
   cancelText = 'Avbryt',
   confirmText = 'Ja',
-  safeConfirm = false,
+  danger = true,
 }: ConfirmModalProps) => (
-  <div className={styles.overlay}>
-    <div className={styles.confirmContainer}>
-      <h2 className={styles.confirmTitle}>{title}</h2>
-      <div className={styles.confirmMessage}>{message}</div>
-      <div className={styles.buttonGroup}>
-        <Button disabled={disabled} onClick={onCancel}>
-          {cancelText}
-        </Button>
-        <Button danger={!safeConfirm} disabled={disabled} onClick={onConfirm}>
-          {confirmText}
-        </Button>
-        <p
-          style={{
-            color: 'red',
-          }}
-        >
-          {errorMessage}{' '}
-        </p>
-      </div>
+  <Flex column gap={15}>
+    <Flex wrap alignItems="center" gap={10}>
+      <Icon name="warning" className={styles.warningIcon} />
+      <h2 className={danger && styles.dangerTitle}>{title}</h2>
+    </Flex>
+    <span>{message}</span>
+    <div>
+      <Button disabled={disabled} onClick={onCancel}>
+        {cancelText}
+      </Button>
+      <Button danger={danger} disabled={disabled} onClick={onConfirm}>
+        {confirmText}
+      </Button>
     </div>
-  </div>
+    {errorMessage && <p className={styles.errorMessage}>{errorMessage} </p>}
+  </Flex>
 );
+
 type State = {
   modalVisible: boolean;
   working: boolean;

--- a/app/components/Modal/Modal.css
+++ b/app/components/Modal/Modal.css
@@ -1,12 +1,3 @@
-.modal {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-  right: 0;
-}
-
 .backdrop {
   position: fixed;
   background: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 80%);
@@ -22,28 +13,37 @@ html[data-theme='dark'] .backdrop {
 }
 
 .content {
+  line-height: 1.3;
   position: fixed;
-  max-width: 680px;
-  top: 20px;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 425px;
+  width: 100%;
+  max-height: calc(100vh - 300px);
+  padding: 35px;
   background: var(--color-white);
-  border-radius: 5px;
-  padding: 40px;
   outline: none;
-  max-height: calc(100vh - 40px);
   overflow-y: auto;
   z-index: 4;
+  /* stylelint-disable indentation */
+  box-shadow: 0 5px 10px
+      rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 12%),
+    0 6px 6px rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 15%);
+  border: 1px solid rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 9%);
+  border-radius: 1rem;
 }
 
 .closeButton {
   position: absolute;
-  top: 7px;
-  right: 10px;
-  font-size: 42px;
+  top: 1rem;
+  right: 1rem;
   padding: 0;
-  color: var(--color-black);
+  color: var(--color-dark-mono-gray-3);
+
+  &:hover {
+    color: var(--color-dark-mono-gray-4);
+  }
 }
 
 .confirmContainer {

--- a/app/components/Modal/index.tsx
+++ b/app/components/Modal/index.tsx
@@ -47,7 +47,7 @@ const Modal = ({
   >
     <div>
       <button onClick={onHide} className={styles.closeButton}>
-        <Icon name="close" />
+        <Icon name="close" size={24} />
       </button>
 
       {children}

--- a/app/components/NavigationTab/index.tsx
+++ b/app/components/NavigationTab/index.tsx
@@ -20,7 +20,16 @@ type Props = {
 const NavigationTab = (props: Props) => (
   <>
     {props.back && (
-      <NavLink to={props.back.path} className={styles.back}>
+      <NavLink
+        to={props.back.path}
+        onClick={(e: Event) => {
+          // TODO fix this hack when react-router is done
+          if (!window.location.hash) return;
+          window.history.back();
+          e.preventDefault();
+        }}
+        className={styles.back}
+      >
         <Icon name="arrow-back" size={19} className={styles.backIcon} />
         <span className={styles.backLabel}>{props.back.label}</span>
       </NavLink>

--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback, Fragment, Component } from 'react';
+import cx from 'classnames';
+import { useEffect, useState, useCallback, useMemo, Component } from 'react';
 import { Cropper } from 'react-cropper';
 import { type Accept, useDropzone } from 'react-dropzone';
 import 'cropperjs/dist/cropper.css';
@@ -82,10 +83,21 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
     },
     [multiple, onDrop]
   );
-  const { getRootProps, getInputProps } = useDropzone({
-    onDrop: onDropCallback,
-    accept: accept,
-  });
+  const { getRootProps, getInputProps, isFocused, isDragAccept, isDragReject } =
+    useDropzone({
+      onDrop: onDropCallback,
+      accept: accept,
+    });
+
+  const style = useMemo(
+    () =>
+      cx(
+        isFocused && styles.focused,
+        isDragAccept && styles.dragAccept,
+        isDragReject && styles.dragReject
+      ),
+    [isFocused, isDragAccept, isDragReject]
+  );
   return (
     <div
       onClick={(e) => {
@@ -96,7 +108,7 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
     >
       <div
         {...getRootProps({
-          className: styles.dropArea,
+          className: cx(styles.dropArea, style),
         })}
       >
         <Flex
@@ -106,7 +118,10 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
           gap={5}
           className={styles.placeholderContainer}
         >
-          <Icon size={70} name="cloud-upload-outline" />
+          <Icon
+            size={60}
+            name={multiple ? 'images-outline' : 'image-outline'}
+          />
           <h4 className={styles.placeholderTitle}>
             {`Dropp ${word} her eller trykk for å velge fra filsystem`}
           </h4>
@@ -273,7 +288,7 @@ export default class ImageUpload extends Component<Props, State> {
             <Flex wrap gap={35}>
               <Button
                 success
-                disabled={files.length === 0}
+                disabled={files.length === 0 && !preview}
                 onClick={this.onSubmit}
               >
                 Last opp

--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -3,7 +3,6 @@ import { Cropper } from 'react-cropper';
 import { type Accept, useDropzone } from 'react-dropzone';
 import 'cropperjs/dist/cropper.css';
 import Button from 'app/components/Button';
-import TextInput from 'app/components/Form/TextInput';
 import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
@@ -59,50 +58,16 @@ const FilePreview = ({ file, onRemove }: FilePreviewProps) => {
   return (
     <Flex
       wrap
-      className={styles.previewRow}
       alignItems="center"
       justifyContent="space-between"
+      className={styles.previewRow}
     >
-      <div
-        style={{
-          width: '90%',
-          display: 'flex',
-        }}
-      >
-        <div
-          style={{
-            width: '80px',
-            display: 'flex',
-            justifyContent: 'center',
-          }}
-        >
-          <img
-            alt="preview"
-            style={{
-              height: '50px',
-            }}
-            src={previewUrl}
-          />
-        </div>
-        <div
-          style={{
-            flex: '1 1 auto',
-          }}
-        >
-          <TextInput
-            disabled
-            value={file.name}
-            style={{
-              width: '100%',
-              height: 50,
-            }}
-          />
-        </div>
-      </div>
+      <img alt="preview" className={styles.previewImage} src={previewUrl} />
+      <div className={styles.fileName}>{file.name}</div>
       <Icon
         onClick={onRemove}
         name="trash"
-        size={32}
+        size={28}
         className={styles.removeIcon}
       />
     </Flex>
@@ -134,12 +99,18 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
           className: styles.dropArea,
         })}
       >
-        <div className={styles.placeholderContainer}>
-          <Icon size={82} name="image" />
-          <h2 className={styles.placeholderTitle}>
-            {`Dropp ${word} her eller trykk for å velge fra fil`}
-          </h2>
-        </div>
+        <Flex
+          column
+          alignItems="center"
+          justifyContent="center"
+          gap={5}
+          className={styles.placeholderContainer}
+        >
+          <Icon size={70} name="cloud-upload-outline" />
+          <h4 className={styles.placeholderTitle}>
+            {`Dropp ${word} her eller trykk for å velge fra filsystem`}
+          </h4>
+        </Flex>
         {image && (
           <Image alt="presentation" className={styles.image} src={image} />
         )}
@@ -256,7 +227,7 @@ export default class ImageUpload extends Component<Props, State> {
       'image/avif': ['*'],
     };
     return (
-      <div className={styles.container}>
+      <>
         {!inModal && (
           <UploadArea
             onDrop={this.onDrop}
@@ -265,12 +236,8 @@ export default class ImageUpload extends Component<Props, State> {
             accept={accept}
           />
         )}
-        <Modal
-          contentClassName={styles.modal}
-          show={cropOpen}
-          onHide={this.closeModal}
-        >
-          <Fragment>
+        <Modal show={cropOpen} onHide={this.closeModal}>
+          <Flex className={styles.modal}>
             {inModal && !preview && (
               <div className={styles.inModalUpload}>
                 <UploadArea
@@ -293,7 +260,7 @@ export default class ImageUpload extends Component<Props, State> {
               />
             )}
             {multiple && !crop && (
-              <Flex wrap column>
+              <Flex wrap column gap={7}>
                 {files.map((file, index) => (
                   <FilePreview
                     onRemove={() => this.onRemove(index)}
@@ -303,18 +270,19 @@ export default class ImageUpload extends Component<Props, State> {
                 ))}
               </Flex>
             )}
-            <Flex
-              wrap
-              className={styles.footer}
-              alignItems="center"
-              justifyContent="space-evenly"
-            >
-              <Button onClick={this.onSubmit}>Last opp</Button>
+            <Flex wrap gap={35}>
+              <Button
+                success
+                disabled={files.length === 0}
+                onClick={this.onSubmit}
+              >
+                Last opp
+              </Button>
               <Button onClick={() => this.closeModal()}>Avbryt</Button>
             </Flex>
-          </Fragment>
+          </Flex>
         </Modal>
-      </div>
+      </>
     );
   }
 }

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -1,22 +1,10 @@
 @import url('~app/styles/variables.css');
 
-.container {
-  border-radius: inherit;
-  height: inherit;
-  width: inherit;
-}
-
 .modal {
-  box-shadow: 0 4px 4px rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 5%);
-  border: 1px solid rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 9%);
-  border-radius: 5px;
-}
-
-.uploadContainer {
-  position: absolute;
-  border-radius: inherit;
-  height: inherit;
-  width: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
 }
 
 .dropArea {
@@ -25,70 +13,67 @@
   width: inherit;
   z-index: 0;
   position: absolute;
-  background-color: gainsboro;
   cursor: pointer;
 }
 
-html[data-theme='dark'] .dropArea {
-  background-color: var(--color-mono-gray-1);
-}
-
 .inModalUpload {
-  height: 320px;
-  width: 600px;
+  width: 325px;
+  height: 200.861px;
+  border-radius: 1rem;
 }
 
 .placeholderContainer {
   overflow: hidden;
   border-radius: inherit;
   height: inherit;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   width: inherit;
   position: absolute;
 }
 
 .placeholderTitle {
-  background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 80%);
-  border-radius: 5px;
-  padding: 0 20px;
+  background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 70%);
+  padding: 10px 40px;
   text-align: center;
 }
 
+.inModalUpload .placeholderTitle {
+  background: none;
+}
+
 .image {
-  border-radius: inherit;
-  height: inherit;
   width: 100%;
+  height: inherit;
   object-fit: cover;
   background: white;
+  border-radius: inherit;
 }
 
 .cropper {
-  height: 400px;
   width: 100%;
 }
 
-.footer {
-  margin-top: 20px;
-}
-
 .previewRow {
+  width: 325px;
   height: 52px;
-  margin: 5px 0;
+  color: var(--color-light-gray-5);
 }
 
-.previewRowImage {
-  height: 50px;
+.previewImage {
   width: 80px;
+  height: 50px;
   object-fit: cover;
+}
+
+.fileName {
+  width: 180px;
+  font-size: 14px;
+  font-weight: 500;
 }
 
 .removeIcon {
   cursor: pointer;
 
   &:hover {
-    color: var(--lego-red-color);
+    color: var(--color-red-3);
   }
 }

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -14,6 +14,10 @@
   z-index: 0;
   position: absolute;
   cursor: pointer;
+
+  &:focus {
+    outline: none;
+  }
 }
 
 .inModalUpload {
@@ -28,6 +32,27 @@
   height: inherit;
   width: inherit;
   position: absolute;
+}
+
+.inModalUpload .placeholderContainer {
+  background-color: var(--color-gray-6);
+  border: 3px dashed var(--color-blue-6);
+}
+
+.focused .placeholderContainer {
+  border: 3px dashed var(--color-orange-6);
+}
+
+.dragAccept .placeholderContainer {
+  border: 3px dashed var(--color-green-6);
+}
+
+.dragReject .placeholderContainer {
+  border: 3px dashed var(--color-red-4);
+}
+
+html[data-theme='dark'] .inModalUpload .placeholderContainer {
+  background-color: var(--color-gray-8);
 }
 
 .placeholderTitle {
@@ -55,7 +80,7 @@
 .previewRow {
   width: 325px;
   height: 52px;
-  color: var(--color-light-gray-5);
+  color: var(--color-gray-2);
 }
 
 .previewImage {

--- a/app/components/UserAttendance/AttendanceModal.css
+++ b/app/components/UserAttendance/AttendanceModal.css
@@ -96,9 +96,7 @@ html[data-theme='dark'] .list > li:nth-child(even) {
 }
 
 .row {
-  display: flex;
   height: 50px;
-  align-items: center;
 }
 
 .row > img {

--- a/app/components/UserAttendance/AttendanceModal.css
+++ b/app/components/UserAttendance/AttendanceModal.css
@@ -1,63 +1,137 @@
+.modal {
+  height: calc(100vh - 400px);
+}
+
+.search {
+  width: 60%;
+  height: 35px;
+  padding: 10px;
+  border: 1px solid var(--color-light-gray-1);
+  border-radius: 5px;
+  color: var(--color-gray-5);
+
+  &:focus-within {
+    border-color: var(--color-gray-5);
+  }
+}
+
+/* Search icon */
+.search > div {
+  color: var(--color-light-gray-1);
+}
+
+.search input {
+  border: none;
+  outline: none;
+  box-shadow: none;
+  font-size: 0.9rem;
+
+  &:focus {
+    border: none;
+    box-shadow: none;
+  }
+
+  &::placeholder {
+    color: var(--color-light-gray-1);
+  }
+}
+
+html[data-theme='dark'] .search input {
+  background: none;
+}
+
 .list {
+  position: relative;
   width: 100%;
   min-height: 100px;
-  max-height: calc(100vh - 210px);
-  padding: 0 30px;
-  margin-bottom: 5px;
+  height: 80%;
   overflow-y: auto;
+  /* stylelint-disable indentation */
+  background:
+  /*
+  Shadow cover TOP
+  */ linear-gradient(
+        var(--color-white) 30%,
+        rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 0%)
+      )
+      center top,
+    /*
+  Shadow cover BOTTOM
+  */
+      linear-gradient(
+        rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 0%),
+        var(--color-white) 70%
+      )
+      center bottom,
+    /*
+  Shadow TOP
+  */
+      radial-gradient(
+        farthest-side at 50% 0,
+        rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 15%),
+        rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 0%)
+      )
+      center top,
+    /*
+  Shadow BOTTOM
+  */
+      radial-gradient(
+        farthest-side at 50% 100%,
+        rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 15%),
+        rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 0%)
+      )
+      center bottom;
+  /* stylelint-enable indentation */
+  background-repeat: no-repeat;
+  background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+  background-attachment: local, local, scroll, scroll;
 }
 
-.list > li {
-  border-bottom: 1px solid var(--color-mono-gray-3);
+.list > li:nth-child(even) {
+  background-color: rgba(0, 0, 0, 3%);
 }
 
-.list > li:last-child {
-  border-bottom: none;
-}
-
-.nav {
-  display: flex;
-  flex: 1;
-  padding: 5px;
-  width: 100%;
-  justify-content: center;
-}
-
-.navButton {
-  display: flex;
-  height: 30px;
-  min-width: 75px;
-  padding-left: 5px;
-  padding-right: 5px;
-  justify-content: center;
-}
-
-.navButton:last-child {
-  border-right: none;
+html[data-theme='dark'] .list > li:nth-child(even) {
+  background-color: rgba(255, 255, 255, 3%);
 }
 
 .row {
   display: flex;
   height: 50px;
   align-items: center;
-  margin-top: 5px;
-  margin-bottom: 5px;
 }
 
 .row > img {
   width: 50px;
   height: 50px;
-  margin-right: 10px;
+  margin: 0 10px;
 }
 
-.navButton:hover,
-.activeItem {
-  color: #1c1c1c;
-  border-bottom: 1px solid #c24538;
+.nav {
+  margin: 5px auto;
+  height: 40px;
+  border: 1px solid var(--color-light-gray-2);
   border-radius: 5px;
+  font-size: 0.9rem;
 }
 
-html[data-theme='dark'] .navButton:hover,
-html[data-theme='dark'] .activeItem {
+.navButton {
+  height: 100%;
   color: var(--lego-font-color);
+  border-radius: inherit;
+  text-align: center;
+  padding: 5px 15px;
+  font-weight: 500;
+}
+
+.activeItem {
+  background-color: var(--color-red-8);
+  box-shadow: 0 0 0 1px var(--color-red-3);
+  color: var(--color-red-3);
+}
+
+html[data-theme='dark'] .activeItem {
+  background-color: var(--color-red-0);
+  box-shadow: 0 0 0 1px var(--color-red-3);
+  color: var(--color-red-3);
 }

--- a/app/components/UserAttendance/AttendanceModal.tsx
+++ b/app/components/UserAttendance/AttendanceModal.tsx
@@ -116,12 +116,12 @@ class AttendanceModal extends Component<Props, State> {
         <ul className={styles.list}>
           {registrations.map((registration) => (
             <li key={registration.id}>
-              <div className={styles.row}>
+              <Flex alignItems="center" className={styles.row}>
                 <ProfilePicture size={30} user={registration.user} />
                 <Link to={`/users/${registration.user.username}`}>
                   {registration.user.fullName}
                 </Link>
-              </div>
+              </Flex>
             </li>
           ))}
         </ul>

--- a/app/components/UserAttendance/AttendanceModal.tsx
+++ b/app/components/UserAttendance/AttendanceModal.tsx
@@ -2,9 +2,12 @@ import cx from 'classnames';
 import { flatMap } from 'lodash';
 import { Component } from 'react';
 import { Link } from 'react-router-dom';
+import Button from 'app/components/Button';
+import { TextInput } from 'app/components/Form';
+import Icon from 'app/components/Icon';
 import { ProfilePicture } from 'app/components/Image';
+import Flex from 'app/components/Layout/Flex';
 import type { ID, User } from 'app/models';
-import Button from '../Button';
 import styles from './AttendanceModal.css';
 
 export type Registration = {
@@ -47,11 +50,13 @@ const Tab = ({ name, index, activePoolIndex, togglePool }: TabProps) => (
 
 type State = {
   pools: Pool[];
+  filter: string;
 };
 
 class AttendanceModal extends Component<Props, State> {
   state = {
     pools: [],
+    filter: '',
   };
   static defaultProps = {
     title: 'Status',
@@ -82,13 +87,34 @@ class AttendanceModal extends Component<Props, State> {
 
   render() {
     const { title, togglePool, selectedPool } = this.props;
-    const { pools } = this.state;
-    const activePool = pools[selectedPool];
+    const { pools, filter } = this.state;
+    const registrations = pools[selectedPool].registrations.filter(
+      (registration) => {
+        return registration.user.fullName
+          .toLowerCase()
+          .includes(filter.toLowerCase());
+      }
+    );
+
     return (
-      <div>
+      <Flex
+        column
+        justifyContent="space-between"
+        gap={15}
+        className={styles.modal}
+      >
         <h2>{title}</h2>
+        <Flex alignItems="center" className={styles.search}>
+          <Icon name="search" size={16} />
+          <TextInput
+            type="text"
+            placeholder="Søk etter navn"
+            onChange={(e) => this.setState({ filter: e.target.value })}
+          />
+        </Flex>
+
         <ul className={styles.list}>
-          {activePool.registrations.map((registration) => (
+          {registrations.map((registration) => (
             <li key={registration.id}>
               <div className={styles.row}>
                 <ProfilePicture size={30} user={registration.user} />
@@ -100,7 +126,7 @@ class AttendanceModal extends Component<Props, State> {
           ))}
         </ul>
 
-        <div className={styles.nav}>
+        <Flex justifyContent="space-between" className={styles.nav}>
           {pools.map((pool, i) => (
             <Tab
               name={pool.name}
@@ -110,8 +136,8 @@ class AttendanceModal extends Component<Props, State> {
               togglePool={togglePool}
             />
           ))}
-        </div>
-      </div>
+        </Flex>
+      </Flex>
     );
   }
 }

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -53,7 +53,7 @@ const GroupMembersList = ({
       <>
         <ConfirmModalWithParent
           title="Bekreft utmelding"
-          message={`Er du sikker på at du vil melde ut "${user.fullName}" fra gruppen "${groupsById[abakusGroup].name}?"`}
+          message={`Er du sikker på at du vil melde ut "${user.fullName}" fra gruppen "${groupsById[abakusGroup].name}"?`}
           onConfirm={() => removeMember(membership)}
         >
           <i key="icon" className={`fa fa-times ${styles.removeIcon}`} />

--- a/app/routes/interestgroups/components/InterestGroupMemberList.css
+++ b/app/routes/interestgroups/components/InterestGroupMemberList.css
@@ -12,41 +12,6 @@
   --color-co-leader-silver: #c0c0c0;
 }
 
-.list {
-  width: 100%;
-  min-height: 100px;
-  max-height: calc(100vh - 210px);
-  padding: 0 30px;
-  margin-bottom: 5px;
-  overflow-y: auto;
-}
-
-.list > li {
-  border-bottom: 1px solid var(--color-mono-gray-3);
-}
-
-.list > li:last-child {
-  border-bottom: none;
-}
-
-.row {
-  display: flex;
-  height: 50px;
-  align-items: center;
-  margin-top: 5px;
-  margin-bottom: 5px;
-}
-
-.row > img {
-  width: 50px;
-  height: 50px;
-  margin-right: 10px;
-}
-
-.row i {
-  margin-right: 5px;
-}
-
 .leader {
   font-weight: 900;
   text-shadow: 0.0625em 0.125em 0.875em var(--color-gold-blur);
@@ -60,17 +25,11 @@
 }
 
 .leadericon {
-  margin: 0.2em 0.2em 0;
   filter: drop-shadow(0.0625em 0.125em 0.625em var(--color-gold-blur));
   color: var(--color-leader-gold);
 }
 
 .coleadericon {
-  margin: 0.2em 0.2em 0;
   filter: drop-shadow(0.0625em 0.125em 0.625em var(--color-silver-blur));
   color: var(--color-co-leader-silver);
-}
-
-.suffix {
-  font-style: italic;
 }

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -136,6 +136,10 @@ export default class GalleryDetail extends Component<Props, State> {
         <Helmet title={gallery.title} />
         <NavigationTab
           title={gallery.title}
+          back={{
+            label: 'Tilbake',
+            path: '/photos',
+          }}
           details={
             <>
               <GalleryDetailsRow gallery={gallery} showDescription />
@@ -155,17 +159,6 @@ export default class GalleryDetail extends Component<Props, State> {
             </>
           }
         >
-          <NavigationLink
-            onClick={(e: Event) => {
-              // TODO fix this hack when react-router is done
-              if (!window.location.hash) return;
-              window.history.back();
-              e.preventDefault();
-            }}
-            to="/photos"
-          >
-            <i className="fa fa-angle-left" /> Tilbake
-          </NavigationLink>
           {actionGrant?.includes('edit') && (
             <div>
               <NavigationLink to="#" onClick={() => this.toggleUpload()}>

--- a/app/routes/photos/components/GalleryDetailsRow.tsx
+++ b/app/routes/photos/components/GalleryDetailsRow.tsx
@@ -1,6 +1,6 @@
-import moment from 'moment-timezone';
 import { Link } from 'react-router-dom';
 import { Flex } from 'app/components/Layout';
+import Time from 'app/components/Time';
 import styles from './GalleryDetailsRow.css';
 
 type Props = {
@@ -26,7 +26,7 @@ const GalleryDetailsRow = ({
 
       {gallery.takenAt && (
         <span className={styles.detail}>
-          {moment(gallery.takenAt).format('ll')}
+          <Time time={gallery.takenAt} format="DD.MM.YYYY" />
         </span>
       )}
 

--- a/app/routes/photos/components/GalleryPictureModal.css
+++ b/app/routes/photos/components/GalleryPictureModal.css
@@ -1,30 +1,9 @@
 @import url('~app/styles/variables.css');
 
-.modal {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-  right: 0;
-}
-
-.backdrop {
-  position: fixed;
-  background: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 80%);
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
 .content {
   padding: 0;
-  border-radius: 0;
-  background: none;
   max-width: 1100px;
-  margin: 0 auto;
-  overflow-y: auto;
+  max-height: calc(100vh - 100px);
 
   @media (max-width: 800px) {
     position: fixed;
@@ -35,30 +14,10 @@
   }
 }
 
-.topContent {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radi: 0;
-
-  @media (max-width: 800px) {
-    border-radius: 0;
-  }
-}
-
-.bottomContent {
-  border-top-right-radius: 0;
-  border-top-left-radius: 0;
-
-  @media (max-width: 800px) {
-    border-radius: 0;
-    height: inherit;
-  }
-}
-
 .pictureContainer {
   display: grid;
   justify-content: center;
-  background-color: var(--color-white);
-  min-height: 700px;
+  min-height: 600px;
 }
 
 .pictureDescription {

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -231,6 +231,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
       deleteComment,
     } = this.props;
     const { showMore } = this.state;
+
     return (
       <Modal
         onHide={() => push(`/photos/${gallery.id}`)}
@@ -239,7 +240,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
       >
         <Swipeable onSwiping={this.handleSwipe}>
           <OnKeyDownHandler handler={this.handleKeyDown} />
-          <Content className={styles.topContent}>
+          <Content>
             <Flex
               width="100%"
               justifyContent="space-between"
@@ -253,9 +254,7 @@ export default class GalleryPictureModal extends Component<Props, State> {
                 />
 
                 <Flex column justifyContent="space-around">
-                  <h5 className={styles.header}>
-                    <Link to={`/photos/${gallery.id}`}>{gallery.title}</Link>
-                  </h5>
+                  <Link to={`/photos/${gallery.id}`}>{gallery.title}</Link>
                   <GalleryDetailsRow size="small" gallery={gallery} />
                 </Flex>
               </Flex>
@@ -327,14 +326,16 @@ export default class GalleryPictureModal extends Component<Props, State> {
               </Dropdown>
             </Flex>
           </Content>
+
           <Flex className={styles.pictureContainer}>
             <ProgressiveImage
               key={picture.id}
               src={picture.file}
-              alt="some alt"
+              alt={picture.description}
             />
           </Flex>
-          <Content className={styles.bottomContent}>
+
+          <Content>
             <Flex justifyContent="center">
               {this.state.hasPrevious && (
                 <Link

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -110,12 +110,15 @@
   --color-green-8: #108944;
   --color-green-9: #06371b;
 
-  --color-red-0: #fcc5d8;
   --color-red-1: #a82a2a;
   --color-red-2: #c23030;
   --color-red-3: #f31260;
   --color-red-4: #f4256d;
-  --color-red-5: #fcc5d8;
+  --color-red-5: #f881ab;
+  --color-red-6: #faa8c5;
+  --color-red-7: #fcc5d8;
+  --color-red-8: #fdd8e5;
+  --color-red-9: #fee7ef;
 
   --color-select-hover: rgb(178, 212, 255);
   --color-select-multi-bg: rgb(230, 230, 230);
@@ -239,7 +242,11 @@
   --color-red-2: #c23030;
   --color-red-3: #f4256d;
   --color-red-4: #f55656;
-  --color-red-5: #fcc5d8;
+  --color-red-5: #f881ab;
+  --color-red-6: #faa8c5;
+  --color-red-7: #fcc5d8;
+  --color-red-8: #fdd8e5;
+  --color-red-9: #fee7ef;
 
   --color-select-hover: var(--color-gray-4);
   --color-select-multi-bg: var(--color-gray-5);


### PR DESCRIPTION
Hah, you thought I was done!?

---

[Improve the general modal component](https://github.com/webkom/lego-webapp/commit/7211258db5a9036d9ac4968f609554c61b704c40) 

Only in terms of styling. It's now smaller, yet prettier.

---

[Utilize the back prop on gallery pages](https://github.com/webkom/lego-webapp/commit/28a0ed70444fc89f5cc6b60c9bf6ff2ff8d547bb) 

Also move the routing hack to this navigation link. The hack ensures
that the user ends up where it left off in the y-axis.
  
[Improve the image upload modal](https://github.com/webkom/lego-webapp/commit/39c73b4b0b5e1a9be1a90bd8c080a33d042de248) 

Mostly just styling changes.

[Make upload area react to change](https://github.com/webkom/lego-webapp/commit/69c5affc3a26d165b383b0b94133d17bf51b3793) 

It will give feedback when it's focused, or accepts/rejects a file.

Also update some colors.

### Before
Unnecessary big and all the way at the top.

<p align="center">
	<img src="https://user-images.githubusercontent.com/69514187/211218719-7bc90ed3-5c19-425f-8704-612e7f87a130.png" width="400" />
</p>

### After
Images are not correctly scaled here, so these are in reality much smaller than before and centered in the middle of the screen.

<p align="center">
	<img src="https://user-images.githubusercontent.com/69514187/211217916-13786c08-4bcc-4ecb-ae3e-c03f5eadd73a.png" width="40%" />
	<img src="https://user-images.githubusercontent.com/69514187/211217937-568877d9-6254-471b-a736-5d06c84e8892.png" width="40%" />
</p>

Notice the color feedback on the border. It works the same for all image uploaders, e.g. the one for changing your profile picture. The flickering in the middle of the video is me opening finder, relax.

<video src="https://user-images.githubusercontent.com/69514187/211218355-c1796967-89e1-40c8-a95a-28650d8a8775.mov"></video>

---
  
[Improve the attendance modal](https://github.com/webkom/lego-webapp/commit/a8b69dc49e059485651a513e6e4f8882e9615958) 

- Add a search field
- General styling improvements. It now further resembles the webapp's table.

### Before
This modal is huuuge, and ugly.

<p align="center">
	<img src="https://user-images.githubusercontent.com/69514187/211218989-157d1ab6-d3c0-432a-8388-298810ef5122.png" width="400" />
</p>

### After
<p align="center">
	<img src="https://user-images.githubusercontent.com/69514187/211219042-64842da8-7c7a-4a4e-bb95-51f76a82ae61.png" width="40%" />
	<img src="https://user-images.githubusercontent.com/69514187/211219088-f41fd1f2-05f8-45b1-949d-666c68c4de6e.png" width="40%" />
</p>
---

[Use shared styling for interest group member list](https://github.com/webkom/lego-webapp/commit/cf2215fb87ddb8011fae539211a5df64bb433e16) 

The list now resembles the attendance modal. It uses the same shared
styling and has been given a search field as well.

---
  
[Improve the confirm modal](https://github.com/webkom/lego-webapp/commit/464a84202512b89afcb528f37ecda1e8a5889a59) 

Not only does it look better, but it now better
conveys that an action is destructive (when of type `danger`).

### Before
<p align="center">
	<img src="https://user-images.githubusercontent.com/69514187/211218630-6f34e2aa-c541-4d90-bf07-49ea83ce7838.png" width="98%" />
</p>

### After
Difficult to notice here, but the modal is centered in the middle of the screen, instead of all the way at the top. Looks much better.

<p align="center">
	<img src="https://user-images.githubusercontent.com/69514187/212183382-39711dcd-022b-4ebc-ae1c-f9409ed5f2bc.png" width="49%" />
	<img src="https://user-images.githubusercontent.com/69514187/212183466-60e0cffa-b90d-427e-bea7-0efefcacd8a2.png" width="49%" />
</p>

---
  
[Clean up the gallery picture modal](https://github.com/webkom/lego-webapp/commit/b1dbc85fb653949be918126e34eb01c85803960c) 

Changes had to be made to "support" the new global modal changes.

---
  
 Resolves ABA-198