### PR TITLE
Clean up tables

### DIFF
--- a/app/components/Modal/Modal.css
+++ b/app/components/Modal/Modal.css
@@ -40,6 +40,7 @@ html[data-theme='dark'] .backdrop {
   right: 1rem;
   padding: 0;
   color: var(--color-dark-mono-gray-3);
+  transition: color 150ms ease-in-out;
 
   &:hover {
     color: var(--color-dark-mono-gray-4);

--- a/app/components/Table/Table.css
+++ b/app/components/Table/Table.css
@@ -4,23 +4,23 @@
   overflow-x: scroll;
 }
 
-table {
+.wrapper table {
   width: 100%;
 }
 
-thead button {
+.wrapper thead button {
   padding: 0;
 }
 
-thead i {
+.wrapper thead i {
   cursor: pointer;
 }
 
-tr:nth-child(even) {
+.wrapper tr:nth-child(even) {
   background-color: var(--color-light-gray-5);
 }
 
-html[data-theme='dark'] tr:nth-child(even) {
+html[data-theme='dark'] .wrapper tr:nth-child(even) {
   background-color: var(--color-gray-8);
 }
 

--- a/app/routes/users/UserSettingsOAuth2Route.ts
+++ b/app/routes/users/UserSettingsOAuth2Route.ts
@@ -17,6 +17,8 @@ const mapStateToProps = (state) => {
     applications: selectOAuth2Applications(state),
     grants: selectOAuth2Grants(state),
     actionGrant: state.oauth2Applications.actionGrant,
+    fetchingApplications: state.oauth2Applications.fetching,
+    fetchingGrants: state.oauth2Grants.fetching,
   };
 };
 

--- a/app/routes/users/components/UserSettingsOAuth2.css
+++ b/app/routes/users/components/UserSettingsOAuth2.css
@@ -1,10 +1,17 @@
-.table {
-  width: 100%;
+.copyIcon {
+  cursor: pointer;
 }
 
-.table i {
-  display: flex;
-  justify-content: center;
+.copied {
+  color: var(--color-green-6);
+}
+
+.deleteIcon {
   cursor: pointer;
-  color: var(--color-red-2);
+  color: var(--color-red-3);
+  transition: color 150ms ease-in-out;
+
+  &:hover {
+    color: var(--color-red-5);
+  }
 }

--- a/app/routes/users/components/UserSettingsOAuth2Form.tsx
+++ b/app/routes/users/components/UserSettingsOAuth2Form.tsx
@@ -29,7 +29,7 @@ const UserSettingsOAuth2Form = (props: Props) => {
 
   return (
     <div>
-      <h1>{props.create ? 'Opprett' : 'Endre'} Applikasjon</h1>
+      <h1>{props.create ? 'Opprett' : 'Endre'} applikasjon</h1>
 
       <Form onSubmit={props.handleSubmit(submit)}>
         <Field


### PR DESCRIPTION
As mentioned in #3407, there was some clean ups that I wanted to make. There are two remaining tables in the BDB that I've started to work on, but whilst doing so I realized that the entire BDB codebase needs a retouch, not just the tables. Since I'm not sure when I'll finish that, it's nice to get this in before.

---

[Clean up oauth2 tables](https://github.com/webkom/lego-webapp/commit/6ed34027a0726b537e3eec680c4e7a290f3d782c) 

Most notably, they now use the `<Table/>` component, but I've also made some minor adjustments/improvements.

### Before
<img width="869" alt="Screenshot 2023-01-14 at 14 35 38" src="https://user-images.githubusercontent.com/69514187/212474535-64ea01bd-6c35-441b-9a46-274210fbc6c0.png">

### After
<img width="869" alt="image" src="https://user-images.githubusercontent.com/69514187/212474289-c1f58995-9f03-4082-bbca-2d71aaf65a40.png">

<img width="869" alt="Screenshot 2023-01-14 at 14 30 49" src="https://user-images.githubusercontent.com/69514187/212474284-173d8e7e-8129-48f9-85f7-1d828e9e56f0.png">

A feature that is very much not needed, but I had some spare time ..

https://user-images.githubusercontent.com/69514187/212474849-adbb9dd5-f2e2-4aec-b7cf-6082df05b2bf.mov

### Before
<img width="869" alt="image" src="https://user-images.githubusercontent.com/69514187/212474576-f7df465a-1cb0-4a7a-974b-4e1cb0357485.png">

### After
<img width="869" alt="image" src="https://user-images.githubusercontent.com/69514187/212474628-f29b4117-0bcc-495c-99b2-e4eb39e88755.png">

<img width="869" alt="Screenshot 2023-01-14 at 14 37 38" src="https://user-images.githubusercontent.com/69514187/212485706-f572bf30-1af1-477c-8d7c-b0281067bcc4.png">

---

[Make the table selectors more specific](https://github.com/webkom/lego-webapp/commit/a5389291e4c08e8c7227b41ef493c8873da7b168) 

The current "unspecific" CSS would sometimes affect other tables which had nothing to do
with the `<Table/>` component.

### Example of bug
Very nondeterministic, and a little refresh corrects it.
<img width="332" alt="image" src="https://user-images.githubusercontent.com/69514187/212474965-82788ba6-2eed-49d2-92bf-60b3f63e200d.png">
