### PR TITLE
Handle outside clicks properly on reactions modal

### DIFF
--- a/app/components/Reactions/index.tsx
+++ b/app/components/Reactions/index.tsx
@@ -81,7 +81,7 @@ class Reactions extends Component<Props, State> {
   };
 
   handleOutsideClick = (e) => {
-    if (this.node.current && this.node.current.contains(e.target)) {
+    if (this.node?.current?.contains(e.target)) {
       return;
     }
 


### PR DESCRIPTION
# Description

It is currently impossible to close the reactions modal, because `this.node` will be undefined.

Introduced in https://github.com/webkom/lego-webapp/pull/3262/files#diff-8d572e7c201a00b5932067713ac2f6df7f84f11cf3ccbbdd4d87ac6bdd3945e0R84.

# Testing

- [x] I have thoroughly tested my changes.

You can now close it, either by reacting or by clicking outside.