### PR TITLE
Make table CSS more specific

### DIFF
--- a/app/routes/users/components/UserSettingsNotifications.css
+++ b/app/routes/users/components/UserSettingsNotifications.css
@@ -7,6 +7,6 @@
 }
 
 /* Override the Checkbox alignment from flex-start to center */
-td div {
-  justify-content: center !important;
+.table td div {
+  justify-content: center;
 }


### PR DESCRIPTION
# Description

This was overlooked since it is not an issue in the local build ..

<img width="332" alt="image" src="https://user-images.githubusercontent.com/69514187/213581040-46b57228-bcaf-4516-9544-deffc4bc1410.png">

# Testing

- [ ] I have thoroughly tested my changes.

I have not been able to test it, since it is not a bug locally 🤔, but this will most likely fix it. I have, however, tested that it does not break the notifications table, so it can't get any worse ..