### PR TITLE
Deep copy activationTimeMoment to prevent wrong displaytime

### DIFF
--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -227,7 +227,7 @@ export default class EventDetail extends Component<Props, State> {
 
     // The UserGrid is expanded when there's less than 5 minutes till activation
     const minUserGridRows = currentMoment.isAfter(
-      activationTimeMoment.subtract(5, 'minutes')
+      moment(activationTimeMoment).subtract(5, 'minutes')
     )
       ? MIN_USER_GRID_ROWS
       : 0;


### PR DESCRIPTION
# Description

Deep copy activationTimeMoment to prevent wrong displaytime

# Result

Now it works as intended

# Testing

- [ ] I have thoroughly tested my changes.

Works on my machine :tm: 
