### PR TITLE
Fix Event Statistics Overflow Issues

### DIFF
--- a/app/components/Chart/Chart.css
+++ b/app/components/Chart/Chart.css
@@ -1,0 +1,13 @@
+@import url('~app/styles/variables.css');
+
+.wrapOnMobile {
+  margin-top: 3rem;
+
+  @media (--mobile-device) {
+    margin-top: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+}

--- a/app/components/Chart/ChartLabel.tsx
+++ b/app/components/Chart/ChartLabel.tsx
@@ -1,6 +1,7 @@
 import type { DistributionDataPoint } from 'app/components/Chart/utils';
 import { CHART_COLORS } from 'app/components/Chart/utils';
 import { Flex } from 'app/components/Layout';
+import styles from './Chart.css';
 
 const ChartLabel = ({
   distributionData,
@@ -8,7 +9,7 @@ const ChartLabel = ({
   distributionData: DistributionDataPoint[];
 }) => {
   return (
-    <div>
+    <div className={styles.wrapOnMobile}>
       {distributionData.map((dataPoint, i) => (
         <Flex key={i} alignItems="center">
           <span

--- a/app/components/Chart/PieChart.tsx
+++ b/app/components/Chart/PieChart.tsx
@@ -13,7 +13,7 @@ const DistributionPieChart = ({
   dataKey: string;
 }) => {
   return (
-    <PieChart width={400} height={350}>
+    <PieChart width={400} height={275}>
       <Pie
         data={distributionData}
         cx={200}

--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -143,3 +143,11 @@
   margin: 0 auto;
   border-bottom: 1px solid #6772e585;
 }
+
+.noRegistrationsText {
+  text-align: center;
+}
+
+.chartContainer {
+  overflow: hidden;
+}

--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -42,7 +42,7 @@ const PieChartWithLabel = ({
   return (
     <>
       <h4>{label}</h4>
-      <Flex alignItems="center">
+      <Flex alignItems="center" style={{ marginBottom: '3rem' }} wrap={true}>
         <DistributionPieChart
           dataKey="count"
           distributionData={distributionData}
@@ -257,9 +257,9 @@ const EventAttendeeStatistics = ({
         </Flex>
       )}
       {registrations.length === 0 ? (
-        <p style={{ textAlign: 'center' }}>Ingen er påmeldt enda.</p>
+        <p className={styles.noRegistrationsText}>Ingen er påmeldt enda.</p>
       ) : (
-        <>
+        <div className={styles.chartContainer}>
           <PieChartWithLabel
             label={'Kjønnsfordeling'}
             distributionData={genderDistribution}
@@ -283,13 +283,12 @@ const EventAttendeeStatistics = ({
 
           <h4>Påmeldinger og avmeldinger per dag</h4>
           <LineChart
-            width={500}
+            width={375}
             height={300}
             data={registrationTimeDistribution}
             margin={{
-              top: 5,
+              top: 10,
               right: 30,
-              left: 20,
               bottom: 5,
             }}
           >
@@ -313,7 +312,7 @@ const EventAttendeeStatistics = ({
               activeDot={{ r: 8 }}
             />
           </LineChart>
-        </>
+        </div>
       )}
     </>
   );

--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -149,15 +149,6 @@ const createAttendeeDataPoints = (
     registrationTimeDistribution: [],
   };
 
-  const dataTekTotal: DistributionDataPoint = {
-    name: 'Datateknologi',
-    count: 0,
-  };
-  const komTekTotal: DistributionDataPoint = {
-    name: 'Kommunikasjonsteknologi og digital sikkerhet',
-    count: 0,
-  };
-
   for (const registration of registrations) {
     addRegistrationDateDataPoint(
       attendeeStatistics.registrationTimeDistribution,
@@ -173,10 +164,16 @@ const createAttendeeDataPoints = (
     const grade = registration.user.grade?.name ?? 'Ikke student';
     if (grade.includes('Datateknologi')) {
       addGenericDataPoint(attendeeStatistics.dataTekDistribution, grade);
-      dataTekTotal.count++;
+      addGenericDataPoint(
+        attendeeStatistics.totalDistribution,
+        'Datateknologi'
+      );
     } else if (grade.includes('Kommunikasjonsteknologi')) {
       addGenericDataPoint(attendeeStatistics.komTekDistribution, grade);
-      komTekTotal.count++;
+      addGenericDataPoint(
+        attendeeStatistics.totalDistribution,
+        'Kommunikasjonsteknologi og digital sikkerhet'
+      );
     } else {
       addGenericDataPoint(attendeeStatistics.totalDistribution, grade);
     }
@@ -201,9 +198,6 @@ const createAttendeeDataPoints = (
       false
     );
   }
-
-  attendeeStatistics.totalDistribution.push(dataTekTotal);
-  attendeeStatistics.totalDistribution.push(komTekTotal);
 
   sortAttendeeStatistics(attendeeStatistics);
 


### PR DESCRIPTION
# Description

Event Statistics on mobile had major overflow issues. This PR makes the stats look prettier on mobile.

# Result

### Before
![image](https://user-images.githubusercontent.com/26925695/214373687-eb8adb97-dbdf-4825-ba16-ee5d7c97791f.png)

### After
![image](https://user-images.githubusercontent.com/26925695/214373764-8fe55fc4-ef75-4ba4-819c-7136c0eaf69c.png)

# Testing

- [X] I have thoroughly tested my changes.
Tested with responsive mode in the web browser, down to a size of iPhone 8 Plus, which is a quite small phone nowadays. 

---

Resolves ABA-216
