### PR TITLE
Improve styling of the calendar

### DIFF
--- a/app/routes/events/components/Calendar.css
+++ b/app/routes/events/components/Calendar.css
@@ -8,55 +8,26 @@
   composes: contentContainer from '~app/styles/utilities.css';
 }
 
-.grid {
-  display: flex;
-  width: 100%;
-  flex-wrap: wrap;
-  margin: 0;
-}
-
 .header {
   display: flex;
   justify-content: space-between;
-  margin: 0 0 2rem;
+  align-items: center;
+  margin: 0 0 1rem;
 }
 
-.dayNumber {
-  position: absolute;
-  top: 5px;
-  right: 8px;
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, calc(100% / 7));
+  max-width: 100%;
 }
 
-.currentDay {
-  width: 29px;
-  height: 29px;
-  border-radius: 50%;
-  color: var(--color-white);
-  text-align: center;
-  background-color: var(--color-red-3);
-}
-
-.headingItem {
-  flex: 0 14.2857%;
-  color: #444;
-  text-align: right;
-  padding-right: 8px;
-  border-bottom: 2px solid var(--color-mono-gray-4);
-}
-
-html[data-theme='dark'] .headingItem {
-  color: var(--lego-font-color);
-}
-
-.day {
-  flex: 0 14.2857%;
+.cell {
+  position: relative;
+  padding-top: 26px;
+  min-height: 120px;
+  background: var(--color-white);
   border-right: var(--calendar-border);
   border-bottom: var(--calendar-border);
-  background: var(--color-white);
-  position: relative;
-  min-height: 100px;
-  padding: 20px 10px;
-  overflow-x: hidden;
 
   &:nth-child(7n + 1) {
     border-left: var(--calendar-border);
@@ -67,26 +38,77 @@ html[data-theme='dark'] .headingItem {
   }
 }
 
+.eventPill {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  padding: 2px 5px;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin: 3px;
+  line-height: 1.25;
+}
+
+.eventTitle {
+  font-size: 13px;
+  color: var(--color-white);
+}
+
+.dayNumber {
+  position: absolute;
+  top: 2px;
+  right: 5px;
+  font-size: 13px;
+}
+
+.currentDay {
+  font-size: 14px;
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  color: #fff;
+  text-align: center;
+  background-color: var(--color-event-red);
+}
+
+.popoverEventTitle {
+  font-size: 22px;
+  display: inline-block;
+  line-height: 1.3;
+  padding-bottom: 10px;
+}
+
+.popoverEventTitleText {
+  vertical-align: middle;
+}
+
+.popoverEventDescription {
+  line-height: 1.3;
+}
+
+.iconWithText {
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+}
+
+.infoIcon {
+  width: 25px;
+  display: flex;
+  justify-content: center;
+  padding-right: 0.2em;
+}
+
+.weekdayHeading {
+  padding-right: 1px;
+  text-align: right;
+  border-bottom: 1px solid var(--color-mono-gray-4);
+}
+
 .prevNextMonthDay {
-  color: var(--color-mono-gray-2);
+  color: var(--color-gray-3);
 }
 
-html[data-theme='dark'] .prevNextMonthDay {
-  color: var(--color-mono-gray-4);
-}
-
-.previousEvent a {
-  color: var(--color-dark-mono-gray-5);
-}
-
-html[data-theme='dark'] .previousEvent a {
-  color: var(--color-mono-gray-5);
-}
-
-.previousEvent span {
+.previousEvent {
   opacity: 0.5;
-}
-
-.cell {
-  composes: truncateString from '~app/styles/utilities.css';
 }

--- a/app/routes/events/components/Calendar.tsx
+++ b/app/routes/events/components/Calendar.tsx
@@ -1,6 +1,6 @@
-import { Component } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
+import Icon from 'app/components/Icon';
 import type { ActionGrant, IcalToken } from 'app/models';
 import createMonthlyCalendar from 'app/utils/createMonthlyCalendar';
 import styles from './Calendar.css';
@@ -9,55 +9,58 @@ import EventFooter from './EventFooter';
 import Toolbar from './Toolbar';
 
 const WEEKDAYS = ['Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør', 'Søn'];
+
+const pathForPrevMonth = (date: moment.Moment) => {
+  const prevMonth = date.clone().subtract(1, 'months');
+  return `${prevMonth.year()}/${prevMonth.month() + 1}`;
+};
+
+const pathForNextMonth = (date: moment.Moment) => {
+  const nextMonth = date.clone().add(1, 'months');
+  return `${nextMonth.year()}/${nextMonth.month() + 1}`;
+};
+
 type Props = {
   weekOffset: number;
-  date: moment$Moment;
+  date: moment.Moment;
   icalToken: IcalToken;
   actionGrant: ActionGrant;
 };
 
-function pathForPrevMonth(date: moment$Moment) {
-  const newDate = date.clone().subtract(1, 'months');
-  return `${newDate.year()}/${newDate.month() + 1}`;
-}
+const Calendar = (props: Props) => {
+  const { actionGrant, date, icalToken, weekOffset } = props;
+  return (
+    <div className={styles.root}>
+      <Helmet title="Kalender" />
+      <Toolbar actionGrant={actionGrant} />
 
-function pathForNextMonth(date: moment$Moment) {
-  const newDate = date.clone().add(1, 'months');
-  return `${newDate.year()}/${newDate.month() + 1}`;
-}
+      <h2 className={styles.header}>
+        <Link to={`/events/calendar/${pathForPrevMonth(date)}`}>
+          <Icon name="arrow-back" />
+        </Link>
+        <span>{date.format('MMMM YYYY')}</span>
+        <Link to={`/events/calendar/${pathForNextMonth(date)}`}>
+          <Icon name="arrow-forward" />
+        </Link>
+      </h2>
 
-export default class Calendar extends Component<Props> {
-  static defaultProps = {
-    weekOffset: 0,
-  };
-
-  render() {
-    const { actionGrant, date, icalToken } = this.props;
-    return (
-      <div className={styles.root}>
-        <Helmet title="Kalender" />
-        <Toolbar actionGrant={actionGrant} />
-
-        <h2 className={styles.header}>
-          <Link to={`/events/calendar/${pathForPrevMonth(date)}`}>«</Link>
-          <span>{date.format('MMMM YYYY')}</span>
-          <Link to={`/events/calendar/${pathForNextMonth(date)}`}>»</Link>
-        </h2>
-
-        <div className={styles.grid}>
-          {WEEKDAYS.map((d) => (
-            <div key={d} className={styles.headingItem}>
-              {d}
-            </div>
-          ))}
-          {createMonthlyCalendar(date, this.props.weekOffset).map(
-            (dateProps, i) => (
-              <CalendarCell key={i} {...(dateProps as Record<string, any>)} />
-            )
-          )}
-        </div>
-        <EventFooter icalToken={icalToken} />
+      <div className={styles.grid}>
+        {WEEKDAYS.map((d) => (
+          <div key={d} className={styles.weekdayHeading}>
+            {d}
+          </div>
+        ))}
+        {createMonthlyCalendar(date, weekOffset).map((dateProps) => (
+          <CalendarCell
+            key={dateProps.day.format('DD/MM/YY')}
+            day={dateProps.day}
+            prevOrNextMonth={dateProps.prevOrNextMonth}
+          />
+        ))}
       </div>
-    );
-  }
-}
+      <EventFooter icalToken={icalToken} />
+    </div>
+  );
+};
+
+export default Calendar;

--- a/app/routes/events/components/CalendarCell.tsx
+++ b/app/routes/events/components/CalendarCell.tsx
@@ -3,100 +3,108 @@ import moment from 'moment-timezone';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { createSelector } from 'reselect';
-import Circle from 'app/components/Circle';
+import Icon from 'app/components/Icon';
 import Pill from 'app/components/Pill';
 import Popover from 'app/components/Popover';
+import { FromToTime } from 'app/components/Time';
 import type { Event } from 'app/models';
-import { colorForEvent } from '../utils';
+import { colorForEvent, textColorForEvent } from '../utils';
 import styles from './Calendar.css';
 import type { Moment } from 'moment-timezone';
 
-const renderEvent = ({
-  id,
-  title,
-  description,
-  eventType,
-  registrationCount,
-  startTime,
-  totalCapacity,
-}: Event) => (
-  <Popover
-    key={id}
-    triggerComponent={
-      <div
-        className={cx(
-          styles.cell,
-          moment(startTime) < moment() && styles.previousEvent
-        )}
-      >
-        <span>
-          <Circle
-            color={colorForEvent(eventType)}
-            style={{
-              marginRight: '5px',
-            }}
-          />
-        </span>
-        <Link to={`/events/${id}`} title={title}>
-          {title}
-        </Link>
-      </div>
-    }
-  >
-    <div>
-      <h3 className={styles.eventItemTitle}>
-        {title}
-        {totalCapacity > 0 && (
-          <Pill
-            style={{
-              marginLeft: 10,
-            }}
+const renderEvent = (event: Event) => {
+  const {
+    id,
+    eventType,
+    title,
+    description,
+    totalCapacity,
+    registrationCount,
+  } = event;
+
+  const startTime = moment(event.startTime);
+  const endTime = moment(event.endTime);
+
+  const isPreviousEvent =
+    moment(startTime).startOf('day') < moment().startOf('day');
+
+  const pillColor = colorForEvent(eventType);
+  const titleColor = textColorForEvent(eventType);
+  return (
+    <Popover
+      triggerComponent={
+        <Link to={`/events/${id}`}>
+          <div
+            className={cx(
+              styles.eventPill,
+              isPreviousEvent && styles.previousEvent
+            )}
+            style={{ backgroundColor: pillColor }}
           >
+            <span className={styles.eventTitle} style={{ color: titleColor }}>
+              {title}
+            </span>
+          </div>
+        </Link>
+      }
+    >
+      <h3 className={styles.popoverEventTitle}>
+        <span className={styles.popoverEventTitleText}>{title}</span>
+        {totalCapacity > 0 && (
+          <Pill style={{ marginLeft: 10 }}>
             {`${registrationCount} / ${totalCapacity}`}
           </Pill>
         )}
       </h3>
+      <p className={styles.popoverEventDescription}>{description}</p>
+      <div className={styles.iconWithText}>
+        <Icon name="time-outline" className={styles.infoIcon} />
+        <strong>
+          {moment.duration(endTime.diff(startTime)) <
+          moment.duration(1, 'days') ? (
+            <span>
+              <time>{startTime.format('HH:mm')}</time> -{' '}
+              <time>{endTime.format('HH:mm')}</time>
+            </span>
+          ) : (
+            <FromToTime from={event.startTime} to={event.endTime} />
+          )}
+        </strong>
+      </div>
+      <div className={styles.iconWithText}>
+        <Icon name="location-outline" className={styles.infoIcon} />
+        <strong>{event.location}</strong>
+      </div>
+    </Popover>
+  );
+};
 
-      {description}
-    </div>
-  </Popover>
-);
-
-type CalendarCellProps = {
+type Props = {
   day: Moment;
-  className: string;
   prevOrNextMonth: boolean;
   events: Array<Event>;
 };
 
-/**
- * Represents a cell in the calendar
- */
-const CalendarCell = ({
-  day,
-  className,
-  prevOrNextMonth,
-  events = [],
-}: CalendarCellProps) => (
-  <div
-    className={cx(
-      styles.day,
-      prevOrNextMonth && styles.prevNextMonthDay,
-      className
-    )}
-  >
-    <strong
-      className={cx(
-        styles.dayNumber,
-        day.isSame(moment(), 'day') && styles.currentDay
-      )}
+const CalendarCell = (props: Props) => {
+  const { day, prevOrNextMonth, events } = props;
+  return (
+    <div
+      className={cx(styles.cell, prevOrNextMonth && styles.prevNextMonthDay)}
     >
-      {day.date()}
-    </strong>
-    {events.map(renderEvent)}
-  </div>
-);
+      <strong
+        className={cx(
+          styles.dayNumber,
+          day.isSame(moment(), 'day') && styles.currentDay
+        )}
+      >
+        {day.date()}
+      </strong>
+      {events.map(renderEvent)}
+    </div>
+  );
+};
 
+// Select events that occur on the a specific day. Events that last over multiple days will be selected for every day it takes place. However, some events, like parties, might last over midnight, and it looks kind of weird for that event to be selected for two different days. Therefore, we add the criteria that an event has to last for more 24 hours in order for it to get selected for multiple days.
 const selectEvents = createSelector(
   (state) => state.events.items,
   (state) => state.events.byId,
@@ -104,13 +112,21 @@ const selectEvents = createSelector(
   (eventIds, eventsById, day) =>
     eventIds
       .map((id) => eventsById[id])
-      .filter((event) => moment(event.startTime).isSame(day, 'day'))
+      .filter(
+        (event) =>
+          moment(event.startTime).isSame(day, 'day') ||
+          (moment(event.startTime).isSameOrBefore(day, 'day') &&
+            moment(event.endTime).isSameOrAfter(day, 'day') &&
+            moment.duration(
+              moment(event.endTime).diff(moment(event.startTime))
+            ) > moment.duration(1, 'days'))
+      )
 );
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
   return {
     events: selectEvents(state, ownProps),
   };
-}
+};
 
 export default connect(mapStateToProps)(CalendarCell);

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -30,7 +30,7 @@ export const eventTypeToString = (eventType: EventType): string => {
   return EVENT_CONSTANTS[eventType] || EVENT_CONSTANTS['other'];
 };
 // Colors for different event types
-export const COLOR_CONSTANTS: Record<EventType, string> = {
+const COLOR_CONSTANTS: Record<EventType, string> = {
   company_presentation: '#A1C34A',
   lunch_presentation: '#A1C34A',
   alternative_presentation: '#8A2BE2',
@@ -41,10 +41,28 @@ export const COLOR_CONSTANTS: Record<EventType, string> = {
   event: 'var(--color-event-red)',
   kid_event: 'var(--color-event-black)',
   other: 'var(--color-event-black)',
-};
+} as const;
 // Returns the color code of an EventType
 export const colorForEvent = (eventType: EventType) => {
   return COLOR_CONSTANTS[eventType] || COLOR_CONSTANTS['other'];
+};
+
+// Hard-coded text colors for different event types
+const TEXT_COLOR_CONSTANTS: Record<EventType, string> = {
+  company_presentation: '#000',
+  lunch_presentation: '#000',
+  alternative_presentation: '#FFF',
+  course: '#000',
+  breakfast_talk: '#000',
+  party: '#000',
+  social: '#FFF',
+  event: '#FFF',
+  kid_event: 'var(--color-white)',
+  other: 'var(--color-white)',
+} as const;
+// Returns a color that is appropriate to be used for text put on top of a background with the color code of an EventType
+export const textColorForEvent = (eventType: EventType) => {
+  return TEXT_COLOR_CONSTANTS[eventType] || TEXT_COLOR_CONSTANTS['other'];
 };
 
 type Option<T = string, K = string> = { label: T; value: K };

--- a/app/utils/createMonthlyCalendar.ts
+++ b/app/utils/createMonthlyCalendar.ts
@@ -1,19 +1,20 @@
 import { range, takeWhile, last } from 'lodash';
 import moment from 'moment-timezone';
-import type { Moment } from 'moment-timezone';
 /**
  * Generate days of an entire month.
  *
  * @TODO: memoize
  */
 
-export default function createMonthlyCalendar(
-  date: Moment,
-  weekOffset = 0
-): {
-  day: Moment;
+type CalendarDay = {
+  day: moment.Moment;
   prevOrNextMonth: boolean;
-}[] {
+};
+
+const createMonthlyCalendar = (
+  date: moment.Moment,
+  weekOffset = 0
+): CalendarDay[] => {
   const startOfMonth = date.startOf('month');
   let diff = startOfMonth.weekday() - weekOffset;
   if (diff < 0) diff += 7;
@@ -34,4 +35,6 @@ export default function createMonthlyCalendar(
     prevOrNextMonth: true,
   }));
   return [...prevMonthDays, ...currentMonthDays, ...nextMonthDays];
-}
+};
+
+export default createMonthlyCalendar;


### PR DESCRIPTION
# Notable changes
- Changed design of the event entry to a pill design
- Added time and place for the event in the popover
- Events that last over multiple days will be shown on each day they take place.
- Made the calendar taller and decreased the font size for the day numbers and weekend heading.

In addition to many minor changes like centering the registration pill in the popover, improving variable names, changing colors etc.

# Result
### Example 1 (light mode):
![before1](https://user-images.githubusercontent.com/66320400/214376828-1b171324-2386-4c73-a2bc-1669248fbffd.png)
![after1](https://user-images.githubusercontent.com/66320400/214376808-d319d3fe-160c-4059-8c81-27fbf8614fd8.png)

### Example 2 (dark mode):
![before2](https://user-images.githubusercontent.com/66320400/214376825-73361dd0-0057-4a03-b7d4-dbbb738e430f.png)
![after2](https://user-images.githubusercontent.com/66320400/214376814-7cf7d95d-c66d-41da-aeb9-526e0ff267e3.png)

### Example 3 (another month with popover):
![before4](https://user-images.githubusercontent.com/66320400/214382522-3eb5a8a5-31d0-4c2c-9287-69016c2dc9b8.jpg)
![after4](https://user-images.githubusercontent.com/66320400/214382517-1741a2df-fc56-49e8-baa6-981080f6b9ad.jpg)

# Testing

- [sort of ] I have thoroughly tested my changes.
I have scrolled through the calendar and all the months look fine.

# Notes
- I mentioned that I wanted to improve the styling of the calendar on phones. That will be implemented in a separate PR.
- I realize that the Pill-component can be used for the event pills instead of implementing it myself. I remember trying to do that when I first started on this project, but couldn't get it to work. However, I may give it another shot now.

---

Resolves [this linear task](https://linear.app/abakus-webkom/issue/ABA-176/improve-the-layout-of-the-calendar)
