### PR TITLE
Change meeting icon from calendar to people

### DIFF
--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -91,7 +91,7 @@ function AccountDropdownItems({
       <Dropdown.ListItem>
         <Link to="/meetings/" onClick={onClose}>
           Møteinnkallinger
-          <Icon name="calendar-outline" size={24} />
+          <Icon name="people-outline" size={24} />
         </Link>
       </Dropdown.ListItem>
       <Dropdown.Divider />
@@ -196,7 +196,7 @@ class Header extends Component<Props, State> {
           history.push(`/meetings/${this.props.upcomingMeeting}`);
         }}
       >
-        <Icon name="calendar" className={styles.meetingIcon} />
+        <Icon name="people" className={styles.meetingIcon} />
       </button>
     ));
     return (


### PR DESCRIPTION
# Description

Changed the meeing icons from a calendar to two people. I think the calendar icon is a bit confusing as it does not lead to the clandar page. The two people is not an ideal icon, but I think it is an improvement and can't really think of any icon that screams meeting.

I did consider something like this:
<img alt="Screenshot 2023-01-24 at 23 02 54" src="https://user-images.githubusercontent.com/8343002/214434192-2fb4a74b-7ef6-4877-b727-9458ada2e697.png" width=100 height=100>
but I don't think it looks quite right.

# Result

Before: 
![Screenshot 2023-01-24 at 23 17 26](https://user-images.githubusercontent.com/8343002/214433790-f6c9fedc-6884-4400-8222-63a2b60d2562.png)
After:
![Screenshot 2023-01-24 at 23 17 13](https://user-images.githubusercontent.com/8343002/214433802-032b693a-ee6d-4d73-a944-8b79aac842c4.png)


# Testing

- [x] I have thoroughly tested my changes.
