### PR TITLE
Correct the registration info status on the pills

### DIFF
--- a/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
@@ -115,6 +115,7 @@ const getRegistrationInfo = (pool, registration) => {
         registrationInfo.reason = `Adminpåmeldt av ${registration.createdBy.username}: ${registration.adminRegistrationReason}`;
       }
     } else {
+      registrationInfo.status = 'Påmeldt';
       registrationInfo.reason = `Adminpåmeldt: ${registration.adminRegistrationReason}`;
     }
   } else if (pool) {


### PR DESCRIPTION
# Description

When an admin registration has no creator, the status would show "Venteliste", since that's the default status. This fix corrects the status on such cases to show "Påmeldt".

I didn't even know an admin registration could have no creator, so this was never tested for before.

# Result

**Before**
<img width="520" alt="image" src="https://user-images.githubusercontent.com/69514187/214701965-5c3124db-8bc3-44d4-b10a-f7c178472276.png">

**After**
<img width="520" alt="image" src="https://user-images.githubusercontent.com/69514187/214701848-d4fa0bfe-a94e-4478-83e8-fb5cdfd143c6.png">

# Testing

- [x] I have thoroughly tested my changes.

It now shows the correct status. See images above.