### PR TITLE
Set default Pill text color to black

### DIFF
--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -58,7 +58,6 @@ const Attendance = ({ event }) => {
       <Pill
         style={{
           marginLeft: '5px',
-          color: 'black',
           whiteSpace: 'nowrap',
         }}
       >

--- a/app/components/Pill/Pill.css
+++ b/app/components/Pill/Pill.css
@@ -1,5 +1,6 @@
 .pill {
   background: var(--color-mono-gray-4);
+  color: #000;
   padding: 2px 10px;
   border-radius: 4px;
   text-transform: uppercase;


### PR DESCRIPTION
# Description
The Pill component looks ugly on dark mode since its white on light gray text. This PR hard codes the text color to be black on both dark and light mode.

# Result

Before:
![image](https://user-images.githubusercontent.com/66320400/215568891-4b83adba-916d-4728-8241-9ea72a0eec4b.png)

After:
![image](https://user-images.githubusercontent.com/66320400/215569273-69c51244-6399-4845-bafa-2bbead7b82a7.png)

# Testing

- [X] I have thoroughly tested my changes.

I have tested it for all occurrences of the Pill component.
