### PR TITLE
Fix Helmet for Server Side Rendering

### DIFF
--- a/server/pageRenderer.ts
+++ b/server/pageRenderer.ts
@@ -86,10 +86,10 @@ export default function pageRenderer({
   preparedStateCode = '',
 }: PageRendererProps = {}): string {
   const isSSR = app === undefined ? 'false' : 'true';
-  const { helmet } = helmetContext as FilledContext;
   const selectedTheme: string =
     (!isEmpty(state) && selectCurrentUser(state).selectedTheme) || 'auto';
   const { body, scripts, styles, links } = readyHtml(app);
+  const { helmet } = helmetContext as FilledContext;
   return `
     <!DOCTYPE html>
     <html data-theme=${serialize(

--- a/server/ssr.tsx
+++ b/server/ssr.tsx
@@ -74,10 +74,12 @@ const createServerSideRenderer = (req: Request, res: Response) => {
       getCookie: (key) => req.cookies[key],
     }
   );
+
   const providerData = {
     store,
     storeState: store.getState(),
   };
+
   const unsubscribe = store.subscribe(() => {
     const newStoreState = store.getState();
 
@@ -88,6 +90,7 @@ const createServerSideRenderer = (req: Request, res: Response) => {
 
     providerData.storeState = newStoreState;
   });
+
   const app = (
     <HelmetProvider context={helmetContext}>
       <ReactReduxContext.Provider value={providerData}>


### PR DESCRIPTION
# Description

The helmet component has been set after the `readyHtml(app)` now. This is just because helmetContext is based on the existing scripts and styles that 'readyHtml' produces.

# Result

Helmet should work now, with properly updated / overwritten `og` tags.

# Testing

- [X] I have (somewhat) thoroughly tested my changes.
- I have tested that different routes all successfully have inserted Helmet tags into Head


How testing was done:
Simply:
 - Build the components using `yarn build`
 - Run SSR frontend with 'yarn ssr' (local backend)
 - Inspect that different pages have their correct `<meta>` tags in `<Head>`

---

Resolves ... (either GitHub issue or Linear task)
Resolves [ABA-181](https://linear.app/abakus-webkom/issue/ABA-181/fix-helmet)
