### PR TITLE
Add models for data types fetched from LEGO

### DIFF
--- a/app/actions/CommentActions.ts
+++ b/app/actions/CommentActions.ts
@@ -1,19 +1,15 @@
 import callAPI from 'app/actions/callAPI';
-import type { ID } from 'app/models';
 import { commentSchema } from 'app/reducers';
+import type { ID } from 'app/store/models';
+import type CommentType from 'app/store/models/Comment';
 import type { Thunk } from 'app/types';
 import { Comment } from './ActionTypes';
 
-export type CommentEntity = {
-  text: string;
-  contentTarget: string;
-  parent?: number;
-};
 export function addComment({
   text,
   contentTarget,
   parent,
-}: CommentEntity): Thunk<Promise<Record<string, any> | null | undefined>> {
+}: CommentType): Thunk<Promise<Record<string, any> | null | undefined>> {
   return callAPI({
     types: Comment.ADD,
     endpoint: '/comments/',

--- a/app/components/AnnouncementInLine/index.tsx
+++ b/app/components/AnnouncementInLine/index.tsx
@@ -2,14 +2,14 @@ import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import Icon from 'app/components/Icon';
 import { useAppSelector } from 'app/store/hooks';
-import type { AnyEvent } from 'app/store/models/Event';
-import type { AnyGroup } from 'app/store/models/Group';
-import type { AnyMeeting } from 'app/store/models/Meeting';
+import type { UnknownEvent } from 'app/store/models/Event';
+import type { UnknownGroup } from 'app/store/models/Group';
+import type { UnknownMeeting } from 'app/store/models/Meeting';
 
 type Props = {
-  event?: AnyEvent;
-  meeting?: AnyMeeting;
-  group?: AnyGroup;
+  event?: UnknownEvent;
+  meeting?: UnknownMeeting;
+  group?: UnknownGroup;
 };
 
 const AnnouncementInLine = ({ event, meeting, group }: Props) => {

--- a/app/components/AnnouncementInLine/index.tsx
+++ b/app/components/AnnouncementInLine/index.tsx
@@ -1,13 +1,15 @@
 import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import Icon from 'app/components/Icon';
-import type { Group, Event, Meeting } from 'app/models';
 import { useAppSelector } from 'app/store/hooks';
+import type { AnyEvent } from 'app/store/models/Event';
+import type { AnyGroup } from 'app/store/models/Group';
+import type { AnyMeeting } from 'app/store/models/Meeting';
 
 type Props = {
-  event?: Event;
-  meeting?: Meeting;
-  group?: Group;
+  event?: AnyEvent;
+  meeting?: AnyMeeting;
+  group?: AnyGroup;
 };
 
 const AnnouncementInLine = ({ event, meeting, group }: Props) => {

--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -8,21 +8,23 @@ import { EditorField } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { ProfilePicture } from 'app/components/Image';
-import type { User } from 'app/models';
 import { useAppDispatch } from 'app/store/hooks';
+import type { ID } from 'app/store/models';
+import type { CurrentUser } from 'app/store/models/User';
 import { EDITOR_EMPTY } from 'app/utils/constants';
 import { createValidator, legoEditorRequired } from 'app/utils/validation';
 import styles from './CommentForm.css';
 
 type Props = {
   contentTarget: string;
-  user: User;
+  user: CurrentUser;
   loggedIn: boolean;
   submitText?: string;
   inlineMode?: boolean;
   autoFocus?: boolean;
-  parent?: number;
+  parent?: ID;
 };
+
 const validate = createValidator({
   text: [legoEditorRequired('Kommentaren kan ikke være tom')],
 });

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -5,7 +5,9 @@ import DisplayContent from 'app/components/DisplayContent';
 import { ProfilePicture } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import Time from 'app/components/Time';
-import type { ID, Comment as CommentType, User } from 'app/models';
+import type { ID } from 'app/store/models';
+import type CommentType from 'app/store/models/Comment';
+import type { CurrentUser } from 'app/store/models/User';
 import Button from '../Button';
 import styles from './Comment.css';
 
@@ -13,11 +15,11 @@ type Props = {
   comment: CommentType;
   commentFormProps: {
     contentTarget: string;
-    user: User;
+    user: CurrentUser;
     loggedIn: boolean;
   };
   deleteComment: (id: ID, contentTarget: string) => Promise<void>;
-  user: User;
+  user: CurrentUser;
   contentTarget: string;
 };
 type State = {

--- a/app/components/Comments/CommentTree.tsx
+++ b/app/components/Comments/CommentTree.tsx
@@ -1,5 +1,7 @@
 import cx from 'classnames';
-import type { ID, Comment as CommentType, User } from 'app/models';
+import type { ID } from 'app/store/models';
+import type CommentType from 'app/store/models/Comment';
+import type { CurrentUser } from 'app/store/models/User';
 import type { Tree } from 'app/utils';
 import Comment from './Comment';
 import styles from './CommentTree.css';
@@ -9,12 +11,12 @@ type Props = {
   isChild?: boolean;
   commentFormProps: {
     contentTarget: string;
-    user: User;
+    user: CurrentUser;
     loggedIn: boolean;
   };
   level?: number;
   deleteComment: (id: ID, contentTarget: string) => Promise<void>;
-  user: User;
+  user: CurrentUser;
   contentTarget: string;
 };
 

--- a/app/components/Comments/CommentView.tsx
+++ b/app/components/Comments/CommentView.tsx
@@ -1,19 +1,21 @@
 import CommentForm from 'app/components/CommentForm';
 import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
-import type { ID, Comment, User } from 'app/models';
+import type { ID } from 'app/store/models';
+import type Comment from 'app/store/models/Comment';
+import type { CurrentUser } from 'app/store/models/User';
 import { generateTreeStructure } from 'app/utils';
 import CommentTree from './CommentTree';
-import type { StyleHTMLAttributes } from 'react';
+import type { CSSProperties } from 'react';
 
 type Props = {
   comments: Array<Comment>;
   formDisabled?: boolean;
   contentTarget: string;
-  user: User;
+  user: CurrentUser;
   loggedIn: boolean;
   displayTitle?: boolean;
-  style?: StyleHTMLAttributes<HTMLDivElement>;
+  style?: CSSProperties;
   newOnTop?: boolean;
   deleteComment: (id: ID, contentTarget: string) => Promise<void>;
 };

--- a/app/components/Comments/__tests__/Comment.spec.tsx
+++ b/app/components/Comments/__tests__/Comment.spec.tsx
@@ -1,10 +1,13 @@
 import { shallow } from 'enzyme';
+import type CommentType from 'app/store/models/Comment';
 import Comment from '../Comment';
 
-const comment = {
+const comment: CommentType = {
   id: 1,
   text: 'this is a nice comment',
   createdAt: '2016-02-02T22:17:21.838103Z',
+  updatedAt: '2016-02-02T22:17:21.838103Z',
+  contentTarget: 'event-1',
   author: {
     id: 1,
     username: 'cat',
@@ -14,6 +17,7 @@ const comment = {
     lastName: 'Catson',
     profilePicture: 'picture',
   },
+  parent: null,
 };
 describe('components', () => {
   describe('Comment', () => {

--- a/app/components/Comments/__tests__/CommentTree.spec.tsx
+++ b/app/components/Comments/__tests__/CommentTree.spec.tsx
@@ -1,6 +1,6 @@
 import { mount, shallow } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
-import { generateTreeStructure } from '../../../utils';
+import { generateTreeStructure } from 'app/utils';
 import CommentTree from '../CommentTree';
 import comments from './fixtures/comments';
 

--- a/app/components/Comments/__tests__/fixtures/comments.ts
+++ b/app/components/Comments/__tests__/fixtures/comments.ts
@@ -1,10 +1,12 @@
-const comments = [
+import type Comment from 'app/store/models/Comment';
+
+const comments: Comment[] = [
   {
     id: 2,
     text: 'blaargarhgh',
     createdAt: '2016-02-02T22:17:21.838103Z',
     updatedAt: '2016-02-02T22:17:21.838103Z',
-    source: 'event-1',
+    contentTarget: 'event-1',
     author: {
       id: 1,
       username: 'webkom',
@@ -13,13 +15,14 @@ const comments = [
       fullName: 'webkom webkom',
       profilePicture: 'https://example.picture/profile.png',
     },
+    parent: null,
   },
   {
     id: 3,
     text: 'sure man',
     createdAt: '2016-02-04T22:17:21.838103Z',
     updatedAt: '2016-02-04T22:17:21.838103Z',
-    source: 'event-1',
+    contentTarget: 'event-1',
     author: {
       id: 2,
       username: 'plebkom',
@@ -28,6 +31,7 @@ const comments = [
       fullName: 'plebkom lelkom',
       profilePicture: 'https://example.picture/profile.png',
     },
+    parent: null,
   },
   {
     id: 4,
@@ -35,7 +39,7 @@ const comments = [
     text: 'how can mirrors be real',
     createdAt: '2016-02-04T22:17:21.838103Z',
     updatedAt: '2016-02-04T22:17:21.838103Z',
-    source: 'event-1',
+    contentTarget: 'event-1',
     author: {
       id: 1,
       username: 'webkom',

--- a/app/components/Content/ContentHeader.tsx
+++ b/app/components/Content/ContentHeader.tsx
@@ -11,6 +11,7 @@ type Props = {
   event?: Event;
   color?: string;
 } & HTMLAttributes<HTMLDivElement>;
+
 const DEFAULT_BORDER_COLOR = '#FCD748';
 
 /**

--- a/app/models.ts
+++ b/app/models.ts
@@ -347,20 +347,6 @@ export type Meeting = {
   actionGrant?: ActionGrant;
 };
 
-export type Announcement = {
-  id: ID;
-  message: string;
-  users: User[];
-  groups: Group[];
-  events: Event[];
-  meetings: Meeting[];
-  fromGroup: Group;
-  sent?: Dateish;
-};
-
-export type CreateAnnouncement = Announcement & {
-  send: boolean | null | undefined;
-};
 export type AddPenalty = {
   id: ID;
   user: ID;

--- a/app/models.ts
+++ b/app/models.ts
@@ -1,3 +1,4 @@
+import type Comment from 'app/store/models/Comment';
 import type { Moment } from 'moment';
 // TODO: Id handling could be opaque
 export type ID = number;
@@ -177,22 +178,6 @@ type EventBase = {
 
 export type Company = Record<string, any>;
 
-export type Comment = {
-  id: ID;
-  text: string;
-  author: Pick<
-    User,
-    | 'profilePicture'
-    | 'profilePicturePlaceholder'
-    | 'username'
-    | 'id'
-    | 'fullName'
-  >;
-  createdAt: Dateish;
-  updatedAt: Dateish;
-  parent?: ID;
-};
-
 export type Permission = string;
 export type EventRegistrationPresence = 'PRESENT' | 'NOT_PRESENT' | 'UNKNOWN';
 export type LEGACY_EventRegistrationPhotoConsent =
@@ -257,7 +242,7 @@ export type Event = EventBase & {
   totalCapacity: number;
   thumbnail: string | null | undefined;
   company: Company;
-  comments: Array<Comment>;
+  comments: Comment[];
   contentTarget: string;
   pools: Array<EventPool>;
   survey: ID | null | undefined;

--- a/app/models.ts
+++ b/app/models.ts
@@ -279,18 +279,6 @@ export type UserFollowing = {
   follower: User;
   target: ID;
 };
-export type Article = {
-  id: ID;
-  title: string;
-  cover: string;
-  coverPlaceholder: string;
-  author: ID;
-  description: string;
-  tags: Tags[];
-  createdAt: Dateish;
-  pinned: boolean;
-  documentType?: 'article';
-};
 export type Feed = Record<string, any>;
 export type FeedItem = Record<string, any>;
 

--- a/app/models.ts
+++ b/app/models.ts
@@ -176,8 +176,6 @@ type EventBase = {
   legacyRegistrationCount: number;
 };
 
-export type Company = Record<string, any>;
-
 export type Permission = string;
 export type EventRegistrationPresence = 'PRESENT' | 'NOT_PRESENT' | 'UNKNOWN';
 export type LEGACY_EventRegistrationPhotoConsent =

--- a/app/reducers/articles.ts
+++ b/app/reducers/articles.ts
@@ -1,32 +1,13 @@
 import { orderBy } from 'lodash';
 import { createSelector } from 'reselect';
-import type { Article as ArticleType } from 'app/models';
 import { mutateComments } from 'app/reducers/comments';
-import type { ReactionEntity } from 'app/reducers/reactions';
 import { mutateReactions } from 'app/reducers/reactions';
+import { typeable } from 'app/reducers/utils';
+import type { UnknownArticle } from 'app/store/models/Article';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
 import { Article } from '../actions/ActionTypes';
 
-export type ArticleEntity = {
-  id: number;
-  title: string;
-  contentTarget: string;
-  description: string;
-  author: Record<string, any>;
-  cover: string;
-  coverPlaceholder: string;
-  createdAt: string;
-  content: string;
-  startTime: string;
-  text: string;
-  tags: Array<string>;
-  reactionsGrouped: Array<ReactionEntity>;
-  reactions: Array<ReactionEntity>;
-  actionGrant: Record<string, any>;
-  comments: Array<number>;
-  youtubeUrl: string;
-};
 export default createEntityReducer({
   key: 'articles',
   types: {
@@ -41,18 +22,20 @@ function transformArticle(article) {
   return { ...article };
 }
 
-export const selectArticles = createSelector(
-  (state) => state.articles.byId,
-  (state) => state.articles.items,
-  (_, props) => props && props.pagination,
-  (articlesById, articleIds, pagination) =>
-    orderBy<ArticleType>(
-      (pagination ? pagination.items : articleIds).map((id) =>
-        transformArticle(articlesById[id])
-      ) as ReadonlyArray<ArticleType>,
-      ['createdAt', 'id'],
-      ['desc', 'desc']
-    )
+export const selectArticles = typeable(
+  createSelector(
+    (state) => state.articles.byId,
+    (state) => state.articles.items,
+    (_, props) => props && props.pagination,
+    (articlesById, articleIds, pagination) =>
+      orderBy<UnknownArticle>(
+        (pagination ? pagination.items : articleIds).map((id) =>
+          transformArticle(articlesById[id])
+        ) as ReadonlyArray<UnknownArticle>,
+        ['createdAt', 'id'],
+        ['desc', 'desc']
+      )
+  )
 );
 export const selectArticlesByTag = createSelector(
   selectArticles,

--- a/app/reducers/frontpage.ts
+++ b/app/reducers/frontpage.ts
@@ -2,13 +2,23 @@ import { sortBy } from 'lodash';
 import moment from 'moment-timezone';
 import { createSelector } from 'reselect';
 import { Frontpage } from 'app/actions/ActionTypes';
-import type { Article, Event } from 'app/models';
+import type { Event } from 'app/models';
+import type { UnknownArticle } from 'app/store/models/Article';
 import { fetching } from 'app/utils/createEntityReducer';
 import { selectArticles } from './articles';
 import { selectEvents } from './events';
 
-const isEvent = (item: Article | Event): item is Event =>
-  item.documentType === 'event';
+export type WithDocumentType<T> = T & {
+  documentType: 'event' | 'article';
+};
+
+export const isEvent = <T extends Event>(
+  item: WithDocumentType<T | unknown>
+): item is WithDocumentType<T> => item.documentType === 'event';
+
+export const isArticle = <T extends UnknownArticle>(
+  item: WithDocumentType<T | unknown>
+): item is WithDocumentType<T> => item.documentType === 'article';
 
 export default fetching(Frontpage.FETCH);
 export const selectFrontpage = createSelector(
@@ -30,7 +40,7 @@ export const selectFrontpage = createSelector(
         // Always sort pinned items first:
         (item) => !item.pinned,
         (item) => {
-          // For events we care about when the event starts, whereas for articles
+          // For events, we care about when the event starts, whereas for articles
           // we look at when it was written:
           const timeField = isEvent(item) ? item.startTime : item.createdAt;
           return Math.abs(now.diff(timeField));

--- a/app/reducers/search.ts
+++ b/app/reducers/search.ts
@@ -2,10 +2,11 @@ import { produce } from 'immer';
 import { get } from 'lodash';
 import moment from 'moment-timezone';
 import { createSelector } from 'reselect';
-import type { User, Event, Company, Group, Meeting, Dateish } from 'app/models';
+import type { User, Event, Group, Meeting, Dateish } from 'app/models';
 import { resolveGroupLink } from 'app/reducers/groups';
 import { categoryOptions } from 'app/routes/pages/PageDetailRoute';
 import type { SearchArticle } from 'app/store/models/Article';
+import type { SearchCompany } from 'app/store/models/Company';
 import { Search } from '../actions/ActionTypes';
 
 type SearchResultBase = {
@@ -45,7 +46,7 @@ interface SearchMapping {
   'events.event': SearchResultMapping<Event>;
   'flatpages.page': SearchResultMapping<Record<string, string>>;
   'gallery.gallery': SearchResultMapping<any>;
-  'companies.company': SearchResultMapping<Company>;
+  'companies.company': SearchResultMapping<SearchCompany>;
   'tags.tag': SearchResultMapping<Record<string, string>>;
   'users.abakusgroup': SearchResultMapping<Group>;
   'meetings.meeting': SearchResultMapping<Meeting>;

--- a/app/reducers/search.ts
+++ b/app/reducers/search.ts
@@ -2,17 +2,10 @@ import { produce } from 'immer';
 import { get } from 'lodash';
 import moment from 'moment-timezone';
 import { createSelector } from 'reselect';
-import type {
-  User,
-  Article,
-  Event,
-  Company,
-  Group,
-  Meeting,
-  Dateish,
-} from 'app/models';
+import type { User, Event, Company, Group, Meeting, Dateish } from 'app/models';
 import { resolveGroupLink } from 'app/reducers/groups';
 import { categoryOptions } from 'app/routes/pages/PageDetailRoute';
+import type { SearchArticle } from 'app/store/models/Article';
 import { Search } from '../actions/ActionTypes';
 
 type SearchResultBase = {
@@ -48,7 +41,7 @@ export const isUserResult = (value: SearchResult): value is UserSearchResult =>
 
 interface SearchMapping {
   'users.user': SearchResultMapping<User, UserSearchResult>;
-  'articles.article': SearchResultMapping<Article>;
+  'articles.article': SearchResultMapping<SearchArticle>;
   'events.event': SearchResultMapping<Event>;
   'flatpages.page': SearchResultMapping<Record<string, string>>;
   'gallery.gallery': SearchResultMapping<any>;

--- a/app/reducers/utils.ts
+++ b/app/reducers/utils.ts
@@ -1,0 +1,13 @@
+import type { Selector } from 'reselect';
+
+/*
+Helper for allowing type overrides on selector functions
+F.ex. the article selector selects UnknownArticle from the store, but we know it will be a PublicArticle
+With this we can write selectArticles<PublicArticle[]>(...)
+ */
+export const typeable =
+  <State, Result, Params extends never | readonly any[] = any[]>(
+    selector: Selector<State, Result, Params>
+  ) =>
+  <T extends Result = Result>(state: State, ...params: Params) =>
+    selector(state, ...params) as unknown as T;

--- a/app/routes/announcements/components/AnnouncementItem.tsx
+++ b/app/routes/announcements/components/AnnouncementItem.tsx
@@ -2,13 +2,15 @@ import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import Flex from 'app/components/Layout/Flex';
 import Time from 'app/components/Time';
-import type { ActionGrant, Announcement, ID } from 'app/models';
+import type { ActionGrant } from 'app/models';
+import type { ID } from 'app/store/models';
+import type { DetailedAnnouncement } from 'app/store/models/Announcement';
 import styles from './AnnouncementsList.css';
 
 type Props = {
-  announcement: Announcement;
-  sendAnnouncement: (arg0: ID) => Promise<any>;
-  deleteAnnouncement: (arg0: ID) => Promise<any>;
+  announcement: DetailedAnnouncement;
+  sendAnnouncement: (id: ID) => Promise<unknown>;
+  deleteAnnouncement: (id: ID) => Promise<unknown>;
   actionGrant: ActionGrant;
 };
 

--- a/app/routes/announcements/components/AnnouncementsCreate.tsx
+++ b/app/routes/announcements/components/AnnouncementsCreate.tsx
@@ -5,14 +5,17 @@ import Button from 'app/components/Button';
 import { ContentMain } from 'app/components/Content';
 import { Form, SelectInput, TextArea } from 'app/components/Form';
 import Flex from 'app/components/Layout/Flex';
-import type { ActionGrant, CreateAnnouncement } from 'app/models';
+import type { ActionGrant } from 'app/models';
 import { selectAutocomplete } from 'app/reducers/search';
+import type { DetailedAnnouncement } from 'app/store/models/Announcement';
 import styles from './AnnouncementsList.css';
 
 type Props = {
-  createAnnouncement: (arg0: CreateAnnouncement) => Promise<any>;
+  createAnnouncement: (
+    announcement: DetailedAnnouncement & { send: boolean }
+  ) => Promise<unknown>;
   actionGrant: ActionGrant;
-  handleSubmit: (arg0: (...args: Array<any>) => any) => void;
+  handleSubmit: (arg0: (...args: Array<any>) => any) => any;
   invalid: boolean;
   pristine: boolean;
   submitting: boolean;

--- a/app/routes/announcements/components/AnnouncementsList.tsx
+++ b/app/routes/announcements/components/AnnouncementsList.tsx
@@ -1,22 +1,23 @@
 import { Content, ContentMain } from 'app/components/Content';
 import Flex from 'app/components/Layout/Flex';
+import type { ActionGrant } from 'app/models';
+import type { ID } from 'app/store/models';
 import type {
-  ActionGrant,
-  Announcement,
-  CreateAnnouncement,
-  ID,
-} from 'app/models';
+  DetailedAnnouncement,
+  ListAnnouncement,
+} from 'app/store/models/Announcement';
 import AnnouncementItem from './AnnouncementItem';
 import AnnouncementsCreate from './AnnouncementsCreate';
 import styles from './AnnouncementsList.css';
 
 type Props = {
-  announcement: Announcement;
-  announcements: Array<Announcement>;
+  announcements: Array<ListAnnouncement>;
   actionGrant: ActionGrant;
-  sendAnnouncement: (arg0: ID) => Promise<any>;
-  createAnnouncement: (arg0: CreateAnnouncement) => Promise<any>;
-  deleteAnnouncement: (arg0: ID) => Promise<any>;
+  sendAnnouncement: (id: ID) => Promise<unknown>;
+  createAnnouncement: (
+    announcement: DetailedAnnouncement & { send: boolean }
+  ) => Promise<unknown>;
+  deleteAnnouncement: (id: ID) => Promise<unknown>;
   handleSubmit: (arg0: (...args: Array<any>) => any) => void;
   invalid: string;
   pristine: string;

--- a/app/routes/articles/ArticleDetailRoute.ts
+++ b/app/routes/articles/ArticleDetailRoute.ts
@@ -10,6 +10,8 @@ import {
 } from 'app/reducers/articles';
 import { selectEmojis } from 'app/reducers/emojis';
 import { selectUserById } from 'app/reducers/users';
+import type { PublicArticle } from 'app/store/models/Article';
+import type { PublicUser } from 'app/store/models/User';
 import helmet from 'app/utils/helmet';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
@@ -54,7 +56,7 @@ export default compose(
   ),
   connect(mapStateToProps, mapDispatchToProps),
   loadingIndicator(['article.content']),
-  helmet((props, config) => {
+  helmet((props: { article: PublicArticle; author: PublicUser }, config) => {
     const tags = props.article.tags.map((content) => ({
       content,
       property: 'article:tag',
@@ -95,7 +97,7 @@ export default compose(
       },
       {
         property: 'article:published_time',
-        content: props.article.createdAt,
+        content: props.article.createdAt.toString(),
       },
       {
         property: 'og:description',

--- a/app/routes/articles/ArticleListRoute.ts
+++ b/app/routes/articles/ArticleListRoute.ts
@@ -7,8 +7,14 @@ import { selectArticles } from 'app/reducers/articles';
 import { selectPaginationNext } from 'app/reducers/selectors';
 import { selectPopularTags } from 'app/reducers/tags';
 import { selectUserById } from 'app/reducers/users';
+import type { PublicArticle } from 'app/store/models/Article';
+import type { PublicUser } from 'app/store/models/User';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import Overview from './components/Overview';
+
+export type ArticleWithAuthorDetails = Omit<PublicArticle, 'author'> & {
+  author: PublicUser;
+};
 
 const mapStateToProps = (state, props) => {
   const query = {
@@ -21,15 +27,20 @@ const mapStateToProps = (state, props) => {
     query,
     entity: 'articles',
   })(state);
-  return {
-    articles: selectArticles(state, {
+  const articles: ArticleWithAuthorDetails[] = selectArticles<PublicArticle[]>(
+    state,
+    {
       pagination,
-    }).map((article) => ({
-      ...article,
-      author: selectUserById(state, {
-        userId: article.author,
-      }),
-    })),
+    }
+  ).map((article) => ({
+    ...article,
+    author: selectUserById(state, {
+      userId: article.author,
+    }),
+  }));
+
+  return {
+    articles,
     fetching: state.articles.fetching,
     hasMore: pagination.hasMore,
     tags: selectPopularTags(state),

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -8,28 +8,34 @@ import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
 import Tags from 'app/components/Tags';
 import Tag from 'app/components/Tags/Tag';
 import type { ID } from 'app/models';
-import type { ArticleEntity } from 'app/reducers/articles';
-import type { CommentEntity } from 'app/reducers/comments';
 import type { EmojiEntity } from 'app/reducers/emojis';
 import type { ReactionEntity } from 'app/reducers/reactions';
-import type { UserEntity } from 'app/reducers/users';
+import type {
+  AdminDetailedArticle,
+  DetailedArticle,
+} from 'app/store/models/Article';
+import type Comment from 'app/store/models/Comment';
+import type { CurrentUser, DetailedUser } from 'app/store/models/User';
 import styles from './ArticleDetail.css';
 
 type Props = {
-  article: ArticleEntity;
-  comments: Array<CommentEntity>;
+  article: DetailedArticle | AdminDetailedArticle;
+  comments: Array<Comment>;
   loggedIn: boolean;
-  author: UserEntity;
-  currentUser: UserEntity;
-  deleteComment: (id: ID, contentTarget: string) => Promise<any>;
+  author: DetailedUser;
+  currentUser: CurrentUser;
+  deleteComment: (id: ID, contentTarget: string) => Promise<void>;
   emojis: Array<EmojiEntity>;
-  addReaction: (arg0: { emoji: string; contentTarget: string }) => Promise<any>;
+  addReaction: (arg0: {
+    emoji: string;
+    contentTarget: string;
+  }) => Promise<unknown>;
   reactionsGrouped: Array<ReactionEntity>;
   deleteReaction: (arg0: {
     reactionId: ID;
     contentTarget: string;
-  }) => Promise<any>;
-  fetchEmojis: () => Promise<any>;
+  }) => Promise<void>;
+  fetchEmojis: () => Promise<void>;
   fetchingEmojis: boolean;
 };
 
@@ -96,7 +102,6 @@ const ArticleDetail = ({
 
       {article.contentTarget && (
         <CommentView
-          formEnabled
           user={currentUser}
           contentTarget={article.contentTarget}
           loggedIn={loggedIn}

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -20,7 +20,7 @@ import styles from './ArticleDetail.css';
 
 type Props = {
   article: DetailedArticle | AdminDetailedArticle;
-  comments: Array<Comment>;
+  comments: Comment[];
   loggedIn: boolean;
   author: DetailedUser;
   currentUser: CurrentUser;

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -18,19 +18,18 @@ import Flex from 'app/components/Layout/Flex';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import NavigationTab from 'app/components/NavigationTab';
 import Tooltip from 'app/components/Tooltip';
-import type { ArticleEntity } from 'app/reducers/articles';
-import type { UserEntity } from 'app/reducers/users';
+import type { DetailedArticle } from 'app/store/models/Article';
+import type { CurrentUser } from 'app/store/models/User';
 import { createValidator, validYoutubeUrl } from 'app/utils/validation';
-import styles from './ArticleEditor.css';
 
 export type Props = {
-  article?: ArticleEntity;
+  article?: DetailedArticle;
   articleId: number;
-  currentUser: UserEntity;
+  currentUser: CurrentUser;
   isNew: boolean;
   handleSubmit: (arg0: Record<string, any>) => void;
-  submitArticle: (arg0: Record<string, any>) => Promise<any>;
-  deleteArticle: (arg0: number) => Promise<any>;
+  submitArticle: (arg0: Record<string, any>) => Promise<void>;
+  deleteArticle: (arg0: number) => Promise<void>;
   push: (arg0: string) => void;
   initialized: boolean;
 };
@@ -108,8 +107,6 @@ const ArticleEditor = ({
           label="Festet på forsiden"
           name="pinned"
           component={CheckBox.Field}
-          fieldClassName={styles.metaField}
-          className={styles.formField}
           normalize={(v) => !!v}
         />
         <Field

--- a/app/routes/articles/components/Overview.tsx
+++ b/app/routes/articles/components/Overview.tsx
@@ -9,12 +9,12 @@ import Tags from 'app/components/Tags';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';
 import type { ActionGrant } from 'app/models';
-import type { ArticleEntity } from 'app/reducers/articles';
+import type { ArticleWithAuthorDetails } from 'app/routes/articles/ArticleListRoute';
 import styles from './Overview.css';
 
 const HEADLINE_EVENTS = 2;
 
-const OverviewItem = ({ article }: { article: ArticleEntity }) => (
+const OverviewItem = ({ article }: { article: ArticleWithAuthorDetails }) => (
   <div className={styles.item}>
     <Link to={`/articles/${article.id}`} className={styles.imageLink}>
       <Image src={article.cover} placeholder={article.coverPlaceholder} />
@@ -48,7 +48,7 @@ const OverviewItem = ({ article }: { article: ArticleEntity }) => (
 );
 
 type Props = {
-  articles: Array<Record<string, any>>;
+  articles: ArticleWithAuthorDetails[];
   fetching: boolean;
   hasMore: boolean;
   fetchAll: (arg0: { next?: boolean }) => Promise<any>;

--- a/app/routes/bdb/components/BdbDetail.tsx
+++ b/app/routes/bdb/components/BdbDetail.tsx
@@ -10,7 +10,7 @@ import LoadingIndicator from 'app/components/LoadingIndicator';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
-import type { CompanySemesterContactedStatus, ID } from 'app/models';
+import type { CompanySemesterContactedStatus } from 'app/models';
 import type {
   CompanyEntity,
   BaseSemesterStatusEntity,
@@ -19,6 +19,9 @@ import type {
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import type { UserEntity } from 'app/reducers/users';
 import { EVENT_CONSTANTS } from 'app/routes/events/utils';
+import type { ID } from 'app/store/models';
+import type Comment from 'app/store/models/Comment';
+import type { CurrentUser } from 'app/store/models/User';
 import truncateString from 'app/utils/truncateString';
 import {
   sortByYearThenSemester,
@@ -30,9 +33,9 @@ import styles from './bdb.css';
 
 type Props = {
   company: CompanyEntity;
-  comments: Array<Record<string, any>>;
+  comments: Comment[];
   companyEvents: Array<Record<string, any>>;
-  currentUser: any;
+  currentUser: CurrentUser;
   deleteSemesterStatus: (arg0: number, arg1: number) => Promise<any>;
   deleteCompanyContact: (arg0: number, arg1: number) => Promise<any>;
   loggedIn: boolean;
@@ -41,7 +44,6 @@ type Props = {
     arg0: BaseSemesterStatusEntity,
     arg1: Record<string, any> | null | undefined
   ) => Promise<any>;
-  companyEvents: Array<Record<string, any>>;
   fetching: boolean;
   editCompany: (arg0: Record<string, any>) => void;
   deleteCompany: (arg0: number) => Promise<any>;

--- a/app/routes/company/CompaniesRoute.ts
+++ b/app/routes/company/CompaniesRoute.ts
@@ -3,14 +3,14 @@ import { compose } from 'redux';
 import { fetchAll } from 'app/actions/CompanyActions';
 import { LoginPage } from 'app/components/LoginForm';
 import { selectActiveCompanies } from 'app/reducers/companies';
+import { selectPaginationNext } from 'app/reducers/selectors';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
-import { selectPaginationNext } from '../../reducers/selectors';
 import CompaniesPage from './components/CompaniesPage';
 
 const mapStateToProps = (state, props) => {
   const { query } = props.location;
-  const companies = selectActiveCompanies(state, props);
+  const companies = selectActiveCompanies(state);
   const { pagination } = selectPaginationNext({
     query: {},
     entity: 'companies',

--- a/app/routes/company/CompanyDetailRoute.ts
+++ b/app/routes/company/CompanyDetailRoute.ts
@@ -10,10 +10,10 @@ import {
   selectEventsForCompany,
   selectJoblistingsForCompany,
 } from 'app/reducers/companies';
+import { selectPagination } from 'app/reducers/selectors';
 import createQueryString from 'app/utils/createQueryString';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
-import { selectPagination } from '../../reducers/selectors';
 import CompanyDetail from './components/CompanyDetail';
 
 const queryString = (companyId) =>

--- a/app/routes/company/components/CompaniesPage.tsx
+++ b/app/routes/company/components/CompaniesPage.tsx
@@ -7,20 +7,20 @@ import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
-import type { Company } from 'app/models';
+import type { ListCompany } from 'app/store/models/Company';
 import utilities from 'app/styles/utilities.css';
 import styles from './CompaniesPage.css';
 import type { ElementRef } from 'react';
 
 type Props = {
-  companies: Array<Company>;
+  companies: ListCompany[];
   fetchMore: () => void;
   showFetchMore: () => void;
   hasMore: boolean;
   fetching: boolean;
 };
 
-const CompanyItem = ({ company }: Company) => {
+const CompanyItem = ({ company }: { company: ListCompany }) => {
   return (
     <div className={styles.companyItem}>
       <div className={styles.companyItemContent}>
@@ -31,6 +31,7 @@ const CompanyItem = ({ company }: Company) => {
                 <Image
                   src={company.logo}
                   placeholder={company.logoPlaceholder}
+                  alt={`${company.name} logo`}
                 />
               }
             </div>
@@ -72,7 +73,7 @@ const CompanyItem = ({ company }: Company) => {
 };
 
 type CompanyListProps = {
-  companies: Array<Company>;
+  companies: ListCompany[];
 };
 
 const CompanyList = ({ companies = [] }: CompanyListProps) => (
@@ -161,7 +162,6 @@ class CompaniesPage extends Component<Props, State> {
             <span className={styles.iconInfo}> Kommende arrangementer</span>
           </Flex>
         </div>
-        <div id="nav" className={styles.navigationBar} />
         <InfiniteScroll
           element="div"
           hasMore={props.hasMore}

--- a/app/routes/company/components/Company.css
+++ b/app/routes/company/components/Company.css
@@ -57,14 +57,6 @@
   width: 100%;
 }
 
-.companyEvent {
-  width: 150%;
-  display: flex;
-  background: var(--color-white);
-  margin-top: 10px;
-  justify-content: center;
-}
-
 .companyEventsShowMore {
   padding-left: 10px;
   padding-bottom: 20px;

--- a/app/routes/company/components/CompanyDetail.tsx
+++ b/app/routes/company/components/CompanyDetail.tsx
@@ -11,12 +11,15 @@ import NavigationTab from 'app/components/NavigationTab';
 import { jobType, Year } from 'app/routes/joblistings/components/Items';
 import EventItem from 'app/routes/overview/components/EventItem';
 import { renderMeta } from 'app/routes/overview/components/utils';
+import type { DetailedCompany } from 'app/store/models/Company';
+import type { ListEvent } from 'app/store/models/Event';
+import type { ListJoblisting } from 'app/store/models/Joblisting';
 import styles from './Company.css';
 
 type Props = {
-  company: Record<string, any>;
-  companyEvents: Array<Record<string, any>>;
-  joblistings: Array<Record<string, any>>;
+  company: DetailedCompany;
+  companyEvents: ListEvent[];
+  joblistings: ListJoblisting[];
   showFetchMoreEvents: boolean;
   fetchMoreEvents: () => Promise<any>;
   loggedIn: boolean;
@@ -48,8 +51,6 @@ function insertInfoBubbles(company) {
           }}
           link={info[1] && info[1].includes('.') ? info[1] : undefined}
           small
-          iconClass={styles.icon}
-          dataClass={styles.data}
         />
       ))}
     </div>
@@ -67,7 +68,8 @@ class CompanyEvents extends Component<EventProps, any> {
     const { loggedIn, companyEvents, showFetchMoreEvents, fetchMoreEvents } =
       this.props;
     const sortedEvents = companyEvents.sort(
-      (a, b) => new Date(b.startTime) - new Date(a.startTime)
+      (a, b) =>
+        new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
     );
     const upcomingEvents = sortedEvents.filter((event) =>
       moment().isBefore(moment(event.startTime))
@@ -79,7 +81,6 @@ class CompanyEvents extends Component<EventProps, any> {
     const EventTable = ({ events }) =>
       events.map((event) => (
         <EventItem
-          className={styles.companyEvent}
           key={event.id}
           item={event}
           url={`/events/${event.id}`}
@@ -159,15 +160,18 @@ const CompanyDetail = (props: Props) => {
           <Year joblisting={joblisting} />
         </td>
         <td>
-          {joblisting.applicationUrl && (
-            <a
-              href={joblisting.applicationUrl}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <strong>SØK HER</strong>
-            </a>
-          )}
+          {
+            // TODO: this doesn't work, because applicationUrl doesn't exist with list-serializer
+            joblisting.applicationUrl && (
+              <a
+                href={joblisting.applicationUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <strong>SØK HER</strong>
+              </a>
+            )
+          }
         </td>
       </tr>
     ));
@@ -175,8 +179,12 @@ const CompanyDetail = (props: Props) => {
     <Content>
       <Helmet title={company.name} />
       {company.logo && (
-        <div className={styles.companyLogoDetail}>
-          <Image src={company.logo} className={styles.companyImage} />
+        <div>
+          <Image
+            src={company.logo}
+            className={styles.companyImage}
+            alt={`${company.name} logo`}
+          />
         </div>
       )}
 

--- a/app/routes/events/components/EventAdministrate/Attendees.tsx
+++ b/app/routes/events/components/EventAdministrate/Attendees.tsx
@@ -7,7 +7,6 @@ import LoadingIndicator from 'app/components/LoadingIndicator';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import type {
   Event,
-  Comment,
   EventPool,
   ActionGrant,
   User,
@@ -16,16 +15,18 @@ import type {
   EventRegistrationPaymentStatus,
   EventRegistrationPresence,
 } from 'app/models';
+import type Comment from 'app/store/models/Comment';
+import type { CurrentUser } from 'app/store/models/User';
 import styles from './Abacard.css';
 import { RegisteredTable, UnregisteredTable } from './RegistrationTables';
 
 export type Props = {
   eventId: number;
   event: Event;
-  comments: Array<Comment>;
+  comments: Comment[];
   pools: Array<EventPool>;
   loggedIn: boolean;
-  currentUser: Record<string, any>;
+  currentUser: CurrentUser;
   error: Record<string, any>;
   loading: boolean;
   registered: Array<EventRegistration>;

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -26,7 +26,6 @@ import {
 } from 'app/components/UserAttendance';
 import UserGrid from 'app/components/UserGrid';
 import type {
-  ID,
   EventPool,
   EventRegistration,
   Event,
@@ -34,9 +33,10 @@ import type {
   AddPenalty,
   FollowerItem,
 } from 'app/models';
-import type { CommentEntity } from 'app/reducers/comments';
 import { resolveGroupLink } from 'app/reducers/groups';
-import type { UserEntity } from 'app/reducers/users';
+import type { ID } from 'app/store/models';
+import type Comment from 'app/store/models/Comment';
+import type { CurrentUser } from 'app/store/models/User';
 import {
   colorForEvent,
   penaltyHours,
@@ -93,9 +93,9 @@ type Props = {
   eventId: ID;
   event: Event;
   loggedIn: boolean;
-  currentUser: UserEntity;
+  currentUser: CurrentUser;
   actionGrant: ActionGrant;
-  comments: Array<CommentEntity>;
+  comments: Array<Comment>;
   error?: Record<string, any>;
   pools: Array<EventPool>;
   registrations: Array<EventRegistration>;

--- a/app/routes/joblistings/components/Items.tsx
+++ b/app/routes/joblistings/components/Items.tsx
@@ -1,11 +1,7 @@
-import type { Workplace, Joblisting } from 'app/models';
+import type { ListJoblisting, Workplace } from 'app/store/models/Joblisting';
 import joinValues from 'app/utils/joinValues';
-import type { $Keys } from 'utility-types';
 
-type YearProps = {
-  joblisting: Joblisting;
-};
-export const Year = ({ joblisting }: YearProps) => (
+export const Year = ({ joblisting }: { joblisting: ListJoblisting }) => (
   <span>
     {joblisting.fromYear === joblisting.toYear
       ? `${joblisting.fromYear}. `
@@ -13,20 +9,20 @@ export const Year = ({ joblisting }: YearProps) => (
     klasse
   </span>
 );
-type WorkplacesProps = {
-  places: Array<Workplace>;
-};
-export const Workplaces = ({ places }: WorkplacesProps) => (
+
+export const Workplaces = ({ places }: { places: Workplace[] }) => (
   <span>{joinValues(places.map((place) => place.town))}</span>
 );
-const types = {
+
+const jobTypes = {
   full_time: 'Fulltid',
   part_time: 'Deltid',
   summer_job: 'Sommerjobb',
   master_thesis: 'Masteroppgave',
   other: 'Annet',
 };
-type JobType = $Keys<typeof types>;
+export type JobType = keyof typeof jobTypes;
+
 export const jobType = (status: JobType) => {
-  return types[status];
+  return jobTypes[status];
 };

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -15,19 +15,18 @@ import Flex from 'app/components/Layout/Flex';
 import LoadingIndicator from 'app/components/LoadingIndicator/';
 import Time from 'app/components/Time';
 import type { ActionGrant } from 'app/models';
+import type { DetailedJoblisting } from 'app/store/models/Joblisting';
 import { jobType, Year, Workplaces } from './Items';
 
 type Props = {
-  joblisting: Record<string, any>;
+  joblisting: DetailedJoblisting;
   actionGrant: ActionGrant;
   fetching: boolean;
-  push: (arg0: string) => void;
 };
 
 const JoblistingDetail = ({
   joblisting,
   actionGrant,
-  push,
   fetching = false,
 }: Props) => {
   if (fetching || !joblisting) {

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -17,8 +17,12 @@ import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import NavigationTab from 'app/components/NavigationTab';
-import type { Joblisting, Workplace, ID } from 'app/models';
 import { httpCheck } from 'app/routes/bdb/utils';
+import type { ID } from 'app/store/models';
+import type {
+  DetailedJoblisting,
+  Workplace,
+} from 'app/store/models/Joblisting';
 import { validYoutubeUrl } from 'app/utils/validation';
 import { places, jobTypes, yearValues } from '../constants';
 import styles from './JoblistingEditor.css';
@@ -30,8 +34,8 @@ type SelectInputObject = {
 };
 type Props = {
   joblistingId?: string;
-  joblisting: Joblisting;
-  handleSubmit: (arg0: (...args: Array<any>) => any) => void;
+  joblisting: DetailedJoblisting;
+  handleSubmit: any;
   submitJoblisting: (arg0: Workplace) => Promise<any>;
   deleteJoblisting: (arg0: ID) => Promise<any>;
   event: SelectInputObject;
@@ -146,7 +150,6 @@ class JoblistingEditor extends Component<Props, State> {
             component={SelectInput.AutocompleteField}
             filter={['companies.company']}
             onChange={(event) => {
-              // $FlowFixMe
               this.fetchContacts(event).then(() => {
                 dispatch(
                   change('joblistingEditor', 'responsible', {

--- a/app/routes/joblistings/components/JoblistingList.tsx
+++ b/app/routes/joblistings/components/JoblistingList.tsx
@@ -4,11 +4,12 @@ import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';
+import type { ListJoblisting } from 'app/store/models/Joblisting';
 import { Year, jobType, Workplaces } from './Items';
 import styles from './JoblistingList.css';
 
 type JobListingItemProps = {
-  joblisting: /*TODO: JobListing*/ Record<string, any>;
+  joblisting: ListJoblisting;
 };
 
 const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
@@ -18,6 +19,7 @@ const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
         className={styles.companyLogo}
         src={joblisting.company.logo}
         placeholder={joblisting.company.logoPlaceholder}
+        alt={`${joblisting.company.name} logo`}
       />
     )}
     <div className={styles.listItem}>
@@ -60,7 +62,7 @@ const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
 );
 
 type JobListingsListProps = {
-  joblistings: /*TODO: JobListings*/ Array<Record<string, any>>;
+  joblistings: ListJoblisting[];
 };
 
 const JoblistingsList = ({ joblistings }: JobListingsListProps) => (

--- a/app/routes/joblistings/components/JoblistingPage.tsx
+++ b/app/routes/joblistings/components/JoblistingPage.tsx
@@ -2,13 +2,19 @@ import { Helmet } from 'react-helmet-async';
 import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator/';
 import type { ActionGrant } from 'app/models';
+import type { ListJoblisting } from 'app/store/models/Joblisting';
 import JoblistingsList from './JoblistingList';
 import styles from './JoblistingPage.css';
 import JoblistingsRightNav from './JoblistingRightNav';
 
 type Props = {
-  joblistings: Array</*TODO: JobListing*/ any>;
-  search: Record<string, any>;
+  joblistings: ListJoblisting[];
+  search: {
+    grades?: string;
+    jobTypes?: string;
+    workplaces?: string;
+    order?: string;
+  };
   actionGrant: ActionGrant;
   history: Record<string, any>;
 };

--- a/app/routes/joblistings/components/JoblistingRightNav.tsx
+++ b/app/routes/joblistings/components/JoblistingRightNav.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import { CheckBox, RadioButton } from 'app/components/Form/';
 import type { ActionGrant } from 'app/models';
+import type { JobType } from 'app/routes/joblistings/components/Items';
 import { jobTypes } from '../constants';
 import styles from './JoblistingRightNav.css';
 
@@ -21,7 +22,6 @@ const updateFilters = (type, value, filters) => {
           grades: newFilter.grades.toString(),
         }
       : {}),
-    //$FlowFixMe[exponential-spread]
     ...(newFilter.jobTypes.length > 0
       ? {
           jobTypes: newFilter.jobTypes.toString(),
@@ -63,7 +63,7 @@ const FilterLink = ({
 
 type Filter = {
   grades: Array<string>;
-  jobTypes: Array<string>;
+  jobTypes: JobType[];
   workplaces: Array<string>;
 };
 type Order = {
@@ -74,10 +74,10 @@ type Order = {
 type Props = {
   actionGrant: ActionGrant;
   query: {
-    grades: string;
-    jobTypes: string;
-    workplaces: string;
-    order: string;
+    grades?: string;
+    jobTypes?: string;
+    workplaces?: string;
+    order?: string;
   };
   history: any;
 };
@@ -98,7 +98,7 @@ const JoblistingsRightNav = (props: Props) => {
     const query = props.query;
     setFilters({
       grades: query.grades ? query.grades.split(',') : [],
-      jobTypes: query.jobTypes ? query.jobTypes.split(',') : [],
+      jobTypes: query.jobTypes ? (query.jobTypes.split(',') as JobType[]) : [],
       workplaces: query.workplaces ? query.workplaces.split(',') : [],
     });
     setOrder({
@@ -147,7 +147,7 @@ const JoblistingsRightNav = (props: Props) => {
       >
         {props.actionGrant.includes('create') && (
           <Link to="/joblistings/create">
-            <Button className={styles.createButton}>Ny jobbannonse</Button>
+            <Button>Ny jobbannonse</Button>
           </Link>
         )}
         <h3 className={styles.rightHeader}>Sorter etter:</h3>
@@ -160,8 +160,7 @@ const JoblistingsRightNav = (props: Props) => {
           <RadioButton
             name="sort"
             id="deadline"
-            inputValue={true}
-            value={order.deadline}
+            checked={order.deadline}
             onChange={() => {
               props.history.push({
                 pathname: '/joblistings',
@@ -180,8 +179,7 @@ const JoblistingsRightNav = (props: Props) => {
           <RadioButton
             name="sort"
             id="company"
-            inputValue={true}
-            value={order.company}
+            checked={order.company}
             onChange={() => {
               props.history.push({
                 pathname: '/joblistings',
@@ -200,8 +198,7 @@ const JoblistingsRightNav = (props: Props) => {
           <RadioButton
             name="sort"
             id="createdAt"
-            inputValue={true}
-            value={order.createdAt}
+            checked={order.createdAt}
             onChange={() => {
               props.history.push({
                 pathname: '/joblistings',

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -19,24 +19,26 @@ import { MazemapEmbed } from 'app/components/MazemapEmbed';
 import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
 import Time, { FromToTime } from 'app/components/Time';
 import { AttendanceStatus } from 'app/components/UserAttendance';
-import type { Dateish, ID, Meeting, Comment, User } from 'app/models';
+import type { Dateish, ID, Meeting, User } from 'app/models';
 import {
   statusesText,
   MeetingInvitationStatus,
 } from 'app/reducers/meetingInvitations';
 import type { MeetingInvitationEntity } from 'app/reducers/meetingInvitations';
+import type Comment from 'app/store/models/Comment';
+import type { CurrentUser } from 'app/store/models/User';
 import urlifyString from 'app/utils/urlifyString';
 import styles from './MeetingDetail.css';
 
 type Props = {
   meeting: Meeting;
-  currentUser: User;
+  currentUser: CurrentUser;
   showAnswer: boolean;
   meetingInvitations: Array<MeetingInvitationEntity & { id: ID }>;
   setInvitationStatus: (
     meetingId: number,
     status: MeetingInvitationStatus,
-    user: User
+    user: CurrentUser
   ) => Promise<void>;
   reportAuthor: User;
   createdBy: User;

--- a/app/routes/overview/components/ArticleItem.tsx
+++ b/app/routes/overview/components/ArticleItem.tsx
@@ -2,12 +2,12 @@ import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import Card from 'app/components/Card';
 import { Image } from 'app/components/Image';
-import type { Article } from 'app/models';
+import type { PublicArticle } from 'app/store/models/Article';
 import truncateString from 'app/utils/truncateString';
 import styles from './ArticleItem.css';
 
 type Props = {
-  item: Article;
+  item: PublicArticle;
   url: string;
   meta: Record<string, any>;
 };

--- a/app/routes/overview/components/EventItem.tsx
+++ b/app/routes/overview/components/EventItem.tsx
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import Card from 'app/components/Card';
 import { Image } from 'app/components/Image';
@@ -16,60 +15,57 @@ type Props = {
   isFrontPage: boolean;
 };
 
-class EventItem extends Component<Props> {
-  render() {
-    const { item, url, meta, loggedIn, isFrontPage } = this.props;
-    const info = eventStatus(item, loggedIn);
-    return (
-      <Card overflow className={styles.body}>
-        <Link to={url} className={styles.link}>
-          <Flex className={styles.wrapper}>
-            {isFrontPage ? (
-              <Flex column className={styles.leftFrontpage}>
-                {item.cover && (
-                  <Image
-                    className={styles.imageFrontpage}
-                    width={270}
-                    height={80}
-                    src={item.cover}
-                    alt={`${item.title} cover image`}
-                    placeholder={item.coverPlaceholder}
-                  />
-                )}
-                <span className={styles.info}>{info}</span>
-              </Flex>
-            ) : (
-              <Flex column className={styles.left}>
-                {item.cover && (
-                  <Image
-                    className={styles.image}
-                    src={item.cover}
-                    placeholder={item.coverPlaceholder}
-                    alt={`${item.title} cover image`}
-                    width={390}
-                    height={80}
-                  />
-                )}
-                <span className={styles.info}>{info}</span>
-              </Flex>
-            )}
+const EventItem = ({ item, url, meta, loggedIn, isFrontPage }: Props) => {
+  const info = eventStatus(item, loggedIn);
+  return (
+    <Card overflow className={styles.body}>
+      <Link to={url} className={styles.link}>
+        <Flex className={styles.wrapper}>
+          {isFrontPage ? (
+            <Flex column className={styles.leftFrontpage}>
+              {item.cover && (
+                <Image
+                  className={styles.imageFrontpage}
+                  width={270}
+                  height={80}
+                  src={item.cover}
+                  alt={`${item.title} cover image`}
+                  placeholder={item.coverPlaceholder}
+                />
+              )}
+              <span className={styles.info}>{info}</span>
+            </Flex>
+          ) : (
+            <Flex column className={styles.left}>
+              {item.cover && (
+                <Image
+                  className={styles.image}
+                  src={item.cover}
+                  placeholder={item.coverPlaceholder}
+                  alt={`${item.title} cover image`}
+                  width={390}
+                  height={80}
+                />
+              )}
+              <span className={styles.info}>{info}</span>
+            </Flex>
+          )}
 
-            <div
-              className={styles.right}
-              style={{
-                borderBottom: `5px solid ${colorForEvent(item.eventType)}`,
-              }}
-            >
-              <>
-                <h2 className={styles.itemTitle}>{item.title}</h2>
-                {meta}
-              </>
-            </div>
-          </Flex>
-        </Link>
-      </Card>
-    );
-  }
-}
+          <div
+            className={styles.right}
+            style={{
+              borderBottom: `5px solid ${colorForEvent(item.eventType)}`,
+            }}
+          >
+            <>
+              <h2 className={styles.itemTitle}>{item.title}</h2>
+              {meta}
+            </>
+          </div>
+        </Flex>
+      </Link>
+    </Card>
+  );
+};
 
 export default EventItem;

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -5,8 +5,11 @@ import Icon from 'app/components/Icon';
 import { Container, Flex } from 'app/components/Layout';
 import Poll from 'app/components/Poll';
 import RandomQuote from 'app/components/RandomQuote';
-import type { Event, Article, Readme } from 'app/models';
+import type { Event, Readme } from 'app/models';
+import type { WithDocumentType } from 'app/reducers/frontpage';
+import { isArticle, isEvent } from 'app/reducers/frontpage';
 import type { PollEntity } from 'app/reducers/polls';
+import type { PublicArticle } from 'app/store/models/Article';
 import ArticleItem from './ArticleItem';
 import CompactEvents from './CompactEvents';
 import EventItem from './EventItem';
@@ -18,14 +21,14 @@ import { renderMeta } from './utils';
 // import Banner, { COLORS } from 'app/components/Banner';
 
 type Props = {
-  frontpage: Array<Article | Event>;
-  readmes: Array<Readme>;
+  frontpage: WithDocumentType<PublicArticle | Event>[];
+  readmes: Readme[];
   poll: PollEntity | null | undefined;
   votePoll: () => Promise<void>;
   loggedIn: boolean;
 };
 
-const itemUrl = (item: Event | Article) => {
+const itemUrl = (item: WithDocumentType<PublicArticle | Event>) => {
   return `/${item.documentType === 'event' ? 'events' : 'articles'}/${item.id}`;
 };
 
@@ -40,11 +43,7 @@ const Overview = (props: Props) => {
 
   const { loggedIn, frontpage, readmes, poll, votePoll } = props;
 
-  const events = useMemo(
-    () =>
-      frontpage.filter((item): item is Event => item.documentType === 'event'),
-    [frontpage]
-  );
+  const events = useMemo(() => frontpage.filter(isEvent), [frontpage]);
 
   const pinned = frontpage[0];
 
@@ -54,10 +53,7 @@ const Overview = (props: Props) => {
   );
 
   const articles = useMemo(
-    () =>
-      frontpage.filter(
-        (item): item is Article => item.documentType === 'article'
-      ),
+    () => frontpage.filter(isArticle) as WithDocumentType<PublicArticle>[],
     [frontpage]
   );
 
@@ -140,7 +136,7 @@ const Events = ({
   events,
   loggedIn,
 }: {
-  events: Event[];
+  events: WithDocumentType<Event>[];
   loggedIn: boolean;
 }) => (
   <Flex column className={styles.events}>
@@ -163,7 +159,11 @@ const Events = ({
   </Flex>
 );
 
-const Weekly = ({ weeklyArticle }: { weeklyArticle: Article }) => (
+const Weekly = ({
+  weeklyArticle,
+}: {
+  weeklyArticle: WithDocumentType<PublicArticle>;
+}) => (
   <Flex column>
     {weeklyArticle && (
       <>
@@ -181,8 +181,11 @@ const Weekly = ({ weeklyArticle }: { weeklyArticle: Article }) => (
     )}
   </Flex>
 );
-
-const Articles = ({ articles }: { articles: Article[] }) => (
+const Articles = ({
+  articles,
+}: {
+  articles: WithDocumentType<PublicArticle>[];
+}) => (
   <Flex column>
     <Link to="/articles">
       <h3 className="u-ui-heading">Artikler</h3>

--- a/app/routes/overview/components/Pinned.tsx
+++ b/app/routes/overview/components/Pinned.tsx
@@ -2,13 +2,15 @@ import { Link } from 'react-router-dom';
 import Card from 'app/components/Card';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
-import type { Event, Article } from 'app/models';
+import type { Event } from 'app/models';
+import type { PublicArticle } from 'app/store/models/Article';
 import styles from './Pinned.css';
+import type { ReactElement } from 'react';
 
 type Props = {
-  item: Event | Article;
+  item: Event | PublicArticle;
   url: string;
-  meta: Element<'span'> | null;
+  meta: ReactElement<'span'> | null;
 };
 
 const Pinned = ({ item, url, meta }: Props) => (

--- a/app/routes/overview/components/utils.tsx
+++ b/app/routes/overview/components/utils.tsx
@@ -2,27 +2,27 @@ import moment from 'moment-timezone';
 import Tags from 'app/components/Tags';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';
-import type { Event, Article } from 'app/models';
+import type { Event } from 'app/models';
+import type { WithDocumentType } from 'app/reducers/frontpage';
+import { isEvent } from 'app/reducers/frontpage';
 import { eventTypeToString } from 'app/routes/events/utils';
+import type { PublicArticle } from 'app/store/models/Article';
 import truncateString from 'app/utils/truncateString';
 import styles from './Overview.css';
 
-export const renderMeta = (item: Event | Article) => {
-  const isEvent = item.eventType ? true : false;
+export const renderMeta = (item: WithDocumentType<Event | PublicArticle>) => {
+  const itemTime = isEvent(item) ? item.startTime : item.createdAt;
 
   let format =
-    moment().year() === moment(item.startTime).year()
-      ? 'DD. MMM'
-      : 'DD. MMM YYYY';
-  if (isEvent) {
+    moment().year() === moment(itemTime).year() ? 'DD. MMM' : 'DD. MMM YYYY';
+  if (isEvent(item)) {
     format += ' HH:mm';
   }
 
   return (
     <span className={styles.itemInfo}>
-      <Time time={isEvent ? item.startTime : item.createdAt} format={format} />
-
-      {item.location !== '-' && isEvent && (
+      <Time time={itemTime} format={format} />
+      {isEvent(item) && item.location !== '-' && (
         <span>
           <span> • </span>
           <span> {truncateString(item.location, 8)} </span>
@@ -32,7 +32,7 @@ export const renderMeta = (item: Event | Article) => {
       <span> • </span>
       <span className={styles.type}>
         {' '}
-        {isEvent ? eventTypeToString(item.eventType) : 'Artikkel'}{' '}
+        {isEvent(item) ? eventTypeToString(item.eventType) : 'Artikkel'}{' '}
       </span>
 
       {item.tags?.length > 0 && (

--- a/app/store/models/AllowedPermissionsMixin.d.ts
+++ b/app/store/models/AllowedPermissionsMixin.d.ts
@@ -1,0 +1,7 @@
+type PermissionAction = 'list' | 'create' | 'view' | 'edit' | 'delete';
+
+interface AllowedPermissionsMixin {
+  actionGrant: PermissionAction[];
+}
+
+export default AllowedPermissionsMixin;

--- a/app/store/models/Announcement.d.ts
+++ b/app/store/models/Announcement.d.ts
@@ -1,0 +1,43 @@
+import type { Dateish } from 'app/models';
+import type { ID } from 'app/store/models';
+import type { ListEvent } from 'app/store/models/Event';
+import type { PublicGroup } from 'app/store/models/Group';
+import type { DetailedMeeting } from 'app/store/models/Meeting';
+import type { PublicUser } from 'app/store/models/User';
+
+interface CompleteAnnouncement {
+  id: ID;
+  message: string;
+  fromGroup: null | PublicGroup;
+  sent: null | Dateish;
+  users: PublicUser[];
+  groups: PublicGroup[];
+  events: ListEvent[];
+  meetings: DetailedMeeting[];
+}
+
+export type ListAnnouncement = Pick<
+  CompleteAnnouncement,
+  | 'id'
+  | 'message'
+  | 'fromGroup'
+  | 'sent'
+  | 'users'
+  | 'groups'
+  | 'events'
+  | 'meetings'
+>;
+
+export type DetailedAnnouncement = Pick<
+  CompleteAnnouncement,
+  | 'id'
+  | 'message'
+  | 'fromGroup'
+  | 'sent'
+  | 'users'
+  | 'groups'
+  | 'events'
+  | 'meetings'
+>;
+
+export type UnknownAnnouncement = ListAnnouncement | DetailedAnnouncement;

--- a/app/store/models/Article.d.ts
+++ b/app/store/models/Article.d.ts
@@ -1,4 +1,5 @@
 import type { Dateish } from 'app/models';
+import type AllowedPermissionsMixin from 'app/store/models/AllowedPermissionsMixin';
 import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
 import type { ID } from 'app/store/models/index';
@@ -37,7 +38,8 @@ export type DetailedArticle = Pick<
   | 'pinned'
   | 'reactionsGrouped'
   | 'youtubeUrl'
->;
+> &
+  AllowedPermissionsMixin;
 
 export type AdminDetailedArticle = DetailedArticle & ObjectPermissionsMixin;
 
@@ -57,7 +59,8 @@ export type PublicArticle = Pick<
   | 'tags'
   | 'createdAt'
   | 'pinned'
->;
+> &
+  AllowedPermissionsMixin;
 
 export type UnknownArticle =
   | DetailedArticle

--- a/app/store/models/Article.d.ts
+++ b/app/store/models/Article.d.ts
@@ -1,0 +1,66 @@
+import type { Dateish } from 'app/models';
+import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
+import type { ReactionsGrouped } from 'app/store/models/Reaction';
+import type { ID } from 'app/store/models/index';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+interface CompleteArticle {
+  id: ID;
+  title: string;
+  cover: string;
+  coverPlaceholder: string;
+  author: ID;
+  description: string;
+  comments: ID[];
+  contentTarget: ContentTarget;
+  tags: string[];
+  content: string;
+  createdAt: Dateish;
+  pinned: boolean;
+  reactionsGrouped?: ReactionsGrouped;
+  youtubeUrl: string;
+}
+
+export type DetailedArticle = Pick<
+  CompleteArticle,
+  | 'id'
+  | 'title'
+  | 'cover'
+  | 'coverPlaceholder'
+  | 'author'
+  | 'description'
+  | 'comments'
+  | 'contentTarget'
+  | 'tags'
+  | 'content'
+  | 'createdAt'
+  | 'pinned'
+  | 'reactionsGrouped'
+  | 'youtubeUrl'
+>;
+
+export type AdminDetailedArticle = DetailedArticle & ObjectPermissionsMixin;
+
+export type SearchArticle = Pick<
+  CompleteArticle,
+  'id' | 'title' | 'cover' | 'description' | 'content' | 'pinned' | 'createdAt'
+>;
+
+export type PublicArticle = Pick<
+  CompleteArticle,
+  | 'id'
+  | 'title'
+  | 'cover'
+  | 'coverPlaceholder'
+  | 'author'
+  | 'description'
+  | 'tags'
+  | 'createdAt'
+  | 'pinned'
+>;
+
+export type UnknownArticle =
+  | DetailedArticle
+  | AdminDetailedArticle
+  | SearchArticle
+  | PublicArticle;

--- a/app/store/models/Comment.d.ts
+++ b/app/store/models/Comment.d.ts
@@ -1,0 +1,14 @@
+import type { Dateish } from 'app/models';
+import type User from 'app/store/models/User';
+import type { ID } from 'app/store/models/index';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+export default interface Comment {
+  id: ID;
+  text: string;
+  author: User;
+  contentTarget: ContentTarget;
+  createdAt: Dateish;
+  updatedAt: Dateish;
+  parent: ID | null;
+}

--- a/app/store/models/Company.ts
+++ b/app/store/models/Company.ts
@@ -1,0 +1,156 @@
+import type { ID } from 'app/store/models/index';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+export enum CompanyContactedStatus {
+  CompanyPresentation = 'company_presentation',
+  Course = 'course',
+  BreakfastTalk = 'breakfast_talk',
+  LunchPresentation = 'lunch_presentation',
+  Bedex = 'bedex',
+  Interested = 'interested',
+  NotInterested = 'not_interested',
+  Contacted = 'contacted',
+  NotContacted = 'not_contacted',
+}
+
+interface CompleteSemesterStatus {
+  id: ID;
+  semester: ID;
+  contactedStatus: CompanyContactedStatus[];
+  contract?: string;
+  statistics?: string;
+  evaluation?: string;
+  contractName?: string;
+  statisticsName?: string;
+  evaluationName?: string;
+}
+
+export type SemesterStatus = Pick<
+  CompleteSemesterStatus,
+  'id' | 'semester' | 'contactedStatus'
+>;
+
+export type DetailedSemesterStatus = Pick<
+  CompleteSemesterStatus,
+  | 'id'
+  | 'semester'
+  | 'contactedStatus'
+  | 'contract'
+  | 'statistics'
+  | 'evaluation'
+  | 'contractName'
+  | 'statisticsName'
+  | 'evaluationName'
+>;
+
+export type AnySemesterStatus = SemesterStatus | DetailedSemesterStatus;
+
+export interface CompanyContact {
+  id: ID;
+  name: string;
+  role?: string;
+  mail?: string;
+  phone?: string;
+  mobile?: string;
+}
+
+interface CompanyFile {
+  id: ID;
+  file: string;
+}
+
+interface Company {
+  id: ID;
+  name: string;
+  active: boolean;
+  description: string;
+  website: string;
+  companyType: string;
+  logo: string;
+  logoPlaceholder: string;
+  phone?: string;
+  address?: string;
+  eventCount?: number;
+  joblistingCount?: number;
+  thumbnail?: string;
+  semesterStatuses?: SemesterStatus[];
+  studentContact?: ID | null;
+  adminComment?: string;
+  paymentMail: string;
+  comments: ID[];
+  contentTarget: ContentTarget;
+  files: CompanyFile[];
+  companyContacts: CompanyContact[];
+}
+
+export type ListCompany = Pick<
+  Company,
+  | 'id'
+  | 'name'
+  | 'description'
+  | 'eventCount'
+  | 'joblistingCount'
+  | 'website'
+  | 'companyType'
+  | 'address'
+  | 'logo'
+  | 'logoPlaceholder'
+  | 'thumbnail'
+  | 'active'
+>;
+
+export type AdminListCompany = Pick<
+  Company,
+  | 'id'
+  | 'name'
+  | 'semesterStatuses'
+  | 'studentContact'
+  | 'adminComment'
+  | 'active'
+>;
+
+export type DetailCompany = Pick<
+  Company,
+  | 'id'
+  | 'name'
+  | 'description'
+  | 'phone'
+  | 'companyType'
+  | 'website'
+  | 'address'
+  | 'logo'
+  | 'logoPlaceholder'
+>;
+
+export type SearchCompany = Pick<
+  Company,
+  'id' | 'name' | 'description' | 'website' | 'companyType' | 'address'
+>;
+
+export type AdminDetailCompany = Pick<
+  Company,
+  | 'id'
+  | 'name'
+  | 'studentContact'
+  | 'description'
+  | 'phone'
+  | 'companyType'
+  | 'website'
+  | 'address'
+  | 'paymentMail'
+  | 'comments'
+  | 'contentTarget'
+  | 'semesterStatuses'
+  | 'active'
+  | 'adminComment'
+  | 'logo'
+  | 'files'
+  | 'companyContacts'
+>;
+
+export type UnknownCompany =
+  | ListCompany
+  | AdminListCompany
+  | DetailCompany
+  | SearchCompany
+  | AdminDetailCompany;

--- a/app/store/models/Company.ts
+++ b/app/store/models/Company.ts
@@ -109,7 +109,7 @@ export type AdminListCompany = Pick<
   | 'active'
 >;
 
-export type DetailCompany = Pick<
+export type DetailedCompany = Pick<
   Company,
   | 'id'
   | 'name'
@@ -151,6 +151,6 @@ export type AdminDetailCompany = Pick<
 export type UnknownCompany =
   | ListCompany
   | AdminListCompany
-  | DetailCompany
+  | DetailedCompany
   | SearchCompany
   | AdminDetailCompany;

--- a/app/store/models/CompanyInterest.d.ts
+++ b/app/store/models/CompanyInterest.d.ts
@@ -1,0 +1,62 @@
+import type { Dateish } from 'app/models';
+import type Company from 'app/store/models/Company';
+import type { ID } from 'app/store/models/index';
+
+interface CompleteCompanyInterest {
+  id: ID;
+  companyName: string;
+  company: Company | null;
+  contactPerson: string;
+  mail: string;
+  phone: string;
+  semesters: ID[];
+  createdAt: Dateish;
+
+  events: string[];
+  otherOffers: string[];
+  collaborations: string[];
+  targetGrades: number[];
+  participantRangeStart: number;
+  participantRangeEnd: number;
+  comment: string;
+  courseComment: string;
+  breakfastTalkComment: string;
+  otherEventComment: string;
+}
+
+export type DetailedCompanyInterest = Pick<
+  CompleteCompanyInterest,
+  | 'id'
+  | 'companyName'
+  | 'company'
+  | 'contactPerson'
+  | 'mail'
+  | 'phone'
+  | 'semesters'
+  | 'events'
+  | 'otherOffers'
+  | 'collaborations'
+  | 'targetGrades'
+  | 'participantRangeStart'
+  | 'participantRangeEnd'
+  | 'comment'
+  | 'courseComment'
+  | 'breakfastTalkComment'
+  | 'otherEventComment'
+>;
+
+export type ListCompanyInterest = Pick<
+  CompleteCompanyInterest,
+  | 'id'
+  | 'companyName'
+  | 'company'
+  | 'contactPerson'
+  | 'mail'
+  | 'phone'
+  | 'semesters'
+  | 'createdAt'
+>;
+
+export type UnknownCompanyInterest =
+  | ListCompanyInterest
+  | DetailedCompanyInterest;

--- a/app/store/models/CompanySemester.d.ts
+++ b/app/store/models/CompanySemester.d.ts
@@ -1,0 +1,8 @@
+import type { ID, Semester } from 'app/store/models/index';
+
+export default interface CompanySemester {
+  id: ID;
+  semester: Semester;
+  year: number;
+  activeInterestForm?: boolean;
+}

--- a/app/store/models/EmailList.d.ts
+++ b/app/store/models/EmailList.d.ts
@@ -1,0 +1,37 @@
+import type { ID } from 'app/store/models/index';
+
+interface CompleteEmailList {
+  id: ID;
+  name: string;
+  email: string;
+  users: ID[];
+  groups: ID[];
+  groupRoles: string[];
+  requireInternalAddress: boolean;
+  additionalEmails?: string[];
+}
+
+export type PublicEmailList = Pick<
+  CompleteEmailList,
+  | 'id'
+  | 'users'
+  | 'name'
+  | 'email'
+  | 'groups'
+  | 'groupRoles'
+  | 'requireInternalAddress'
+>;
+
+export type DetailedEmailList = Pick<
+  CompleteEmailList,
+  | 'id'
+  | 'name'
+  | 'email'
+  | 'users'
+  | 'groups'
+  | 'groupRoles'
+  | 'requireInternalAddress'
+  | 'additionalEmails'
+>;
+
+export type UnknownEmailList = PublicEmailList | DetailedEmailList;

--- a/app/store/models/EmailUser.d.ts
+++ b/app/store/models/EmailUser.d.ts
@@ -1,0 +1,8 @@
+import type { ID } from 'app/store/models/index';
+
+export default interface EmailUser {
+  id: ID;
+  user: ID;
+  internalEmail: string;
+  internalEmailEnabled: boolean;
+}

--- a/app/store/models/Emoji.d.ts
+++ b/app/store/models/Emoji.d.ts
@@ -1,0 +1,7 @@
+export default interface Emoji {
+  shortCode: string;
+  keywords: Array<string>;
+  unicodeString: string;
+  fitzpatrickScale: boolean;
+  category: string;
+}

--- a/app/store/models/Event.d.ts
+++ b/app/store/models/Event.d.ts
@@ -1,0 +1,244 @@
+import type { Dateish } from 'app/models';
+import type { ID } from 'app/store/models';
+import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
+import type User from 'app/store/models/User';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+export enum EventType {
+  CompanyPresentation = 'company_presentation',
+  LunchPresentation = 'lunch_presentation',
+  AlternativePresentation = 'alternative_presentation',
+  Course = 'course',
+  BreakfastTalk = 'breakfast_talk',
+  KidEvent = 'kid_event',
+  Party = 'party',
+  Social = 'social',
+  Other = 'other',
+  Event = 'event',
+}
+
+interface Event {
+  id: ID;
+  title: string;
+  description: string;
+  cover: string;
+  coverPlaceholder: string;
+  text: string;
+  eventType: EventType;
+  eventStatusType: string;
+  location: string;
+  comments: ID[];
+  contentTarget: ContentTarget;
+  startTime: Dateish;
+  endTime: Dateish;
+  mergeTime?: Dateish;
+  thumbnail: string;
+  pools: ID[];
+  totalCapacity: number;
+  registrationCloseTime?: Dateish;
+  registrationDeadlineHours?: number;
+  unregistrationCloseTime?: Dateish;
+  unregistrationDeadline?: Dateish;
+  unregistrationDeadlineHours?: number;
+  company?: ID;
+  responsibleGroup?: ID;
+  activeCapacity?: number;
+  feedbackDescription: string;
+  feedbackRequired: boolean;
+  isPriced: boolean;
+  priceMember: number;
+  priceGuest?: number;
+  useStripe: boolean;
+  paymentDueDate?: Dateish;
+  useCaptcha: boolean;
+  waitingRegistrationCount?: number;
+  tags: string[];
+  isMerged: boolean;
+  heedPenalties: boolean;
+  createdBy: User;
+  registrationCount: number;
+  legacyRegistrationCount: number;
+  survey?: ID;
+  useConsent: boolean;
+  youtubeUrl: string;
+  useContactTracing: boolean;
+  mazemapPoi?: number;
+  pinned: boolean;
+
+  // for survey
+  attendedCount: number;
+
+  // user specific
+  price: number;
+  activationTime: Dateish;
+  isAdmitted: boolean;
+  spotsLeft: number;
+  pendingRegistration: boolean;
+  photoConsents: ID[];
+
+  unansweredSurveys: ID[];
+}
+
+export type PublicEvent = Pick<
+  Event,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'eventType'
+  | 'eventStatusType'
+  | 'location'
+  | 'thumbnail'
+>;
+
+// This corresponds to EventReadSerializer in the backend
+export type ListEvent = Pick<
+  Event,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'cover'
+  | 'coverPlaceholder'
+  | 'eventType'
+  | 'eventStatusType'
+  | 'location'
+  | 'startTime'
+  | 'endTime'
+  | 'thumbnail'
+  | 'totalCapacity'
+  | 'company'
+  | 'registrationCount'
+  | 'tags'
+  | 'activationTime'
+  | 'isAdmitted'
+  | 'survey'
+> &
+  ObjectPermissionsMixin;
+
+export type DetailedEvent = Pick<
+  Event,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'cover'
+  | 'coverPlaceholder'
+  | 'text'
+  | 'eventType'
+  | 'eventStatusType'
+  | 'location'
+  | 'comments'
+  | 'contentTarget'
+  | 'startTime'
+  | 'endTime'
+  | 'mergeTime'
+  | 'pools'
+  | 'registrationCloseTime'
+  | 'registrationDeadlineHours'
+  | 'unregistrationCloseTime'
+  | 'unregistrationDeadline'
+  | 'unregistrationDeadlineHours'
+  | 'company'
+  | 'responsibleGroup'
+  | 'activeCapacity'
+  | 'feedbackDescription'
+  | 'feedbackRequired'
+  | 'isPriced'
+  | 'priceMember'
+  | 'priceGuest'
+  | 'useStripe'
+  | 'paymentDueDate'
+  | 'useCaptcha'
+  | 'waitingRegistrationCount'
+  | 'tags'
+  | 'isMerged'
+  | 'heedPenalties'
+  | 'createdBy'
+  | 'registrationCount'
+  | 'legacyRegistrationCount'
+  | 'survey'
+  | 'useConsent'
+  | 'youtubeUrl'
+  | 'useContactTracing'
+  | 'mazemapPoi'
+> &
+  ObjectPermissionsMixin;
+
+export type EventForSurvey = Pick<
+  Event,
+  'registrationCount' | 'waitingRegistrationCount' | 'attendedCount'
+> &
+  ListEvent;
+
+// User specific event serializer that appends data based on request.user
+export type UserDetailedEvent = Pick<
+  Event,
+  | 'price'
+  | 'activationTime'
+  | 'isAdmitted'
+  | 'spotsLeft'
+  | 'pendingRegistration'
+  | 'photoConsents'
+> &
+  DetailedEvent;
+
+export type AuthUserDetailedEvent = Pick<
+  Event,
+  'waitingRegistrations' | 'unansweredSurveys'
+> &
+  UserDetailedEvent;
+
+export type AdministrateEvent = Pick<
+  Event,
+  | 'pools'
+  | 'unregistered'
+  | 'waitingRegistrations'
+  | 'useConsent'
+  | 'useContactTracing'
+  | 'createdBy'
+> &
+  ListEvent;
+
+export type FrontpageEvent = Pick<
+  Event,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'cover'
+  | 'coverPlaceholder'
+  | 'text'
+  | 'eventType'
+  | 'eventStatusType'
+  | 'location'
+  | 'startTime'
+  | 'thumbnail'
+  | 'endTime'
+  | 'totalCapacity'
+  | 'company'
+  | 'registrationCount'
+  | 'tags'
+  | 'activationTime'
+  | 'isAdmitted'
+  | 'pinned'
+>;
+
+export type SearchEvent = Pick<
+  Event,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'text'
+  | 'cover'
+  | 'location'
+  | 'startTime'
+  | 'endTime'
+>;
+
+export type UnknownEvent =
+  | PublicEvent
+  | ListEvent
+  | DetailedEvent
+  | EventForSurvey
+  | UserDetailedEvent
+  | AuthUserDetailedEvent
+  | AdministrateEvent
+  | FrontpageEvent
+  | SearchEvent;

--- a/app/store/models/Feed.d.ts
+++ b/app/store/models/Feed.d.ts
@@ -1,0 +1,9 @@
+import type { ID } from 'app/store/models/index';
+
+export type FeedType = 'notifications' | 'personal' | `user`;
+export type FeedID = 'notifications' | 'personal' | `user-${ID}`;
+
+export default interface Feed {
+  type: FeedType;
+  activities: ID[];
+}

--- a/app/store/models/FeedActivity.d.ts
+++ b/app/store/models/FeedActivity.d.ts
@@ -1,0 +1,27 @@
+import type { Dateish } from 'app/models';
+import type { ID } from 'app/store/models/index';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+interface Activity {
+  activityId: ID;
+  verb: number;
+  time: Dateish;
+  extraContext: Record<string, string>;
+  actor: ContentTarget;
+  object: ContentTarget;
+  target: ContentTarget;
+}
+
+export default interface FeedActivity {
+  id: ID;
+  orderingKey: string;
+  verb: string;
+  createdAt: Dateish;
+  updatedAt: Dateish;
+  lastActivity: Activity;
+  activities: Activity[];
+  activityCount: number;
+  actorIds: ID[];
+  read: boolean;
+  seen: boolean;
+}

--- a/app/store/models/FetchEntityPayload.d.ts
+++ b/app/store/models/FetchEntityPayload.d.ts
@@ -1,0 +1,8 @@
+import type { ID } from 'app/store/models/index';
+
+export default interface FetchEntityPayload<Entity> {
+  result: ID[];
+  entities: Record<ID, Entity>;
+  next: null | string;
+  previous: null | string;
+}

--- a/app/store/models/Gallery.d.ts
+++ b/app/store/models/Gallery.d.ts
@@ -1,0 +1,64 @@
+import type { Dateish } from 'app/models';
+import type { GalleryCoverPicture } from 'app/store/models/GalleryPicture';
+import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
+import type { ID } from 'app/store/models/index';
+
+interface Gallery {
+  id: ID;
+  title: string;
+  description: string;
+  cover: GalleryCoverPicture;
+  location: string;
+  takenAt: Dateish;
+  createdAt: Dateish;
+  pictureCount: number;
+  event: ID;
+  photographers: ID[];
+  publicMetadata: unknown;
+  pictures: ID[];
+}
+
+export type ListGallery = Pick<
+  Gallery,
+  | 'id'
+  | 'title'
+  | 'cover'
+  | 'location'
+  | 'takenAt'
+  | 'createdAt'
+  | 'pictureCount'
+>;
+
+export type AdminListGallery = ListGallery & ObjectPermissionsMixin;
+
+export type DetailedGallery = Pick<
+  Gallery,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'location'
+  | 'takenAt'
+  | 'createdAt'
+  | 'event'
+  | 'photographers'
+  | 'cover'
+  | 'publicMetadata'
+  | 'pictures'
+>;
+
+export type SearchGallery = Pick<
+  Gallery,
+  'id' | 'title' | 'location' | 'description'
+>;
+
+export type GalleryMetadata = Pick<
+  Gallery,
+  'id' | 'title' | 'description' | 'cover'
+>;
+
+export type UnknownGallery =
+  | ListGallery
+  | AdminListGallery
+  | DetailedGallery
+  | SearchGallery
+  | GalleryMetadata;

--- a/app/store/models/GalleryPicture.d.ts
+++ b/app/store/models/GalleryPicture.d.ts
@@ -1,0 +1,36 @@
+import type { ID } from 'app/store/models/index';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+interface GalleryPicture {
+  id: ID;
+  gallery: ID;
+  description: string;
+  taggees: ID[];
+  active: boolean;
+  file: string;
+  thumbnail: string;
+  rawFile: string;
+  comments: ID[];
+  contentTarget: ContentTarget;
+}
+
+export type GalleryCoverPicture = Pick<
+  GalleryPicture,
+  'file' | 'thumbnail' | 'id'
+>;
+
+export type GalleryListPicture = Pick<
+  GalleryPicture,
+  | 'id'
+  | 'gallery'
+  | 'description'
+  | 'taggees'
+  | 'active'
+  | 'file'
+  | 'thumbnail'
+  | 'rawFile'
+  | 'comments'
+  | 'contentTarget'
+>;
+
+export type UnknownGalleryPicture = GalleryCoverPicture | GalleryListPicture;

--- a/app/store/models/Group.d.ts
+++ b/app/store/models/Group.d.ts
@@ -1,0 +1,60 @@
+interface Group {
+  id: number;
+  name: string;
+  description: string;
+  contactEmail: string;
+  parent: number;
+  logo: string | null;
+  logoPlaceholder: string | null;
+  numberOfUsers: number;
+  type: string;
+  showBadge: boolean;
+  active: boolean;
+}
+
+export type DetailedGroup = Pick<
+  Group,
+  | 'id'
+  | 'name'
+  | 'description'
+  | 'contactEmail'
+  | 'parent'
+  | 'permissions'
+  | 'parentPermissions'
+  | 'type'
+  | 'text'
+  | 'logo'
+  | 'numberOfUsers'
+  | 'showBadge'
+  | 'active'
+>;
+
+export type PublicGroup = Pick<
+  Group,
+  | 'id'
+  | 'name'
+  | 'description'
+  | 'contactEmail'
+  | 'parent'
+  | 'logo'
+  | 'logoPlaceholder'
+  | 'type'
+  | 'showBadge'
+  | 'active'
+>;
+
+export type PublicListGroup = Pick<Group, 'numberOfUsers'> & PublicGroup;
+
+export type PublicDetailedGroup = Pick<Group, 'text'> & PublicListGroup;
+
+export type SearchGroup = Pick<Group, 'id' | 'name' | 'type' | 'logo'>;
+
+export type UnknownGroup =
+  | PublicGroup
+  | DetailedGroup
+  | PublicListGroup
+  | PublicDetailedGroup
+  | SearchGroup;
+
+// Used when a group is a field in another model
+export type FieldGroup = Pick<Group, 'id' | 'name' | 'contactEmail' | 'type'>;

--- a/app/store/models/Joblisting.ts
+++ b/app/store/models/Joblisting.ts
@@ -1,0 +1,73 @@
+import type { Dateish } from 'app/models';
+import type { ID } from 'app/store/models/index';
+
+enum JobType {
+  FullTime = 'full_time',
+  PartTime = 'part_time',
+  SummerJob = 'summer_job',
+  MasterThesis = 'master_thesis',
+  Other = 'other',
+}
+
+type JoblistingYear = 1 | 2 | 3 | 4 | 5;
+
+interface Workplace {
+  id: ID;
+  town: string;
+}
+
+interface Joblisting {
+  id: ID;
+  title: string;
+  text: string;
+  company: ID;
+  responsible: ID;
+  contactEmail: string;
+  description: string;
+  deadline: Dateish;
+  jobType: JobType;
+  workplaces: Workplace[];
+  visibleFrom: Dateish;
+  visibleTo: Dateish;
+  fromYear: JoblistingYear;
+  toYear: JoblistingYear;
+  applicationUrl: string;
+  youtubeUrl: string;
+  createdAt: Dateish;
+}
+
+export type ListJoblisting = Pick<
+  Joblisting,
+  | 'id'
+  | 'title'
+  | 'company'
+  | 'deadline'
+  | 'jobType'
+  | 'workplaces'
+  | 'fromYear'
+  | 'toYear'
+  | 'createdAt'
+>;
+
+export type DetailedJoblisting = Pick<
+  Joblisting,
+  | 'id'
+  | 'title'
+  | 'text'
+  | 'company'
+  | 'responsible'
+  | 'contactEmail'
+  | 'description'
+  | 'deadline'
+  | 'jobType'
+  | 'workplaces'
+  | 'visibleFrom'
+  | 'visibleTo'
+  | 'fromYear'
+  | 'toYear'
+  | 'applicationUrl'
+  | 'youtubeUrl'
+  | 'createdAt'
+>;
+
+export type UnknownJoblisting = ListJoblisting | DetailedJoblisting;

--- a/app/store/models/Joblisting.ts
+++ b/app/store/models/Joblisting.ts
@@ -1,4 +1,5 @@
 import type { Dateish } from 'app/models';
+import type { CompanyContact, ListCompany } from 'app/store/models/Company';
 import type { ID } from 'app/store/models/index';
 
 enum JobType {
@@ -11,7 +12,7 @@ enum JobType {
 
 type JoblistingYear = 1 | 2 | 3 | 4 | 5;
 
-interface Workplace {
+export interface Workplace {
   id: ID;
   town: string;
 }
@@ -20,9 +21,9 @@ interface Joblisting {
   id: ID;
   title: string;
   text: string;
-  company: ID;
-  responsible: ID;
-  contactEmail: string;
+  company: ListCompany; // TODO: normalize?
+  responsible: CompanyContact | null;
+  contactMail: string;
   description: string;
   deadline: Dateish;
   jobType: JobType;
@@ -56,7 +57,7 @@ export type DetailedJoblisting = Pick<
   | 'text'
   | 'company'
   | 'responsible'
-  | 'contactEmail'
+  | 'contactMail'
   | 'description'
   | 'deadline'
   | 'jobType'

--- a/app/store/models/Meeting.d.ts
+++ b/app/store/models/Meeting.d.ts
@@ -1,0 +1,58 @@
+import type { Dateish } from 'app/models';
+import type { ID } from 'app/store/models/index';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+interface Meeting {
+  id: number;
+  createdBy: ID;
+  description: string;
+  title: string;
+  location: string;
+  startTime: Dateish;
+  endTime: Dateish;
+  report: string;
+  reportAuthor?: ID;
+  invitations: ID[];
+  comments: ID[];
+  contentTarget: ContentTarget;
+  mazemapPoi?: number;
+}
+
+export type DetailedMeeting = Pick<
+  Meeting,
+  | 'id'
+  | 'createdBy'
+  | 'description'
+  | 'title'
+  | 'location'
+  | 'startTime'
+  | 'endTime'
+  | 'report'
+  | 'reportAuthor'
+  | 'invitations'
+  | 'comments'
+  | 'content_target'
+  | 'mazemapPoi'
+>;
+
+export type ListMeeting = Pick<
+  Meeting,
+  | 'id'
+  | 'createdBy'
+  | 'title'
+  | 'location'
+  | 'startTime'
+  | 'endTime'
+  | 'reportAuthor'
+  | 'mazemapPoi'
+>;
+
+export type SearchMeeting = Pick<
+  Meeting,
+  'id' | 'title' | 'description' | 'report' | 'startTime'
+>;
+
+export type UnknownMeeting = DetailedMeeting | ListMeeting | SearchMeeting;
+
+// Used when a meeting is a field in another model
+export type FieldMeeting = Pick<Meeting, 'id' | 'title'>;

--- a/app/store/models/MeetingInvitation.d.ts
+++ b/app/store/models/MeetingInvitation.d.ts
@@ -1,0 +1,11 @@
+enum MeetingInvitationStatus {
+  NoAnswer = 'NO_ANSWER',
+  Attending = 'ATTENDING',
+  NotAttending = 'NOT_ATTENDING',
+}
+
+export interface MeetingInvitation {
+  user: ID;
+  status: MeetingInvitationStatus;
+  meeting: ID;
+}

--- a/app/store/models/Membership.d.ts
+++ b/app/store/models/Membership.d.ts
@@ -1,0 +1,13 @@
+import type { Dateish } from 'app/models';
+import type User from 'app/store/models/User';
+import type { ID } from 'app/store/models/index';
+
+export default interface Membership {
+  id: ID;
+  user: User;
+  abakusGroup: ID;
+  role: string;
+  isActive: boolean;
+  emailListsEnabled: boolean;
+  createdAt: Dateish;
+}

--- a/app/store/models/OAuth2Application.d.ts
+++ b/app/store/models/OAuth2Application.d.ts
@@ -1,0 +1,12 @@
+import type { PublicUser } from 'app/store/models/User';
+import type { ID } from 'app/store/models/index';
+
+export default interface OAuth2Application {
+  id: ID;
+  name: string;
+  description: string;
+  redirectUris: string[];
+  clientId: string;
+  clientSecret: string;
+  user: PublicUser;
+}

--- a/app/store/models/OAuth2Grant.d.ts
+++ b/app/store/models/OAuth2Grant.d.ts
@@ -1,0 +1,15 @@
+import type { Dateish } from 'app/models';
+import type { ID } from 'app/store/models/index';
+
+export default interface OAuth2Grant {
+  id: ID;
+  user: ID;
+  token: string;
+  application: {
+    id: ID;
+    name: string;
+    description: string;
+  };
+  expires: Dateish;
+  scopes: Record<string, string>; // key: scope, value: description
+}

--- a/app/store/models/ObjectPermissionsMixin.d.ts
+++ b/app/store/models/ObjectPermissionsMixin.d.ts
@@ -1,0 +1,10 @@
+import { ID } from 'app/store/models/index';
+
+interface ObjectPermissionsMixin {
+  canEditUsers: ID[];
+  canViewGroups: ID[];
+  canEditGroups: ID[];
+  requireAuth: boolean;
+}
+
+export default ObjectPermissionsMixin;

--- a/app/store/models/ObjectPermissionsMixin.d.ts
+++ b/app/store/models/ObjectPermissionsMixin.d.ts
@@ -1,4 +1,4 @@
-import { ID } from 'app/store/models/index';
+import type { ID } from 'app/store/models';
 
 interface ObjectPermissionsMixin {
   canEditUsers: ID[];

--- a/app/store/models/Page.d.ts
+++ b/app/store/models/Page.d.ts
@@ -1,0 +1,36 @@
+import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
+import type { ID } from 'app/store/models/index';
+
+interface Page {
+  pk: ID;
+  title: string;
+  slug: string;
+  content: string;
+  picture: string;
+  picturePlaceholder: string;
+  category: string;
+}
+
+export type ListPage = Pick<Page, 'pk' | 'title' | 'slug' | 'category'>;
+
+export type DetailedPage = Pick<
+  Page,
+  | 'pk'
+  | 'title'
+  | 'slug'
+  | 'content'
+  | 'picture'
+  | 'picturePlaceholder'
+  | 'category'
+>;
+
+export type AuthDetailedPage = DetailedPage & ObjectPermissionsMixin;
+
+export type UnknownPage = ListPage | DetailedPage | AuthDetailedPage;
+
+export type SearchPage = Pick<
+  Page,
+  'title' | 'slug' | 'content' | 'picture' | 'category'
+> & {
+  id: ID;
+};

--- a/app/store/models/PastMembership.d.ts
+++ b/app/store/models/PastMembership.d.ts
@@ -1,0 +1,11 @@
+import type { Dateish } from 'app/models';
+import type Group from 'app/store/models/Group';
+import type { ID } from 'app/store/models/index';
+
+export default interface PastMembership {
+  id: ID;
+  abakusGroup: Group;
+  role: string;
+  startDate: Dateish;
+  endDate?: Dateish;
+}

--- a/app/store/models/Penalty.d.ts
+++ b/app/store/models/Penalty.d.ts
@@ -1,0 +1,12 @@
+import type { Dateish } from 'app/models';
+import type { ID } from 'app/store/models/index';
+
+export default interface Penalty {
+  id: ID;
+  createdAt: Dateish;
+  user: ID;
+  reason: string;
+  weight: number;
+  sourceEvent: ID;
+  exactExpiration: Dateish;
+}

--- a/app/store/models/Poll.d.ts
+++ b/app/store/models/Poll.d.ts
@@ -1,0 +1,25 @@
+import type { Dateish } from 'app/models';
+import type { ID } from 'app/store/models/index';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+interface PollOption {
+  id: ID;
+  name: string;
+  votes: number;
+}
+
+export default interface Poll {
+  id: ID;
+  createdAt: Dateish;
+  validUntil: Dateish;
+  title: string;
+  description: string;
+  options: PollOption[];
+  resultsHidden: boolean;
+  totalVotes: number;
+  comments: unknown; // TODO: is it even possible to comment on polls?
+  contentTarget: ContentTarget;
+  tags: string[];
+  hasAnswered: boolean;
+  pinned: boolean;
+}

--- a/app/store/models/Pool.d.ts
+++ b/app/store/models/Pool.d.ts
@@ -1,0 +1,36 @@
+import type { Dateish } from 'app/models';
+import type { PublicGroup } from 'app/store/models/Group';
+import type { ID } from 'app/store/models/index';
+
+interface CompletePool {
+  id: ID;
+  name: string;
+  capacity: number;
+  activationDate: Dateish;
+  permissionGroups: PublicGroup[];
+  registrationCount: number;
+  registrations: ID[];
+}
+
+export type PublicPool = Pick<
+  CompletePool,
+  | 'id'
+  | 'name'
+  | 'capacity'
+  | 'activationDate'
+  | 'permissionGroups'
+  | 'registrationCount'
+>;
+
+export type AuthPool = Pick<
+  CompletePool,
+  | 'id'
+  | 'name'
+  | 'capacity'
+  | 'activationDate'
+  | 'permissionGroups'
+  | 'registrationCount'
+  | 'registrations'
+>;
+
+export type UnknownPool = PublicPool | AuthPool;

--- a/app/store/models/Quote.d.ts
+++ b/app/store/models/Quote.d.ts
@@ -1,0 +1,15 @@
+import type { Dateish } from 'app/models';
+import type { ReactionsGrouped } from 'app/store/models/Reaction';
+import type { ID } from 'app/store/models/index';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
+
+export default interface Quote {
+  id: ID;
+  createdAt: Dateish;
+  text: string;
+  source: string;
+  approved: boolean;
+  tags: string[];
+  reactionsGrouped: ReactionsGrouped[];
+  contentTarget: ContentTarget;
+}

--- a/app/store/models/Reaction.d.ts
+++ b/app/store/models/Reaction.d.ts
@@ -1,0 +1,16 @@
+import type { ID } from 'app/store/models/index';
+import { ContentTarget } from 'app/store/utils/contentTarget';
+
+export default interface Reaction {
+  reactionId: ID;
+  emoji: string;
+  contentTarget: ContentTarget;
+}
+
+export interface ReactionsGrouped {
+  emoji: string;
+  unicodeString: string;
+  count: number;
+  hasReacted: boolean;
+  reactionId?: ID;
+}

--- a/app/store/models/Reaction.d.ts
+++ b/app/store/models/Reaction.d.ts
@@ -1,5 +1,5 @@
 import type { ID } from 'app/store/models/index';
-import { ContentTarget } from 'app/store/utils/contentTarget';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export default interface Reaction {
   reactionId: ID;

--- a/app/store/models/Registration.d.ts
+++ b/app/store/models/Registration.d.ts
@@ -1,0 +1,85 @@
+import type { Dateish } from 'app/models';
+import type { PhotoConsent } from 'app/store/models/User';
+import type { ID } from 'app/store/models/index';
+
+interface Registration {
+  id: ID;
+  user: ID;
+  createdBy: ID;
+  updatedBy: ID;
+  pool: ID;
+  event: ID;
+  presence: string; //TODO: enum
+  feedback: string;
+  sharedMemberships: unknown;
+  status: string; //TODO: enum
+  registrationDate: Dateish;
+  unregistrationDate: Dateish;
+  adminRegistrationReason: string;
+  paymentIntentId: string | null;
+  paymentStatus: string | null; //TODO: enum
+  paymentAmount: number;
+  paymentAmountRefunded: number;
+  LEGACYPhotoConsent: string; //TODO: enum
+  photoConsents: PhotoConsent[];
+}
+
+export type AnonymizedRegistration = Pick<
+  Registration,
+  'id' | 'pool' | 'status'
+>;
+
+export type PublicRegistration = Pick<
+  Registration,
+  'id' | 'user' | 'pool' | 'status'
+>;
+
+export type ReadRegistration = Pick<
+  Registration,
+  | 'feedback'
+  | 'sharedMemberships'
+  | 'presence'
+  | 'LEGACYPhotoConsent'
+  | 'status'
+  | 'event'
+> &
+  PublicRegistration;
+
+export type SearchRegistration = Pick<
+  Registration,
+  'presence' | 'LEGACYPhotoConsent'
+> &
+  PublicRegistration;
+
+export type PaymentRegistration = Pick<Registration, 'paymentStatus'> &
+  ReadRegistration;
+
+export type DetailedRegistration = Pick<
+  Registration,
+  | 'id'
+  | 'user'
+  | 'createdBy'
+  | 'updatedBy'
+  | 'pool'
+  | 'event'
+  | 'presence'
+  | 'feedback'
+  | 'status'
+  | 'registrationDate'
+  | 'unregistrationDate'
+  | 'adminRegistrationReason'
+  | 'paymentIntentId'
+  | 'paymentStatus'
+  | 'paymentAmount'
+  | 'paymentAmountRefunded'
+  | 'LEGACYPhotoConsent'
+  | 'photoConsents'
+>;
+
+export type UnknownRegistration =
+  | AnonymizedRegistration
+  | PublicRegistration
+  | ReadRegistration
+  | SearchRegistration
+  | PaymentRegistration
+  | DetailedRegistration;

--- a/app/store/models/RestrictedMail.d.ts
+++ b/app/store/models/RestrictedMail.d.ts
@@ -1,0 +1,48 @@
+import type { Dateish } from 'app/models';
+import type { PublicEvent } from 'app/store/models/Event';
+import type { FieldGroup } from 'app/store/models/Group';
+import type { FieldMeeting } from 'app/store/models/Meeting';
+import type { PublicUser } from 'app/store/models/User';
+
+interface CompleteRestrictedMail {
+  id: ID;
+  fromAddress: string;
+  hideSender: boolean;
+  used: Dateish;
+  createdAt: Dateish;
+  weekly: boolean;
+  users: PublicUser[];
+  groups: FieldGroup[];
+  events: PublicEvent[];
+  meetings: FieldMeeting[];
+  rawAddresses: string[];
+  tokenQueryParam: string;
+}
+
+export type ListRestrictedMail = Pick<
+  CompleteRestrictedMail,
+  'id' | 'fromAddress' | 'hideSender' | 'used' | 'createdAt' | 'weekly'
+>;
+
+export type NormalRestrictedMail = Pick<
+  CompleteRestrictedMail,
+  'users',
+  'groups',
+  'events',
+  'meetings',
+  'rawAddresses',
+  'weekly',
+  'hideSender'
+> &
+  ListRestrictedMail;
+
+export type DetailedRestrictedMail = Pick<
+  CompleteRestrictedMail,
+  'tokenQueryParam'
+> &
+  NormalRestrictedMail;
+
+export type UnknownRestrictedMail =
+  | ListRestrictedMail
+  | NormalRestrictedMail
+  | DetailedRestrictedMail;

--- a/app/store/models/Survey.d.ts
+++ b/app/store/models/Survey.d.ts
@@ -1,0 +1,11 @@
+import type { Dateish } from 'app/models';
+import type { EventType } from 'app/store/models/Event';
+import type { ID } from 'app/store/models/index';
+
+interface Survey {
+  id: ID;
+  title: string;
+  activeFrom: Dateish;
+  event: ID;
+  templateType: EventType | null;
+}

--- a/app/store/models/SurveyAnswer.d.ts
+++ b/app/store/models/SurveyAnswer.d.ts
@@ -1,0 +1,19 @@
+import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
+import type { ID } from 'app/store/models/index';
+
+interface CompleteSurveyAnswer {
+  id: ID;
+  submission: ID;
+  question: SurveyQuestion;
+  answerText: string;
+  selectedOptions: ID[];
+  hideFromPublic: boolean;
+}
+
+export type SurveyAnswer = Pick<
+  CompleteSurveyAnswer,
+  'id' | 'submission' | 'question' | 'answerText' | 'selectedOptions'
+>;
+
+export type AdminSurveyAnswer = Pick<CompleteSurveyAnswer, 'hideFromPublic'> &
+  CompleteSurveyAnswer;

--- a/app/store/models/SurveyQuestion.ts
+++ b/app/store/models/SurveyQuestion.ts
@@ -1,0 +1,28 @@
+import type { ID } from 'app/store/models/index';
+
+export enum SurveyQuestionType {
+  SingleChoice = 'single_choice',
+  MultipleChoice = 'multiple_choice',
+  TextField = 'text_field',
+  PieChart = 'pie_chart',
+  BarChart = 'bar_chart',
+}
+export enum SurveyQuestionDisplayType {
+  PieChart = 'pie_chart',
+  BarChart = 'bar_chart',
+}
+
+export interface SurveyQuestion {
+  id: ID;
+  displayType: SurveyQuestionDisplayType;
+  questionType: SurveyQuestionType;
+  questionText: string;
+  mandatory: boolean;
+  options: SurveyQuestionOption[];
+  relativeIndex: number;
+}
+
+export interface SurveyQuestionOption {
+  id: ID;
+  optionText: string;
+}

--- a/app/store/models/SurveySubmission.d.ts
+++ b/app/store/models/SurveySubmission.d.ts
@@ -1,0 +1,9 @@
+import type { SurveyAnswer } from 'app/store/models/SurveyAnswer';
+import type { ID } from 'app/store/models/index';
+
+interface SurveySubmission {
+  id: ID;
+  user: ID;
+  survey: ID;
+  answers: SurveyAnswer[];
+}

--- a/app/store/models/Tag.d.ts
+++ b/app/store/models/Tag.d.ts
@@ -1,0 +1,25 @@
+import type { ID } from 'app/store/models/index';
+
+enum TaggedType {
+  Article = 'article',
+  Event = 'event',
+  Joblisting = 'joblisting',
+  Poll = 'poll',
+  Quote = 'quote',
+}
+
+interface Tag {
+  tag: string;
+  usages: number;
+  relatedCounts: {
+    [key in TaggedType]: number;
+  };
+}
+
+export type ListTag = Pick<Tag, 'tag' | 'usages'>;
+
+export type DetailedTag = Pick<Tag, 'tag' | 'usages' | 'relatedCounts'>;
+
+export type UnknownTag = ListTag | DetailedTag;
+
+export type SearchTag = Pick<Tag, 'tag'> & { id: ID };

--- a/app/store/models/User.d.ts
+++ b/app/store/models/User.d.ts
@@ -1,0 +1,155 @@
+import type { Dateish, PhotoConsentDomain, Semester } from 'app/models';
+import type EmailList from 'app/store/models/EmailList';
+import type Group from 'app/store/models/Group';
+import type Membership from 'app/store/models/Membership';
+import type PastMembership from 'app/store/models/PastMembership';
+import type { ID } from 'app/store/models/index';
+
+export interface PhotoConsent {
+  year: number;
+  semester: Semester;
+  domain: PhotoConsentDomain;
+  isConsenting: boolean | null;
+  updatedAt: Dateish;
+}
+
+interface User {
+  id: number;
+  username: string;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+  gender: 'male' | 'female' | 'other';
+  email: string;
+  emailAddress: string;
+  emailListsEnabled: boolean;
+  internalEmailAddress?: string;
+  phoneNumber?: string;
+  profilePicture: string;
+  profilePicturePlaceholder: string;
+  allergies: string;
+  isActive: boolean;
+  isStudent: boolean;
+  abakusEmailLists: EmailList[];
+  penalties: ID[];
+  icalToken: string;
+  abakusGroups: ID[];
+  isAbakusMember: boolean;
+  isAbakomMember: boolean;
+  pastMemberships: PastMembership[];
+  selectedTheme: string;
+
+  permissionsPerGroup: {
+    abakusGroup: Pick<Group, 'id' | 'name'>;
+    permissions: string[];
+    parentPermissions: {
+      abakusGroup: Pick<Group, 'id' | 'name'>;
+      permissions: string[];
+    }[];
+  }[];
+  photoConsents?: PhotoConsent[];
+
+  memberships: Membership[];
+}
+
+export type CurrentUser = Pick<
+  User,
+  | 'id'
+  | 'username'
+  | 'firstName'
+  | 'lastName'
+  | 'fullName'
+  | 'email'
+  | 'emailAddress'
+  | 'phoneNumber'
+  | 'emailListsEnabled'
+  | 'profilePicture'
+  | 'profilePicturePlaceholder'
+  | 'gender'
+  | 'allergies'
+  | 'isActive'
+  | 'isStudent'
+  | 'abakusEmailLists'
+  | 'abakusGroups'
+  | 'isAbakusMember'
+  | 'isAbakomMember'
+  | 'penalties'
+  | 'icalToken'
+  | 'memberships'
+  | 'pastMemberships'
+  | 'internalEmailAddress'
+  | 'selectedTheme'
+  | 'permissionsPerGroup'
+  | 'photoConsents'
+>;
+
+export type DetailedUser = Pick<
+  User,
+  | 'id'
+  | 'username'
+  | 'firstName'
+  | 'lastName'
+  | 'fullName'
+  | 'gender'
+  | 'email'
+  | 'emailAddress'
+  | 'emailListsEnabled'
+  | 'profilePicture'
+  | 'profilePicturePlaceholder'
+  | 'allergies'
+  | 'isActive'
+  | 'penalties'
+  | 'abakusGroups'
+  | 'pastMemberships'
+  | 'permissionsPerGroup'
+>;
+
+export type PublicUser = Pick<
+  User,
+  | 'id'
+  | 'username'
+  | 'firstName'
+  | 'lastName'
+  | 'fullName'
+  | 'gender'
+  | 'profilePicture'
+  | 'profilePicturePlaceholder'
+  | 'internalEmailAddress'
+>;
+
+export type PublicUserWithAbakusGroups = Pick<User, 'abakusGroups'> &
+  PublicUser;
+
+export type PublicUserWithGroups = Pick<
+  User,
+  'abakusGroups' | 'pastMemberships' | 'memberships'
+> &
+  PublicUser;
+
+export type AdministrateUser = Pick<User, 'abakusGroups' | 'allergies'> &
+  PublicUser;
+
+export type AdministrateExportUser = Pick<User, 'email' | 'phoneNumber'> &
+  AdministrateUser;
+
+export type SearchUser = Pick<
+  User,
+  | 'id'
+  | 'username'
+  | 'firstName'
+  | 'lastName'
+  | 'fullName'
+  | 'gender'
+  | 'profilePicture'
+  | 'profilePicturePlaceholder'
+>;
+
+export type UnknownUser =
+  | CurrentUser
+  | DetailedUser
+  | PublicUser
+  | PublicUserWithAbakusGroups
+  | PublicUserWithGroups
+  | AdministrateUser
+  | AdministrateExportUser
+  | SearchUser;

--- a/app/store/models/User.d.ts
+++ b/app/store/models/User.d.ts
@@ -144,6 +144,9 @@ export type SearchUser = Pick<
   | 'profilePicturePlaceholder'
 >;
 
+/*
+Some user object, unknown serializer
+ */
 export type UnknownUser =
   | CurrentUser
   | DetailedUser

--- a/app/store/models/entities.ts
+++ b/app/store/models/entities.ts
@@ -1,0 +1,117 @@
+import type { UnknownAnnouncement } from 'app/store/models/Announcement';
+import type { UnknownArticle } from 'app/store/models/Article';
+import type Comment from 'app/store/models/Comment';
+import type { UnknownCompany } from 'app/store/models/Company';
+import type { UnknownCompanyInterest } from 'app/store/models/CompanyInterest';
+import type CompanySemester from 'app/store/models/CompanySemester';
+import type { UnknownEmailList } from 'app/store/models/EmailList';
+import type EmailUser from 'app/store/models/EmailUser';
+import type Emoji from 'app/store/models/Emoji';
+import type { UnknownEvent } from 'app/store/models/Event';
+import type Feed from 'app/store/models/Feed';
+import type FeedActivity from 'app/store/models/FeedActivity';
+import type { UnknownGallery } from 'app/store/models/Gallery';
+import type { UnknownGalleryPicture } from 'app/store/models/GalleryPicture';
+import type { UnknownGroup } from 'app/store/models/Group';
+import type { UnknownJoblisting } from 'app/store/models/Joblisting';
+import type { UnknownMeeting } from 'app/store/models/Meeting';
+import type { MeetingInvitation } from 'app/store/models/MeetingInvitation';
+import type Membership from 'app/store/models/Membership';
+import type OAuth2Application from 'app/store/models/OAuth2Application';
+import type { UnknownPage } from 'app/store/models/Page';
+import type Penalty from 'app/store/models/Penalty';
+import type Poll from 'app/store/models/Poll';
+import type { UnknownPool } from 'app/store/models/Pool';
+import type Quote from 'app/store/models/Quote';
+import type Reaction from 'app/store/models/Reaction';
+import type { UnknownRegistration } from 'app/store/models/Registration';
+import type { UnknownRestrictedMail } from 'app/store/models/RestrictedMail';
+import type { Survey } from 'app/store/models/Survey';
+import type { SurveySubmission } from 'app/store/models/SurveySubmission';
+import type { UnknownTag } from 'app/store/models/Tag';
+import type { UnknownUser } from 'app/store/models/User';
+import type { ID } from 'app/store/models/index';
+import type OAuth2Grant from './OAuth2Grant';
+
+export enum EntityType {
+  Announcements = 'announcements',
+  Articles = 'articles',
+  Comments = 'comments',
+  Companies = 'companies',
+  CompanyInterests = 'companyInterest', // Why the fuck is this not plural?
+  CompanySemesters = 'companySemesters',
+  EmailLists = 'emailLists',
+  EmailUsers = 'emailUsers',
+  Emojis = 'emojis',
+  Events = 'events',
+  FeedActivities = 'feedActivities',
+  Feeds = 'feeds',
+  Galleries = 'galleries',
+  GalleryPictures = 'galleryPictures',
+  Groups = 'groups',
+  Joblistings = 'joblistings',
+  MeetingInvitations = 'meetingInvitations',
+  Meetings = 'meetings',
+  Memberships = 'memberships',
+  OAuth2Applications = 'oauth2Applications',
+  OAuth2Grants = 'oauth2Grants',
+  Pages = 'pages',
+  Penalties = 'penalties',
+  Polls = 'polls',
+  Pools = 'pools',
+  Quotes = 'quotes',
+  Reactions = 'reactions',
+  Registrations = 'registrations',
+  RestrictedMails = 'restrictedMails',
+  SurveySubmissions = 'surveySubmissions',
+  Surveys = 'surveys',
+  Tags = 'tags',
+  Users = 'users',
+  FollowersCompany = 'followersCompany',
+  FollowersUser = 'followersUser',
+  FollowersEvent = 'followersEvent',
+}
+
+// Most fetch success redux actions are normalized such that payload.entities is a subset of this interface.
+export default interface Entities {
+  [EntityType.Announcements]: Record<ID, UnknownAnnouncement>;
+  [EntityType.Articles]: Record<ID, UnknownArticle>;
+  [EntityType.Comments]: Record<ID, Comment>;
+  [EntityType.Companies]: Record<ID, UnknownCompany>;
+  [EntityType.CompanyInterests]: Record<ID, UnknownCompanyInterest>;
+  [EntityType.CompanySemesters]: Record<ID, CompanySemester>;
+  [EntityType.EmailLists]: Record<ID, UnknownEmailList>;
+  [EntityType.EmailUsers]: Record<ID, EmailUser>;
+  [EntityType.Emojis]: Record<ID, Emoji>;
+  [EntityType.Events]: Record<ID, UnknownEvent>;
+  [EntityType.FeedActivities]: Record<ID, FeedActivity>;
+  [EntityType.Feeds]: Record<ID, Feed>;
+  [EntityType.Galleries]: Record<ID, UnknownGallery>;
+  [EntityType.GalleryPictures]: Record<ID, UnknownGalleryPicture>;
+  [EntityType.Groups]: Record<ID, UnknownGroup>;
+  [EntityType.Joblistings]: Record<ID, UnknownJoblisting>;
+  [EntityType.MeetingInvitations]: Record<ID, MeetingInvitation>;
+  [EntityType.Meetings]: Record<ID, UnknownMeeting>;
+  [EntityType.Memberships]: Record<ID, Membership>;
+  [EntityType.OAuth2Applications]: Record<ID, OAuth2Application>;
+  [EntityType.OAuth2Grants]: Record<ID, OAuth2Grant>;
+  [EntityType.Pages]: Record<ID, UnknownPage>;
+  [EntityType.Penalties]: Record<ID, Penalty>;
+  [EntityType.Polls]: Record<ID, Poll>;
+  [EntityType.Pools]: Record<ID, UnknownPool>;
+  [EntityType.Quotes]: Record<ID, Quote>;
+  [EntityType.Reactions]: Record<ID, Reaction>;
+  [EntityType.Registrations]: Record<ID, UnknownRegistration>;
+  [EntityType.RestrictedMails]: Record<ID, UnknownRestrictedMail>;
+  [EntityType.SurveySubmissions]: Record<ID, SurveySubmission>;
+  [EntityType.Surveys]: Record<ID, Survey>;
+  [EntityType.Tags]: Record<ID, UnknownTag>;
+  [EntityType.Users]: Record<ID, UnknownUser>;
+  [EntityType.FollowersCompany]: Record<ID, unknown>; // AFAIK unused
+  [EntityType.FollowersUser]: Record<ID, unknown>; // AFAIK unused
+  [EntityType.FollowersEvent]: Record<ID, unknown>; // AFAIK unused
+}
+
+export interface NormalizedEntityPayload<EntityKeys extends keyof Entities> {
+  entities: Pick<Entities, EntityKeys>;
+}

--- a/app/store/models/index.ts
+++ b/app/store/models/index.ts
@@ -1,0 +1,7 @@
+// usually a number, but some entities (f.ex. tags) use the name as id
+export type ID = number | string;
+
+export enum Semester {
+  Spring = 'spring',
+  Autumn = 'autumn',
+}

--- a/app/store/utils/contentTarget.ts
+++ b/app/store/utils/contentTarget.ts
@@ -1,0 +1,15 @@
+import type { ID } from 'app/store/models';
+import getEntityType from 'app/utils/getEntityType';
+import type { EntityServerName } from 'app/utils/getEntityType';
+
+export type ContentTarget = `${EntityServerName}-${ID}`;
+
+export const parseContentTarget = (contentTarget: string) => {
+  const [serverTargetType, targetId] = contentTarget.split('-') as [
+    EntityServerName,
+    ID
+  ];
+  const targetType = getEntityType(serverTargetType);
+
+  return { targetType, targetId };
+};

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -1,4 +1,4 @@
-import type { ID } from 'app/models';
+import type { ID } from 'app/store/models';
 
 export type Tree<T> = Array<
   T & {


### PR DESCRIPTION
Adds typescript types for all entity types from LEGO with different types for the different serializers. They are in `app/store/models`. I have also added an Unknown<entityName> type for each entity which is simply a union of the different serializers, which is used f.ex. in the redux store where we can't know which of the types it is. 

I have also gone through the announcement, article and company (not bdb yet) pages and replaced the types with these new ones.

# Result

There should be no functional difference.

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---