### PR TITLE
EventAdministrate design improvements

### DIFF
--- a/app/routes/events/components/EventAdministrate/Attendees.tsx
+++ b/app/routes/events/components/EventAdministrate/Attendees.tsx
@@ -1,7 +1,6 @@
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { formatPhoneNumber, parsePhoneNumber } from 'react-phone-number-input';
-import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
@@ -140,12 +139,6 @@ const Attendees = ({
   return (
     <div>
       <Flex justifyContent="space-between">
-        <h2>
-          <Link to={`/events/${eventId}`}>
-            <i className="fa fa-angle-left" />
-            {` ${event.title}`}
-          </Link>
-        </h2>
         {event.useContactTracing &&
           (currentUser.id === event.createdBy ||
             currentUser.id === event.createdBy.id) &&

--- a/app/routes/events/components/EventAdministrate/Attendees.tsx
+++ b/app/routes/events/components/EventAdministrate/Attendees.tsx
@@ -171,18 +171,21 @@ const Attendees = ({
             {`${paidCount}/${event.registrationCount} har betalt`}
           </div>
         </div>
-        {registered.length === 0 && <li>Ingen påmeldte</li>}
-        <RegisteredTable
-          event={event}
-          registered={registered}
-          loading={loading}
-          handlePresence={handlePresence}
-          handlePayment={handlePayment}
-          handleUnregister={handleUnregister}
-          showPresence={showPresence}
-          showUnregister={showUnregister}
-          pools={pools}
-        />
+        {registered.length === 0 ? (
+          <li>Ingen påmeldte</li>
+        ) : (
+          <RegisteredTable
+            event={event}
+            registered={registered}
+            loading={loading}
+            handlePresence={handlePresence}
+            handlePayment={handlePayment}
+            handleUnregister={handleUnregister}
+            showPresence={showPresence}
+            showUnregister={showUnregister}
+            pools={pools}
+          />
+        )}
         <strong
           style={{
             marginTop: '10px',
@@ -190,7 +193,11 @@ const Attendees = ({
         >
           Avmeldte:
         </strong>
-        <UnregisteredTable unregistered={unregistered} loading={loading} />
+        {unregistered.length === 0 ? (
+          <li>Ingen avmeldte</li>
+        ) : (
+          <UnregisteredTable unregistered={unregistered} loading={loading} />
+        )}
       </Flex>
     </div>
   );

--- a/app/routes/events/components/EventAdministrate/Attendees.tsx
+++ b/app/routes/events/components/EventAdministrate/Attendees.tsx
@@ -1,5 +1,5 @@
 import moment from 'moment-timezone';
-import { Component } from 'react';
+import { useState } from 'react';
 import { formatPhoneNumber, parsePhoneNumber } from 'react-phone-number-input';
 import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
@@ -47,163 +47,160 @@ export type Props = {
   onQueryChanged: (value: string) => any;
   searching: boolean;
 };
-type State = {
-  generatedCsvUrl?: string;
-};
-export default class Attendees extends Component<Props, State> {
-  state = {
-    generatedCsvUrl: '',
-  };
-  handleUnregister = async (registrationId: number) => {
-    const { unregister, eventId } = this.props;
+
+const Attendees = ({
+  eventId,
+  event,
+  pools,
+  currentUser,
+  error,
+  loading,
+  registered,
+  unregistered,
+  unregister,
+  updatePresence,
+  updatePayment,
+}: Props) => {
+  const [generatedCsvUrl, setGeneratedCsvUrl] = useState('');
+
+  const handleUnregister = async (registrationId: number) => {
     await unregister({
       eventId,
       registrationId,
       admin: true,
     });
   };
-  handlePresence = (registrationId: ID, presence: EventRegistrationPresence) =>
-    this.props.updatePresence(this.props.eventId, registrationId, presence);
-  handlePayment = (
+  const handlePresence = (
+    registrationId: ID,
+    presence: EventRegistrationPresence
+  ) => updatePresence(eventId, registrationId, presence);
+  const handlePayment = (
     registrationId: number,
     paymentStatus: EventRegistrationPaymentStatus
-  ) =>
-    this.props.updatePayment(this.props.eventId, registrationId, paymentStatus);
+  ) => updatePayment(eventId, registrationId, paymentStatus);
 
-  render() {
-    const {
-      eventId,
-      event,
-      error,
-      loading,
-      registered,
-      unregistered,
-      currentUser,
-      pools,
-    } = this.props;
-    const registerCount = registered.filter(
-      (reg) => reg.presence === 'PRESENT' && reg.pool
-    ).length;
-    const adminRegisterCount = registered.filter(
-      (reg) => reg.adminRegistrationReason !== '' && reg.pool
-    ).length;
-    const paidCount = registered.filter(
-      (reg) =>
-        (reg.paymentStatus === 'succeeded' || reg.paymentStatus === 'manual') &&
-        reg.pool
-    ).length;
+  const registerCount = registered.filter(
+    (reg) => reg.presence === 'PRESENT' && reg.pool
+  ).length;
+  const adminRegisterCount = registered.filter(
+    (reg) => reg.adminRegistrationReason !== '' && reg.pool
+  ).length;
+  const paidCount = registered.filter(
+    (reg) =>
+      (reg.paymentStatus === 'succeeded' || reg.paymentStatus === 'manual') &&
+      reg.pool
+  ).length;
 
-    if (loading) {
-      return <LoadingIndicator loading />;
-    }
+  if (loading) {
+    return <LoadingIndicator loading />;
+  }
 
-    if (error) {
-      return <div>{error.message}</div>;
-    }
+  if (error) {
+    return <div>{error.message}</div>;
+  }
 
-    // Not showing the presence column until 1 day before start or if someone has been given set to presence
-    const showPresence =
-      moment().isAfter(moment(event.startTime).subtract(1, 'day')) ||
-      registerCount > 0;
+  // Not showing the presence column until 1 day before start or if someone has been given set to presence
+  const showPresence =
+    moment().isAfter(moment(event.startTime).subtract(1, 'day')) ||
+    registerCount > 0;
 
-    const showUnregister = // Show unregister button until 1 day after event has ended,
-      // or until reg/unreg has ended if that is more than 1 day
-      // after event end
-      moment().isBefore(moment(event.endTime).add('days', 1)) ||
-      moment().isBefore(event.unregistrationCloseTime) ||
-      moment().isBefore(event.registrationCloseTime);
-    const exportInfoMessage = `Informasjonen du eksporterer MÅ slettes når det ikke lenger er behov for den,
+  const showUnregister = // Show unregister button until 1 day after event has ended,
+    // or until reg/unreg has ended if that is more than 1 day
+    // after event end
+    moment().isBefore(moment(event.endTime).add('days', 1)) ||
+    moment().isBefore(event.unregistrationCloseTime) ||
+    moment().isBefore(event.registrationCloseTime);
+  const exportInfoMessage = `Informasjonen du eksporterer MÅ slettes når det ikke lenger er behov for den,
                 og skal kun distribueres gjennom mail. Dersom informasjonen skal deles med personer utenfor Abakus
                 må det spesifiseres for de påmeldte hvem informasjonen skal deles med.`;
 
-    const createInfoCSV = async () => {
-      const data = registered.map((registration) => ({
-        name: registration.user.fullName,
-        email: registration.user.email,
-        phoneNumber: registration.user.phoneNumber,
-      }));
-      const csvBeginning = 'navn,epost,landskode,telefonnummer\n';
-      const csvString = data.reduce(
-        (prev, current) =>
-          prev +
-          `${current.name},${current.email || ''},${
-            parsePhoneNumber(current.phoneNumber).countryCallingCode || ''
-          },${formatPhoneNumber(current.phoneNumber) || ''}\n`,
-        csvBeginning
-      );
-      const blobUrl = URL.createObjectURL(
-        new Blob([csvString], {
-          type: 'text/csv',
-        })
-      );
-      this.setState({
-        generatedCsvUrl: blobUrl,
-      });
-    };
-
-    return (
-      <div>
-        <Flex justifyContent="space-between">
-          <h2>
-            <Link to={`/events/${eventId}`}>
-              <i className="fa fa-angle-left" />
-              {` ${event.title}`}
-            </Link>
-          </h2>
-          {event.useContactTracing &&
-            (currentUser.id === event.createdBy ||
-              currentUser.id === event.createdBy.id) &&
-            moment().isBefore(moment(event.endTime).add('days', 14)) &&
-            (this.state.generatedCsvUrl ? (
-              <a href={this.state.generatedCsvUrl} download="attendees.csv">
-                Last ned
-              </a>
-            ) : (
-              <ConfirmModalWithParent
-                title="Eksporter til csv"
-                closeOnConfirm={true}
-                message={exportInfoMessage}
-                onConfirm={createInfoCSV}
-              >
-                <Button size="large">Eksporter deltakere til csv</Button>
-              </ConfirmModalWithParent>
-            ))}
-        </Flex>
-        <Flex column>
-          <div>
-            <strong>Påmeldte:</strong>
-            <div className={styles.attendees}>
-              {`${registerCount}/${event.registrationCount} har møtt opp`}
-            </div>
-            <div className={styles.adminRegistrations}>
-              {`${adminRegisterCount}/${event.registrationCount} er adminpåmeldt`}
-            </div>
-            <div className={styles.adminRegistrations}>
-              {`${paidCount}/${event.registrationCount} har betalt`}
-            </div>
-          </div>
-          {registered.length === 0 && <li>Ingen påmeldte</li>}
-          <RegisteredTable
-            event={event}
-            registered={registered}
-            loading={loading}
-            handlePresence={this.handlePresence}
-            handlePayment={this.handlePayment}
-            handleUnregister={this.handleUnregister}
-            showPresence={showPresence}
-            showUnregister={showUnregister}
-            pools={pools}
-          />
-          <strong
-            style={{
-              marginTop: '10px',
-            }}
-          >
-            Avmeldte:
-          </strong>
-          <UnregisteredTable unregistered={unregistered} loading={loading} />
-        </Flex>
-      </div>
+  const createInfoCSV = async () => {
+    const data = registered.map((registration) => ({
+      name: registration.user.fullName,
+      email: registration.user.email,
+      phoneNumber: registration.user.phoneNumber,
+    }));
+    const csvBeginning = 'navn,epost,landskode,telefonnummer\n';
+    const csvString = data.reduce(
+      (prev, current) =>
+        prev +
+        `${current.name},${current.email || ''},${
+          parsePhoneNumber(current.phoneNumber).countryCallingCode || ''
+        },${formatPhoneNumber(current.phoneNumber) || ''}\n`,
+      csvBeginning
     );
-  }
-}
+    const blobUrl = URL.createObjectURL(
+      new Blob([csvString], {
+        type: 'text/csv',
+      })
+    );
+    setGeneratedCsvUrl(blobUrl);
+  };
+
+  return (
+    <div>
+      <Flex justifyContent="space-between">
+        <h2>
+          <Link to={`/events/${eventId}`}>
+            <i className="fa fa-angle-left" />
+            {` ${event.title}`}
+          </Link>
+        </h2>
+        {event.useContactTracing &&
+          (currentUser.id === event.createdBy ||
+            currentUser.id === event.createdBy.id) &&
+          moment().isBefore(moment(event.endTime).add('days', 14)) &&
+          (generatedCsvUrl ? (
+            <a href={generatedCsvUrl} download="attendees.csv">
+              Last ned
+            </a>
+          ) : (
+            <ConfirmModalWithParent
+              title="Eksporter til csv"
+              closeOnConfirm={true}
+              message={exportInfoMessage}
+              onConfirm={createInfoCSV}
+            >
+              <Button size="large">Eksporter deltakere til csv</Button>
+            </ConfirmModalWithParent>
+          ))}
+      </Flex>
+      <Flex column>
+        <div>
+          <strong>Påmeldte:</strong>
+          <div className={styles.attendees}>
+            {`${registerCount}/${event.registrationCount} har møtt opp`}
+          </div>
+          <div className={styles.adminRegistrations}>
+            {`${adminRegisterCount}/${event.registrationCount} er adminpåmeldt`}
+          </div>
+          <div className={styles.adminRegistrations}>
+            {`${paidCount}/${event.registrationCount} har betalt`}
+          </div>
+        </div>
+        {registered.length === 0 && <li>Ingen påmeldte</li>}
+        <RegisteredTable
+          event={event}
+          registered={registered}
+          loading={loading}
+          handlePresence={handlePresence}
+          handlePayment={handlePayment}
+          handleUnregister={handleUnregister}
+          showPresence={showPresence}
+          showUnregister={showUnregister}
+          pools={pools}
+        />
+        <strong
+          style={{
+            marginTop: '10px',
+          }}
+        >
+          Avmeldte:
+        </strong>
+        <UnregisteredTable unregistered={unregistered} loading={loading} />
+      </Flex>
+    </div>
+  );
+};
+
+export default Attendees;

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
@@ -440,7 +440,9 @@ export class UnregisteredTable extends Component<UnregisteredTableProps> {
         dataIndex: 'registrationDate',
         render: (registrationDate) => (
           <Tooltip
-            content={<Time time={registrationDate} format="DD.MM.YYYY HH:mm" />}
+            content={
+              <Time time={registrationDate} format="DD.MM.YYYY HH:mm:ss" />
+            }
           >
             <Time time={registrationDate} format="DD.MM.YYYY" />
           </Tooltip>

--- a/app/routes/events/components/EventAdministrate/index.tsx
+++ b/app/routes/events/components/EventAdministrate/index.tsx
@@ -27,7 +27,13 @@ const EventAdministrateIndex = (props: Props) => {
   // the other tabs.
   return (
     <Content>
-      <NavigationTab title={props.event ? props.event.title : ''}>
+      <NavigationTab
+        title={props.event ? props.event.title : ''}
+        back={{
+          label: 'Tilbake',
+          path: '/events/' + props.event.id,
+        }}
+      >
         <NavigationLink to={`${base}/attendees`}>Påmeldinger</NavigationLink>
         <NavigationLink to={`${base}/statistics`}>Statistikk</NavigationLink>
         <NavigationLink to={`${base}/admin-register`}>


### PR DESCRIPTION
# Description

The EventAdministrate pages do not have the same structure as other pages regarding title and navigation, such as e.g. articles and meetings. It is also now possible to navigate from each of the sub-pages back to the event. The tables with registered and unregistered students are also hidden if there are no registrations yet.

# Result
The old link is removed and the back-link is added to the title.
**Before**
![Screenshot from 2023-02-04 15-35-07](https://user-images.githubusercontent.com/43182025/216773453-c1c8892c-f3f5-4e92-bc19-fc61120db3ff.png)
**After**
![Screenshot from 2023-02-04 15-35-21](https://user-images.githubusercontent.com/43182025/216773452-055efdfe-b40d-4d19-b5c5-e23db42f18ff.png)

The back-link is also visible on all the sub-pages.
**Before**
![Screenshot from 2023-02-04 15-37-03](https://user-images.githubusercontent.com/43182025/216773448-17a605b5-6b22-4107-850b-deca044892f1.png)
**After**
![Screenshot from 2023-02-04 15-37-15](https://user-images.githubusercontent.com/43182025/216773446-98d4e109-80e8-49f2-8883-ab1908d939f1.png)

The tables are hidden when there are no registered/unregistered students.
**Before**
![Screenshot from 2023-02-04 15-35-52](https://user-images.githubusercontent.com/43182025/216773451-3f97d62c-b01b-4fde-bb38-7a97482b1825.png)
**After**
![Screenshot from 2023-02-04 15-36-00](https://user-images.githubusercontent.com/43182025/216773449-0af5067e-71d7-4884-a7b0-01dc0708c5ef.png)


# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-239
