### PR TITLE
Fix alignment of left/right overview columns

### DIFF
--- a/app/routes/overview/components/CompactEvents.css
+++ b/app/routes/overview/components/CompactEvents.css
@@ -10,7 +10,6 @@
 
 .compactEvents h3 {
   margin-bottom: 10px;
-  padding: 0 10px;
 }
 
 .compactLeft {

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -201,14 +201,7 @@ const Articles = ({ articles }: { articles: Article[] }) => (
 const NextEventSection = ({ events }: { events: Event[] }) => (
   <Flex column>
     <Link to="/events">
-      <h3
-        className="u-ui-heading"
-        style={{
-          padding: '5px 10px 10px',
-        }}
-      >
-        Påmeldinger
-      </h3>
+      <h3 className="u-ui-heading">Påmeldinger</h3>
     </Link>
 
     <NextEvent events={events} />

--- a/app/styles/utilities.css
+++ b/app/styles/utilities.css
@@ -100,6 +100,7 @@ html[data-theme='dark'] .contentContainer {
     @media (--mobile-device) {
       padding: 0;
       margin-bottom: 10px;
+      margin-left: 0.5rem;
     }
   }
 }


### PR DESCRIPTION
Also adds left margin for headings on mobile

# Description

Fixes the y-alignment of pinned element & poll component. Also note that I removed the left margin of the top headers on desktop.

And adds some margin to the left of heading on small screens so there's some space between the screen edge.

# Result

**before**
![image](https://user-images.githubusercontent.com/42850232/216817946-c8d26d5e-4b70-4b98-afc1-cb964546690b.png)

**after**
![image](https://user-images.githubusercontent.com/42850232/216817953-c257186c-8413-4244-b890-e57658e3ebb6.png)


**before**
![Screen Shot 2023-02-05 at 13 12 15](https://user-images.githubusercontent.com/42850232/216817988-d165d5a0-9786-4d52-9386-aa12a3d8d3e7.png)

**after**
![Screen Shot 2023-02-05 at 13 12 53](https://user-images.githubusercontent.com/42850232/216818012-eed7e55d-fa88-4161-b7e0-dc7dafa43eda.png)


# Testing

- [x] I have thoroughly tested my changes.
