### PR TITLE
Fix dropdown overflow & add border to reactionpick

### DIFF
--- a/app/components/Image/ProfilePicture.tsx
+++ b/app/components/Image/ProfilePicture.tsx
@@ -11,8 +11,8 @@ type Props = Omit<
     size: number;
     className?: string;
   } & ComponentProps<typeof CircularPicture>,
-  'placeholder' | 'src' | 'alt'
->;
+  'placeholder' | 'src'
+> & { alt?: string };
 
 const ProfilePicture = ({
   user,

--- a/app/components/Reactions/ReactionPicker.css
+++ b/app/components/Reactions/ReactionPicker.css
@@ -1,6 +1,7 @@
 @import url('~app/styles/variables.css');
 
 .reactionPicker {
+  composes: popover from '~app/styles/utilities.css';
   height: 400px;
   width: 309px;
   line-height: 1.3;

--- a/app/styles/overlay.css
+++ b/app/styles/overlay.css
@@ -1,11 +1,9 @@
 @import url('~app/styles/variables.css');
 
 .content {
+  composes: popover from '~app/styles/utilities.css';
   background: var(--lego-card-color);
   border-radius: 1rem;
-  border: 1px solid var(--color-gray-3);
-  box-shadow: 0 2px 8px 2px rgba(104, 112, 118, 7%),
-    0 2px 4px -1px rgba(104, 112, 118, 4%);
   position: absolute;
   margin-top: 10px;
   z-index: 2;
@@ -43,6 +41,11 @@
     border-right: 7px solid transparent;
     border-bottom: 7px solid var(--lego-card-color);
   }
+}
+
+.dropdownList {
+  border-radius: inherit;
+  overflow: hidden;
 }
 
 .dropdownList > li > a,

--- a/app/styles/utilities.css
+++ b/app/styles/utilities.css
@@ -12,6 +12,12 @@
   margin: 0 auto;
 }
 
+.popover {
+  border: 1px solid var(--border-gray);
+  box-shadow: 0 2px 8px 2px rgba(104, 112, 118, 7%),
+    0 2px 4px -1px rgba(104, 112, 118, 4%);
+}
+
 .contentContainer {
   composes: container;
   background: var(--color-white);


### PR DESCRIPTION
# Description
Fix dropdown overflow.
Add border to reactionpicker popover to get more depth and contrast.

# Result

|before|after|
|----|--------|
| ![image](https://user-images.githubusercontent.com/42850232/216821785-a2481aee-150c-4005-ba9b-2452c5680012.png) |![image](https://user-images.githubusercontent.com/42850232/216821742-e8a18c8d-8d77-4a76-834d-34b6bcd6a4fc.png)  |
|  ![image](https://user-images.githubusercontent.com/42850232/216821801-d9749be5-40dc-492a-83c3-4e3804fdf959.png)  |![image](https://user-images.githubusercontent.com/42850232/216821769-91297f6a-ed36-4649-bdc9-72c1f68bc05a.png) | 

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-242
