### PR TITLE
Add Collapse Animation To LatestReadme

### DIFF
--- a/app/routes/overview/components/LatestReadme.tsx
+++ b/app/routes/overview/components/LatestReadme.tsx
@@ -1,69 +1,50 @@
-import { Component } from 'react';
+import { useEffect, useState } from 'react';
 import Card from 'app/components/Card';
 import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import { readmeIfy } from 'app/components/ReadmeLogo';
+import type { Readme } from 'app/models';
 import styles from './LatestReadme.css';
 
 type Props = {
-  expanded: boolean;
-  readmes: Array<Record<string, any>>;
-};
-type State = {
-  expanded: boolean;
+  expandedInitially: boolean;
+  readmes: Array<Readme>;
 };
 
-class LatestReadme extends Component<Props, State> {
-  state = {
-    expanded: this.props.expanded,
-  };
+const LatestReadme = ({ readmes, expandedInitially }: Props) => {
+  const [expanded, setExpanded] = useState(expandedInitially);
 
-  // eslint-disable-next-line
-  componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.expanded !== this.state.expanded) {
-      this.setState({
-        expanded: nextProps.expanded || false,
-      });
-    }
-  }
+  useEffect(() => {
+    setExpanded(expandedInitially);
+  }, [expandedInitially]);
 
-  render() {
-    const { expanded } = this.state;
+  return (
+    <Card className={styles.latestReadme}>
+      <button className={styles.heading} onClick={() => setExpanded(!expanded)}>
+        <Flex justifyContent="space-between" alignItems="center">
+          {readmeIfy('readme')}
+          <Icon name={expanded ? 'close' : 'arrow-down'} />
+        </Flex>
+      </button>
 
-    const toggle = () =>
-      this.setState((state) => ({
-        expanded: !state.expanded,
-      }));
-
-    const { readmes = [] } = this.props;
-    return (
-      <Card className={styles.latestReadme}>
-        <button className={styles.heading} onClick={toggle}>
-          <Flex justifyContent="space-between" alignItems="center">
-            {readmeIfy('readme')}
-            <Icon name={expanded ? 'close' : 'arrow-down'} />
-          </Flex>
-        </button>
-
-        {expanded && (
-          <Flex
-            wrap
-            justifyContent="space-around"
-            style={{
-              paddingTop: 20,
-            }}
-          >
-            {readmes.slice(0, 4).map(({ image, pdf, title }) => (
-              <a key={title} href={pdf} className={styles.thumb}>
-                <Image src={image} alt={`Cover of ${title}`} />
-              </a>
-            ))}
-          </Flex>
-        )}
-      </Card>
-    );
-  }
-}
+      {expanded && (
+        <Flex
+          wrap
+          justifyContent="space-around"
+          style={{
+            paddingTop: 20,
+          }}
+        >
+          {readmes.slice(0, 4).map(({ image, pdf, title }) => (
+            <a key={title} href={pdf} className={styles.thumb}>
+              <Image src={image} alt={`Cover of ${title}`} />
+            </a>
+          ))}
+        </Flex>
+      )}
+    </Card>
+  );
+};
 
 export default LatestReadme;

--- a/app/routes/overview/components/LatestReadme.tsx
+++ b/app/routes/overview/components/LatestReadme.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Collapse } from 'react-collapse';
 import Card from 'app/components/Card';
 import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
@@ -28,7 +29,7 @@ const LatestReadme = ({ readmes, expandedInitially }: Props) => {
         </Flex>
       </button>
 
-      {expanded && (
+      <Collapse isOpened={expanded}>
         <Flex
           wrap
           justifyContent="space-around"
@@ -42,7 +43,7 @@ const LatestReadme = ({ readmes, expandedInitially }: Props) => {
             </a>
           ))}
         </Flex>
-      )}
+      </Collapse>
     </Card>
   );
 };

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -81,7 +81,10 @@ const Overview = (props: Props) => {
 
   const readMe = (
     <Flex className={styles.readMe}>
-      <LatestReadme readmes={readmes} expanded={frontpage.length === 0} />
+      <LatestReadme
+        readmes={readmes}
+        expandedInitially={frontpage.length === 0}
+      />
     </Flex>
   );
 


### PR DESCRIPTION
# Description
- refactor(LatestReadme): class component => functional
- feat(LatestReadme): animated collapse

Use the Collapse element from "react-select" to animate the LatestReadme component. This makes it much smoother to look at, as it does not jump from collapsed to expanded.

# Result

#### Before 
https://user-images.githubusercontent.com/26925695/216996880-0bac0748-3082-43c4-9b45-2950496f6725.mov

#### After
https://user-images.githubusercontent.com/26925695/216996393-b108e511-d472-44c2-8f95-140d57df5d77.mov



# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-251
