### PR TITLE
Fix navigation through back-links and cancel buttons

### DIFF
--- a/app/routes/announcements/components/AnnouncementsList.tsx
+++ b/app/routes/announcements/components/AnnouncementsList.tsx
@@ -42,7 +42,7 @@ const AnnouncementsList = ({
       />
       {actionGrant.includes('list') && actionGrant.includes('delete') && (
         <ContentMain>
-          <h1> Mine kunngjøringer </h1>
+          <h1> Dine kunngjøringer </h1>
           <Flex column className={styles.list}>
             {announcements.map((a, i) => (
               <AnnouncementItem

--- a/app/routes/articles/ArticleCreateRoute.ts
+++ b/app/routes/articles/ArticleCreateRoute.ts
@@ -1,3 +1,4 @@
+import { push } from 'connected-react-router';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { createArticle } from 'app/actions/ArticleActions';
@@ -17,6 +18,7 @@ const mapStateToProps = () => ({
 const mapDispatchToProps = {
   submitArticle: createArticle,
   uploadFile,
+  push,
 };
 export default compose(
   replaceUnlessLoggedIn(LoginPage),

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -38,8 +38,6 @@ export type Props = {
 const ArticleEditor = ({
   isNew,
   articleId,
-  currentUser,
-  submitArticle,
   handleSubmit,
   deleteArticle,
   push,
@@ -64,7 +62,11 @@ const ArticleEditor = ({
         }
       />
       <NavigationTab
-        title={isNew ? 'Ny artikkel' : 'Redigerer: ' + article.title}
+        title={
+          isNew && article
+            ? 'Ny artikkel'
+            : 'Redigerer artikkel: ' + article.title
+        }
         back={{
           label: 'Tilbake',
           path: `/articles/${isNew ? '' : articleId}`,
@@ -184,7 +186,6 @@ const ArticleEditor = ({
 
 const onSubmit = (
   data,
-  dispatch,
   { currentUser, isNew, articleId, submitArticle }: Props
 ) => {
   const body = {

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -64,10 +64,10 @@ const ArticleEditor = ({
         }
       />
       <NavigationTab
-        title="Rediger artikkel"
+        title={isNew ? 'Ny artikkel' : 'Redigerer: ' + article.title}
         back={{
           label: 'Tilbake',
-          path: `/articles/${articleId}`,
+          path: `/articles/${isNew ? '' : articleId}`,
         }}
       />
 
@@ -164,7 +164,9 @@ const ArticleEditor = ({
           initialized={initialized}
         />
         <Flex wrap>
-          <Button onClick={() => push(`/articles/${articleId}`)}>Avbryt</Button>
+          <Button onClick={() => push(`/articles/${isNew ? '' : articleId}`)}>
+            Avbryt
+          </Button>
           <Button submit success={!isNew}>
             {!isNew ? 'Lagre endringer' : 'Opprett'}
           </Button>

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -56,11 +56,9 @@ const ArticleEditor = ({
 
   return (
     <Content>
-      <Helmet
-        title={isNew ? 'Ny artikkel' : 'Redigerer artikkel: ' + article?.title}
-      />
+      <Helmet title={isNew ? 'Ny artikkel' : 'Redigerer: ' + article?.title} />
       <NavigationTab
-        title={isNew ? 'Ny artikkel' : 'Redigerer artikkel: ' + article?.title}
+        title={isNew ? 'Ny artikkel' : 'Redigerer: ' + article?.title}
         back={{
           label: 'Tilbake',
           path: `/articles/${isNew ? '' : articleId}`,

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -57,16 +57,10 @@ const ArticleEditor = ({
   return (
     <Content>
       <Helmet
-        title={
-          !isNew && article ? `Redigerer: ${article.title}` : 'Ny artikkel'
-        }
+        title={isNew ? 'Ny artikkel' : 'Redigerer artikkel: ' + article?.title}
       />
       <NavigationTab
-        title={
-          isNew && article
-            ? 'Ny artikkel'
-            : 'Redigerer artikkel: ' + article.title
-        }
+        title={isNew ? 'Ny artikkel' : 'Redigerer artikkel: ' + article?.title}
         back={{
           label: 'Tilbake',
           path: `/articles/${isNew ? '' : articleId}`,

--- a/app/routes/events/components/EventFooter.tsx
+++ b/app/routes/events/components/EventFooter.tsx
@@ -15,7 +15,7 @@ const icalTypes = [
   },
   {
     name: 'personal',
-    title: 'Mine møter og favorittarrangementer',
+    title: 'Dine møter og favorittarrangementer',
   },
 ];
 

--- a/app/routes/interestgroups/components/InterestGroupList.tsx
+++ b/app/routes/interestgroups/components/InterestGroupList.tsx
@@ -26,13 +26,7 @@ const InterestGroupList = ({ actionGrant, interestGroups }: Props) => {
     <Content>
       <Helmet title="Interessegrupper" />
       <div className={styles.section}>
-        <NavigationTab
-          title="Interessegrupper"
-          back={{
-            label: 'Hjem',
-            path: '/',
-          }}
-        />
+        <NavigationTab title="Interessegrupper" />
         <p>
           <Link to="/pages/generelt/39-praktisk-informasjon">Her</Link> finner
           du all praktisk informasjon knyttet til våre interessegrupper.

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -163,7 +163,7 @@ class MeetingDetails extends Component<Props> {
               />
             }
             back={{
-              label: 'Mine møter',
+              label: 'Dine møter',
               path: '/meetings',
             }}
           >

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -132,8 +132,8 @@ const MeetingEditor = ({
         title={isEditPage ? `Redigerer: ${meeting.title}` : 'Nytt møte'}
         className={styles.detailTitle}
         back={{
-          label: 'Mine møter',
-          path: '/meetings',
+          label: `${isEditPage ? 'Tilbake' : 'Dine møter'}`,
+          path: `/meetings/${isEditPage ? meetingId : ''}`,
         }}
       />
       <LegoFinalForm
@@ -264,7 +264,11 @@ const MeetingEditor = ({
               )}
               <SubmissionError />
               <Flex wrap>
-                <Button onClick={() => push(`/meetings/${meeting.id}`)}>
+                <Button
+                  onClick={() =>
+                    push(`/meetings/${isEditPage ? meeting.id : ''}`)
+                  }
+                >
                   Avbryt
                 </Button>
                 {spySubmittable((submittable) => (

--- a/cypress/e2e/router_spec.js
+++ b/cypress/e2e/router_spec.js
@@ -147,7 +147,7 @@ describe('Navigate throughout app', () => {
     cy.get(c('NavigationTab'))
       .first()
       .within(() => {
-        cy.contains('Mine møter').click();
+        cy.contains('Dine møter').click();
       });
     cy.url().should('contain', '/meetings');
     cy.contains('Dine Møter');


### PR DESCRIPTION
# Description

As described in https://github.com/webkom/lego/issues/3203, the back-link when creating a new article is not longer broken. The Cancel buttons in the meeting and article editors, while creating new instances of these, are now canceling the action and routing the user back to the meetings/articles page. Also, the back-link from the interest groups page is removed, as it isn't consistent with the other pages.

Additionally, the wording of the webapp is now consistently using "your" instead of "my" (e.g. your meetings). If someone has a strong opinion on having "my" instead of "your", don't hesitate to let me know :) 

This video shows the broken back-link and the Cancel button that is not working.
[Screencast from 06. feb. 2023 kl. 22.09 +0100.webm](https://user-images.githubusercontent.com/43182025/217088690-204d1d79-4ef1-42eb-ba5b-39365775aa48.webm)

# Result
The title of the article is shown in the header of the editor.
**Before**
![Screenshot from 2023-02-06 22-12-03](https://user-images.githubusercontent.com/43182025/217089345-03836643-8d77-4079-a08d-e9f8bb39ab2a.png)

**After**
![Screenshot from 2023-02-06 22-11-54](https://user-images.githubusercontent.com/43182025/217089139-512c0611-75ee-4d6a-a34f-8a8d4ba3b715.png)

The unnecessary Home back-link is removed from the interest groups page.
**Before**
![Screenshot from 2023-02-06 22-15-02](https://user-images.githubusercontent.com/43182025/217089768-0785bec4-3341-42eb-99e0-997cffa68427.png)

**After**
![Screenshot from 2023-02-06 22-15-09](https://user-images.githubusercontent.com/43182025/217089746-78c96704-7ee4-4cdc-94e2-17759acf3dc8.png)


# Testing

- [x] I have thoroughly tested my changes.

The changes have been tested locally by clicking around in the webapp :nerd_face: 

---

Resolves ABA-254 and https://github.com/webkom/lego/issues/3203
