### PR TITLE
Add organizer logo to event pages

### DIFF
--- a/app/components/Table/Table.css
+++ b/app/components/Table/Table.css
@@ -44,7 +44,7 @@
 }
 
 .icon {
-  color: var(--color-gray-6);
+  color: var(--color-gray-7);
 }
 
 .iconActive {

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -620,7 +620,7 @@ const CompanyInterestPage = (props: Props) => {
           {interestText.text.second[language]}
           <br />
           <br />
-          {interestText.bedex[language] 
+          {interestText.bedex[language]
           <br />
           <br />
           {interestText.anniversaryCollaboration[language]}

--- a/app/routes/events/components/EventAdministrate/Administrate.css
+++ b/app/routes/events/components/EventAdministrate/Administrate.css
@@ -124,4 +124,9 @@ a.transparent:hover {
   justify-content: center;
   cursor: pointer;
   color: var(--color-red-3);
+  transition: color var(--easing-medium);
+
+  &:hover {
+    color: var(--color-red-5);
+  }
 }

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -58,3 +58,9 @@
 .registeredBox {
   margin-top: 1em;
 }
+
+.organizerLogo {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -11,6 +11,8 @@ import {
 } from 'app/components/Content';
 import DisplayContent from 'app/components/DisplayContent';
 import Icon from 'app/components/Icon';
+import CircularPicture from 'app/components/Image/CircularPicture';
+import ProfilePicture from 'app/components/Image/ProfilePicture';
 import InfoList from 'app/components/InfoList';
 import { Flex } from 'app/components/Layout';
 import { MazemapEmbed } from 'app/components/MazemapEmbed';
@@ -315,7 +317,7 @@ export default class EventDetail extends Component<Props, State> {
           }
         : null,
     ];
-
+    c;
     const groupLink =
       event.responsibleGroup && resolveGroupLink(event.responsibleGroup);
 
@@ -323,18 +325,16 @@ export default class EventDetail extends Component<Props, State> {
       event.responsibleGroup && {
         key: 'Arrangør',
         value: (
-          <span>
-            {groupLink ? (
-              <Link to={groupLink}>{event.responsibleGroup.name}</Link>
-            ) : (
-              event.responsibleGroup.name
-            )}{' '}
-            {event.responsibleGroup.contactEmail && (
-              <a href={`mailto:${event.responsibleGroup.contactEmail}`}>
-                {event.responsibleGroup.contactEmail}
-              </a>
+          <Link to={groupLink} className={styles.organizerLogo}>
+            {groupLink && (
+              <CircularPicture
+                alt={event.responsibleGroup.name}
+                src={event.responsibleGroup.logo}
+                size={40}
+              />
             )}
-          </span>
+            {event.responsibleGroup.name}
+          </Link>
         ),
       },
       event?.createdBy

--- a/app/routes/overview/components/CompactEvents.css
+++ b/app/routes/overview/components/CompactEvents.css
@@ -8,10 +8,6 @@
   text-align: left;
 }
 
-.compactEvents h3 {
-  margin-bottom: 10px;
-}
-
 .compactLeft {
   padding-right: 20px;
 }
@@ -19,8 +15,6 @@
 .compactLeft,
 .compactRight {
   flex: 1;
-  padding-top: 5px;
-  padding-bottom: 5px;
 
   @media (--mobile-device) {
     padding: 0 10px 10px;

--- a/app/routes/users/components/UserSettingsNotifications.css
+++ b/app/routes/users/components/UserSettingsNotifications.css
@@ -10,3 +10,7 @@
 .table td div {
   justify-content: center;
 }
+
+.table tr:nth-child(even) {
+  background-color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 3%);
+}

--- a/app/routes/users/components/UserSettingsOAuth2.css
+++ b/app/routes/users/components/UserSettingsOAuth2.css
@@ -7,6 +7,7 @@
 }
 
 .deleteIcon {
+  justify-content: center;
   cursor: pointer;
   color: var(--color-red-3);
   transition: color var(--easing-medium);

--- a/app/routes/users/components/UserSettingsOAuth2.tsx
+++ b/app/routes/users/components/UserSettingsOAuth2.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
+import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import Table from 'app/components/Table';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
@@ -14,7 +15,7 @@ import styles from './UserSettingsOAuth2.css';
 type Props = {
   applications: Array<any>;
   grants: Array<any>;
-  deleteOAuth2Grant: (grantId: number) => void;
+  deleteOAuth2Grant: (grantId: number) => Promise<void>;
   actionGrant: Array<string>;
   fetchingApplications: boolean;
   fetchingGrants: boolean;
@@ -90,15 +91,20 @@ const UserSettingsOAuth2 = (props: Props) => {
     {
       dataIndex: 'delete',
       render: (id, grant) => (
-        <Tooltip
-          content="Fjern"
-          onClick={() => props.deleteOAuth2Grant(grant.id)}
-          style={{
-            marginTop: '-7px',
-          }}
+        <ConfirmModalWithParent
+          title="Bekreft handling"
+          message={`Er du sikker på at du vil fjerne token?`}
+          onConfirm={() => props.deleteOAuth2Grant(grant.id)}
+          closeOnCancel
         >
-          <Icon name="trash-outline" size={20} className={styles.deleteIcon} />
-        </Tooltip>
+          <Tooltip content="Fjern" style={{ marginTop: '-7px' }}>
+            <Icon
+              name="trash-outline"
+              size={18}
+              className={styles.deleteIcon}
+            />
+          </Tooltip>
+        </ConfirmModalWithParent>
       ),
     },
   ];

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -46,6 +46,12 @@ ul {
   list-style: none;
 }
 
+h1 {
+  font-size: 30px;
+  margin: 15px 0;
+}
+
+h1,
 h2,
 h3,
 h4 {
@@ -100,12 +106,6 @@ th:first-child {
 
 th:last-child {
   border-radius: 0 2em 2em 0;
-}
-
-h1 {
-  font-size: 30px;
-  font-weight: bold;
-  margin: 15px 0;
 }
 
 label {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@loadable/component": "^5.15.3",
     "@reduxjs/toolkit": "^1.9.2",
     "@sentry/browser": "^7.36.0",
-    "@sentry/integrations": "^7.34.0",
+    "@sentry/integrations": "^7.36.0",
     "@sentry/node": "^7.36.0",
     "@stripe/react-stripe-js": "^1.14.2",
     "@stripe/stripe-js": "^1.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,13 +1761,13 @@
     "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/integrations@^7.34.0":
-  version "7.34.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.34.0.tgz#891dd31a7c021cd1b78b3a05dff80deddfbca71b"
-  integrity sha512-xbWnTvG4gkKeCVpmhhdPtMbQkPO0RAfEJ8VPO5TWmUMT23ZWy2kE0gTZHtnBopy7AXxg231XxTi4fxnwgQGxEQ==
+"@sentry/integrations@^7.36.0":
+  version "7.36.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.36.0.tgz#fd3827a5627256e57aa8f5a62c834ae1db5fe370"
+  integrity sha512-wrRoUqdeGi64NNimGVk8U8DBiXamxTYPBux0/faFDyau8EJyQFcv8zOyB78Za4W2Ss3ZXNaE/WtFF8UxalHzBQ==
   dependencies:
-    "@sentry/types" "7.34.0"
-    "@sentry/utils" "7.34.0"
+    "@sentry/types" "7.36.0"
+    "@sentry/utils" "7.36.0"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
@@ -1807,11 +1807,6 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
   integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
 
-"@sentry/types@7.34.0":
-  version "7.34.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.34.0.tgz#e0dc6a927dd13e4cacbca7bfee67a088885e8309"
-  integrity sha512-K+OeHIrl35PSYn6Zwqe4b8WWyAJQoI5NeWxHVkM7oQTGJ1YLG4BvLsR+UiUXnKdR5krE4EDtEA5jLsDlBEyPvw==
-
 "@sentry/types@7.36.0":
   version "7.36.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.36.0.tgz#205baaf7332ff55d1fb35413cbde16dea4168520"
@@ -1823,14 +1818,6 @@
   integrity sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==
   dependencies:
     "@sentry/types" "6.19.7"
-    tslib "^1.9.3"
-
-"@sentry/utils@7.34.0":
-  version "7.34.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.34.0.tgz#32fb6db8b352477d219ddff8200372959c68b445"
-  integrity sha512-VIHHXEBw0htzqxnU8A7WkXKvmsG2pZVqHlAn0H9W/yyFQtXMuP1j1i0NsjADB/3JXUKK83kTNWGzScXvp0o+Jg==
-  dependencies:
-    "@sentry/types" "7.34.0"
     tslib "^1.9.3"
 
 "@sentry/utils@7.36.0":


### PR DESCRIPTION
# Description

Added organiser logo to event pages for user eye satisfaction and increased organiser pride. I am open to improvement suggestions. Important to note that the email link is removed since I believe it has minimal importance being here and it could be easily found at group page.

# Result

**before** 
<img width="565" alt="image" src="https://user-images.githubusercontent.com/90712892/217255619-e4c0a1ae-1bd2-4f91-85c7-9d58c58b4420.png">

**after**
![image](https://user-images.githubusercontent.com/90712892/219108384-02320e8c-8542-4c75-a853-d69719945e1d.png)
# Testing

- I have thoroughly tested my changes on mobile and window views

---
