### PR TITLE
Increase size of modal on smaller screens

### DIFF
--- a/app/components/Modal/Modal.css
+++ b/app/components/Modal/Modal.css
@@ -18,9 +18,9 @@ html[data-theme='dark'] .backdrop {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  max-width: 425px;
-  width: 100%;
-  max-height: calc(100vh - 300px);
+  width: 475px;
+  max-width: 100%;
+  max-height: calc(100vh - 100px);
   padding: 35px;
   background: var(--color-white);
   outline: none;
@@ -30,6 +30,10 @@ html[data-theme='dark'] .backdrop {
   box-shadow: 0 2px 8px 2px rgba(104, 112, 118, 7%),
     0 2px 4px -1px rgba(104, 112, 118, 4%);
   border-radius: 1rem;
+
+  @media (--tall-viewport) {
+    max-height: calc(100vh - 300px);
+  }
 }
 
 .closeButton {

--- a/app/components/UserAttendance/AttendanceModal.css
+++ b/app/components/UserAttendance/AttendanceModal.css
@@ -1,5 +1,9 @@
 .modal {
-  height: calc(100vh - 400px);
+  height: calc(100vh - 100px - 70px);
+
+  @media (--tall-viewport) {
+    max-height: calc(100vh - 300px - 70px);
+  }
 }
 
 .search {

--- a/app/routes/photos/components/GalleryPictureModal.css
+++ b/app/routes/photos/components/GalleryPictureModal.css
@@ -2,7 +2,7 @@
 
 .content {
   padding: 0;
-  max-width: 1100px;
+  width: var(--lego-max-width);
   max-height: calc(100vh - 100px);
 
   @media (max-width: 800px) {

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -2,6 +2,7 @@
 @custom-media --medium-viewport (max-width: 45em);
 @custom-media --mobile-device (max-width: 992px);
 @custom-media --lego-max-width (max-width: 1100px);
+@custom-media --tall-viewport (min-height: 900px);
 
 :root {
   --lego-background-color: #f8f9fa;


### PR DESCRIPTION
# Description

The new modal, although very pretty, was really small on smaller devices. This PR increases the height for screens that are shorter than 900px high, so that there is less whitespace on top and more visible contents.  
It is also in general made a little bit wider.

# Result

|  | Before | After |
:------------------:|:-----------------------------:|:-----------------------------:
iPhone 12 Pro (390x844) | ![image](https://user-images.githubusercontent.com/13599770/217305625-a3a5ea78-c71a-4ec2-a149-dd44c8875780.png) | ![image](https://user-images.githubusercontent.com/13599770/217304486-79e5efb2-177f-4b49-9d3d-033632700e50.png)
Surface Duo (540x720)  | ![image](https://user-images.githubusercontent.com/13599770/217305500-a1617203-0207-44d4-af31-833b51d9dc93.png) | ![image](https://user-images.githubusercontent.com/13599770/217304837-e7aab98a-4500-4491-aa4b-1e508cebf606.png)
Screen longer than 900px | ![image](https://user-images.githubusercontent.com/13599770/217305288-3f67c2fe-0a44-4292-a2f2-a20820b5b289.png) | ![image](https://user-images.githubusercontent.com/13599770/217305089-b5150cba-1e6a-4289-a2cf-672771581cc9.png)

# Testing

- [x] I have thoroughly tested my changes.

Went through all the usages of the modal component I could find and checked that looked fine

---

Resolves ABA-258
