### PR TITLE
Fix sidebar background color

### DIFF
--- a/app/routes/pages/components/PageDetail.css
+++ b/app/routes/pages/components/PageDetail.css
@@ -114,7 +114,7 @@
 }
 
 .sidebarOpenBtn {
-  background-color: #f7f7f7;
+  background-color: var(--color-red-2);
   width: 40px;
   height: 65px;
   position: sticky;
@@ -123,9 +123,8 @@
   align-items: center;
   justify-content: center;
   border-radius: 0 50px 50px 0;
-  border: 1px solid #d1d1d1;
   border-left: 0;
-  color: var(--lego-red);
+  color: #000;
   z-index: 10;
 
   @media (--mobile-device) {

--- a/app/routes/pages/components/Sidebar.css
+++ b/app/routes/pages/components/Sidebar.css
@@ -100,7 +100,7 @@
   .sidebar {
     width: 100%;
     max-width: 100%;
-    background-color: #f6f6f6;
+    background-color: var(--lego-card-color);
     height: 100%;
   }
 


### PR DESCRIPTION
# Description
The text in the sidebar on mobile wasn't visible on dark mode due to white text on white background. I also changed the color of the sidebar button to red.

# Result
**Before:**
![image](https://user-images.githubusercontent.com/66320400/217540016-c81db5e6-d291-4710-b7bd-8939dfa2d9c4.png)
**After**
![image](https://user-images.githubusercontent.com/66320400/217540083-84a9da6d-7e59-46c7-bf88-f26f50682ff9.png)

Sidebar button:
**Before**
![image](https://user-images.githubusercontent.com/66320400/217540498-b94825c1-07be-440d-a218-8aaebe60b512.png)
![image](https://user-images.githubusercontent.com/66320400/217540563-9c39e0ff-e80a-4a41-807b-f66c900c1743.png)

**After**
![image](https://user-images.githubusercontent.com/66320400/217541360-6af5d8f3-7ebd-420a-a664-3d0b315eef39.png)
![image](https://user-images.githubusercontent.com/66320400/217541430-030fa5d4-cc03-4cb0-ad91-a0967e4fa3c9.png)


# Testing

- [X] I have thoroughly tested my changes.
Not much to test here.
