### PR TITLE
Add helmet og properties to joblistings

### DIFF
--- a/app/routes/joblistings/JoblistingDetailedRoute.ts
+++ b/app/routes/joblistings/JoblistingDetailedRoute.ts
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetchJoblisting } from 'app/actions/JoblistingActions';
 import { selectJoblistingById } from 'app/reducers/joblistings';
+import helmet from 'app/utils/helmet';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import JoblistingDetail from './components/JoblistingDetail';
 
@@ -21,6 +22,50 @@ const mapStateToProps = (state, props) => {
   };
 };
 
+const propertyGenerator = ({ joblisting }, config) => {
+  if (!joblisting) return;
+
+  return [
+    {
+      property: 'og:title',
+      content: joblisting.title,
+    },
+    {
+      element: 'title',
+      children: joblisting.title,
+    },
+    {
+      element: 'link',
+      rel: 'canonical',
+      href: `${config.webUrl}/joblistings/${joblisting.id}`,
+    },
+    {
+      property: 'og:description',
+      content: joblisting.description,
+    },
+    {
+      property: 'og:type',
+      content: 'website',
+    },
+    {
+      property: 'og:image:width',
+      content: '1667',
+    },
+    {
+      property: 'og:image:height',
+      content: '500',
+    },
+    {
+      property: 'og:url',
+      content: `${config.webUrl}/joblistings/${joblisting.id}`,
+    },
+    {
+      property: 'og:image',
+      content: joblisting.company.logo,
+    },
+  ];
+};
+
 const mapDispatchToProps = {
   fetchJoblisting,
   push,
@@ -29,5 +74,6 @@ export default compose(
   withPreparedDispatch('fetchJoblistingDetailed', (props, dispatch) =>
     dispatch(fetchJoblisting(props.match.params.joblistingId))
   ),
-  connect(mapStateToProps, mapDispatchToProps)
+  connect(mapStateToProps, mapDispatchToProps),
+  helmet(propertyGenerator)
 )(JoblistingDetail);


### PR DESCRIPTION
# Description

Add helmet props to joblistings. This fixes the generic meta that  is displayed when sharing
joblistings urls on facebook, slack etc.

# Result


# Testing

- [x] I have thoroughly tested my changes.

I tested that the properties are present when SSRing, and tested that it looks okay in an opengraph
debugger.

---

Fixes ABA-265
