### PR TITLE
Fix article editor submit function

### DIFF
--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -175,6 +175,7 @@ const ArticleEditor = ({
 
 const onSubmit = (
   data,
+  dispatch,
   { currentUser, isNew, articleId, submitArticle }: Props
 ) => {
   const body = {


### PR DESCRIPTION
# Description

Saving articles is broken in staging. It was simply an argument that was mistakenly removed from the `onSubmit` function in https://github.com/webkom/lego-webapp/pull/3526.

# Result

Articles can once again be saved!

# Testing

- [x] I have thoroughly tested my changes.

I successfully saved an article in staging.