### PR TITLE
Only show loading indicator when necesarry

### DIFF
--- a/app/routes/events/EventListRoute.ts
+++ b/app/routes/events/EventListRoute.ts
@@ -31,7 +31,7 @@ const mapStateToProps = (state, ownProps) => {
       actionGrant,
     })(state, ownProps),
     icalToken,
-    notLoading: !state.events.fetching,
+    fetching: state.events.fetching,
   };
 };
 
@@ -63,6 +63,5 @@ export default compose(
   withPreparedDispatch('fetchEventList', (props, dispatch) =>
     dispatch(fetchData())
   ),
-  connect(mapStateToProps, mapDispatchToProps),
-  loadingIndicator(['notLoading'])
+  connect(mapStateToProps, mapDispatchToProps)
 )(EventList);

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -9,6 +9,7 @@ import EventItem from 'app/components/EventItem';
 import { CheckBox } from 'app/components/Form/';
 import { selectTheme, selectStyles } from 'app/components/Form/SelectInput';
 import Icon from 'app/components/Icon';
+import LoadingIndicator from 'app/components/LoadingIndicator';
 import type { Event, ActionGrant, IcalToken } from 'app/models';
 import { EventTime } from 'app/models';
 import EventFooter from './EventFooter';
@@ -81,6 +82,7 @@ type EventListProps = {
   fetchMore: () => Promise<any>;
   loggedIn: boolean;
   location: Record<string, any>;
+  fetching: boolean;
 };
 type Option = {
   filterRegDateFunc: (arg0: Event) => boolean;
@@ -149,8 +151,9 @@ class EventList extends Component<EventListProps, State> {
   };
 
   render() {
-    const { icalToken, showFetchMore, fetchMore, events, loggedIn } =
+    const { icalToken, showFetchMore, fetchMore, events, loggedIn, fetching } =
       this.props;
+
     const { field, filterRegDateFunc } = this.state.selectedOption;
     const { showCompanyPresentation, showCourse, showSocial, showOther } =
       this.state.filterEventTypesSettings;
@@ -261,7 +264,8 @@ class EventList extends Component<EventListProps, State> {
           field={field}
           loggedIn={loggedIn}
         />
-        {isEmpty(this.props.events) && (
+        {isEmpty(events) && fetching && <LoadingIndicator loading />}
+        {isEmpty(events) && !fetching && (
           <EmptyState icon="book-outline" size={40}>
             <h2 className={styles.noEvents}>Ingen kommende arrangementer</h2>
           </EmptyState>


### PR DESCRIPTION
# Description

Currently on /events, you'll get a loading indicator even though you have events stored. This is for obvious reasons unnecessary, and is fixed here.

# Result

**Before**

https://user-images.githubusercontent.com/69514187/218099688-faaacea5-44e9-4445-800a-431ae77b2d11.mov


**After**

Whenever the theme changes, that's me doing a hard refresh. Notice that I do a hard refresh on two different routes.

https://user-images.githubusercontent.com/69514187/218099269-ea8c28de-14c3-446c-87df-843a27094ec6.mov

# Testing

- [x] I have thoroughly tested my changes.

Navigated between routes and did hard refreshes. This should not affect anything else.

---

Resolves ABA-267
