### PR TITLE
Improve /companies page

### DIFF
--- a/app/components/Card/Card.css
+++ b/app/components/Card/Card.css
@@ -12,3 +12,8 @@
   box-shadow: 0 2px 8px 2px rgba(104, 112, 118, 7%),
     0 2px 4px -1px rgba(104, 112, 118, 4%);
 }
+
+.isHoverable:hover {
+  transition: box-shadow var(--easing-medium);
+  box-shadow: 0 12px 20px 6px rgba(104, 112, 118, 8%);
+}

--- a/app/components/Card/index.tsx
+++ b/app/components/Card/index.tsx
@@ -4,15 +4,10 @@ import type { HTMLAttributes } from 'react';
 
 type Props = {
   className?: string;
-
-  /** Small */
   tight?: boolean;
-
-  /** Shadow */
   shadow?: boolean;
-
-  /** Hidden overflow */
-  overflow?: boolean;
+  hideOverflow?: boolean;
+  isHoverable?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
 function Card({
@@ -20,7 +15,8 @@ function Card({
   className,
   tight = false,
   shadow = true,
-  overflow = false,
+  hideOverflow = false,
+  isHoverable = false,
   ...htmlAttributes
 }: Props) {
   return (
@@ -29,10 +25,11 @@ function Card({
         className,
         styles.card,
         tight && styles.tight,
-        shadow && styles.shadow
+        shadow && styles.shadow,
+        isHoverable && styles.isHoverable
       )}
       style={{
-        overflow: overflow && 'hidden',
+        overflow: hideOverflow && 'hidden',
       }}
       {...htmlAttributes}
     >

--- a/app/routes/company/components/CompaniesPage.css
+++ b/app/routes/company/components/CompaniesPage.css
@@ -30,18 +30,8 @@
 .companyItem {
   width: 220px;
   height: 220px;
-  padding-bottom: 10px;
-  margin-bottom: 15px;
-  margin-left: 8px;
-  color: var(--color-black);
-  box-shadow: 5px 2px 5px #ede7e7;
-  border-radius: 2px;
+  padding: 0;
   word-wrap: break-word;
-}
-
-html[data-theme='dark'] .companyItem {
-  box-shadow: 5px 2px 5px
-    rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 10%);
 }
 
 .companyItemContent {
@@ -52,19 +42,6 @@ html[data-theme='dark'] .companyItem {
   height: 100%;
 }
 
-.companyItemTitle {
-  color: var(--lego-font-color);
-  font-weight: 700;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  line-height: 25px;
-  height: 46px;
-}
-
-.companyItemTitle > * {
-  padding-bottom: 10px;
-}
-
 .iconLink {
   color: var(--lego-link-color);
   display: flex;
@@ -72,12 +49,15 @@ html[data-theme='dark'] .companyItem {
 }
 
 .companyInfo {
+  background-color: var(--additive-background);
   color: var(--secondary-font-color);
-  font-style: italic;
-  justify-content: space-between;
-  padding: 0 30px;
-  border-top: 2px solid var(--lego-red-color);
-  padding-top: 20px;
+  font-weight: 600;
+  padding: 3px 50px;
+  padding-top: 15px;
+}
+
+.interestingCount {
+  color: var(--lego-red-color);
 }
 
 .companyLogoContainer {
@@ -121,12 +101,7 @@ html[data-theme='dark'] .companyItem {
 }
 
 .iconInfoPlacement {
-  flex-flow: row;
-  display: flex;
-  align-content: stretch;
-  justify-content: center;
-  margin-top: 38px;
-  margin-bottom: 39px;
+  margin: 38px 0;
 }
 
 .infoText {

--- a/app/routes/company/components/CompaniesPage.tsx
+++ b/app/routes/company/components/CompaniesPage.tsx
@@ -1,8 +1,10 @@
 import cx from 'classnames';
-import { createRef, Component } from 'react';
+import { useState, useRef } from 'react';
 import { Helmet } from 'react-helmet-async';
 import InfiniteScroll from 'react-infinite-scroller';
 import { Link } from 'react-router-dom';
+import Button from 'app/components/Button';
+import Card from 'app/components/Card';
 import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
@@ -10,22 +12,13 @@ import LoadingIndicator from 'app/components/LoadingIndicator';
 import type { ListCompany } from 'app/store/models/Company';
 import utilities from 'app/styles/utilities.css';
 import styles from './CompaniesPage.css';
-import type { ElementRef } from 'react';
-
-type Props = {
-  companies: ListCompany[];
-  fetchMore: () => void;
-  showFetchMore: () => void;
-  hasMore: boolean;
-  fetching: boolean;
-};
 
 const CompanyItem = ({ company }: { company: ListCompany }) => {
   return (
-    <div className={styles.companyItem}>
-      <div className={styles.companyItemContent}>
-        <div className={styles.companyLogoContainer}>
-          <Link to={`/companies/${company.id}`}>
+    <Link to={`/companies/${company.id}`}>
+      <Card isHoverable hideOverflow className={styles.companyItem}>
+        <div className={styles.companyItemContent}>
+          <div className={styles.companyLogoContainer}>
             <div className={styles.companyLogo}>
               {
                 <Image
@@ -35,40 +28,28 @@ const CompanyItem = ({ company }: { company: ListCompany }) => {
                 />
               }
             </div>
-          </Link>
+          </div>
+          <Flex justifyContent="space-between" className={styles.companyInfo}>
+            <Flex
+              column
+              alignItems="center"
+              className={company.joblistingCount > 0 && styles.interestingCount}
+            >
+              <Icon name="briefcase" size={20} />
+              <span>{company.joblistingCount}</span>
+            </Flex>
+            <Flex
+              column
+              alignItems="center"
+              className={company.eventCount > 0 && styles.interestingCount}
+            >
+              <Icon name="calendar-clear" size={20} />
+              <span>{company.eventCount}</span>
+            </Flex>
+          </Flex>
         </div>
-        <Flex className={styles.companyInfo}>
-          <Flex column alignItems="center">
-            <Icon name="briefcase" size={20} />
-            <span>{company.joblistingCount}</span>
-          </Flex>
-          {company.website && (
-            <div className={styles.iconLink}>
-              <a
-                href={company.website}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Flex column alignItems="center">
-                  <Icon
-                    name="at-circle"
-                    size={20}
-                    style={{
-                      color: 'var(--lego-link-color)',
-                    }}
-                  />
-                  <span>Link her</span>
-                </Flex>
-              </a>
-            </div>
-          )}
-          <Flex column alignItems="center">
-            <Icon name="calendar-clear" size={20} />
-            <span>{company.eventCount}</span>
-          </Flex>
-        </Flex>
-      </div>
-    </div>
+      </Card>
+    </Link>
   );
 };
 
@@ -84,96 +65,91 @@ const CompanyList = ({ companies = [] }: CompanyListProps) => (
   </div>
 );
 
-type State = {
-  expanded: boolean;
+type Props = {
+  companies: ListCompany[];
+  fetchMore: () => void;
+  showFetchMore: () => void;
+  hasMore: boolean;
+  fetching: boolean;
 };
 
-class CompaniesPage extends Component<Props, State> {
-  state = {
-    expanded: false,
-  };
-  top = createRef<ElementRef<'h2'>>();
+const CompaniesPage = (props: Props) => {
+  const [expanded, setExpanded] = useState(false);
+  const top = useRef<HTMLHeadingElement>(null);
 
-  render() {
-    const { props } = this;
-    return (
-      <div className={styles.root}>
-        <Helmet title="Bedrifter" />
-        <h1 ref={this.top}>Bedrifter</h1>
-        <div>
+  return (
+    <div className={styles.root}>
+      <Helmet title="Bedrifter" />
+      <h1 ref={top}>Bedrifter</h1>
+      <div>
+        <p className={styles.infoText}>
+          Vil du jobbe som in-house utvikler i din drømmebedrift? Ser du for deg
+          en hverdag som konsulent på oppdrag hos de kuleste kundene? Er
+          sikkerhet din greie, eller drømmer du om å drive med spillutvikling på
+          heltid? På denne siden har vi samlet et utvalg potensielle
+          arbeidsgivere for deg som student, som gjenspeiler mangfoldet du har i
+          jobbmuligheter.
+        </p>
+        {!expanded && (
+          <Button
+            flat
+            className={cx(styles.readMore, 'accordion')}
+            onClick={() => setExpanded(true)}
+          >
+            Vis mer
+          </Button>
+        )}
+        <div className={!expanded && utilities.hiddenOnMobile}>
           <p className={styles.infoText}>
-            Vil du jobbe som in-house utvikler i din drømmebedrift? Ser du for
-            deg en hverdag som konsulent på oppdrag hos de kuleste kundene? Er
-            sikkerhet din greie, eller drømmer du om å drive med spillutvikling
-            på heltid? På denne siden har vi samlet et utvalg potensielle
-            arbeidsgivere for deg som student, som gjenspeiler mangfoldet du har
-            i jobbmuligheter.
+            Trykk deg inn på en bedrift for å se hva slags type bedrift det er,
+            les mer om hva de jobber med og se hvor de holder til. Bla deg
+            gjennom en oversikt over tidligere eller kommende arrangementer og
+            se hvem som har jobbannonser ute for øyeblikket. Hvis du vil lese
+            mer om bedriften så kan du navigere deg til nettsiden deres via
+            linken.
           </p>
-          {!this.state.expanded && (
-            <button
-              className={cx(styles.readMore, 'accordion')}
-              onClick={() => {
-                this.setState({
-                  expanded: true,
-                });
-              }}
-            >
-              Vis mer
-            </button>
-          )}
-          <div className={this.state.expanded ? ' ' : utilities.hiddenOnMobile}>
-            <p className={styles.infoText}>
-              Trykk deg inn på en bedrift for å se hva slags type bedrift det
-              er, les mer om hva de jobber med og se hvor de holder til. Bla deg
-              gjennom en oversikt over tidligere eller kommende arrangementer og
-              se hvem som har jobbannonser ute for øyeblikket. Hvis du vil lese
-              mer om bedriften så kan du navigere deg til nettsiden deres via
-              linken.
-            </p>
 
-            <p className={styles.infoText}>
-              Savner du en bedrift? Savner du noe informasjon om en bedrift? Ta
-              kontakt med Bedkom, vi tar gjerne imot innspill!
-            </p>
-            <button
-              className={cx(styles.readMore, 'accordion')}
-              onClick={() => {
-                this.setState({
-                  expanded: false,
-                });
-                this.top.current && this.top.current.scrollIntoView();
-              }}
-            >
-              Vis mindre
-            </button>
-          </div>
+          <p className={styles.infoText}>
+            Savner du en bedrift? Savner du noe informasjon om en bedrift? Ta
+            kontakt med Bedkom, vi tar gjerne imot innspill!
+          </p>
+          <Button
+            flat
+            className={cx(styles.readMore, 'accordion')}
+            onClick={() => {
+              setExpanded(false);
+              top.current?.scrollIntoView();
+            }}
+          >
+            Vis mindre
+          </Button>
         </div>
-        <div className={styles.iconInfoPlacement}>
-          <Flex>
-            <Icon name="briefcase" size={25} />
-            <span className={styles.iconInfo}> Aktive jobbannonser</span>
-          </Flex>
-          <Flex>
-            <Icon name="at-circle" size={25} />
-            <span className={styles.iconInfo}> Nettside</span>
-          </Flex>
-          <Flex>
-            <Icon name="calendar-clear" size={25} />
-            <span className={styles.iconInfo}> Kommende arrangementer</span>
-          </Flex>
-        </div>
-        <InfiniteScroll
-          element="div"
-          hasMore={props.hasMore}
-          loadMore={() => props.hasMore && !props.fetching && props.fetchMore()}
-          initialLoad={false}
-          loader={<LoadingIndicator loading />}
-        >
-          <CompanyList companies={props.companies} />
-        </InfiniteScroll>
       </div>
-    );
-  }
-}
+      <Flex
+        justifyContent="center"
+        gap={5}
+        className={styles.iconInfoPlacement}
+      >
+        <Flex>
+          <Icon name="briefcase" size={25} />
+          <span className={styles.iconInfo}> Aktive jobbannonser</span>
+        </Flex>
+        <Flex>
+          <Icon name="calendar-clear" size={25} />
+          <span className={styles.iconInfo}> Kommende arrangementer</span>
+        </Flex>
+      </Flex>
+      <InfiniteScroll
+        element="div"
+        hasMore={props.hasMore}
+        loadMore={() => props.hasMore && !props.fetching && props.fetchMore()}
+        initialLoad={false}
+        loader={<LoadingIndicator loading />}
+      >
+        <CompanyList companies={props.companies} />
+      </InfiniteScroll>
+    </div>
+  );
+};
 
 export default CompaniesPage;

--- a/app/routes/overview/components/EventItem.tsx
+++ b/app/routes/overview/components/EventItem.tsx
@@ -18,7 +18,7 @@ type Props = {
 const EventItem = ({ item, url, meta, loggedIn, isFrontPage }: Props) => {
   const info = eventStatus(item, loggedIn);
   return (
-    <Card overflow className={styles.body}>
+    <Card hideOverflow className={styles.body}>
       <Link to={url} className={styles.link}>
         <Flex className={styles.wrapper}>
           {isFrontPage ? (

--- a/app/routes/overview/components/Pinned.tsx
+++ b/app/routes/overview/components/Pinned.tsx
@@ -16,7 +16,7 @@ type Props = {
 const Pinned = ({ item, url, meta }: Props) => (
   <Flex column className={styles.pinned}>
     <h3 className="u-ui-heading">Festet oppslag</h3>
-    <Card overflow className={styles.body}>
+    <Card hideOverflow className={styles.body}>
       <Link to={url} className={styles.innerLinks}>
         <Image
           className={styles.image}

--- a/app/routes/polls/components/PollsList.tsx
+++ b/app/routes/polls/components/PollsList.tsx
@@ -50,7 +50,7 @@ const PollsList = ({
             to={`/polls/${poll.id}`}
             className={styles.pollItem}
           >
-            <Card className={styles.pollListItem}>
+            <Card isHoverable className={styles.pollListItem}>
               <Flex>
                 <Icon name="stats-chart" size={35} className={styles.icon} />
                 <h3 className={styles.heading}>{poll.title}</h3>


### PR DESCRIPTION
# Description

The cards now employ the `<Card />` component, making them resemble the rest of the webapp more. Also some other minimal styling changes. Finally, the whole card is a link, and not just the image, which has been an annoying bug for a really long time.

`CompaniesPage` is rewritten to a functional component.

`isHoverable` prop is added for cards that work as links.

# Result

**Before**

https://user-images.githubusercontent.com/69514187/218262039-63f5871d-414a-4c4e-8f1e-3428489a9dc8.mov

**After**

https://user-images.githubusercontent.com/69514187/218261983-40312029-efa0-4d6e-a58e-bc2eb7ec54a6.mov

# Testing

- [x] I have thoroughly tested my changes.

Tested on light and dark mode, and on mobile (some minimal changes here to the expanded text functionality).

---

Resolves ABA-270