### PR TITLE
Created Allergies Tab

### DIFF
--- a/app/routes/events/EventAllergiesRoute.ts
+++ b/app/routes/events/EventAllergiesRoute.ts
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import { getRegistrationGroups } from 'app/reducers/events';
+import Allergies from './components/EventAdministrate/Allergies';
+
+const mapStateToProps = (state, props) => {
+  const { eventId, event, actionGrant, loading } = props;
+  const { registered, unregistered } = getRegistrationGroups(state, {
+    eventId,
+  });
+  return {
+    eventId,
+    actionGrant,
+    loading,
+    event,
+    registered,
+    unregistered,
+  };
+};
+
+export default connect(mapStateToProps)(Allergies);

--- a/app/routes/events/components/EventAdministrate/Allergies.tsx
+++ b/app/routes/events/components/EventAdministrate/Allergies.tsx
@@ -1,0 +1,109 @@
+import moment from 'moment-timezone';
+import { Link } from 'react-router-dom';
+import { Flex } from 'app/components/Layout';
+import LoadingIndicator from 'app/components/LoadingIndicator';
+import Table from 'app/components/Table';
+import type {
+  Event,
+  EventPool,
+  ActionGrant,
+  User,
+  ID,
+  EventRegistration,
+  EventRegistrationPaymentStatus,
+  EventRegistrationPresence,
+} from 'app/models';
+import type Comment from 'app/store/models/Comment';
+import type { CurrentUser } from 'app/store/models/User';
+import { RegistrationPill, getRegistrationInfo } from './RegistrationTables';
+
+export type Props = {
+  eventId: number;
+  event: Event;
+  comments: Comment[];
+  pools: Array<EventPool>;
+  loggedIn: boolean;
+  currentUser: CurrentUser;
+  error: Record<string, any>;
+  loading: boolean;
+  registered: Array<EventRegistration>;
+  unregistered: Array<EventRegistration>;
+  usersResult: Array<User>;
+  actionGrant: ActionGrant;
+  onQueryChanged: (value: string) => any;
+  searching: boolean;
+};
+
+const Allergies = ({ eventId, event, error, loading, registered }: Props) => {
+  if (loading) {
+    return <LoadingIndicator loading />;
+  }
+
+  if (error) {
+    return <div>{error.message}</div>;
+  }
+
+  const columns = [
+    {
+      title: 'Bruker',
+      dataIndex: 'user',
+      search: true,
+      centered: false,
+      render: (user) => (
+        <Link to={`/users/${user.username}`}>{user.fullName}</Link>
+      ),
+      filterMapping: (user) => user.fullName,
+    },
+    {
+      title: 'Status',
+      dataIndex: 'pool',
+      render: (pool, registration) => {
+        const registrationInfo = getRegistrationInfo(registration);
+        return (
+          <RegistrationPill
+            status={registrationInfo.status}
+            reason={registrationInfo.reason}
+            className={registrationInfo.className}
+          />
+        );
+      },
+      sorter: (a, b) => {
+        if (a.pool && !b.pool) return -1;
+        if (!a.pool && b.pool) return 1;
+        return 0;
+      },
+    },
+    {
+      title: 'Matallergier / Preferanser',
+      dataIndex: 'user.allergies',
+      centered: false,
+      render: (allergies) => <span>{allergies}</span>,
+      sorter: (a, b) => a.user.allergies.localeCompare(b.user.allergies),
+    },
+  ];
+  const numOfAllergies = () => {
+    return registered.filter(
+      (registration) => registration.user.allergies.length != 0
+    ).length;
+  };
+  return (
+    <div>
+      <Flex column>
+        {numOfAllergies() == 0 ? (
+          <li>Ingen påmeldte med allergier</li>
+        ) : (
+          <Table
+            hasMore={false}
+            columns={columns}
+            loading={loading}
+            data={registered.filter((registration) => {
+              return registration.user.allergies;
+            })}
+          />
+        )}
+      </Flex>
+    </div>
+  );
+};
+
+export default Allergies;

--- a/app/routes/events/components/EventAdministrate/Attendees.tsx
+++ b/app/routes/events/components/EventAdministrate/Attendees.tsx
@@ -31,12 +31,16 @@ export type Props = {
   loading: boolean;
   registered: Array<EventRegistration>;
   unregistered: Array<EventRegistration>;
-  unregister: (arg0: {
+  unregister: (registrationId: {
     eventId: ID;
     registrationId: ID;
     admin: boolean;
   }) => Promise<void>;
-  updatePresence: (arg0: number, arg1: number, arg2: string) => Promise<any>;
+  updatePresence: (
+    eventId: number,
+    registrationId: number,
+    presence: string
+  ) => Promise<any>;
   updatePayment: (
     arg0: ID,
     arg1: ID,
@@ -111,7 +115,7 @@ const Attendees = ({
   const showUnregister = // Show unregister button until 1 day after event has ended,
     // or until reg/unreg has ended if that is more than 1 day
     // after event end
-    moment().isBefore(moment(event.endTime).add('days', 1)) ||
+    moment().isBefore(moment(event.endTime).add(1, 'day')) ||
     moment().isBefore(event.unregistrationCloseTime) ||
     moment().isBefore(event.registrationCloseTime);
   const exportInfoMessage = `Informasjonen du eksporterer MÅ slettes når det ikke lenger er behov for den,
@@ -147,7 +151,7 @@ const Attendees = ({
         {event.useContactTracing &&
           (currentUser.id === event.createdBy ||
             currentUser.id === event.createdBy.id) &&
-          moment().isBefore(moment(event.endTime).add('days', 14)) &&
+          moment().isBefore(moment(event.endTime).add(14, 'days')) &&
           (generatedCsvUrl ? (
             <a href={generatedCsvUrl} download="attendees.csv">
               Last ned

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
@@ -72,7 +72,7 @@ type RegistrationPillProps = {
   className: string;
 };
 
-const RegistrationPill = ({
+export const RegistrationPill = ({
   status,
   reason,
   className,
@@ -93,7 +93,7 @@ const RegistrationPill = ({
   );
 };
 
-const getRegistrationInfo = (pool, registration) => {
+export const getRegistrationInfo = (registration) => {
   const registrationInfo = {
     status: 'Venteliste',
     reason: '',
@@ -118,7 +118,7 @@ const getRegistrationInfo = (pool, registration) => {
       registrationInfo.status = 'Påmeldt';
       registrationInfo.reason = `Adminpåmeldt: ${registration.adminRegistrationReason}`;
     }
-  } else if (pool) {
+  } else if (registration.pool) {
     registrationInfo.status = 'Påmeldt';
     registrationInfo.className = styles.greenPill;
   }
@@ -247,7 +247,7 @@ export class RegisteredTable extends Component<Props> {
         title: 'Status',
         dataIndex: 'pool',
         render: (pool, registration) => {
-          const registrationInfo = getRegistrationInfo(pool, registration);
+          const registrationInfo = getRegistrationInfo(registration);
           return (
             <RegistrationPill
               status={registrationInfo.status}
@@ -255,6 +255,11 @@ export class RegisteredTable extends Component<Props> {
               className={registrationInfo.className}
             />
           );
+        },
+        sorter: (a, b) => {
+          if (a.pool && !b.pool) return -1;
+          if (!a.pool && b.pool) return 1;
+          return 0;
         },
       },
       {
@@ -341,13 +346,7 @@ export class RegisteredTable extends Component<Props> {
         title: 'Tilbakemelding',
         dataIndex: 'feedback',
         centered: false,
-        render: (feedback, registration) => (
-          <span>
-            {feedback || '-'}
-            <br />
-            {`Matallergier: ${registration.user.allergies || '-'}`}
-          </span>
-        ),
+        render: (feedback) => <span>{feedback || '-'}</span>,
         sorter: (a, b) => a.feedback.localeCompare(b.feedback),
       },
       {

--- a/app/routes/events/components/EventAdministrate/index.tsx
+++ b/app/routes/events/components/EventAdministrate/index.tsx
@@ -35,6 +35,7 @@ const EventAdministrateIndex = (props: Props) => {
         }}
       >
         <NavigationLink to={`${base}/attendees`}>Påmeldinger</NavigationLink>
+        <NavigationLink to={`${base}/allergies`}>Allergier</NavigationLink>
         <NavigationLink to={`${base}/statistics`}>Statistikk</NavigationLink>
         <NavigationLink to={`${base}/admin-register`}>
           Adminregistrering

--- a/app/routes/events/index.tsx
+++ b/app/routes/events/index.tsx
@@ -8,6 +8,7 @@ const EventAdministrateRoute = loadable(
   () => import('./EventAdministrateRoute')
 );
 const EventAttendeeRoute = loadable(() => import('./EventAttendeeRoute'));
+const EventAllergiesRoute = loadable(() => import('./EventAllergiesRoute'));
 const EventAdminRegisterRoute = loadable(
   () => import('./EventAdminRegisterRoute')
 );
@@ -84,6 +85,15 @@ const eventRoute = ({
                 exact
                 path={`${match.path}/attendees`}
                 Component={EventAttendeeRoute}
+                passedProps={{
+                  currentUser,
+                  loggedIn,
+                }}
+              />
+              <RouteWrapper
+                exact
+                path={`${match.path}/allergies`}
+                Component={EventAllergiesRoute}
                 passedProps={{
                   currentUser,
                   loggedIn,


### PR DESCRIPTION
As discussed previously, I have now created a seperate tab for allergies in EventAdministrate. Currently anyone can still see all the allergies, but we can add an anonymized list later on.  

Before:

![Skjermbilde 2023-02-12 kl  00 56 11](https://user-images.githubusercontent.com/45620425/218286435-f834412f-c230-4dce-93d9-1d417358738d.jpeg)

After:
![Skjermbilde 2023-02-12 kl  00 56 35](https://user-images.githubusercontent.com/45620425/218286468-909a6e06-008c-4f39-9385-013503ddf88a.jpeg)
![Skjermbilde 2023-02-12 kl  00 57 49](https://user-images.githubusercontent.com/45620425/218286473-55fa9131-7d2b-4116-8bf3-e13081ac9115.jpeg)


Newst version:
<img width="1102" alt="Skjermbilde 2023-02-21 kl  22 04 20" src="https://user-images.githubusercontent.com/45620425/220458723-abac8d50-4814-4408-8cb2-eacdf3b4db3a.png">



Most of the code in Allergies.tsx and EventAllergiesRoute.ts was copied and slightly altered from Attendees.tsx and EventAttendees.ts. Unsure if everything is necessary or if there is anything I should have done differently, please let me know if so. 


Resolves ABA-175
