### PR TITLE
Include waiting list to summary pool tab

### DIFF
--- a/app/components/UserAttendance/AttendanceModal.css
+++ b/app/components/UserAttendance/AttendanceModal.css
@@ -127,3 +127,8 @@ html[data-theme='dark'] .search input {
   box-shadow: 0 0 0 1px var(--lego-red-color);
   color: var(--lego-red-color);
 }
+
+.opacity {
+  transition: opacity var(--linear-fast);
+  opacity: 0.4;
+}

--- a/app/components/UserAttendance/AttendanceModal.tsx
+++ b/app/components/UserAttendance/AttendanceModal.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames';
 import { flatMap } from 'lodash-es';
-import { Component } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import { TextInput } from 'app/components/Form';
@@ -21,7 +21,7 @@ export type Pool = {
 };
 
 type Props = {
-  pools: Array<Pool>;
+  pools: Pool[];
   title: string;
   togglePool: (arg0: number) => void;
   selectedPool: number;
@@ -48,109 +48,99 @@ const Tab = ({ name, index, activePoolIndex, togglePool }: TabProps) => (
   </Button>
 );
 
-type State = {
-  pools: Pool[];
-  filter: string;
-};
+const AttendanceModal = ({
+  title = 'Status',
+  pools,
+  togglePool,
+  selectedPool,
+  isMeeting,
+}: Props) => {
+  const [amendedPools, setAmendedPools] = useState<Pool[]>([]);
+  const [registrations, setRegistrations] = useState<Registration[]>([]);
+  const [filter, setFilter] = useState<string>('');
 
-class AttendanceModal extends Component<Props, State> {
-  state = {
-    pools: [],
-    filter: '',
-  };
-  static defaultProps = {
-    title: 'Status',
-  };
+  useEffect(() => {
+    generateAmendedPools(pools);
+  }, [pools]);
 
-  UNSAFE_componentWillMount() {
-    this.generateAmendedPools(this.props.pools);
-  }
-
-  generateAmendedPools = (pools: Pool[]) => {
-    if (pools.length === 1)
-      return this.setState({
-        pools,
-      });
+  const generateAmendedPools = (pools: Pool[]) => {
+    if (pools.length === 1) return setAmendedPools(pools);
 
     const registrations = flatMap(pools, (pool) => pool.registrations);
     const summaryPool = {
       name: 'Alle',
       registrations,
     };
-    return this.setState({
-      pools: [summaryPool, ...pools],
-    });
+    return setAmendedPools([summaryPool, ...pools]);
   };
 
-  render() {
-    const { title, togglePool, selectedPool, isMeeting } = this.props;
-    const { pools, filter } = this.state;
-
-    const registrations = pools[selectedPool].registrations.filter(
+  useEffect(() => {
+    const registrations = amendedPools[selectedPool]?.registrations.filter(
       (registration) => {
         return registration.user.fullName
           .toLowerCase()
           .includes(filter.toLowerCase());
       }
     );
+    setRegistrations(registrations);
+  }, [filter, amendedPools, selectedPool]);
 
-    return (
-      <Flex
-        column
-        justifyContent="space-between"
-        gap={15}
-        className={styles.modal}
-      >
-        <h2>{title}</h2>
-        <Flex alignItems="center" className={styles.search}>
-          <Icon name="search" size={16} />
-          <TextInput
-            type="text"
-            placeholder="Søk etter navn"
-            onChange={(e) => this.setState({ filter: e.target.value })}
-          />
-        </Flex>
-
-        <ul className={styles.list}>
-          {registrations.map((registration) => (
-            <li key={registration.id}>
-              <Flex
-                alignItems="center"
-                className={cx(
-                  styles.row,
-                  !isMeeting &&
-                    !registration.pool &&
-                    pools[selectedPool].name === 'Alle' &&
-                    styles.opacity
-                )}
-              >
-                <ProfilePicture
-                  size={30}
-                  user={registration.user}
-                  alt={`${registration.user.name}'s profile picture`}
-                />
-                <Link to={`/users/${registration.user.username}`}>
-                  {registration.user.fullName}
-                </Link>
-              </Flex>
-            </li>
-          ))}
-        </ul>
-
-        <Flex justifyContent="space-between" className={styles.nav}>
-          {pools.map((pool, i) => (
-            <Tab
-              name={pool.name}
-              key={i}
-              index={i}
-              activePoolIndex={selectedPool}
-              togglePool={togglePool}
-            />
-          ))}
-        </Flex>
+  return (
+    <Flex
+      column
+      justifyContent="space-between"
+      gap={15}
+      className={styles.modal}
+    >
+      <h2>{title}</h2>
+      <Flex alignItems="center" className={styles.search}>
+        <Icon name="search" size={16} />
+        <TextInput
+          type="text"
+          placeholder="Søk etter navn"
+          onChange={(e) => setFilter(e.target.value)}
+        />
       </Flex>
-    );
-  }
-}
+
+      <ul className={styles.list}>
+        {registrations?.map((registration) => (
+          <li key={registration.id}>
+            <Flex
+              alignItems="center"
+              className={cx(
+                styles.row,
+                !isMeeting &&
+                  !registration.pool &&
+                  amendedPools[selectedPool].name === 'Alle' &&
+                  styles.opacity
+              )}
+            >
+              <ProfilePicture
+                size={30}
+                user={registration.user}
+                alt={`${registration.user.fullName}'s profile picture`}
+              />
+              <Link to={`/users/${registration.user.username}`}>
+                {registration.user.fullName}
+              </Link>
+            </Flex>
+          </li>
+        ))}
+      </ul>
+
+      <Flex justifyContent="space-between" className={styles.nav}>
+        {amendedPools.map((pool, i) => (
+          <Tab
+            name={pool.name}
+            key={i}
+            index={i}
+            activePoolIndex={selectedPool}
+            togglePool={togglePool}
+          />
+        ))}
+      </Flex>
+    </Flex>
+  );
+};
 
 export default AttendanceModal;

--- a/app/components/UserAttendance/AttendanceModal.tsx
+++ b/app/components/UserAttendance/AttendanceModal.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { flatMap } from 'lodash';
+import { flatMap } from 'lodash-es';
 import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
@@ -25,7 +25,7 @@ type Props = {
   title: string;
   togglePool: (arg0: number) => void;
   selectedPool: number;
-  allRegistrations?: Registration[];
+  isMeeting?: boolean;
 };
 
 type TabProps = {
@@ -63,19 +63,16 @@ class AttendanceModal extends Component<Props, State> {
   };
 
   UNSAFE_componentWillMount() {
-    this.generateAmendedPools(this.props.pools, this.props.allRegistrations);
+    this.generateAmendedPools(this.props.pools);
   }
 
-  generateAmendedPools = (
-    pools: Array<Pool>,
-    allRegistrations?: Registration[]
-  ) => {
+  generateAmendedPools = (pools: Pool[]) => {
     if (pools.length === 1)
       return this.setState({
         pools,
       });
-    const registrations =
-      allRegistrations || flatMap(pools, (pool) => pool.registrations);
+
+    const registrations = flatMap(pools, (pool) => pool.registrations);
     const summaryPool = {
       name: 'Alle',
       registrations,
@@ -86,8 +83,9 @@ class AttendanceModal extends Component<Props, State> {
   };
 
   render() {
-    const { title, togglePool, selectedPool } = this.props;
+    const { title, togglePool, selectedPool, isMeeting } = this.props;
     const { pools, filter } = this.state;
+
     const registrations = pools[selectedPool].registrations.filter(
       (registration) => {
         return registration.user.fullName
@@ -116,8 +114,21 @@ class AttendanceModal extends Component<Props, State> {
         <ul className={styles.list}>
           {registrations.map((registration) => (
             <li key={registration.id}>
-              <Flex alignItems="center" className={styles.row}>
-                <ProfilePicture size={30} user={registration.user} />
+              <Flex
+                alignItems="center"
+                className={cx(
+                  styles.row,
+                  !isMeeting &&
+                    !registration.pool &&
+                    pools[selectedPool].name === 'Alle' &&
+                    styles.opacity
+                )}
+              >
+                <ProfilePicture
+                  size={30}
+                  user={registration.user}
+                  alt={`${registration.user.name}'s profile picture`}
+                />
                 <Link to={`/users/${registration.user.username}`}>
                   {registration.user.fullName}
                 </Link>

--- a/app/components/UserAttendance/withModal.tsx
+++ b/app/components/UserAttendance/withModal.tsx
@@ -1,7 +1,7 @@
 import { Children, cloneElement, Component } from 'react';
 import Modal from 'app/components/Modal';
 import AttendanceModal from './AttendanceModal';
-import type { Pool, Registration } from './AttendanceModal';
+import type { Pool } from './AttendanceModal';
 import type { ComponentType, ReactElement } from 'react';
 
 type State = {
@@ -11,8 +11,8 @@ type State = {
 
 type WithModalProps = {
   pools: Pool[];
-  registrations?: Registration[];
   title?: string;
+  isMeeting?: boolean;
 };
 
 export default function withModal<Props extends WithModalProps>(
@@ -51,7 +51,7 @@ export default function withModal<Props extends WithModalProps>(
               selectedPool={this.state.selectedTab}
               togglePool={this.toggleTab}
               pools={this.props.pools}
-              allRegistrations={this.props.registrations}
+              isMeeting={this.props.isMeeting}
             />
           </Modal>
         </div>

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -448,7 +448,6 @@ export default class EventDetail extends Component<Props, State> {
                       <ModalParentComponent
                         key="modal"
                         pools={pools}
-                        registrations={registrations}
                         title="Påmeldte"
                       >
                         <RegisteredSummary
@@ -456,6 +455,7 @@ export default class EventDetail extends Component<Props, State> {
                           currentRegistration={currentRegistration}
                         />
                         <AttendanceStatus
+                          pools={pools}
                           legacyRegistrationCount={
                             event.legacyRegistrationCount
                           }

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -540,7 +540,6 @@ function EventEditor({
                 <ModalParentComponent
                   key="modal"
                   pools={pools || []}
-                  registrations={registrations || []}
                   title="Påmeldte"
                 >
                   <AttendanceStatus pools={pools} />

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -18,7 +18,10 @@ import LoadingIndicator from 'app/components/LoadingIndicator';
 import { MazemapEmbed } from 'app/components/MazemapEmbed';
 import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
 import Time, { FromToTime } from 'app/components/Time';
-import { AttendanceStatus } from 'app/components/UserAttendance';
+import {
+  AttendanceStatus,
+  ModalParentComponent,
+} from 'app/components/UserAttendance';
 import type { Dateish, ID, Meeting, User } from 'app/models';
 import {
   statusesText,
@@ -196,7 +199,14 @@ class MeetingDetails extends Component<Props> {
                   {this.attendanceButtons(statusMe, meeting.startTime)}
                   <InfoList items={infoItems} />
                   <li>
-                    <AttendanceStatus.Modal pools={this.sortInvitations()} />
+                    <ModalParentComponent
+                      isMeeting
+                      key="modal"
+                      pools={this.sortInvitations()}
+                      title="Påmeldte"
+                    >
+                      <AttendanceStatus pools={this.sortInvitations()} />
+                    </ModalParentComponent>
                   </li>
                   {meeting.mazemapPoi && (
                     <MazemapEmbed mazemapPoi={meeting.mazemapPoi} />


### PR DESCRIPTION
# Description

[Include waiting list to summary pool tab](https://github.com/webkom/lego-webapp/commit/445fa3ab8b67b4698733d815fb788dac148a5238) 

It makes more sense to include everyone in this tab, and it's annoying to
have to check multiple tabs when looking for someone.

People on waiting list are given an opacity to their row as a visual label.
`isMeeting` prop had to be added, because meeting registrations don't
have pools the same way events does.

---
  
[Rewrite AttendanceModal to a functional component](https://github.com/webkom/lego-webapp/commit/2c5428b4b0d04332db728ba41557faa30b2158fc)

# Result

Please check out the changes locally, as I'm not going to show the names of registered users.

# Testing

- [x] I have thoroughly tested my changes.

The attendance modal is used on events and meetings, and I've tested for both. Also tested for when there is no waiting list.