### PR TITLE
Fix chart colors

### DIFF
--- a/app/components/Chart/BarChart.tsx
+++ b/app/components/Chart/BarChart.tsx
@@ -4,9 +4,11 @@ import { CHART_COLORS } from 'app/components/Chart/utils';
 
 const DistributionBarChart = ({
   dataKey,
+  chartColors = CHART_COLORS,
   distributionData,
 }: {
   distributionData: DistributionDataPoint[];
+  chartColors: string[];
   dataKey: string;
 }) => {
   return (
@@ -33,7 +35,7 @@ const DistributionBarChart = ({
         {distributionData.map((entry, index) => (
           <Cell
             key={`cell-${index}`}
-            fill={CHART_COLORS[index % CHART_COLORS.length]}
+            fill={chartColors[index % chartColors.length]}
           />
         ))}
       </Bar>

--- a/app/components/Chart/PieChart.tsx
+++ b/app/components/Chart/PieChart.tsx
@@ -7,9 +7,11 @@ import {
 
 const DistributionPieChart = ({
   dataKey,
+  chartColors = CHART_COLORS,
   distributionData,
 }: {
   distributionData: DistributionDataPoint[];
+  chartColors: string[];
   dataKey: string;
 }) => {
   return (
@@ -27,7 +29,7 @@ const DistributionPieChart = ({
         {distributionData.map((entry, index) => (
           <Cell
             key={`cell-${index}`}
-            fill={CHART_COLORS[index % CHART_COLORS.length]}
+            fill={chartColors[index % chartColors.length]}
           />
         ))}
       </Pie>

--- a/app/routes/surveys/components/Submissions/Results.tsx
+++ b/app/routes/surveys/components/Submissions/Results.tsx
@@ -2,6 +2,7 @@ import Select from 'react-select';
 import DistributionBarChart from 'app/components/Chart/BarChart';
 import ChartLabel from 'app/components/Chart/ChartLabel';
 import DistributionPieChart from 'app/components/Chart/PieChart';
+import { CHART_COLORS } from 'app/components/Chart/utils';
 import { selectTheme, selectStyles } from 'app/components/Form/SelectInput';
 import InfoBubble from 'app/components/InfoBubble';
 import type { SurveyEntity, QuestionEntity } from 'app/reducers/surveys';
@@ -131,6 +132,9 @@ const Results = ({
 
             return true;
           });
+          const chartColors = CHART_COLORS.filter(
+            (_, i) => !colorsToRemove.includes(i)
+          );
           const graphType = graphOptions.find(
             (a) => a.value === question.displayType
           );
@@ -152,11 +156,13 @@ const Results = ({
                       {question.displayType !== 'bar_chart' ? (
                         <DistributionPieChart
                           distributionData={pieData}
+                          chartColors={chartColors}
                           dataKey="selections"
                         />
                       ) : (
                         <DistributionBarChart
                           distributionData={pieData}
+                          chartColors={chartColors}
                           dataKey="selections"
                         />
                       )}


### PR DESCRIPTION
# Description

Chart colors were wrong when some options had no responses. In this example all respondents responded with 4 or 5.
Before:
<img width="516" alt="Screenshot 2023-02-12 at 20 45 44" src="https://user-images.githubusercontent.com/8343002/218333441-bbf9bb26-7582-4aed-9ce3-5a7c16a5ee8d.png">
After:
<img width="516" alt="Screenshot 2023-02-12 at 20 46 11" src="https://user-images.githubusercontent.com/8343002/218333460-620d931d-4c1a-4659-94cb-4a5d4be5f803.png">

# Result

The charts now show the correct colors even if some options are not included in the graph.

# Testing

- [x] I have thoroughly tested my changes.

I have looked at the graphs, and compared with the individual responses.

---