### PR TITLE
Allow multiple and other authors on articles

### DIFF
--- a/app/components/Form/ObjectPermissions.tsx
+++ b/app/components/Form/ObjectPermissions.tsx
@@ -1,5 +1,6 @@
 import { SelectInput, CheckBox } from 'app/components/Form';
 import Tooltip from 'app/components/Tooltip';
+import type { PublicGroup } from 'app/store/models/Group';
 
 /*
  * Usage inside redux-form:
@@ -26,10 +27,10 @@ const ObjectPermissions = ({
   requireAuth,
   ...props
 }: {
-  canEditUsers?: any;
-  canEditGroups?: any;
-  canViewGroups?: any;
-  requireAuth?: any;
+  canEditUsers?: PublicGroup[];
+  canEditGroups?: PublicGroup[];
+  canViewGroups?: PublicGroup[];
+  requireAuth?: boolean;
 }) => {
   return [
     requireAuth && (
@@ -78,28 +79,13 @@ export const normalizeObjectPermissions = ({
   canViewGroups: initialCanViewGroups,
   canEditGroups: initialCanEditGroups,
   canEditUsers: initialCanEditUsers,
+  currentUser: currentUser,
 }: Record<string, any>) => {
-  const canEditUsers = initialCanEditUsers && initialCanEditUsers.map(toIds);
-  const canViewGroups = initialCanViewGroups && initialCanViewGroups.map(toIds);
-  const canEditGroups = initialCanEditGroups && initialCanEditGroups.map(toIds);
   return {
     requireAuth: !!requireAuth,
-    ...(canEditUsers
-      ? {
-          canEditUsers,
-        }
-      : {}),
-    //$FlowFixMe
-    ...(canEditGroups
-      ? {
-          canEditGroups,
-        }
-      : {}),
-    ...(canViewGroups
-      ? {
-          canViewGroups,
-        }
-      : {}),
+    canEditUsers: initialCanEditUsers?.map(toIds) ?? {},
+    canViewGroups: initialCanViewGroups?.map(toIds) ?? {},
+    canEditGroups: initialCanEditGroups?.map(toIds) ?? {},
   };
 };
 export const objectPermissionsToInitialValues = ({
@@ -107,38 +93,19 @@ export const objectPermissionsToInitialValues = ({
   canEditGroups: initialCanEditGroups,
   canEditUsers: initialCanEditUsers,
 }: Record<string, any>) => {
-  const canEditGroups =
-    initialCanEditGroups &&
-    initialCanEditGroups
-      .filter(Boolean)
-      .map((group) => ({ ...group, label: group.name, value: group.id }));
-  const canViewGroups =
-    initialCanViewGroups &&
-    initialCanViewGroups
-      .filter(Boolean)
-      .map((group) => ({ ...group, label: group.name, value: group.id }));
-  const canEditUsers =
-    initialCanEditUsers &&
-    initialCanEditUsers
-      .filter(Boolean)
-      .map((user) => ({ ...user, label: user.fullName, value: user.id }));
+  const canEditGroups = initialCanEditGroups
+    ?.filter(Boolean)
+    .map((group) => ({ ...group, label: group.name, value: group.id }));
+  const canViewGroups = initialCanViewGroups
+    ?.filter(Boolean)
+    .map((group) => ({ ...group, label: group.name, value: group.id }));
+  const canEditUsers = initialCanEditUsers
+    ?.filter(Boolean)
+    .map((user) => ({ ...user, label: user.fullName, value: user.id }));
   return {
-    ...(canEditUsers
-      ? {
-          canEditUsers,
-        }
-      : {}),
-    //$FlowFixMe
-    ...(canEditGroups
-      ? {
-          canEditGroups,
-        }
-      : {}),
-    ...(canViewGroups
-      ? {
-          canViewGroups,
-        }
-      : {}),
+    canEditUsers: canEditUsers ?? {},
+    canEditGroups: canEditGroups ?? {},
+    canViewGroups: canViewGroups ?? {},
   };
 };
 export const objectPermissionsInitialValues = {

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -38,8 +38,9 @@ export const reactionSchema = new schema.Entity('reactions');
 export const articleSchema = new schema.Entity('articles', {
   comments: [commentSchema],
   reactions: [reactionSchema],
-  author: userSchema,
+  authors: [userSchema],
 });
+
 export const galleryPictureSchema = new schema.Entity('galleryPictures', {
   comments: [commentSchema],
 });

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -70,6 +70,7 @@ export const selectUserById = createSelector(
   (state, props) => props.userId,
   (usersById, userId) => usersById[userId] || {}
 );
+
 export const selectUserByUsername = createSelector(
   (state) => state.users.byId,
   (state, props) => props.username,

--- a/app/routes/articles/ArticleCreateRoute.ts
+++ b/app/routes/articles/ArticleCreateRoute.ts
@@ -4,17 +4,26 @@ import { compose } from 'redux';
 import { createArticle } from 'app/actions/ArticleActions';
 import { uploadFile } from 'app/actions/FileActions';
 import { LoginPage } from 'app/components/LoginForm';
+import { selectCurrentUser } from 'app/reducers/auth';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import ArticleEditor from './components/ArticleEditor';
 
-const mapStateToProps = () => ({
-  isNew: true,
-  article: {},
-  initialValues: {
-    content: '',
-  },
-});
-
+const mapStateToProps = (state, props) => {
+  const currentUser = selectCurrentUser(state);
+  const authors = [currentUser];
+  return {
+    isNew: true,
+    article: {},
+    initialValues: {
+      content: '',
+      authors: authors.map((user) => ({
+        ...user,
+        label: user.fullName,
+        value: user.id,
+      })),
+    },
+  };
+};
 const mapDispatchToProps = {
   submitArticle: createArticle,
   uploadFile,

--- a/app/routes/articles/ArticleDetailRoute.ts
+++ b/app/routes/articles/ArticleDetailRoute.ts
@@ -25,8 +25,10 @@ const mapStateToProps = (state, props) => {
   const comments = selectCommentsForArticle(state, {
     articleId,
   });
-  const author = selectUserById(state, {
-    userId: article.author,
+  const authors = article.authors?.map((e) => {
+    return selectUserById(state, {
+      userId: e,
+    });
   });
   const emojis = selectEmojis(state);
   return {
@@ -35,7 +37,7 @@ const mapStateToProps = (state, props) => {
     comments,
     article,
     articleId,
-    author,
+    authors,
     emojis,
   };
 };
@@ -56,11 +58,17 @@ export default compose(
   ),
   connect(mapStateToProps, mapDispatchToProps),
   loadingIndicator(['article.content']),
-  helmet((props: { article: PublicArticle; author: PublicUser }, config) => {
+  helmet((props: { article: PublicArticle; authors: PublicUser[] }, config) => {
     const tags = props.article.tags.map((content) => ({
       content,
       property: 'article:tag',
     }));
+
+    const authors = props.authors.map((author) => ({
+      property: 'article:authors',
+      content: `${config.webUrl}/users/${author.username}`,
+    }));
+
     return [
       {
         property: 'og:title',
@@ -103,10 +111,7 @@ export default compose(
         property: 'og:description',
         content: props.article.description,
       },
-      {
-        property: 'article:author',
-        content: `${config.webUrl}/users/${props.author.username}`,
-      },
+      ...authors,
       ...tags,
     ];
   })

--- a/app/routes/articles/ArticleEditRoute.ts
+++ b/app/routes/articles/ArticleEditRoute.ts
@@ -9,6 +9,8 @@ import {
 import { objectPermissionsToInitialValues } from 'app/components/Form/ObjectPermissions';
 import { LoginPage } from 'app/components/LoginForm';
 import { selectArticleById } from 'app/reducers/articles';
+import { selectCurrentUser } from 'app/reducers/auth';
+import { selectUserById } from 'app/reducers/users';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
@@ -19,13 +21,26 @@ const mapStateToProps = (state, props) => {
   const article = selectArticleById(state, {
     articleId,
   });
+
+  const currentUser = selectCurrentUser(state);
+  const authors = article?.authors?.length
+    ? article.authors.map((e) => selectUserById(state, { userId: e }))
+    : [currentUser];
+
   return {
     article,
     articleId,
     isNew: false,
     initialValues: {
       ...article,
-      ...objectPermissionsToInitialValues(article),
+      ...objectPermissionsToInitialValues({
+        canViewGroups: article.canViewGroups,
+        canEditGroups: article.canEditGroups,
+        canEditUsers: article.canEditUsers,
+      }),
+      authors: authors
+        .filter(Boolean)
+        .map((user) => ({ user, label: user.fullName, value: user.id })),
       tags: (article.tags || []).map((tag) => ({
         label: tag,
         value: tag,

--- a/app/routes/articles/ArticleListRoute.ts
+++ b/app/routes/articles/ArticleListRoute.ts
@@ -12,8 +12,8 @@ import type { PublicUser } from 'app/store/models/User';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import Overview from './components/Overview';
 
-export type ArticleWithAuthorDetails = Omit<PublicArticle, 'author'> & {
-  author: PublicUser;
+export type ArticleWithAuthorDetails = Omit<PublicArticle, 'authors'> & {
+  authors: Array<PublicUser>;
 };
 
 const mapStateToProps = (state, props) => {
@@ -34,8 +34,10 @@ const mapStateToProps = (state, props) => {
     }
   ).map((article) => ({
     ...article,
-    author: selectUserById(state, {
-      userId: article.author,
+    authors: article.authors.map((e) => {
+      return selectUserById(state, {
+        userId: e,
+      });
     }),
   }));
 

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -22,7 +22,7 @@ type Props = {
   article: DetailedArticle | AdminDetailedArticle;
   comments: Comment[];
   loggedIn: boolean;
-  author: DetailedUser;
+  authors: DetailedUser[];
   currentUser: CurrentUser;
   deleteComment: (id: ID, contentTarget: string) => Promise<void>;
   emojis: Array<EmojiEntity>;
@@ -30,7 +30,7 @@ type Props = {
     emoji: string;
     contentTarget: string;
   }) => Promise<unknown>;
-  reactionsGrouped: Array<ReactionEntity>;
+  reactionsGrouped: ReactionEntity[];
   deleteReaction: (arg0: {
     reactionId: ID;
     contentTarget: string;
@@ -41,7 +41,7 @@ type Props = {
 
 const ArticleDetail = ({
   article,
-  author,
+  authors,
   loggedIn,
   currentUser,
   comments,
@@ -70,16 +70,30 @@ const ArticleDetail = ({
         )}
       </NavigationTab>
 
-      <div className={styles.articleDetails}>
-        <span className={styles.detail}>
-          Skrevet av
-          <Link to={`/users/${author.username}`}> {author.fullName}</Link>
-        </span>
-        <span className={styles.detail}>
-          {moment(article.createdAt).format('lll')}
-        </span>
-      </div>
-
+      {
+        <div className={styles.articleDetails}>
+          <span className={styles.detail}>
+            Skrevet av{' '}
+            {authors?.map((e, i) => {
+              return (
+                <span key={e.username}>
+                  <Link
+                    to={`/users/${e.username}`}
+                    className={styles.overviewAuthor}
+                  >
+                    {' '}
+                    {e.fullName}
+                  </Link>
+                  {i === authors.length - 1 ? '' : ','}
+                </span>
+              );
+            })}
+          </span>
+          <span className={styles.detail}>
+            {moment(article.createdAt).format('lll')}
+          </span>
+        </div>
+      }
       <DisplayContent content={article.content} />
 
       <Tags>

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -19,9 +19,14 @@ import LoadingIndicator from 'app/components/LoadingIndicator';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import NavigationTab from 'app/components/NavigationTab';
 import Tooltip from 'app/components/Tooltip';
+import type { EditingEvent } from 'app/routes/events/utils';
 import type { DetailedArticle } from 'app/store/models/Article';
 import type { CurrentUser } from 'app/store/models/User';
-import { createValidator, validYoutubeUrl } from 'app/utils/validation';
+import {
+  createValidator,
+  validYoutubeUrl,
+  required,
+} from 'app/utils/validation';
 
 export type Props = {
   article?: DetailedArticle;
@@ -132,6 +137,17 @@ const ArticleEditor = ({
           }) => keyCode === 32 || keyCode === 13}
         />
 
+        <Field
+          placeholder="Velg forfattere"
+          name="authors"
+          label="Forfattere"
+          component={SelectInput.AutocompleteField}
+          isMulti
+          filter={['users.user']}
+          id="article-title"
+          required
+        />
+
         <Fields
           names={[
             'requireAuth',
@@ -141,6 +157,7 @@ const ArticleEditor = ({
           ]}
           component={ObjectPermissions}
         />
+
         <Field
           placeholder="En kort beskrivelse av artikkelen"
           name="description"
@@ -197,23 +214,42 @@ const onSubmit = (
         }
       : {}),
     ...normalizeObjectPermissions(data),
+    authors: data.authors.map((e) => e.value),
     youtubeUrl: data.youtubeUrl,
     title: data.title,
-    author: currentUser.id,
     description: data.description,
     content: data.content,
     tags: (data.tags || []).map((tag) => tag.value.toLowerCase()),
     pinned: data.pinned,
   };
+
   return submitArticle(body);
+};
+
+type ValidationError<T> = Partial<{
+  [key in keyof T]: string | Record<string, string>[];
+}>;
+
+const validate = (data) => {
+  const errors: ValidationError<EditingEvent> = {};
+  const [isValidYoutubeUrl, errorMessage = ''] = validYoutubeUrl()(
+    data.youtubeUrl
+  );
+
+  if (!isValidYoutubeUrl) {
+    errors.youtubeUrl = errorMessage;
+  }
+
+  if (!data.authors || data.authors.length === 0) {
+    errors.authors = 'Forfatter er påkrevd';
+  }
+  return errors;
 };
 
 export default legoForm({
   destroyOnUnmount: false,
   form: 'article',
-  validate: createValidator({
-    youtubeUrl: [validYoutubeUrl()],
-  }),
+  validate,
   enableReinitialize: true,
   onSubmit,
 })(ArticleEditor);

--- a/app/routes/articles/components/Overview.tsx
+++ b/app/routes/articles/components/Overview.tsx
@@ -24,17 +24,17 @@ const OverviewItem = ({ article }: { article: ArticleWithAuthorDetails }) => (
     </h2>
 
     <span className={styles.itemInfo}>
-      {article.author.id && (
-        <span>
-          <Link
-            to={`/users/${article.author.username}`}
-            className={styles.overviewAuthor}
-          >
-            {' '}
-            {article.author.fullName}
-          </Link>{' '}
-        </span>
-      )}
+      {article.authors.map((e) => {
+        return (
+          <span key={e.username}>
+            <Link to={`/users/${e.username}`} className={styles.overviewAuthor}>
+              {' '}
+              {e.fullName}
+            </Link>{' '}
+          </span>
+        );
+      })}
+
       <Time time={article.createdAt} format="DD.MM.YYYY HH:mm" />
       <Tags className={styles.tagline}>
         {article.tags.map((tag) => (

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -82,6 +82,7 @@ export type EditingEvent = Event & {
   addFee: boolean;
   registrationDeadline: Dateish;
   hasFeedbackQuestion: boolean;
+  authors: Option[];
 };
 
 // Event fields that should be created or updated based on the API.

--- a/app/store/models/Article.d.ts
+++ b/app/store/models/Article.d.ts
@@ -10,7 +10,7 @@ interface CompleteArticle {
   title: string;
   cover: string;
   coverPlaceholder: string;
-  author: ID;
+  authors: Array<ID>;
   description: string;
   comments: ID[];
   contentTarget: ContentTarget;
@@ -28,7 +28,7 @@ export type DetailedArticle = Pick<
   | 'title'
   | 'cover'
   | 'coverPlaceholder'
-  | 'author'
+  | 'authors'
   | 'description'
   | 'comments'
   | 'contentTarget'
@@ -54,7 +54,7 @@ export type PublicArticle = Pick<
   | 'title'
   | 'cover'
   | 'coverPlaceholder'
-  | 'author'
+  | 'authors'
   | 'description'
   | 'tags'
   | 'createdAt'

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,4 +1,5 @@
 import type { RootState } from 'app/store/createRootReducer';
+import type { ID } from './models';
 import type { ThunkAction } from '@reduxjs/toolkit';
 import type { JwtPayload } from 'jwt-decode';
 
@@ -12,7 +13,7 @@ export type EntityID = number;
 export type ArticleEntity = {
   id: EntityID;
   title: string;
-  author: number;
+  authors: Array<ID>;
   content: string;
   tags: Array<string>;
   cover: string;


### PR DESCRIPTION
# Description



Option to add multiple/other users as author on articles.

# Result

Before:

![image](https://user-images.githubusercontent.com/113468143/218505044-c62b9c8c-21a4-4e61-8b64-dec95d16636a.png)


After:

![image](https://user-images.githubusercontent.com/113468143/218504669-8ef699b3-b57f-4a78-8f52-afe5e5a1f300.png)

Before:

![image](https://user-images.githubusercontent.com/113468143/218505118-cf7e5700-62c1-48d1-823b-afd8d960e5ef.png)

After:

![image](https://user-images.githubusercontent.com/113468143/218505221-881cf7fe-f84c-4ed9-a494-4f0ca05ba2af.png)

After:

![image](https://user-images.githubusercontent.com/113468143/218505960-2eceb807-e33f-4f33-80a3-c21e4a8d2ac9.png)


# Testing

- [ X] I have thoroughly tested my changes.


---

Depends on: https://github.com/webkom/lego/pull/3220
Resolves: https://github.com/webkom/lego/issues/3195
