### PR TITLE
Expand sidebar element based on pathname

### DIFF
--- a/app/routes/pages/PageDetailRoute.ts
+++ b/app/routes/pages/PageDetailRoute.ts
@@ -151,6 +151,7 @@ const sections: Record<string, Entry> = {
     fetchItemActions: [],
   },
 };
+
 export const categoryOptions = Object.keys(sections)
   .map<Entry>((key) => sections[key])
   .filter((entry: Entry) => entry.pageSelector === selectFlatpageForPages)

--- a/app/routes/pages/components/PageHierarchy.tsx
+++ b/app/routes/pages/components/PageHierarchy.tsx
@@ -1,5 +1,5 @@
-import { Component } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import Icon from 'app/components/Icon';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import styles from './PageHierarchy.css';
@@ -84,43 +84,32 @@ type AccordionProps = {
   children: ReactNode;
   currentCategory: string;
 };
-type AccordionState = {
-  isOpen: boolean;
+
+const AccordionContainer = ({ title, children }: AccordionProps) => {
+  const location = useLocation();
+  const currentCategory = location.pathname.split('/')[2];
+
+  const [isOpen, setIsOpen] = useState(
+    currentCategory === title.toLowerCase() ||
+      (currentCategory === 'info-om-abakus' &&
+        title.toLowerCase() === 'generelt')
+  );
+
+  return (
+    <div>
+      <button className={styles.dropdownBtn} onClick={() => setIsOpen(!isOpen)}>
+        {title}
+        <Icon
+          name="chevron-up-outline"
+          className={styles.dropdownIcon}
+          style={
+            isOpen
+              ? { transform: 'rotateX(0deg)' }
+              : { transform: 'rotateX(180deg)' }
+          }
+        />
+      </button>
+      {isOpen && <div className={styles.dropdownContainer}>{children}</div>}
+    </div>
+  );
 };
-
-class AccordionContainer extends Component<AccordionProps, AccordionState> {
-  state: AccordionState = {
-    isOpen:
-      this.props.currentCategory === this.props.title.toLowerCase() ||
-      (this.props.currentCategory === undefined &&
-        this.props.title.toLowerCase() === 'generelt'),
-  };
-  handleClick = () => {
-    this.setState((state) => ({
-      isOpen: !state.isOpen,
-    }));
-  };
-
-  render() {
-    const { title, children }: AccordionProps = this.props;
-    return (
-      <div>
-        <button className={styles.dropdownBtn} onClick={this.handleClick}>
-          {title}{' '}
-          <Icon
-            name="chevron-up-outline"
-            className={styles.dropdownIcon}
-            style={
-              this.state.isOpen
-                ? { transform: 'rotateX(0deg)' }
-                : { transform: 'rotateX(180deg)' }
-            }
-          />
-        </button>{' '}
-        {this.state.isOpen ? (
-          <div className={styles.dropdownContainer}>{children}</div>
-        ) : null}
-      </div>
-    );
-  }
-}

--- a/app/routes/pages/components/Sidebar.tsx
+++ b/app/routes/pages/components/Sidebar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 import cx from 'classnames';
 import { Component } from 'react';
 import Icon from 'app/components/Icon';


### PR DESCRIPTION
# Description

You can now visit any page and the correct category will be expanded.

This is done by using the url pathname to determine which category we're currently in, instead of it being passed down as prop.

# Result

https://user-images.githubusercontent.com/69514187/218572725-f30825a0-b921-4363-bcb2-3c000e11201c.mov


# Testing

- [x] I have thoroughly tested my changes.

Tested for "info-om-abakus" (which is an edge case), and for when you're not logged in.