### PR TITLE
Sort upcoming events on profile page

### DIFF
--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -201,14 +201,15 @@ export const selectEvents = createSelector(
       ReturnType<typeof transformEvent>
     >
 );
+export const selectSortedEvents = createSelector(selectEvents, (events) =>
+  [...events].sort((a, b) => a.startTime.unix() - b.startTime.unix())
+);
 export const selectPreviousEvents = createSelector(selectEvents, (events) =>
   events.filter((event) => event.isUsersUpcoming === false)
 );
-export const selectUpcomingEvents = createSelector(selectEvents, (events) =>
-  events.filter((event) => event.isUsersUpcoming)
-);
-export const selectSortedEvents = createSelector(selectEvents, (events) =>
-  [...events].sort((a, b) => a.startTime.unix() - b.startTime.unix())
+export const selectUpcomingEvents = createSelector(
+  selectSortedEvents,
+  (events) => events.filter((event) => event.isUsersUpcoming)
 );
 export const selectEventById = createSelector(
   (state) => state.events.byId,


### PR DESCRIPTION
# Description

It has annoyed me for too long that the events on the profile page are shown in a seemingly random order. This sorts them by start-date.
I simply replaced `selectEvents` with `selectSortedEvents` in `selectUpcomingEvents`. 

# Result

Before:
<img width="692" alt="Screenshot 2023-02-13 at 22 24 52" src="https://user-images.githubusercontent.com/8343002/218577863-7e25977a-1bf8-4af0-971e-573c9c3a2a02.png">
After:
<img width="692" alt="Screenshot 2023-02-13 at 22 25 04" src="https://user-images.githubusercontent.com/8343002/218577897-f0001f56-7d65-4108-ac3e-53886c52abfd.png">

# Testing

- [x] I have thoroughly tested my changes.