### PR TITLE
Stop latest readme card from expanding during fetch

### DIFF
--- a/app/routes/overview/IndexRoute.ts
+++ b/app/routes/overview/IndexRoute.ts
@@ -29,6 +29,7 @@ const mapStateToProps = (state) => ({
   }),
   readmes: state.readme,
   poll: selectPinnedPolls(state)[0],
+  fetchingFrontpage: state.frontpage.fetching,
 });
 
 const mapDispatchToProps = {
@@ -36,6 +37,7 @@ const mapDispatchToProps = {
   logout,
   votePoll,
 };
+
 export default compose(
   // Feed not in use
   // prepare(({ loggedIn }, dispatch) =>

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -22,6 +22,7 @@ import { renderMeta } from './utils';
 
 type Props = {
   frontpage: WithDocumentType<PublicArticle | Event>[];
+  fetchingFrontpage: boolean;
   readmes: Readme[];
   poll: PollEntity | null | undefined;
   votePoll: () => Promise<void>;
@@ -41,7 +42,8 @@ const Overview = (props: Props) => {
     setArticlesToShow(articlesToShow + 2);
   };
 
-  const { loggedIn, frontpage, readmes, poll, votePoll } = props;
+  const { loggedIn, frontpage, readmes, poll, votePoll, fetchingFrontpage } =
+    props;
 
   const events = useMemo(() => frontpage.filter(isEvent), [frontpage]);
 
@@ -79,7 +81,7 @@ const Overview = (props: Props) => {
     <Flex className={styles.readMe}>
       <LatestReadme
         readmes={readmes}
-        expandedInitially={frontpage.length === 0}
+        expandedInitially={frontpage.length === 0 && !fetchingFrontpage}
       />
     </Flex>
   );


### PR DESCRIPTION
# Description

When fetching the frontpage, its length would be `0` causing the card to be expanded. This made it look buggy.

# Result

**Before**

https://user-images.githubusercontent.com/69514187/218763093-8b427a89-a6b0-4d36-985a-3820ab91f399.mov

**After**

https://user-images.githubusercontent.com/69514187/218762686-648e0800-9262-4d02-815c-f5f9cf3817e2.mov


# Testing

- [x] I have thoroughly tested my changes.

See result above.
