### PR TITLE
Fix cypress tests failing for event_visit_spec

### DIFF
--- a/cypress/e2e/event_visit_spec.js
+++ b/cypress/e2e/event_visit_spec.js
@@ -53,6 +53,7 @@ describe('View event', () => {
 
     cy.contains('button', 'Kommenter').should('not.exist');
 
+    cy.wait(2000);
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
       .last()
       .click()
@@ -76,9 +77,9 @@ describe('View event', () => {
     // Nested comments should work as expected
     // TODO fix form clearing
     cy.reload();
+    cy.wait(2000);
     cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
       .last()
-      .wait(500)
       .click()
       .wait(100);
     cy.contains('button', 'Kommenter').should('be.disabled');


### PR DESCRIPTION
# Description

Fixes two errors with the comment testing in the event_visit_spec. The first is not waiting after cypress.get() which caused an error. The second is the cypress tests sometimes missing the comment form. Due to using a hook rather than having the props passed down, the send announcement button will get its actiongrant after the page has been loaded. This causes the button for sending an announcement to appear after the page has been loaded. This *sometimes* caused the cypress test to fail as the comment is pushed a bit down between selecting and clicking. This is "solved" by waiting for a little bit after loading.

# Testing

- [X] I have thoroughly tested my changes.

If the cypress tests actually passes, this works
