### PR TITLE
Small fixes on infopage design

### DIFF
--- a/app/routes/pages/components/LandingPage.css
+++ b/app/routes/pages/components/LandingPage.css
@@ -2,7 +2,7 @@
 
 .pageContainer {
   position: relative;
-  margin-top: -2em;
+  margin-top: -15px;
 }
 
 .banner {
@@ -19,13 +19,28 @@
 }
 
 .emailContainer {
-  margin-top: -2em;
   margin-bottom: 30px;
+}
+
+div > .locationContainerItem {
+  margin: 0 1%;
+  flex-basis: 31.3333%;
+  width: 31.3333%;
+
+  @media (--medium-viewport) {
+    flex-basis: 50%;
+    margin: 0;
+  }
+
+  @media (--small-viewport) {
+    flex-basis: 98%;
+  }
 }
 
 .title {
   font-size: 1.2rem;
   line-height: 1.2rem;
+  margin-top: 0.2rem;
   margin-bottom: 0.4rem;
 }
 
@@ -46,7 +61,7 @@
   font-family: Inter, sans-serif;
   font-weight: 600;
   text-transform: uppercase;
-  margin: 3rem auto 1.5rem;
+  margin: 3rem auto 0;
 }
 
 .contactUsLink {
@@ -84,15 +99,14 @@
 }
 
 .emails {
-  margin-top: 30px;
-}
-
-.organization {
   margin-top: 25px;
 }
 
+.organization {
+  margin-top: 10px;
+}
+
 .socialMediaContainer {
-  margin-top: -2em;
   margin-bottom: 30px;
 }
 
@@ -103,11 +117,15 @@
   margin: 6px;
   align-items: center;
 
-  @media (--mobile-device) {
+  @media (--medium-viewport) {
     flex-direction: row;
-    flex-basis: 100%;
+    flex-basis: 50%;
     margin: auto;
     padding: 0.8rem;
+  }
+
+  @media (--small-viewport) {
+    flex-basis: 100%;
   }
 }
 

--- a/app/routes/pages/components/LandingPage.tsx
+++ b/app/routes/pages/components/LandingPage.tsx
@@ -165,42 +165,35 @@ const LandingPage: PageRenderer = ({ loggedIn }) => {
 
       <Flex className={styles.locationContainer}>
         <div className={styles.houseIcon}>
-          <Icon
-            name="home"
-            size={80}
-            style={{
-              marginRight: '1rem',
-            }}
-          />
+          <Icon name="home" size={80} />
         </div>
-        <TextWithTitle
-          title="Postadresse"
-          text={info.postAddress}
-          extraStyle={{
-            flexBasis: '33.33333%',
-          }}
-        />
-        <div
-          style={{
-            flexBasis: '33.33333%',
-          }}
-        >
-          <TextWithTitle title="Besøksadresse" text={info.officeAddress} />
+        <Flex wrap>
+          <div className={styles.locationContainerItem}>
+            <TextWithTitle
+              title="Besøksadresse"
+              text={info.officeAddress}
+              extraStyle={{ margin: 0 }}
+            />
+            <TextWithTitle
+              title="Webkom's besøksadresse"
+              text={info.webkomOfficeAddress}
+              extraStyle={{ margin: 0 }}
+            />
+          </div>
           <TextWithTitle
-            title="Webkom's besøksadresse"
-            text={info.webkomOfficeAddress}
+            title="Postadresse"
+            text={info.postAddress}
+            extraClassName={styles.locationContainerItem}
           />
-        </div>
-        <TextWithTitle
-          title="Kontortid"
-          text={info.officeHours}
-          extraStyle={{
-            flexBasis: '33.33333%',
-          }}
-        />
+          <TextWithTitle
+            title="Kontortid"
+            text={info.officeHours}
+            extraClassName={styles.locationContainerItem}
+          />
+        </Flex>
       </Flex>
 
-      <Flex>
+      <Flex alignItems="center">
         <Icon name="briefcase" size={80} className={styles.organizationIcon} />
         <div className={styles.organization}>
           <h3 className={styles.title}>Organisasjonsnummer</h3>

--- a/app/routes/pages/components/PageDetail.css
+++ b/app/routes/pages/components/PageDetail.css
@@ -1,6 +1,6 @@
 @import url('~app/styles/variables.css');
 
-.cont {
+div .cont {
   padding: 0;
 }
 
@@ -20,16 +20,13 @@
 
 .navTab {
   position: relative;
-  margin-top: -2em;
+  margin-top: -30px;
 }
 
 .detail {
   flex: 1;
-  min-width: 300px;
   width: 100%;
-  max-width: 685px;
-  margin: auto;
-  padding-right: 10px;
+  padding: 1em;
 }
 
 .header {
@@ -39,7 +36,7 @@
 .headWrapper {
   display: flex;
   flex-flow: column wrap;
-  margin-top: 35px;
+  margin-top: -15px;
 }
 
 .header1 {
@@ -56,7 +53,8 @@
 }
 
 .mainTxt {
-  padding: 2.5em 0 4em 2em;
+  padding: 2em 1.5em;
+  flex-grow: 1;
 }
 
 .action {
@@ -80,10 +78,9 @@
 }
 
 .banner img {
-  height: 275px;
+  max-height: 275px;
   width: 100%;
   object-fit: contain;
-  margin-top: -2.1em;
 }
 
 .heading {
@@ -138,8 +135,8 @@
   }
 
   .mainTxt {
-    padding: 1.5em;
-    padding-bottom: 3em;
+    padding: 1em;
+    padding-bottom: 1em;
   }
 
   .header1 {
@@ -155,7 +152,6 @@
 
   .navTab {
     display: flex;
-    justify-content: left;
   }
 
   .leaderBoard {

--- a/app/routes/pages/components/subcomponents/EmailItem/EmailItem.css
+++ b/app/routes/pages/components/subcomponents/EmailItem/EmailItem.css
@@ -6,7 +6,11 @@
   padding: 0.3rem;
   flex-basis: calc(100% / 3);
 
-  @media (--mobile-device) {
+  @media (--medium-viewport) {
+    flex-basis: 50%;
+  }
+
+  @media (--small-viewport) {
     flex-basis: 100%;
   }
 }

--- a/app/routes/pages/components/subcomponents/TextWithTitle/TextWithTitle.css
+++ b/app/routes/pages/components/subcomponents/TextWithTitle/TextWithTitle.css
@@ -14,8 +14,8 @@
 
 .title {
   font-size: 1.2rem;
-  line-height: 1.2rem;
-  margin-bottom: 0.4rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.2rem;
 }
 
 .smallerText {
@@ -24,6 +24,7 @@
 
 .textContainer {
   margin-bottom: 1.5rem;
+  white-space: normal;
 }
 
 @media (--mobile-device) {

--- a/app/routes/pages/components/subcomponents/TextWithTitle/index.tsx
+++ b/app/routes/pages/components/subcomponents/TextWithTitle/index.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import styles from './TextWithTitle.css';
 import type { ReactNode } from 'react';
 
@@ -5,20 +6,26 @@ type Props = {
   title: string;
   text: ReactNode;
   extraStyle?: Record<string, any>;
+  extraClassName?: string;
 };
 
-const TextWithBoldTitle = ({ title, text, extraStyle }: Props) => {
+const TextWithBoldTitle = ({
+  title,
+  text,
+  extraStyle,
+  extraClassName,
+}: Props) => {
   return (
-    <div className={styles.container} style={extraStyle}>
+    <div className={cx(styles.container, extraClassName)} style={extraStyle}>
       <h2 className={styles.boldTitle}>{title}</h2>
       <p className={styles.text}>{text}</p>
     </div>
   );
 };
 
-const TextWithTitle = ({ title, text, extraStyle }: Props) => {
+const TextWithTitle = ({ title, text, extraStyle, extraClassName }: Props) => {
   return (
-    <div className={styles.container} style={extraStyle}>
+    <div className={cx(styles.container, extraClassName)} style={extraStyle}>
       <h3 className={styles.title}>{title}</h3>
       <pre className={styles.textContainer}>
         <span className={styles.smallerText}>{text}</span>


### PR DESCRIPTION
# Description

Key points:
* Prevent overflow
* Fill available space
* Add more responsive breakpoints.
* Prevent padding on top caused by a not specific enough selector

# Result

It requires a loot of pictures to showcase every edge case of this change, so to check every screen size you'd rather have to pull this and test it locally.

Before: unnecessary padding on top + overflow on the right side
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/13599770/219825570-f11a9b91-cbe9-4f80-94b8-23b444b75857.png">

After
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/13599770/219825592-1fcf693d-d387-404c-ac40-32cd91ae90e7.png">

Before: doesn't fill the entire page
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/13599770/219825675-14849671-4c2b-4d2d-8ca1-5e880dd50013.png">

After: equal paddings on the right and left side
<img width="1119" alt="image" src="https://user-images.githubusercontent.com/13599770/219825704-e7e43ae7-c854-4772-ae63-c2d75b2dd136.png">

Before: the breakpoints are either desktop or mobile, where mobile is a single row even if its pretty wide
<img width="722" alt="image" src="https://user-images.githubusercontent.com/13599770/219825748-24a7fe5f-a22d-4201-86e1-dec30f50d532.png">

After: three breakpoints, with 3, 2 and 1 columns depending on the screen size
<img width="575" alt="image" src="https://user-images.githubusercontent.com/13599770/219825804-39e74c1a-c5fb-4d31-9b5a-be83573d7863.png">


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.
