### PR TITLE
Stop arrow icons from disappearing on Safari

### DIFF
--- a/app/routes/pages/components/PageHierarchy.css
+++ b/app/routes/pages/components/PageHierarchy.css
@@ -75,7 +75,6 @@
 }
 
 .dropdownIcon {
-  padding-left: 8px;
   transition: var(--easing-medium);
 }
 

--- a/app/routes/pages/components/PageHierarchy.tsx
+++ b/app/routes/pages/components/PageHierarchy.tsx
@@ -100,12 +100,12 @@ const AccordionContainer = ({ title, children }: AccordionProps) => {
       <button className={styles.dropdownBtn} onClick={() => setIsOpen(!isOpen)}>
         {title}
         <Icon
-          name="chevron-up-outline"
+          name="chevron-down-outline"
           className={styles.dropdownIcon}
           style={
             isOpen
-              ? { transform: 'rotateX(0deg)' }
-              : { transform: 'rotateX(180deg)' }
+              ? { transform: 'rotate(0deg)' }
+              : { transform: 'rotate(-90deg)' }
           }
         />
       </button>


### PR DESCRIPTION
# Description

They would disappear on hover, and act weirdly.

# Result

https://user-images.githubusercontent.com/69514187/219899321-69f9b30b-ab82-460a-9c38-4bca7e1dadec.mov


# Testing

- [x] I have thoroughly tested my changes.

Tested on Safari and Google Chrome.