### PR TITLE
Make sure payment button is a submit button

### DIFF
--- a/app/routes/events/components/StripeElement.tsx
+++ b/app/routes/events/components/StripeElement.tsx
@@ -156,7 +156,7 @@ const CardForm = (props: CardFormProps) => {
             options={StripeElementStyle}
           />
         </label>
-        <Button dark className={stripeStyles.stripeButton}>
+        <Button submit dark className={stripeStyles.stripeButton}>
           Betal
         </Button>
       </fieldset>


### PR DESCRIPTION
# Description

`submit` prop was missing, causing  `handleSubmit` to never be triggered.

# Testing

- [x] I have thoroughly tested my changes.

I tested that the button now triggers the handle function, unlike before.