### PR TITLE
Add missing `ignoreQueryPrefix` to abacard route

### DIFF
--- a/app/routes/events/EventAbacardRoute.ts
+++ b/app/routes/events/EventAbacardRoute.ts
@@ -12,7 +12,7 @@ import Abacard from './components/EventAdministrate/Abacard';
 
 const searchTypes = ['users.user'];
 
-const loadData = async (props, dispatch): any => {
+const loadData = async (props, dispatch): Promise<void> => {
   const query = qs.parse(props.location.search, {
     ignoreQueryPrefix: true,
   }).q;
@@ -23,7 +23,7 @@ const loadData = async (props, dispatch): any => {
 };
 
 const mapStateToProps = (state, props) => {
-  const query = qs.parse(props.location.search).q;
+  const query = qs.parse(props.location.search, { ignoreQueryPrefix: true }).q;
   const results = query ? selectAutocomplete(state) : [];
   const { eventId } = props;
   const { registered } = getRegistrationGroups(state, {
@@ -41,7 +41,8 @@ const mapDispatchToProps = (dispatch, { eventId }) => {
   const url = `/events/${eventId}/administrate/abacard?q=`;
   return {
     clearSearch: () => dispatch(replace(url)),
-    markUsernamePresent: (...props) => dispatch(markUsernamePresent(...props)),
+    markUsernamePresent: (eventId: number, username: string) =>
+      dispatch(markUsernamePresent(eventId, username)),
     onQueryChanged: debounce((query) => {
       dispatch(replace(url + query));
 

--- a/app/routes/events/components/EventAdministrate/Abacard.tsx
+++ b/app/routes/events/components/EventAdministrate/Abacard.tsx
@@ -27,11 +27,7 @@ const Abacard = (props: Props) => {
     (reg) => reg.presence === 'PRESENT' && reg.pool
   ).length;
 
-  const handleSelect = ({
-    username,
-  }: {
-    username: string;
-  }): Promise<{ payload: unknown }> =>
+  const handleSelect = ({ username }: { username: string }) =>
     markUsernamePresent(id.toString(), username).then(async (result) => {
       const payload = get(result, 'payload.response.jsonData');
       if (payload && payload.error) return result;


### PR DESCRIPTION
Must have been mistakenly removed in a recent commit. This removes the
`?` prefix from the query.

# Result

Fix abacard search.

# Testing

- [x] I have thoroughly tested my changes.

