### PR TITLE
Fix "cannot load before initialization" error

### DIFF
--- a/app/components/UserAttendance/AttendanceModal.tsx
+++ b/app/components/UserAttendance/AttendanceModal.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { flatMap } from 'lodash-es';
+import { flatMap } from 'lodash';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';


### PR DESCRIPTION
# Description

This broke SSR on events. lodash-es does some special stuff with
aliasing that is not supported on SSR (see config.client.js), thus
breaking the dynamic importing of loadable.

# Result

SSR on eventDetail works.

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-297
