### PR TITLE
Wrap delete button in ArticleEditor in ConfirmModal

### DIFF
--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -16,6 +16,7 @@ import { normalizeObjectPermissions } from 'app/components/Form/ObjectPermission
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
 import LoadingIndicator from 'app/components/LoadingIndicator';
+import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import NavigationTab from 'app/components/NavigationTab';
 import Tooltip from 'app/components/Tooltip';
 import type { DetailedArticle } from 'app/store/models/Article';
@@ -47,8 +48,8 @@ const ArticleEditor = ({
     return <LoadingIndicator loading />;
   }
 
-  const handleDeleteArticle = () => {
-    deleteArticle(articleId).then(() => {
+  const handleDeleteArticle = async () => {
+    await deleteArticle(articleId).then(() => {
       push('/articles/');
     });
   };
@@ -162,10 +163,16 @@ const ArticleEditor = ({
             {!isNew ? 'Lagre endringer' : 'Opprett'}
           </Button>
           {!isNew && (
-            <Button danger onClick={handleDeleteArticle}>
-              <Icon name="trash" size={19} />
-              Slett artikkel
-            </Button>
+            <ConfirmModalWithParent
+              title="Slett artikkelen"
+              message="Er du sikker på at du vil slette artikkelen?"
+              onConfirm={handleDeleteArticle}
+            >
+              <Button danger>
+                <Icon name="trash" size={19} />
+                Slett artikkel
+              </Button>
+            </ConfirmModalWithParent>
           )}
         </Flex>
       </Form>


### PR DESCRIPTION
# Description
At the moment, pressing the delete button in the ArticleEditor results in directly deleting the article. This is not consistent with the rest of the webapp, as a modal or some kind of confirmation is usually needed to delete elements. Therefore, to avoid an article being deleted without confirmation, the delete button is wrapped in a `<ConfirmModalWithParent />` component.

# Result
**Before**

[Screencast from 27. feb. 2023 kl. 16.39 +0100.webm](https://user-images.githubusercontent.com/43182025/221609287-6d251bf9-f0ae-4b8f-8a5a-cc3390a93963.webm)

**After**

[Screencast from 27. feb. 2023 kl. 16.41 +0100.webm](https://user-images.githubusercontent.com/43182025/221609795-ba5254f9-b75e-47c2-b020-be252926b209.webm)


# Testing

- [x] I have thoroughly tested my changes.

Tested manually by deleting an article in staging.

---

Resolves ABA-309
