### PR TITLE
Use correct symbol on EvenStatus-component

### DIFF
--- a/app/utils/eventStatus.ts
+++ b/app/utils/eventStatus.ts
@@ -24,7 +24,7 @@ const eventStatus = (event: Event, loggedIn = false): string => {
     case 'INFINITE':
       // Check if event has been
       if (event.startTime > moment()) {
-        return `${registrationCount}/${totalCapacity} påmeldte`;
+        return `${registrationCount}/${totalCapacity || '∞'} påmeldte`;
       }
 
       if (!loggedIn) {


### PR DESCRIPTION
# Description

Someone pointed out an event with infinite number of places showed x/0 in the listrings-views

# Result

Used code from the same file (line 78)

Before:
![Screenshot from 2023-02-28 11-32-09](https://user-images.githubusercontent.com/42469466/221829363-d064ca59-b358-40a1-b3e0-0855e8ec0866.png)


After:
![Screenshot from 2023-02-28 11-31-57](https://user-images.githubusercontent.com/42469466/221829378-8cdc0223-a4a9-4d63-9a74-de1dccadb5b7.png)

# Testing

- [x]  I have thoroughly tested my changes.

Inspected images above, and made sure the other event-items looked the same:)

---

