### PR TITLE
Circumvent uBlock origin

### DIFF
--- a/server/pageRenderer.ts
+++ b/server/pageRenderer.ts
@@ -78,7 +78,7 @@ const analytics = __DEV__
   : `<script defer data-domain=${config.webUrl.replace(
       /(^\w+:|^)\/\//,
       ''
-    )} src="https://ls.webkom.dev/script.js"></script>`;
+    )} src="https://ls.webkom.dev/js/script.js"></script>`;
 
 export default function pageRenderer({
   app = undefined,


### PR DESCRIPTION
# Description

Circumvent uBlcok's newest filters. For some reason there is a filer that blocks https://\*/script.js.

# Result

Should not be blocked now.

# Testing

- [x] I have thoroughly tested my changes.

This worked on webkom.dev
