### PR TITLE
2 bugs 1 pr

### DIFF
--- a/app/components/Form/TextInput.css
+++ b/app/components/Form/TextInput.css
@@ -66,3 +66,7 @@ span.suffix {
   border-bottom-left-radius: 0;
   font-size: 0.9rem;
 }
+
+.removeBorder {
+  border: none;
+}

--- a/app/components/Form/TextInput.tsx
+++ b/app/components/Form/TextInput.tsx
@@ -37,12 +37,12 @@ const TextInput = ({
     <Flex
       alignItems="center"
       gap={10}
-      style={{ border: removeBorder ? 'none' : 'initial' }}
       className={cx(
         styles.input,
         styles.textInput,
         disabled && styles.disabled,
         !prefix && styles.spacing,
+        removeBorder && styles.removeBorder,
         className
       )}
     >

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -154,10 +154,6 @@
   margin-bottom: 0.5em;
 }
 
-ion-icon {
-  font-size: 20px;
-}
-
 .tooltip {
   text-transform: initial;
   font-weight: initial;


### PR DESCRIPTION
# Description

[Fix bug where border was gone from text inputs](https://github.com/webkom/lego-webapp/commit/43e7c84c9f893a6b6371d1ed88cc3297173e0009) 

`border: initial` didn't work.

| Before | After |
:------------------:|:-----------------------------:
<img width="361" alt="image" src="https://user-images.githubusercontent.com/69514187/223551659-c03b6c20-1733-4245-84ab-90d814d1fd9c.png"> | <img width="361" alt="image" src="https://user-images.githubusercontent.com/69514187/223551848-51ff805d-7132-4110-8fbf-14b9419e9645.png">




---
  
[Do not override all icons to be 20px ..](https://github.com/webkom/lego-webapp/commit/8828e983eacdeac3c7646dcbaf4214bc6893cd27) 

This unspecific styling cascaded to all other ion icons.

Introduced in #3608. I even pointed it out 😠

| Before | After |
:------------------:|:-----------------------------:
<img width="311" alt="image" src="https://user-images.githubusercontent.com/69514187/223551574-9cdebe5f-975f-46e0-9c70-ebe7b223d662.png"> | <img width="311" alt="image" src="https://user-images.githubusercontent.com/69514187/223551530-77dfcfdb-e88c-4ea3-88a5-37062b25ae53.png">
<img width="311" alt="image" src="https://user-images.githubusercontent.com/69514187/223551335-5eeab675-1295-4515-af32-026a3bf55791.png"> | <img width="311" alt="image" src="https://user-images.githubusercontent.com/69514187/223551419-136a1dae-d87f-4aaa-ac73-0226fbc1521f.png">


# Testing

- [x] I have thoroughly tested my changes.

See results above.

---

Resolves ABA-315