### PR TITLE
Add `kid_event` to other category

### DIFF
--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -180,6 +180,7 @@ class EventList extends Component<EventListProps, State> {
           return showSocial;
 
         case 'other':
+        case 'kid_event':
           return showOther;
 
         default:

--- a/app/routes/overview/components/CompactEvents.tsx
+++ b/app/routes/overview/components/CompactEvents.tsx
@@ -63,6 +63,7 @@ export default class CompactEvents extends Component<Props> {
       'alternative_presentation',
       'course',
       'breakfast_talk',
+      'kid_event',
     ]);
     const leftEvents =
       presentations.length > 0 ? presentations : ['Ingen presentasjoner'];


### PR DESCRIPTION
# Description

Also add it to the list of events on the overview page.

# Testing

- [x] I have thoroughly tested my changes.

It now shows up as expected.