### PR TITLE
Export company interests to csv

### DIFF
--- a/app/reducers/companyInterest.ts
+++ b/app/reducers/companyInterest.ts
@@ -41,17 +41,29 @@ export const selectCompanyInterestList = createSelector(
   (state) => state.companyInterest.byId,
   (state) => state.companyInterest.items,
   (state, props) => props,
-  (companyInterestById, companyInterestIds, semesterId) => {
+  (state, props, selectedEventOption) => selectedEventOption,
+  (companyInterestById, companyInterestIds, semesterId, eventValue) => {
     const companyInterests = companyInterestIds.map(
       (id) => companyInterestById[id]
     );
-
-    if (semesterId === 0) {
+    if (semesterId === 0 && eventValue === '') {
       return companyInterests;
     }
+    if (semesterId === 0 && eventValue !== '') {
+      return companyInterests.filter((companyInterest) =>
+        companyInterest.events.includes(eventValue)
+      );
+    }
+    if (semesterId !== 0 && eventValue === '') {
+      return companyInterests.filter((companyInterest) =>
+        companyInterest.semesters.includes(semesterId)
+      );
+    }
 
-    return companyInterests.filter((companyInterest) =>
-      companyInterest.semesters.includes(semesterId)
+    return companyInterests.filter(
+      (companyInterest) =>
+        companyInterest.semesters.includes(semesterId) &&
+        companyInterest.events.includes(eventValue)
     );
   }
 );

--- a/app/routes/companyInterest/CompanyInterestListRoute.ts
+++ b/app/routes/companyInterest/CompanyInterestListRoute.ts
@@ -6,7 +6,7 @@ import { fetchSemesters } from 'app/actions/CompanyActions';
 import {
   fetchAll,
   deleteCompanyInterest,
-  fetch,
+  fetch as fetchCIA,
 } from 'app/actions/CompanyInterestActions';
 import { LoginPage } from 'app/components/LoginForm';
 import { selectCompanyInterestList } from 'app/reducers/companyInterest';
@@ -15,7 +15,7 @@ import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import CompanyInterestList from './components/CompanyInterestList';
-import { semesterToText } from './utils';
+import { getCsvUrl, semesterToText } from './utils';
 
 const mapStateToProps = (state, props) => {
   const semesterId = Number(
@@ -27,7 +27,7 @@ const mapStateToProps = (state, props) => {
   const semesterObj: CompanySemesterEntity | null | undefined = semesters.find(
     (semester) => semester.id === semesterId
   );
-  const selectedOption = {
+  const selectedSemesterOption = {
     id: semesterId ? semesterId : 0,
     semester: semesterObj != null ? semesterObj.semester : '',
     year: semesterObj != null ? semesterObj.year : '',
@@ -40,9 +40,13 @@ const mapStateToProps = (state, props) => {
           })
         : 'Vis alle semestre',
   };
+  const selectedEventOption = {
+    value: 'company_presentation',
+    label: 'Bedriftspresentasjon',
+  };
   const companyInterestList = selectCompanyInterestList(
     state,
-    selectedOption.id
+    selectedSemesterOption.id
   );
   const hasMore = state.companyInterest.hasMore;
   const fetching = state.companyInterest.fetching;
@@ -51,14 +55,32 @@ const mapStateToProps = (state, props) => {
     companyInterestList,
     hasMore,
     fetching,
-    selectedOption,
+    selectedSemesterOption,
+
+    exportSurvey: async (event?: string) => {
+      const blob = await fetch(
+        getCsvUrl(
+          selectedSemesterOption.year,
+          selectedSemesterOption.semester,
+          event
+        ),
+        {
+          headers: {
+            Authorization: `Bearer ${state.auth.token}`,
+          },
+        }
+      ).then((response) => response.blob());
+      return {
+        url: URL.createObjectURL(blob),
+      };
+    },
   };
 };
 
 const mapDispatchToProps = {
   fetchAll,
   deleteCompanyInterest,
-  fetch,
+  fetch: fetchCIA,
   push,
 };
 export default compose(

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -105,6 +105,19 @@
   }
 }
 
+.event_section {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin: 30px auto;
+  align-items: flex-end;
+
+  @media (--small-viewport) {
+    flex-flow: column wrap;
+    align-items: center;
+  }
+}
+
 .companyInterestList {
   @media (--small-viewport) {
     display: none;

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -105,19 +105,6 @@
   }
 }
 
-.event_section {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  margin: 30px auto;
-  align-items: flex-end;
-
-  @media (--small-viewport) {
-    flex-flow: column wrap;
-    align-items: center;
-  }
-}
-
 .companyInterestList {
   @media (--small-viewport) {
     display: none;
@@ -178,4 +165,8 @@ ion-icon {
 
 .label {
   color: rgb(194, 69, 56);
+}
+
+.selector {
+  min-width: 500px;
 }

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -116,6 +116,20 @@ export const OTHER_TYPES = {
   */
 };
 
+export const EVENT_TYPE_OPTIONS = [
+  { value: '', label: 'Vis alle arrangementstyper' },
+  { value: 'company_presentation', label: 'Bedriftspresentasjon' },
+  { value: 'course', label: 'Kurs' },
+  { value: 'breakfast_talk', label: 'Frokostforedrag' },
+  { value: 'lunch_presentation', label: 'Lunsjpresentasjon' },
+  { value: 'bedex', label: 'BedEx' },
+  { value: 'digital_presentation', label: 'Digital presentasjon' },
+  { value: 'other', label: 'Alternativt arrangement' },
+  { value: 'sponsor', label: 'Sponser' },
+  { value: 'start_up', label: 'Start-up kveld' },
+  { value: 'company_to_company', label: 'Bedrift-til-bedrift' },
+];
+
 export const OFFICE_IN_TRONDHEIM = {
   true: { norwegian: 'Ja', english: 'Yes' },
   false: { norwegian: 'Nei', english: 'No' },

--- a/app/routes/companyInterest/utils.tsx
+++ b/app/routes/companyInterest/utils.tsx
@@ -1,7 +1,9 @@
 import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
+import config from 'app/config';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import type { ReactNode } from 'react';
+import qs from 'qs';
 
 export const sortSemesterChronologically = (
   a: CompanySemesterEntity,
@@ -37,6 +39,17 @@ export const SEMESTER_TRANSLATION = {
     english: 'Autumn',
   },
 };
+export const getCsvUrl = (
+  year: number | string,
+  semester: string,
+  event?: string
+) =>
+  `${config.serverUrl}/company-interests/csv/?${qs.stringify({
+    year,
+    semester,
+    event,
+  })}`;
+
 export const semesterToText = ({
   semester,
   year,

--- a/app/routes/companyInterest/utils.tsx
+++ b/app/routes/companyInterest/utils.tsx
@@ -1,9 +1,9 @@
+import qs from 'qs';
 import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import config from 'app/config';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import type { ReactNode } from 'react';
-import qs from 'qs';
 
 export const sortSemesterChronologically = (
   a: CompanySemesterEntity,


### PR DESCRIPTION
# Description
- Implemented filtering company interests by event type, one similar to the filtering by semester.
- Implemented interface for exporting company interests to csv file. The exporting is filtered by semester and event type
- The backend implementation was done in here: [#3231](https://github.com/webkom/lego/pull/3231)

# Result
<img width="823" alt="image" src="https://user-images.githubusercontent.com/90712892/224358688-4f8f8c22-7d36-470a-ac31-cc5bfa346cc1.png">

<img width="844" alt="image" src="https://user-images.githubusercontent.com/90712892/224358616-994b174c-a389-4449-903d-3f08e6fb4df8.png">
# Testing

- [x] I have thoroughly tested my changes.