### PR TITLE
Stop event editor from breaking in dev

### DIFF
--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -176,11 +176,11 @@ export default createEntityReducer({
 function transformEvent(event: EventType) {
   return {
     ...event,
-    startTime: moment(event.startTime),
-    endTime: moment(event.endTime),
+    startTime: event.startTime && moment(event.startTime).toISOString(),
+    endTime: event.endTime && moment(event.endTime).toISOString(),
     activationTime:
-      event.activationTime !== null ? moment(event.activationTime) : null,
-    mergeTime: event.mergeTime && moment(event.mergeTime),
+      event.activationTime && moment(event.activationTime).toISOString(),
+    mergeTime: event.mergeTime && moment(event.mergeTime).toISOString(),
     useCaptcha: config.environment === 'ci' ? false : event.useCaptcha,
   };
 }
@@ -208,7 +208,9 @@ export const selectUpcomingEvents = createSelector(selectEvents, (events) =>
   events.filter((event) => event.isUsersUpcoming)
 );
 export const selectSortedEvents = createSelector(selectEvents, (events) =>
-  [...events].sort((a, b) => a.startTime.unix() - b.startTime.unix())
+  [...events].sort(
+    (a, b) => moment(a.startTime).unix() - moment(b.startTime).unix()
+  )
 );
 export const selectEventById = createSelector(
   (state) => state.events.byId,

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -31,9 +31,9 @@ const groupEvents = ({
 }): GroupedEvents => {
   const nextWeek = moment().add(1, 'week');
   const groups = {
-    currentWeek: (event) => event[field].isSame(moment(), 'week'),
-    nextWeek: (event) => event[field].isSame(nextWeek, 'week'),
-    later: (event) => event[field].isAfter(nextWeek),
+    currentWeek: (event) => moment(event[field]).isSame(moment(), 'week'),
+    nextWeek: (event) => moment(event[field]).isSame(nextWeek, 'week'),
+    later: (event) => moment(event[field]).isAfter(nextWeek),
   };
   return events.reduce((result, event) => {
     for (const groupName in groups) {

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -1,5 +1,6 @@
 import { pick, sumBy, find } from 'lodash';
 import moment from 'moment-timezone';
+import config from 'app/config';
 import type {
   TransformEvent,
   Event,
@@ -236,8 +237,7 @@ export const transformEvent = (data: TransformEvent) => ({
   unregistrationDeadline: calculateUnregistrationDeadline(data),
   unregistrationDeadlineHours: calculateUnregistrationDeadlineHours(data),
   pools: calculatePools(data),
-  useCaptcha: true,
-  // always use Captcha, this blocks the use of CLI
+  useCaptcha: config.environment === 'ci' ? false : data.useCaptcha,
   youtubeUrl: data.youtubeUrl,
   mazemapPoi: calculateMazemapPoi(data),
   feedbackDescription:

--- a/app/routes/overview/components/CompactEvents.tsx
+++ b/app/routes/overview/components/CompactEvents.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Flex } from 'app/components/Layout';
@@ -18,7 +19,8 @@ export default class CompactEvents extends Component<Props> {
       return events
         .filter(
           (event) =>
-            event.endTime.isAfter() && eventTypes.includes(event.eventType)
+            moment(event.endTime).isAfter() &&
+            eventTypes.includes(event.eventType)
         )
         .slice(0, 5)
         .map((event, key) => (

--- a/app/routes/surveys/EditSurveyRoute.ts
+++ b/app/routes/surveys/EditSurveyRoute.ts
@@ -1,4 +1,5 @@
 import { push } from 'connected-react-router';
+import moment from 'moment-timezone';
 import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -54,7 +55,7 @@ const mapStateToProps = (state, props) => {
         ...template,
         title: survey.title || template.title,
         event: initialEvent,
-        activeFrom: survey.event && survey.event.endTime,
+        activeFrom: moment(survey.event?.endTime),
       };
     } else {
       initialValues = {

--- a/app/utils/eventStatus.ts
+++ b/app/utils/eventStatus.ts
@@ -23,7 +23,7 @@ const eventStatus = (event: Event, loggedIn = false): string => {
     case 'NORMAL':
     case 'INFINITE':
       // Check if event has been
-      if (event.startTime > moment()) {
+      if (moment(event.startTime) > moment()) {
         return `${registrationCount}/${totalCapacity || '∞'} påmeldte`;
       }
 


### PR DESCRIPTION
# Description

There was problems with storing non-serializable `moment` objects in the redux store. Issue is fixed by turning event dates into ISO strings.

Multiple places used the dates directly as `moment` objects, which now needs to be wrapped in a `moment()` function. This is the way it's done elsewhere in our codebase.

# Result

https://user-images.githubusercontent.com/69514187/224502008-9c1cf9a8-9e89-4462-ae7c-f39358eac162.mov


# Testing

- [x] I have thoroughly tested my changes.

See video above. 

More testing is needed, as I was experiencing some weird behaviour.

Pages will crash if you try to perform `moment` related functions on a string, so I need to make sure there's no such thing left.