### PR TITLE
Compose text area styling from text editor

### DIFF
--- a/app/components/Form/TextArea.tsx
+++ b/app/components/Form/TextArea.tsx
@@ -1,7 +1,7 @@
 import cx from 'classnames';
 import Textarea from 'react-textarea-autosize';
 import { createField } from './Field';
-import styles from './TextInput.css';
+import styles from './TextEditor.css';
 import type { RefObject } from 'react';
 
 type Props = {


### PR DESCRIPTION
# Description

I don't get the difference between the two ...

# Result

**Before**
<img width="987" alt="image" src="https://user-images.githubusercontent.com/69514187/224504482-0fb6210d-0a4b-4fd7-a18e-fd663b690e1a.png">

**After**
<img width="987" alt="image" src="https://user-images.githubusercontent.com/69514187/224504434-d3ca7c1c-8a50-4102-b389-39ac52ab15ae.png">

# Testing

- [x] I have thoroughly tested my changes.
