### PR TITLE
General changes to surveys

### DIFF
--- a/app/components/Content/ContentSidebar.tsx
+++ b/app/components/Content/ContentSidebar.tsx
@@ -15,7 +15,7 @@ type Props = {
  */
 function ContentSidebar({ children, className }: Props) {
   return (
-    <Flex column className={cx(styles.sidebar, className)}>
+    <Flex column gap={7} className={cx(styles.sidebar, className)}>
       {children}
     </Flex>
   );

--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -72,6 +72,7 @@ export type FormProps = {
   fieldClassName?: string;
   labelClassName?: string;
   showErrors?: boolean;
+  onChange?: (value: string) => void;
 };
 type Options = {
   // Removes the html <label> around the component
@@ -79,9 +80,7 @@ type Options = {
 };
 
 /**
- * Wraps Component, so it works with redux-form/react-final-form and add some
- * default field behaviour.
- *
+ * Wraps field component
  * http://redux-form.com/6.0.5/docs/api/Field.md/
  * https://final-form.org/docs/react-final-form/api/Field
  */
@@ -96,6 +95,7 @@ export function createField(Component: ComponentType<any>, options?: Options) {
       description,
       fieldClassName,
       labelClassName,
+      onChange,
       showErrors = true,
       className = null,
       ...props
@@ -132,6 +132,10 @@ export function createField(Component: ComponentType<any>, options?: Options) {
         <Component
           {...input}
           {...props}
+          onChange={(value) => {
+            input.onChange(value);
+            onChange?.(value);
+          }}
           className={cx(
             className,
             hasWarning && styles.inputWithWarning,

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -52,7 +52,6 @@
   flex-wrap: wrap;
   gap: 10px;
   align-items: center;
-  margin-bottom: 10px;
 }
 
 .registeredBox {

--- a/app/routes/surveys/AddSurveyRoute.ts
+++ b/app/routes/surveys/AddSurveyRoute.ts
@@ -2,7 +2,6 @@ import { push } from 'connected-react-router';
 import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { formValueSelector } from 'redux-form';
 import { fetchEvent } from 'app/actions/EventActions';
 import { LoginPage } from 'app/components/LoginForm';
 import { selectEventById } from 'app/reducers/events';
@@ -69,7 +68,6 @@ const mapStateToProps = (state, props) => {
     }
   }
 
-  const formSelector = formValueSelector('surveyEditor');
   return {
     template,
     selectedTemplateType,
@@ -79,7 +77,6 @@ const mapStateToProps = (state, props) => {
       event: event && fullEvent,
     },
     notFetching,
-    activeFrom: formSelector(state, 'activeFrom') || defaultActiveFrom(12, 0),
   };
 };
 

--- a/app/routes/surveys/EditSurveyRoute.ts
+++ b/app/routes/surveys/EditSurveyRoute.ts
@@ -2,7 +2,6 @@ import { push } from 'connected-react-router';
 import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { formValueSelector } from 'redux-form';
 import {
   editSurvey,
   fetchSurvey,
@@ -80,7 +79,6 @@ const mapStateToProps = (state, props) => {
   const surveyToSend = template
     ? { ...survey, questions: template.questions }
     : survey;
-  const formSelector = formValueSelector('surveyEditor');
   return {
     survey: surveyToSend,
     surveyId,
@@ -89,7 +87,6 @@ const mapStateToProps = (state, props) => {
     selectedTemplateType: templateType,
     initialValues,
     notFetching,
-    activeFrom: formSelector(state, 'activeFrom'),
   };
 };
 

--- a/app/routes/surveys/TemplatesRoute.ts
+++ b/app/routes/surveys/TemplatesRoute.ts
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { LoginPage } from 'app/components/LoginForm';
 import { selectSurveyTemplates } from 'app/reducers/surveys';
-import loadingIndicator from 'app/utils/loadingIndicator';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import { addSurvey, fetchTemplates } from '../../actions/SurveyActions';
@@ -11,7 +10,7 @@ import SurveyPage from './components/SurveyList/SurveyPage';
 
 const mapStateToProps = (state, props) => ({
   surveys: selectSurveyTemplates(state, props),
-  notFetching: !state.surveys.fetching,
+  fetching: state.surveys.fetching,
 });
 
 const mapDispatchToProps = {
@@ -23,6 +22,5 @@ export default compose(
   withPreparedDispatch('fetchTemplates', (props, dispatch) =>
     dispatch(fetchTemplates())
   ),
-  connect(mapStateToProps, mapDispatchToProps),
-  loadingIndicator(['notFetching'])
+  connect(mapStateToProps, mapDispatchToProps)
 )(SurveyPage);

--- a/app/routes/surveys/components/AdminSideBar.tsx
+++ b/app/routes/surveys/components/AdminSideBar.tsx
@@ -50,75 +50,76 @@ class AdminSideBar extends Component<Props, State> {
       : `${config.webUrl}/surveys/${surveyId}/results/?token=${token}`;
     return (
       canEdit && (
-        <ContentSidebar className={styles.adminSideBar}>
-          <strong>Admin</strong>
-          <ul>
-            <li>
-              <Link to="/surveys/add">Ny undersøkelse</Link>
-            </li>
-            <li>
-              <Link to={`/surveys/${surveyId}/edit`}>Endre undersøkelsen</Link>
-            </li>
-            {actionGrant && actionGrant.includes('edit') && shareSurvey && (
-              <CheckBox
-                id="shareSurvey"
-                label="Del spørreundersøkelsen"
-                onChange={() =>
-                  token ? hideSurvey(surveyId) : shareSurvey(surveyId)
-                }
-                value={!!token}
-              />
-            )}
-            {token && (
-              <li>
+        <ContentSidebar>
+          <h3>Admin</h3>
+
+          <Link to="/surveys/add">
+            <Button>
+              <Icon name="add" size={19} />
+              Ny undersøkelse
+            </Button>
+          </Link>
+
+          <Link to={`/surveys/${surveyId}/edit`}>
+            <Button>
+              <Icon name="create-outline" size={19} />
+              Rediger
+            </Button>
+          </Link>
+
+          {actionGrant && actionGrant.includes('csv') && exportSurvey && (
+            <div>
+              {generatedCSV ? (
+                <a href={generatedCSV.url} download={generatedCSV.filename}>
+                  Last ned
+                </a>
+              ) : (
                 <Button
-                  onClick={() => {
-                    navigator.clipboard.writeText(shareLink).then(() => {
-                      this.setState({
-                        copied: true,
-                      });
-                      setTimeout(
-                        () =>
-                          this.setState({
-                            copied: false,
-                          }),
-                        2000
-                      );
-                    });
-                  }}
-                  className={cx(this.state.copied && styles.copied)}
+                  onClick={async () =>
+                    this.setState({
+                      generatedCSV: await exportSurvey(surveyId),
+                    })
+                  }
                 >
-                  <Icon
-                    name={this.state.copied ? 'checkmark' : 'copy-outline'}
-                  />
-                  {this.state.copied ? 'Kopiert!' : 'Kopier delbar link'}
+                  Eksporter til CSV
                 </Button>
-              </li>
-            )}
-            {actionGrant && actionGrant.includes('csv') && exportSurvey && (
-              <div
-                style={{
-                  marginTop: '5px',
-                }}
-              >
-                {generatedCSV ? (
-                  <a href={generatedCSV.url} download={generatedCSV.filename}>
-                    Last ned
-                  </a>
-                ) : (
-                  <Button
-                    onClick={async () =>
+              )}
+            </div>
+          )}
+
+          {actionGrant && actionGrant.includes('edit') && shareSurvey && (
+            <CheckBox
+              id="shareSurvey"
+              label="Del spørreundersøkelsen"
+              onChange={() =>
+                token ? hideSurvey(surveyId) : shareSurvey(surveyId)
+              }
+              value={!!token}
+            />
+          )}
+
+          {token && (
+            <Button
+              onClick={() => {
+                navigator.clipboard.writeText(shareLink).then(() => {
+                  this.setState({
+                    copied: true,
+                  });
+                  setTimeout(
+                    () =>
                       this.setState({
-                        generatedCSV: await exportSurvey(surveyId),
-                      })
-                    }
-                  >
-                    Eksporter til CSV
-                  </Button>
-                )}
-              </div>
-            )}
-          </ul>
+                        copied: false,
+                      }),
+                    2000
+                  );
+                });
+              }}
+              success={this.state.copied}
+            >
+              <Icon name={this.state.copied ? 'checkmark' : 'copy-outline'} />
+              {this.state.copied ? 'Kopiert!' : 'Kopier delbar link'}
+            </Button>
+          )}
         </ContentSidebar>
       )
     );

--- a/app/routes/surveys/components/SubmissionEditor/SubmissionEditor.tsx
+++ b/app/routes/surveys/components/SubmissionEditor/SubmissionEditor.tsx
@@ -25,10 +25,8 @@ type Props = {
 
 const SubmissionEditor = ({
   survey,
-  fetching,
   submitting,
   handleSubmit,
-  submitFunction,
   error,
 }: Props) => {
   return (

--- a/app/routes/surveys/components/SurveyEditor/Option.tsx
+++ b/app/routes/surveys/components/SurveyEditor/Option.tsx
@@ -1,4 +1,4 @@
-import { Field } from 'redux-form';
+import { Field } from 'react-final-form';
 import Button from 'app/components/Button';
 import { RadioButton, TextInput, CheckBox } from 'app/components/Form';
 import { QuestionTypes } from 'app/routes/surveys/utils';
@@ -47,7 +47,7 @@ const MultipleChoice = (props: Props) => {
 const Checkbox = (props: Props) => {
   return (
     <li>
-      <CheckBox checked={false} className={styles.option} />
+      <CheckBox defaultChecked={false} className={styles.option} />
       <Field
         onChange={props.onChange}
         name={`${props.option}.optionText`}

--- a/app/routes/surveys/components/SurveyEditor/Question.tsx
+++ b/app/routes/surveys/components/SurveyEditor/Question.tsx
@@ -1,4 +1,5 @@
-import { Field, FieldArray } from 'redux-form';
+import { Field } from 'react-final-form';
+import { FieldArray } from 'react-final-form-arrays';
 import {
   TextInput,
   TextArea,
@@ -16,18 +17,15 @@ import {
 import styles from '../surveys.css';
 import Option from './Option';
 import type { ReactNode } from 'react';
-import type { FieldArrayProps } from 'redux-form';
-import type { $PropertyType } from 'utility-types';
 
-type Fields = $PropertyType<FieldArrayProps, 'fields'>;
 type Props = {
   deleteQuestion: (arg0: number) => Promise<any>;
   questionData: Record<string, any>;
   question: string;
   relativeIndex: number;
   numberOfQuestions: number;
-  updateRelativeIndexes: (arg0: number, arg1: number, arg2: Fields) => void;
-  fields: Fields;
+  updateRelativeIndexes: (arg0: number, arg1: number, arg2: any) => void;
+  fields: any;
   option?: string;
   value?: string;
 };
@@ -53,6 +51,7 @@ const Question = ({
   fields,
 }: Props) => {
   const indexOptions = questionIndexMappings(numberOfQuestions);
+
   return (
     <div className={styles.question}>
       <div className={styles.left}>
@@ -70,7 +69,7 @@ const Question = ({
         {questionData.questionType.value === QuestionTypes('text') ? (
           <TextArea
             className={styles.freeText}
-            placeholder="Fritekst - sånn vil den se ut :smile:"
+            placeholder="Fritekst - sånn her vil den se ut :smile:"
             value=""
             disabled
           />
@@ -174,7 +173,7 @@ const renderOptions = ({
   fields,
   questionType,
 }: {
-  fields: Fields;
+  fields: any;
   questionType: string;
 }): ReactNode => (
   <ul className={styles.options}>

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
@@ -1,16 +1,14 @@
+import arrayMutators from 'final-form-arrays';
 import { useState } from 'react';
+import { Field } from 'react-final-form';
+import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
-import { Field, FieldArray } from 'redux-form';
 import Button from 'app/components/Button';
 import { Content } from 'app/components/Content';
 import Dropdown from 'app/components/Dropdown';
-import {
-  TextInput,
-  SelectInput,
-  DatePicker,
-  legoForm,
-} from 'app/components/Form';
+import { TextInput, SelectInput, DatePicker } from 'app/components/Form';
+import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
@@ -18,27 +16,29 @@ import Time from 'app/components/Time';
 import type { EventType } from 'app/models';
 import type { SurveyEntity } from 'app/reducers/surveys';
 import { eventTypeToString, EVENT_CONSTANTS } from 'app/routes/events/utils';
+import {
+  DetailNavigation,
+  ListNavigation,
+  QuestionTypes,
+} from 'app/routes/surveys/utils';
+import { spySubmittable } from 'app/utils/formSpyUtils';
 import { createValidator, required } from 'app/utils/validation';
-import { DetailNavigation, ListNavigation, QuestionTypes } from '../../utils';
 import styles from '../surveys.css';
 import Question from './Question';
-import type { Element } from 'react';
-import type { FieldArrayProps, FormProps } from 'redux-form';
+import type { ReactNode } from 'react';
 
-type Props = FormProps & {
+type Props = {
   survey: SurveyEntity;
   autoFocus: Record<string, any>;
   surveyData: Array<Record<string, any>>;
-  submitFunction: (
-    arg0: SurveyEntity,
-    arg1: number | null | undefined
-  ) => Promise<any>;
+  submitFunction: (arg0: any) => Promise<void>;
   push: (arg0: string) => void;
   template?: Record<string, any>;
   selectedTemplateType?: EventType;
   destroy: () => void;
   initialize: () => void;
   activeFrom: string;
+  initialValues: Record<string, any>;
 };
 type TemplateTypeDropdownItemsProps = {
   survey?: Record<string, any>;
@@ -52,13 +52,13 @@ function TemplateTypeDropdownItems({
   destroy,
 }: TemplateTypeDropdownItemsProps) {
   const link = (eventType) =>
-    survey && survey.id
+    survey?.id
       ? `/surveys/${survey.id}/edit/?templateType=${eventType}`
       : `/surveys/add/?templateType=${eventType}`;
 
   return (
     <Dropdown.List>
-      {Object.keys(EVENT_CONSTANTS).map((eventType) => (
+      {Object.keys(EVENT_CONSTANTS).map((eventType: EventType) => (
         <Dropdown.ListItem key={eventType}>
           <Link
             to="#"
@@ -77,57 +77,127 @@ function TemplateTypeDropdownItems({
   );
 }
 
+export const initialQuestion = {
+  questionText: '',
+  questionType: QuestionTypes('single'),
+  mandatory: false,
+  options: [
+    {
+      optionText: '',
+      relativeIndex: {
+        value: 0,
+        label: 0,
+      },
+    },
+  ],
+};
+
+export const hasOptions = (data: Record<string, any>) => {
+  const message = {};
+  message.questions = [];
+  data.questions?.forEach((element, i) => {
+    if (!['multiple_choice', 'single_choice'].includes(element.questionType))
+      return;
+
+    if (element.options.length < 2) {
+      message.questions[i] = {
+        questionText: ['Spørsmål må ha minst ett svaralternativ'],
+      };
+    }
+  });
+  return message;
+};
+const updateRelativeIndexes = (oldIndex, newIndex, fields) => {
+  fields.move(oldIndex, newIndex);
+};
+
+const renderQuestions = ({
+  fields,
+  meta: { touched, error },
+}: any): ReactNode => {
+  return (
+    <>
+      <ul className={styles.questions} key="questions">
+        {fields.map((question, i) => (
+          <Question
+            key={i}
+            numberOfQuestions={fields.length}
+            question={question}
+            questionData={fields.value[i]}
+            deleteQuestion={() => Promise.resolve(fields.remove(i))}
+            updateRelativeIndexes={updateRelativeIndexes}
+            relativeIndex={i}
+            fields={fields}
+          />
+        ))}
+        <span>{error}</span>
+      </ul>
+
+      <Link
+        key="addNew"
+        to="#"
+        onClick={() => {
+          const newQuestion = initialQuestion;
+          fields.push(newQuestion);
+        }}
+      >
+        <Icon name="add-circle" size={30} className={styles.addQuestion} />
+      </Link>
+    </>
+  );
+};
+
+const validate = createValidator(
+  {
+    title: [required()],
+    event: [required()],
+  },
+  hasOptions
+);
+
 const SurveyEditor = ({
   survey,
-  submitting,
   autoFocus,
-  handleSubmit,
   template,
   push,
   destroy,
   activeFrom,
   selectedTemplateType,
+  submitFunction,
+  initialValues,
 }: Props) => {
   const [isTemplatePickerOpen, setTemplatePickerOpen] = useState(false);
 
-  const updateRelativeIndexes = (oldIndex, newIndex, fields) => {
-    fields.move(oldIndex, newIndex);
-  };
+  const onSubmit = (formContent: Record<string, any>) => {
+    // Remove options if it's a free text question, and remove all empty options
+    // options
+    const cleanQuestions = formContent.questions.map((q, i) => {
+      const question = {
+        ...q,
+        questionType: q.questionType?.value,
+        relativeIndex: i,
+      };
 
-  const renderQuestions = ({
-    fields,
-    meta: { touched, error },
-  }: FieldArrayProps): Element<any> => {
-    return (
-      <>
-        <ul className={styles.questions} key="questions">
-          {fields.map((question, i) => (
-            <Question
-              key={i}
-              numberOfQuestions={fields.length}
-              question={question}
-              questionData={fields.get(i)}
-              deleteQuestion={() => Promise.resolve(fields.remove(i))}
-              updateRelativeIndexes={updateRelativeIndexes}
-              relativeIndex={i}
-              fields={fields}
-            />
-          ))}
-          <span>{error}</span>
-        </ul>
+      if (question.questionType === QuestionTypes('text')) {
+        question.options = [];
+      } else {
+        question.options = question.options.filter(
+          (option) => option.optionText !== ''
+        );
+      }
 
-        <Link
-          key="addNew"
-          to="#"
-          onClick={() => {
-            const newQuestion = initialQuestion;
-            fields.push(newQuestion);
-          }}
-        >
-          <Icon name="add-circle" size={30} className={styles.addQuestion} />
-        </Link>
-      </>
-    );
+      return question;
+    });
+    return submitFunction({
+      ...formContent,
+      surveyId: survey?.id,
+      title: formContent.title,
+      event: formContent.event && Number(formContent.event.value),
+      questions: cleanQuestions,
+    }).then((result) => {
+      const id = survey?.id ? survey.id : result.payload.result;
+      push(`/surveys/${String(id)}`);
+    });
   };
 
   const titleField = (
@@ -147,185 +217,131 @@ const SurveyEditor = ({
     <Content className={styles.detail}>
       <Helmet title={editing ? survey.title : 'Ny spørreundersøkelse'} />
 
-      {editing ? (
-        <DetailNavigation title={titleField} surveyId={Number(survey.id)} />
-      ) : (
-        <ListNavigation title={titleField} />
-      )}
-
-      <ConfirmModalWithParent
-        title="Bekreft bruk av mal"
-        message={
-          'Dette vil slette alle ulagrede endringer i undersøkelsen!\n' +
-          'Lagrede endringer vil ikke overskrives før du trykker "Lagre".'
-        }
-        closeOnConfirm
-        onCancel={() => {
-          return Promise.all([setTemplatePickerOpen(false)]);
-        }}
-        onConfirm={() => {
-          return Promise.all([setTemplatePickerOpen(true)]);
+      <LegoFinalForm
+        onSubmit={onSubmit}
+        validate={validate}
+        initialValues={initialValues}
+        subscription={{}}
+        mutators={{
+          ...arrayMutators,
         }}
       >
-        <Button className={styles.templatePicker}>
-          {template ? 'Bytt mal' : 'Bruk mal'}
-          <Dropdown
-            className={styles.templateDropdown}
-            show={isTemplatePickerOpen}
-            toggle={() => setTemplatePickerOpen(!isTemplatePickerOpen)}
-            closeOnContentClick
-          >
-            <TemplateTypeDropdownItems
-              survey={survey}
-              push={push}
-              destroy={destroy}
-            />
-          </Dropdown>
-        </Button>
-      </ConfirmModalWithParent>
+        {({ handleSubmit, submitting }) => (
+          <form onSubmit={handleSubmit}>
+            {editing ? (
+              <DetailNavigation
+                title={titleField}
+                surveyId={Number(survey.id)}
+              />
+            ) : (
+              <ListNavigation title={titleField} />
+            )}
 
-      <form onSubmit={handleSubmit}>
-        <div className={styles.templateType}>
-          {selectedTemplateType && (
-            <span>
-              Mal i bruk: <i>{EVENT_CONSTANTS[selectedTemplateType]}</i>
-            </span>
-          )}
-        </div>
+            <ConfirmModalWithParent
+              title="Bekreft bruk av mal"
+              message={
+                'Dette vil slette alle ulagrede endringer i undersøkelsen!\n' +
+                'Lagrede endringer vil ikke overskrives før du trykker "Lagre".'
+              }
+              closeOnConfirm
+              onCancel={() => {
+                return Promise.all([setTemplatePickerOpen(false)]);
+              }}
+              onConfirm={() => {
+                return Promise.all([setTemplatePickerOpen(true)]);
+              }}
+            >
+              <Button className={styles.templatePicker}>
+                {template ? 'Bytt mal' : 'Bruk mal'}
+                <Dropdown
+                  className={styles.templateDropdown}
+                  show={isTemplatePickerOpen}
+                  toggle={() => setTemplatePickerOpen(!isTemplatePickerOpen)}
+                  closeOnContentClick
+                >
+                  <TemplateTypeDropdownItems
+                    survey={survey}
+                    push={push}
+                    destroy={destroy}
+                  />
+                </Dropdown>
+              </Button>
+            </ConfirmModalWithParent>
 
-        {survey.templateType ? (
-          <h2
-            style={{
-              color: 'var(--lego-color-red)',
-            }}
-          >
-            Dette er malen for arrangementer av type{' '}
-            {eventTypeToString(survey.templateType)}
-          </h2>
-        ) : (
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-            }}
-          >
-            <Field
-              placeholder="Velg arrangement"
-              label="Arrangement"
-              autoFocus={autoFocus}
-              name="event"
-              component={SelectInput.AutocompleteField}
-              className={styles.editEvent}
-              filter={['events.event']}
+            {selectedTemplateType && (
+              <div className={styles.templateType}>
+                <span>
+                  Mal i bruk: <i>{EVENT_CONSTANTS[selectedTemplateType]}</i>
+                </span>
+              </div>
+            )}
+
+            {survey.templateType ? (
+              <h2
+                style={{
+                  color: 'var(--lego-color-red)',
+                }}
+              >
+                Dette er malen for arrangementer av type{' '}
+                {eventTypeToString(survey.templateType)}
+              </h2>
+            ) : (
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <Field
+                  placeholder="Velg arrangement"
+                  label="Arrangement"
+                  autoFocus={autoFocus}
+                  name="event"
+                  component={SelectInput.AutocompleteField}
+                  className={styles.editEvent}
+                  filter={['events.event']}
+                />
+
+                <Field
+                  label="Aktiveringstidspunkt"
+                  name="activeFrom"
+                  component={DatePicker.Field}
+                />
+              </div>
+            )}
+            <FieldArray
+              name="questions"
+              component={renderQuestions}
+              rerenderOnEveryChange={true}
             />
 
-            <Field
-              label="Aktiveringstidspunkt"
-              name="activeFrom"
-              component={DatePicker.Field}
-            />
-          </div>
+            <Flex>
+              {spySubmittable((submittable) => (
+                <Button success disabled={submitting || !submittable} submit>
+                  {editing ? 'Lagre' : 'Opprett'}
+                </Button>
+              ))}
+
+              <Button
+                onClick={() =>
+                  push(editing ? `/surveys/${survey.id}` : '/surveys')
+                }
+              >
+                Avbryt
+              </Button>
+            </Flex>
+          </form>
         )}
-        <FieldArray
-          name="questions"
-          component={renderQuestions}
-          rerenderOnEveryChange={true}
-        />
+      </LegoFinalForm>
 
-        <Flex>
-          <Button success disabled={submitting} submit>
-            {editing ? 'Lagre' : 'Opprett'}
-          </Button>
-          <Button
-            onClick={() => push(editing ? `/surveys/${survey.id}` : '/surveys')}
-          >
-            Avbryt
-          </Button>
-        </Flex>
-
-        <i className={styles.mailInfo}>
-          Deltagerene på arrangementet vil få mail med link til
-          spørreundersøkelsen når den aktiveres (
-          <Time time={activeFrom} format="HH:mm DD. MMM" />
-          ).
-        </i>
-      </form>
+      <i className={styles.mailInfo}>
+        Deltagerene på arrangementet vil få mail med link til
+        spørreundersøkelsen når den aktiveres (
+        <Time time={activeFrom} format="HH:mm DD. MMM" />
+        ).
+      </i>
     </Content>
   );
 };
 
-export const initialQuestion = {
-  questionText: '',
-  questionType: QuestionTypes('single'),
-  mandatory: false,
-  options: [
-    {
-      optionText: '',
-      relativeIndex: {
-        value: 0,
-        label: 0,
-      },
-    },
-  ],
-};
-export const hasOptions = (data: Record<string, any>) => {
-  const message = {};
-  message.questions = [];
-  data.questions?.forEach((element, i) => {
-    if (!['multiple_choice', 'single_choice'].includes(element.questionType))
-      return;
-
-    if (element.options.length < 2) {
-      message.questions[i] = {
-        questionText: ['Spørsmål må ha minst ett svaralternativ'],
-      };
-    }
-  });
-  return message;
-};
-const validate = createValidator(
-  {
-    title: [required()],
-    event: [required()],
-  },
-  hasOptions
-);
-
-const onSubmit = (formContent: Record<string, any>, dispatch, props: Props) => {
-  const { survey, submitFunction, push } = props;
-  const { questions } = formContent;
-  // Remove options if it's a free text question, and remove all empty
-  // options
-  const cleanQuestions = questions.map((q, i) => {
-    const question = {
-      ...q,
-      questionType: q.questionType?.value,
-      relativeIndex: i,
-    };
-
-    if (question.questionType === QuestionTypes('text')) {
-      question.options = [];
-    } else {
-      question.options = question.options.filter(
-        (option) => option.optionText !== ''
-      );
-    }
-
-    return question;
-  });
-  return submitFunction({
-    ...formContent,
-    event: formContent.event && Number(formContent.event.value),
-    surveyId: survey && survey.id,
-    questions: cleanQuestions,
-  }).then((result) => {
-    const id = survey && survey.id ? survey.id : result.payload.result;
-    push(`/surveys/${String(id)}`);
-  });
-};
-
-export default legoForm({
-  form: 'surveyEditor',
-  validate,
-  onSubmit,
-})(SurveyEditor);
+export default SurveyEditor;

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
@@ -12,6 +12,7 @@ import {
   legoForm,
 } from 'app/components/Form';
 import Icon from 'app/components/Icon';
+import Flex from 'app/components/Layout/Flex';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import Time from 'app/components/Time';
 import type { EventType } from 'app/models';
@@ -146,10 +147,14 @@ class SurveyEditor extends Component<Props, State> {
         className={styles.editTitle}
       />
     );
+
+    const editing = !!survey.id;
+
     return (
       <Content className={styles.detail}>
-        <Helmet title={survey.id ? survey.title : 'Ny spørreundersøkelse'} />
-        {survey && survey.id ? (
+        <Helmet title={editing ? survey.title : 'Ny spørreundersøkelse'} />
+
+        {editing ? (
           <DetailNavigation title={titleField} surveyId={Number(survey.id)} />
         ) : (
           <ListNavigation title={titleField} />
@@ -242,10 +247,20 @@ class SurveyEditor extends Component<Props, State> {
             component={this.renderQuestions}
             rerenderOnEveryChange={true}
           />
-          <div className={styles.clear} />
-          <Button success disabled={submitting} submit>
-            Lagre
-          </Button>
+
+          <Flex>
+            <Button success disabled={submitting} submit>
+              {editing ? 'Lagre' : 'Opprett'}
+            </Button>
+            <Button
+              onClick={() =>
+                push(editing ? `/surveys/${survey.id}` : '/surveys')
+              }
+            >
+              Avbryt
+            </Button>
+          </Flex>
+
           <i className={styles.mailInfo}>
             Deltagerene på arrangementet vil få mail med link til
             spørreundersøkelsen når den aktiveres (

--- a/app/routes/surveys/components/SurveyList/SurveyList.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyList.tsx
@@ -21,9 +21,8 @@ const SurveyList = (props: Props) => {
       ) : (
         'Ingen spørreundersøkelser funnet.'
       );
-    } else {
-      return surveys_to_render;
     }
+    return surveys_to_render;
   };
 
   return <div className={styles.surveyList}>{contentToRender()}</div>;

--- a/app/routes/surveys/components/SurveyList/SurveyPage.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyPage.tsx
@@ -13,13 +13,13 @@ type Props = {
   fetchAll: (arg0: Record<string, any>) => Promise<any>;
 };
 
-const SurveyPage = ({ surveys, fetching, push, hasMore, fetchAll }: Props) => {
+const SurveyPage = ({ surveys, fetching, hasMore, fetchAll }: Props) => {
   return (
     <Content>
       <Helmet title="Spørreundersøkelser" />
       <ListNavigation title="Spørreundersøkelser" />
 
-      {fetchAll && (
+      {fetchAll ? (
         <Paginator
           infiniteScroll={true}
           hasMore={hasMore}
@@ -32,8 +32,9 @@ const SurveyPage = ({ surveys, fetching, push, hasMore, fetchAll }: Props) => {
         >
           <SurveyList surveys={surveys} fetching={fetching} />
         </Paginator>
+      ) : (
+        <SurveyList surveys={surveys} fetching={fetching} />
       )}
-      {!fetchAll && <SurveyList surveys={surveys} fetching={fetching} />}
     </Content>
   );
 };

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -258,10 +258,6 @@
   margin: 0 0 10px;
 }
 
-.adminSideBar {
-  flex: 0.65;
-}
-
 .formOption {
   width: 18px;
 }
@@ -330,12 +326,6 @@
   }
 }
 
-.navTab > div > div {
-  font-size: 16px;
-  text-transform: none;
-  font-weight: normal;
-}
-
 .eventSummary {
   margin: 15px 0;
 }
@@ -395,15 +385,5 @@
   @media (--mobile-device) {
     flex-direction: column;
     padding-bottom: 15px;
-  }
-}
-
-.copied {
-  border-color: var(--color-green-8);
-  color: var(--color-green-8);
-  outline-color: var(--color-green-8);
-
-  &:hover:not(:disabled) {
-    border-color: var(--color-green-8);
   }
 }

--- a/app/routes/surveys/utils.tsx
+++ b/app/routes/surveys/utils.tsx
@@ -49,8 +49,7 @@ export const graphMappings = Object.keys(displayTypeStrings).map((key) => ({
   label: string;
 }>;
 export const ListNavigation = ({ title }: { title: ReactNode }) => (
-  <NavigationTab title={title} headerClassName={styles.navTab}>
-    <NavigationLink to="/surveys">Liste</NavigationLink>
+  <NavigationTab title={title}>
     <NavigationLink to="/surveys/add">Ny undersøkelse</NavigationLink>
     <NavigationLink to="/surveys/templates">Maler</NavigationLink>
   </NavigationTab>
@@ -58,14 +57,18 @@ export const ListNavigation = ({ title }: { title: ReactNode }) => (
 export const DetailNavigation = ({
   title,
   surveyId,
-  actionGrant,
 }: {
   title: ReactNode;
   surveyId: number;
   actionGrant?: ActionGrant;
 }) => (
-  <NavigationTab title={title} headerClassName={styles.navTab}>
-    <NavigationLink to="/surveys">Liste</NavigationLink>
+  <NavigationTab
+    title={title}
+    back={{
+      label: 'Tilbake til undersøkelser',
+      path: '/surveys',
+    }}
+  >
     <NavigationLink to={`/surveys/${surveyId}`}>Undersøkelsen</NavigationLink>
     <NavigationLink to={`/surveys/${surveyId}/submissions/summary`}>
       Resultater
@@ -81,7 +84,7 @@ export const TokenNavigation = ({
   surveyId: number;
   actionGrant?: ActionGrant;
 }) => (
-  <NavigationTab title={title} headerClassName={styles.navTab}>
+  <NavigationTab title={title}>
     {actionGrant.includes('EDIT') && (
       <NavigationLink to={`/surveys/${surveyId}/submissions/summary`}>
         Adminversjon


### PR DESCRIPTION
# Description

[Minor changes to surveys pages](https://github.com/webkom/lego-webapp/commit/1b0b1558dd73e7769068127ff5c5eb6a3d2829c3) 

Add a "cancel" button to the editor and a "back" navigator.
Other than that just styling changes.

---
  
[Rewrite survey editor to a functional component](https://github.com/webkom/lego-webapp/commit/745180a8e33f5c1d41ca4f032a2b95c2b6a1e59c)

---

[Migrate survey editor to react-final-form](https://github.com/webkom/lego-webapp/commit/a9f0f246b0ac11b00bf768dbf8a3ec687c7abd7a)

# Testing

- [x] I have thoroughly tested my changes.

The changes to the `<Field />` component has been checked with fields in `redux-form` forms using the `onChange` prop.

Editing works for the three different options; radio buttons, check boxes and text areas.

---

Related to ABA-54 (`redux-form` is still used on the actual survey form)