### PR TITLE
Fix bug where select blurred on select for mobile

### DIFF
--- a/app/components/Form/SelectInput.tsx
+++ b/app/components/Form/SelectInput.tsx
@@ -1,9 +1,11 @@
-import Select, { type ThemeConfig } from 'react-select';
+import Select from 'react-select';
 import Creatable from 'react-select/creatable';
 import mazemapAutocomplete from '../Search/mazemapAutocomplete';
 import withAutocomplete from '../Search/withAutocomplete';
 import { createField } from './Field';
 import style from './SelectInput.css';
+import type { ChangeEvent, FocusEvent } from 'react';
+import type { GroupBase, StylesConfig, ThemeConfig } from 'react-select';
 
 type Props = {
   name: string;
@@ -12,8 +14,18 @@ type Props = {
   tags?: boolean;
   fetching: boolean;
   className?: string;
-  selectStyle?: string;
-  onBlur: (e: any) => void;
+  selectStyle?: StylesConfig<any, false, GroupBase<any>>;
+  onBlur: (
+    event: FocusEvent<HTMLInputElement>,
+    newValue?: string,
+    previousValue?: string,
+    name?: string
+  ) => void;
+  onChange?: (
+    event: ChangeEvent,
+    newValue: string,
+    previousValue: string
+  ) => void;
   onSearch: (arg0: string) => void;
   shouldKeyDownEventCreateNewOption: (arg0: number) => boolean;
   isValidNewOption: (arg0: string) => boolean;
@@ -126,6 +138,7 @@ function SelectInput({
         }}
         styles={selectStyle ?? selectStyles}
         theme={selectTheme}
+        blurInputOnSelect={false}
       />
     </div>
   );


### PR DESCRIPTION
# Description

When on mobile react-select would call onBlur on select. This caused the value to change, but very soon after that it would change back to the original value (empty for new fields/events)

The actual fix is only on the new line 141, the rest is improved types.

# Result

Now it doesn't blur on select (which it didn't do on desktop and now doesn't on mobile either)

# Testing

- [ ] I have thoroughly tested my changes.

I have only tested it on the edit event view, but I assume that it will work the same way everywhere it is used.

It is not actually tested on mobile, only on chrome devtools, but the bug was there to begin with so I hope this will also resolve it for mobile.

---

Resolves ABA-328
