### PR TITLE
Filter out past events from frontpage

### DIFF
--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
@@ -50,7 +51,13 @@ const Overview = (props: Props) => {
   const pinned = frontpage[0];
 
   const eventsShown = useMemo(
-    () => events.filter((item) => item.id !== pinned.id).slice(0, eventsToShow),
+    () =>
+      events
+        .filter(
+          (item) =>
+            item.id !== pinned.id && moment(item.startTime).isAfter(moment())
+        )
+        .slice(0, eventsToShow),
     [events, eventsToShow, pinned]
   );
 


### PR DESCRIPTION
# Description

The frontpage would sometimes show past events if they were loaded in from a different route. This fixes it by filtering out all past events.

# Result

The following images are taken after entering the event-calendar page, and then navigating to the front page.

**before**
The circled dates are in the past, and should not be there.
<img width="693" alt="Screenshot 2023-03-14 at 18 12 39" src="https://user-images.githubusercontent.com/8343002/225086387-e7afd295-9f71-45dc-ae53-dacb66b103c7.png">

**after**
<img width="693" alt="Screenshot 2023-03-14 at 18 13 10" src="https://user-images.githubusercontent.com/8343002/225084884-f664c7a3-651a-4c7f-b760-cd66d7d32450.png">

This is now equivelant to how it would look if you entered straight to the frontpage

# Testing

- [x] I have thoroughly tested my changes.

Clicked around a lot, trying to load many events then observed the results in my dev environment vs production.

---

Resolves ABA-331
