### PR TITLE
Bump lego-editor from 2.0.3 to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@sentry/node": "^7.42.0",
     "@stripe/react-stripe-js": "^1.14.2",
     "@stripe/stripe-js": "^1.46.0",
-    "@webkom/lego-editor": "^2.0.3",
+    "@webkom/lego-editor": "^2.1.0",
     "@webkom/react-meter-bar": "^1.0.3",
     "@webkom/react-prepare": "^1.0.0",
     "animate.css": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,10 +2747,10 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@webkom/lego-editor@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@webkom/lego-editor/-/lego-editor-2.0.3.tgz#2e1257d0430daf25b31b5500c1bb308452193a4c"
-  integrity sha512-G+JNi2y48EyZdndFp+189Qy2a/zzSJXRxZtb00WThnqfYK/UPvsU77iKnQwkh6FKd2ToIV3mFNfOWTahsweULw==
+"@webkom/lego-editor@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@webkom/lego-editor/-/lego-editor-2.1.0.tgz#96c511acb8c18242656099da0d9bc57376d886ac"
+  integrity sha512-JjVV4cT0CtMJQX4kQhMivt290f6W9qW8EVKJRwtncdWUYScrCBlPExLIBLZk296ewhNp+eVTaDy2U6Axj43lPg==
   dependencies:
     classnames "^2.2.6"
     escape-html "^1.0.3"


### PR DESCRIPTION
# Description

Bumps lego-editor to support no overflow, linethrough and correct coloring for link input fields.

# Result

Seems to work(:

# Testing

- [ ] I have thoroughly tested my changes.

Long ass dividers no longer overflow<3

