### PR TITLE
Filter out unnecessary dash at the start of a quote source

### DIFF
--- a/app/routes/quotes/components/AddQuote.tsx
+++ b/app/routes/quotes/components/AddQuote.tsx
@@ -30,7 +30,22 @@ const validate = createValidator({
 });
 
 const AddQuote = ({ addQuotes, actionGrant }: Props) => {
-  const onSubmit = withSubmissionErrorFinalForm(addQuotes);
+  const removeUnnecessaryDash = (source: string) => {
+    if (source === undefined) return undefined;
+
+    const dashIndex = source.indexOf('-');
+    if (source.slice(0, dashIndex).match(/^ *$/)) {
+      source = source.slice(dashIndex + 1).trim();
+    }
+
+    return source;
+  };
+
+  const onSubmit = (quote: { text: string; source: string }) =>
+    withSubmissionErrorFinalForm(addQuotes)({
+      text: quote.text,
+      source: removeUnnecessaryDash(quote.source),
+    });
 
   return (
     <div className={styles.root}>
@@ -86,7 +101,7 @@ const AddQuote = ({ addQuotes, actionGrant }: Props) => {
                   currentQuote={{
                     id: 1,
                     text: values.text || 'Det er bare å gjøre det',
-                    source: values.source || 'Esso',
+                    source: removeUnnecessaryDash(values.source) || 'Esso',
                     approved: true,
                     contentTarget: '',
                     reactionsGrouped: [],


### PR DESCRIPTION
# Description
People keep adding a dash at the beginning of a quote source, even though a dash is added automatically when submitting. This PR will resolve this issue by removing a dash if it's the first non-space character of the source.

# Result
**Before**
![image](https://user-images.githubusercontent.com/66320400/226111220-a4e49d96-e696-4fa1-8aa7-0417498fbcd0.png)

**After**
![image](https://user-images.githubusercontent.com/66320400/226111374-a4d0dea5-a7f6-4a4a-9267-d7f55818ec47.png)

# Testing

- [X] I have thoroughly tested my changes.

I've tested for numerous sources. Notably, you can still have a source like "Ola-Nordmann" without the "Ola-" part being cut out. Again, it will only remove the dash if there are ONLY spaces in front of the dash.

---

Resolves ABA-338