### PR TITLE
Add slugs to events

### DIFF
--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -225,6 +225,22 @@ export const selectEventById = createSelector(
     return {};
   }
 );
+export const selectEventBySlug = createSelector(
+  (state) => state.events.byId,
+  (state, props) => props.eventSlug,
+  (eventsById, eventSlug) => {
+    const event = Object.values(eventsById).find(
+      (event) => event.slug === eventSlug
+    );
+
+    if (event) {
+      return transformEvent(event);
+    }
+
+    return {};
+  }
+);
+
 export const selectPoolsForEvent = createSelector(
   selectEventById,
   (state) => state.pools.byId,

--- a/app/routes/events/EventDetailRoute.ts
+++ b/app/routes/events/EventDetailRoute.ts
@@ -14,6 +14,7 @@ import {
 } from 'app/actions/EventActions';
 import {
   selectEventById,
+  selectEventBySlug,
   selectCommentsForEvent,
   selectPoolsWithRegistrationsForEvent,
   selectPoolsForEvent,
@@ -33,13 +34,20 @@ import EventDetail from './components/EventDetail';
 const mapStateToProps = (state, props) => {
   const {
     match: {
-      params: { eventId },
+      params: { eventIdOrSlug },
     },
     currentUser,
   } = props;
-  const event = selectEventById(state, {
-    eventId,
-  });
+  const event = !isNaN(eventIdOrSlug)
+    ? selectEventById(state, { eventId: eventIdOrSlug })
+    : selectEventBySlug(state, { eventSlug: eventIdOrSlug });
+
+  if (event && event.slug && eventIdOrSlug !== event.slug) {
+    props.history.replace(`/events/${event.slug}`);
+  }
+
+  const eventId = event.id;
+
   const actionGrant = event.actionGrant || [];
   const hasFullAccess = Boolean(event.waitingRegistrations);
   const user = state.auth
@@ -204,8 +212,8 @@ const propertyGenerator = (props, config) => {
 export default compose(
   withPreparedDispatch(
     'fetchEventDetail',
-    (props, dispatch) => dispatch(fetchEvent(props.match.params.eventId)),
-    (props) => [props.match.params.eventId]
+    (props, dispatch) => dispatch(fetchEvent(props.match.params.eventIdOrSlug)),
+    (props) => [props.match.params.eventIdOrSlug]
   ),
   connect(mapStateToProps, mapDispatchToProps),
   loadingIndicator(['notLoading', 'event.text']),

--- a/app/routes/events/EventEditRoute.ts
+++ b/app/routes/events/EventEditRoute.ts
@@ -13,6 +13,7 @@ import { uploadFile } from 'app/actions/FileActions';
 import { LoginPage } from 'app/components/LoginForm';
 import {
   selectEventById,
+  selectEventBySlug,
   selectPoolsWithRegistrationsForEvent,
   selectRegistrationsFromPools,
   selectWaitingRegistrationsForEvent,
@@ -29,10 +30,17 @@ import {
 } from './utils';
 
 const mapStateToProps = (state, props) => {
-  const eventId = props.match.params.eventId;
-  const event = selectEventById(state, {
-    eventId,
-  });
+  const eventIdOrSlug = props.match.params.eventIdOrSlug;
+  const event = !isNaN(eventIdOrSlug)
+    ? selectEventById(state, { eventId: eventIdOrSlug })
+    : selectEventBySlug(state, { eventSlug: eventIdOrSlug });
+
+  if (event && event.slug && eventIdOrSlug !== event.slug) {
+    props.history.replace(`/events/${event.slug}/edit`);
+  }
+
+  const eventId = event.id;
+
   const actionGrant = event.actionGrant || [];
   const pools = selectPoolsWithRegistrationsForEvent(state, {
     eventId,
@@ -138,7 +146,7 @@ const mapDispatchToProps = {
 export default compose(
   replaceUnlessLoggedIn(LoginPage),
   withPreparedDispatch('fetchEventEdit', (props, dispatch) =>
-    dispatch(fetchEvent(props.match.params.eventId))
+    dispatch(fetchEvent(props.match.params.eventIdOrSlug))
   ),
   connect(mapStateToProps, mapDispatchToProps),
   loadingIndicator(['event.title'])

--- a/app/routes/events/index.tsx
+++ b/app/routes/events/index.tsx
@@ -57,7 +57,7 @@ const eventRoute = ({
         />
         <RouteWrapper
           exact
-          path={`${match.path}/:eventId`}
+          path={`${match.path}/:eventIdOrSlug`}
           passedProps={{
             currentUser,
             loggedIn,
@@ -65,7 +65,7 @@ const eventRoute = ({
           Component={DetailRoute}
         />
         <RouteWrapper
-          path={`${match.path}/:eventId/edit`}
+          path={`${match.path}/:eventIdOrSlug/edit`}
           passedProps={{
             currentUser,
             loggedIn,


### PR DESCRIPTION
# Description

To make links prettier, show the slug of the event in the url bar instead of the id. Currently, /events/id will be redirected to /events/slug and /events/slug will work and the url will not change.

Feedback appreciated, backend is here: https://github.com/webkom/lego/pull/3260

# Result

### After: 

https://user-images.githubusercontent.com/64247965/227374605-57846b4a-7429-41e8-be51-19988787e905.mov  
  
###
Before, url would be `http://localhost:3000/events/14`

# Testing

- [x] I have thoroughly tested my changes.

Seems to work fine 🤷 

---

<!-- Resolves ABA-210, but partially-->
