### PR TITLE
Fix css of companyInterest export button

### DIFF
--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -239,49 +239,49 @@ class CompanyInterestList extends Component<Props, State> {
           </Link>
         </Flex>
 
-        <Flex className={styles.section}>
-          <Select
-            name="form-event-selector"
-            value={this.props.selectedEventOption}
-            onChange={this.handleEventChange}
-            options={EVENT_TYPE_OPTIONS}
-            isClearable={false}
-            theme={selectTheme}
-            styles={selectStyles}
-            className={styles.selector}
-          />
+        <Flex
+          wrap
+          justifyContent="space-between"
+          alignItems="flex-end"
+          className={styles.section}
+        >
+          <Flex column>
+            <Select
+              name="form-event-selector"
+              value={this.props.selectedEventOption}
+              onChange={this.handleEventChange}
+              options={EVENT_TYPE_OPTIONS}
+              isClearable={false}
+              theme={selectTheme}
+              styles={selectStyles}
+            />
+          </Flex>
 
-          <div
-            style={{
-              marginTop: '5px',
-            }}
-          >
-            {generatedCSV ? (
-              <a href={generatedCSV.url} download={generatedCSV.filename}>
-                Last ned
-              </a>
-            ) : (
-              <Tooltip
-                style={
-                  this.props.selectedSemesterOption.year && { display: 'none' }
+          {generatedCSV ? (
+            <a href={generatedCSV.url} download={generatedCSV.filename}>
+              Last ned
+            </a>
+          ) : (
+            <Tooltip
+              style={
+                this.props.selectedSemesterOption.year && { display: 'none' }
+              }
+              content={'Vennligst velg semester'}
+            >
+              <Button
+                onClick={async () =>
+                  this.setState({
+                    generatedCSV: await this.exportInterestList(
+                      this.props.selectedEventOption.value
+                    ),
+                  })
                 }
-                content={'Vennligst velg semester'}
+                disabled={!this.props.selectedSemesterOption.year}
               >
-                <Button
-                  onClick={async () =>
-                    this.setState({
-                      generatedCSV: await this.exportInterestList(
-                        this.props.selectedEventOption.value
-                      ),
-                    })
-                  }
-                  disabled={!this.props.selectedSemesterOption.year}
-                >
-                  Eksporter til CSV
-                </Button>
-              </Tooltip>
-            )}
-          </div>
+                Eksporter til CSV
+              </Button>
+            </Tooltip>
+          )}
         </Flex>
 
         <Table


### PR DESCRIPTION
# Description

Integrate the latest css changes to the companyInterestList page with the newly implemented csv export button.

# Screenshots 

before:
<img width="827" alt="image" src="https://user-images.githubusercontent.com/90712892/227770518-f6ea8509-e8e3-4511-ae6c-3edc4c12d28f.png">


after:
<img width="827" alt="image" src="https://user-images.githubusercontent.com/90712892/227770494-8ecbb51e-2776-4a39-923b-747fc2963ab8.png">


# Testing

- [x] I have thoroughly tested my changes.

