### PR TITLE
Statistics Route

### DIFF
--- a/app/actions/EventActions.ts
+++ b/app/actions/EventActions.ts
@@ -73,6 +73,7 @@ export const fetchList =
     dateAfter,
     dateBefore,
     refresh = false,
+    usePagination = true,
     loadNextPage = false,
   }: Record<string, any> = {}): Thunk<any> =>
   (dispatch, getState) => {
@@ -83,6 +84,10 @@ export const fetchList =
 
     if (dateBefore && dateAfter) {
       query.page_size = 60;
+    }
+
+    if (!usePagination) {
+      query.page_size = 0;
     }
 
     const queryString = createQueryString(query);

--- a/app/components/Chart/Chart.css
+++ b/app/components/Chart/Chart.css
@@ -11,3 +11,7 @@
     align-items: center;
   }
 }
+
+.pieChartContainer {
+  margin-bottom: 3rem;
+}

--- a/app/components/Chart/ChartLabel.tsx
+++ b/app/components/Chart/ChartLabel.tsx
@@ -5,8 +5,10 @@ import styles from './Chart.css';
 
 const ChartLabel = ({
   distributionData,
+  displayCount,
 }: {
   distributionData: DistributionDataPoint[];
+  displayCount: boolean;
 }) => {
   return (
     <div className={styles.wrapOnMobile}>
@@ -23,7 +25,10 @@ const ChartLabel = ({
               borderRadius: '1px',
             }}
           />
-          <span> {dataPoint.name}</span>
+          <span>
+            {' '}
+            {dataPoint.name} {displayCount ? `(${dataPoint.count})` : ''}
+          </span>
         </Flex>
       ))}
     </div>

--- a/app/components/Chart/ChartLabel.tsx
+++ b/app/components/Chart/ChartLabel.tsx
@@ -6,9 +6,11 @@ import styles from './Chart.css';
 const ChartLabel = ({
   distributionData,
   displayCount,
+  namedChartColors,
 }: {
   distributionData: DistributionDataPoint[];
   displayCount: boolean;
+  namedChartColors?: Record<string, string>;
 }) => {
   return (
     <div className={styles.wrapOnMobile}>
@@ -16,7 +18,9 @@ const ChartLabel = ({
         <Flex key={i} alignItems="center">
           <span
             style={{
-              backgroundColor: CHART_COLORS[i % CHART_COLORS.length],
+              backgroundColor: namedChartColors
+                ? namedChartColors[dataPoint.name]
+                : CHART_COLORS[i % CHART_COLORS.length],
               width: '10px',
               height: '10px',
               marginRight: '10px',

--- a/app/components/Chart/PieChart.tsx
+++ b/app/components/Chart/PieChart.tsx
@@ -9,10 +9,12 @@ const DistributionPieChart = ({
   dataKey,
   chartColors = CHART_COLORS,
   distributionData,
+  namedChartColors,
 }: {
   distributionData: DistributionDataPoint[];
   chartColors: string[];
   dataKey: string;
+  namedChartColors?: Record<string, string>;
 }) => {
   return (
     <PieChart width={400} height={275}>
@@ -29,7 +31,11 @@ const DistributionPieChart = ({
         {distributionData.map((entry, index) => (
           <Cell
             key={`cell-${index}`}
-            fill={chartColors[index % chartColors.length]}
+            fill={
+              namedChartColors
+                ? namedChartColors[entry.name]
+                : chartColors[index % chartColors.length]
+            }
           />
         ))}
       </Pie>

--- a/app/components/Chart/PieChartWithLabel.tsx
+++ b/app/components/Chart/PieChartWithLabel.tsx
@@ -2,28 +2,33 @@ import ChartLabel from 'app/components/Chart/ChartLabel';
 import DistributionPieChart from 'app/components/Chart/PieChart';
 import type { DistributionDataPoint } from 'app/components/Chart/utils';
 import { Flex } from 'app/components/Layout';
+import styles from './Chart.css';
 
 const PieChartWithLabel = ({
   label,
   distributionData,
   displayCount,
+  namedChartColors,
 }: {
   label: string;
   distributionData: DistributionDataPoint[];
   displayCount?: boolean;
+  namedChartColors?: Record<string, string>;
 }) => {
   return (
     <>
       <h4>{label}</h4>
-      <Flex alignItems="center" style={{ marginBottom: '3rem' }} wrap={true}>
+      <Flex alignItems="center" className={styles.pieChartContainer} wrap>
         {distributionData.length === 0 && <p>Ingen data</p>}
         <DistributionPieChart
           dataKey="count"
           distributionData={distributionData}
+          namedChartColors={namedChartColors}
         />
         <ChartLabel
           distributionData={distributionData}
           displayCount={displayCount}
+          namedChartColors={namedChartColors}
         />
       </Flex>
     </>

--- a/app/components/Chart/PieChartWithLabel.tsx
+++ b/app/components/Chart/PieChartWithLabel.tsx
@@ -1,0 +1,33 @@
+import ChartLabel from 'app/components/Chart/ChartLabel';
+import DistributionPieChart from 'app/components/Chart/PieChart';
+import type { DistributionDataPoint } from 'app/components/Chart/utils';
+import { Flex } from 'app/components/Layout';
+
+const PieChartWithLabel = ({
+  label,
+  distributionData,
+  displayCount,
+}: {
+  label: string;
+  distributionData: DistributionDataPoint[];
+  displayCount?: boolean;
+}) => {
+  return (
+    <>
+      <h4>{label}</h4>
+      <Flex alignItems="center" style={{ marginBottom: '3rem' }} wrap={true}>
+        {distributionData.length === 0 && <p>Ingen data</p>}
+        <DistributionPieChart
+          dataKey="count"
+          distributionData={distributionData}
+        />
+        <ChartLabel
+          distributionData={distributionData}
+          displayCount={displayCount}
+        />
+      </Flex>
+    </>
+  );
+};
+
+export default PieChartWithLabel;

--- a/app/components/Search/utils.tsx
+++ b/app/components/Search/utils.tsx
@@ -113,6 +113,12 @@ const LINKS: Array<Link> = [
     title: 'Spørreundersøkelser',
     url: '/surveys',
   },
+  {
+    admin: true,
+    key: 'statistics',
+    title: 'Statistikk',
+    url: '/statistics',
+  },
 ];
 
 const sortFn = (a, b) => {

--- a/app/components/Statistics/Statistics.css
+++ b/app/components/Statistics/Statistics.css
@@ -5,8 +5,6 @@
 }
 
 .selectPeriodContainer {
-  gap: 0.4rem;
-  flex-wrap: wrap;
   margin-bottom: 3rem;
 }
 

--- a/app/components/Statistics/Statistics.css
+++ b/app/components/Statistics/Statistics.css
@@ -1,0 +1,16 @@
+@import url('~app/styles/variables.css');
+
+.selectPeriod {
+  width: 20rem;
+}
+
+.selectPeriodContainer {
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-bottom: 3rem;
+}
+
+.selectEventType {
+  margin-bottom: 2rem;
+  width: 20rem;
+}

--- a/app/components/Statistics/aggregationUtils.ts
+++ b/app/components/Statistics/aggregationUtils.ts
@@ -1,0 +1,15 @@
+import type { DistributionDataPoint } from 'app/components/Chart/utils';
+
+export const addGenericDataPoint = (
+  selectedDistribution: DistributionDataPoint[],
+  selectedDataPoint: string
+) => {
+  const dataPointEntry = selectedDistribution.find(
+    (entry) => entry.name === selectedDataPoint
+  );
+  if (dataPointEntry) {
+    dataPointEntry.count++;
+  } else {
+    selectedDistribution.push({ name: selectedDataPoint, count: 1 });
+  }
+};

--- a/app/components/Statistics/index.tsx
+++ b/app/components/Statistics/index.tsx
@@ -20,7 +20,7 @@ import { selectStyles, selectTheme } from 'app/components/Form/SelectInput';
 import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import type { Dateish, Event, Group } from 'app/models';
-import { EVENT_CONSTANTS } from 'app/routes/events/utils';
+import { COLOR_CONSTANTS, EVENT_CONSTANTS } from 'app/routes/events/utils';
 import styles from './Statistics.css';
 
 interface Props {
@@ -63,7 +63,7 @@ const EVENT_TYPE_OPTIONS = Object.keys(EVENT_CONSTANTS).map((type) => ({
   value: type,
 }));
 
-const PAST_FIVE_YEARS_OPTIONS = [0, 1, 2, 3, 4].map((yearOffset) => {
+const PAST_FIVE_YEARS_OPTIONS = [...Array(5)].map((_, yearOffset) => {
   const year = moment().year() - yearOffset;
   return { value: year, label: String(year) };
 });
@@ -201,7 +201,7 @@ const Statistics = (props: Props) => {
     return (
       <Content>
         <Helmet title="Statistikk" />
-        <h2>Statistikk</h2>
+        <h1>Statistikk</h1>
         <LoadingIndicator loading={true} />
       </Content>
     );
@@ -210,8 +210,8 @@ const Statistics = (props: Props) => {
   return (
     <Content>
       <Helmet title="Statistikk" />
-      <h2>Statistikk</h2>
-      <Flex className={styles.selectPeriodContainer}>
+      <h1>Statistikk</h1>
+      <Flex wrap gap="0.4rem" className={styles.selectPeriodContainer}>
         <Select
           name="select-year"
           value={
@@ -221,7 +221,7 @@ const Statistics = (props: Props) => {
           }
           options={PAST_FIVE_YEARS_OPTIONS}
           onChange={(selectedYear) => {
-            props.onSelect(String(selectedYear.value), semester as string);
+            props.onSelect(String(selectedYear.value), String(semester));
           }}
           isClearable={false}
           theme={selectTheme}
@@ -254,6 +254,14 @@ const Statistics = (props: Props) => {
           count: eventTypeDataPoint.count,
         }))}
         displayCount={true}
+        namedChartColors={Object.keys(COLOR_CONSTANTS).reduce(
+          (acc, colorConstantKey) => ({
+            ...acc,
+            [EVENT_CONSTANTS[colorConstantKey]]:
+              COLOR_CONSTANTS[colorConstantKey],
+          }),
+          {}
+        )}
       />
 
       <h4>Arrangementstyper per uke</h4>
@@ -278,7 +286,7 @@ const Statistics = (props: Props) => {
             key={EVENT_CONSTANTS[dataPoint.eventType]}
             dataKey={EVENT_CONSTANTS[dataPoint.eventType]}
             stackId="a"
-            fill={CHART_COLORS[index % CHART_COLORS.length]}
+            fill={COLOR_CONSTANTS[dataPoint.eventType]}
           />
         ))}
       </BarChart>

--- a/app/components/Statistics/index.tsx
+++ b/app/components/Statistics/index.tsx
@@ -1,0 +1,314 @@
+import moment from 'moment-timezone';
+import qs from 'qs';
+import { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import Select from 'react-select';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import PieChartWithLabel from 'app/components/Chart/PieChartWithLabel';
+import type { DistributionDataPoint } from 'app/components/Chart/utils';
+import { CHART_COLORS } from 'app/components/Chart/utils';
+import { Content } from 'app/components/Content';
+import { selectStyles, selectTheme } from 'app/components/Form/SelectInput';
+import { Flex } from 'app/components/Layout';
+import LoadingIndicator from 'app/components/LoadingIndicator';
+import type { Dateish, Event, Group } from 'app/models';
+import { EVENT_CONSTANTS } from 'app/routes/events/utils';
+import styles from './Statistics.css';
+
+interface Props {
+  committees: Group[];
+  revueGroups: Group[];
+  previousEvents: Event[];
+  onSelect: (year: string, semester: string) => void;
+}
+
+interface WeekNumberDistribution {
+  weekNumber: string;
+}
+
+interface EventTypeDistribution {
+  eventType: string;
+  count: number;
+  paidCount: number;
+  capacity: number;
+  registrationCount: number;
+}
+
+interface StatisticsDistributions {
+  eventTypeDistribution: EventTypeDistribution[];
+  weekNumberDistribution: WeekNumberDistribution[];
+}
+
+interface EventTypeDistributions {
+  capacityDistribution: DistributionDataPoint[];
+  paidDistribution: DistributionDataPoint[];
+}
+
+const SEMESTER_OPTIONS = [
+  { label: 'hele året', value: 'year' },
+  { label: 'vår', value: 'spring' },
+  { label: 'høst', value: 'autumn' },
+];
+
+const EVENT_TYPE_OPTIONS = Object.keys(EVENT_CONSTANTS).map((type) => ({
+  label: EVENT_CONSTANTS[type],
+  value: type,
+}));
+
+const PAST_FIVE_YEARS_OPTIONS = [0, 1, 2, 3, 4].map((yearOffset) => {
+  const year = moment().year() - yearOffset;
+  return { value: year, label: String(year) };
+});
+
+const addEventWeekDataPoint = (
+  weekNumberDistribution: WeekNumberDistribution[],
+  startTime: Dateish,
+  eventType: string
+) => {
+  const weekNumber = `Uke ${moment(startTime).week()}`;
+  const existingWeekEntry = weekNumberDistribution.find(
+    (entry) => entry.weekNumber === weekNumber
+  );
+
+  if (existingWeekEntry) {
+    existingWeekEntry[eventType] =
+      eventType in existingWeekEntry ? existingWeekEntry[eventType] + 1 : 1;
+  } else {
+    weekNumberDistribution.push({
+      weekNumber,
+      [eventType]: 1,
+    });
+  }
+};
+
+const addEventTypeDataPoint = (
+  eventTypeDistribution: EventTypeDistribution[],
+  event: Event
+) => {
+  const existingEventTypeEntry = eventTypeDistribution.find(
+    (entry) => entry.eventType === event.eventType
+  );
+
+  // Some events have more registrations than its capacity
+  const registrationCount = Math.min(
+    event.registrationCount,
+    event.totalCapacity
+  );
+
+  if (existingEventTypeEntry) {
+    existingEventTypeEntry.count++;
+    existingEventTypeEntry.paidCount += event.isPriced ? 1 : 0;
+    existingEventTypeEntry.capacity += event.totalCapacity;
+    existingEventTypeEntry.registrationCount += registrationCount;
+  } else {
+    eventTypeDistribution.push({
+      eventType: event.eventType,
+      count: 1,
+      paidCount: event.isPriced ? 1 : 0,
+      capacity: event.totalCapacity,
+      registrationCount: registrationCount,
+    });
+  }
+};
+
+const createEventDataPoints = (events: Event[]) => {
+  const eventStatistics: StatisticsDistributions = {
+    eventTypeDistribution: [],
+    weekNumberDistribution: [],
+  };
+
+  for (const event of events) {
+    addEventWeekDataPoint(
+      eventStatistics.weekNumberDistribution,
+      event.startTime,
+      EVENT_CONSTANTS[event.eventType]
+    );
+
+    addEventTypeDataPoint(eventStatistics.eventTypeDistribution, event);
+  }
+
+  return eventStatistics;
+};
+
+const Statistics = (props: Props) => {
+  const { year, semester } = qs.parse(props.location.search, {
+    ignoreQueryPrefix: true,
+  });
+
+  const { eventTypeDistribution, weekNumberDistribution } =
+    createEventDataPoints(props.previousEvents);
+
+  const [selectedEventType, setSelectedEventType] = useState(
+    EVENT_TYPE_OPTIONS[0]
+  );
+  const [eventTypeStatistics, setEventTypeStatistics] =
+    useState<EventTypeDistributions>();
+
+  useEffect(() => {
+    const selectEventTypeDataPoints = (
+      selectedEventType: string
+    ): EventTypeDistributions => {
+      const selectedDataPoint = eventTypeDistribution.find(
+        (eventTypeDataPoint) =>
+          eventTypeDataPoint.eventType === selectedEventType
+      );
+
+      if (!selectedDataPoint)
+        return {
+          capacityDistribution: [],
+          paidDistribution: [],
+        };
+
+      return {
+        capacityDistribution: [
+          {
+            name: 'Ledige plasser',
+            count:
+              selectedDataPoint.capacity - selectedDataPoint.registrationCount,
+          },
+          {
+            name: 'Fylte plasser',
+            count: selectedDataPoint.registrationCount,
+          },
+        ],
+        paidDistribution: [
+          {
+            name: 'Betalt arrangement',
+            count: selectedDataPoint.paidCount,
+          },
+          {
+            name: 'Gratis-arrangement',
+            count: selectedDataPoint.count - selectedDataPoint.paidCount,
+          },
+        ],
+      };
+    };
+
+    if (eventTypeDistribution.length === 0) return;
+
+    setEventTypeStatistics(selectEventTypeDataPoints(selectedEventType.value));
+  }, [eventTypeDistribution.length, selectedEventType]);
+
+  if (eventTypeDistribution.length === 0 || !eventTypeStatistics) {
+    return (
+      <Content>
+        <Helmet title="Statistikk" />
+        <h2>Statistikk</h2>
+        <LoadingIndicator loading={true} />
+      </Content>
+    );
+  }
+
+  return (
+    <Content>
+      <Helmet title="Statistikk" />
+      <h2>Statistikk</h2>
+      <Flex className={styles.selectPeriodContainer}>
+        <Select
+          name="select-year"
+          value={
+            PAST_FIVE_YEARS_OPTIONS.find(
+              (pastYearOption) => pastYearOption.value === Number(year)
+            ) ?? PAST_FIVE_YEARS_OPTIONS[0]
+          }
+          options={PAST_FIVE_YEARS_OPTIONS}
+          onChange={(selectedYear) => {
+            props.onSelect(String(selectedYear.value), semester as string);
+          }}
+          isClearable={false}
+          theme={selectTheme}
+          styles={selectStyles}
+          className={styles.selectPeriod}
+        />
+
+        <Select
+          name="select-semester"
+          value={
+            SEMESTER_OPTIONS.find(
+              (semesterOption) => semesterOption.value === semester
+            ) ?? SEMESTER_OPTIONS[0]
+          }
+          options={SEMESTER_OPTIONS}
+          onChange={(selectedSemester) => {
+            props.onSelect(String(year), selectedSemester.value);
+          }}
+          isClearable={false}
+          theme={selectTheme}
+          styles={selectStyles}
+          className={styles.selectPeriod}
+        />
+      </Flex>
+
+      <PieChartWithLabel
+        label={'Arrangementstyper'}
+        distributionData={eventTypeDistribution.map((eventTypeDataPoint) => ({
+          name: EVENT_CONSTANTS[eventTypeDataPoint.eventType],
+          count: eventTypeDataPoint.count,
+        }))}
+        displayCount={true}
+      />
+
+      <h4>Arrangementstyper per uke</h4>
+      <BarChart
+        width={1000}
+        height={400}
+        data={weekNumberDistribution}
+        margin={{
+          top: 10,
+          right: 30,
+          left: 0,
+          bottom: 0,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="weekNumber" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        {eventTypeDistribution.map((dataPoint, index) => (
+          <Bar
+            key={EVENT_CONSTANTS[dataPoint.eventType]}
+            dataKey={EVENT_CONSTANTS[dataPoint.eventType]}
+            stackId="a"
+            fill={CHART_COLORS[index % CHART_COLORS.length]}
+          />
+        ))}
+      </BarChart>
+
+      <h3>Arrangementstype</h3>
+      <Select
+        name="select-event-type"
+        value={selectedEventType}
+        options={EVENT_TYPE_OPTIONS}
+        onChange={(selectedEventType) => {
+          setSelectedEventType(selectedEventType);
+        }}
+        isClearable={false}
+        theme={selectTheme}
+        styles={selectStyles}
+        className={styles.selectEventType}
+      />
+
+      <PieChartWithLabel
+        label={'Fyllgrad'}
+        distributionData={eventTypeStatistics.capacityDistribution}
+        displayCount={true}
+      />
+      <PieChartWithLabel
+        label={'Betalte arrangementer'}
+        distributionData={eventTypeStatistics.paidDistribution}
+        displayCount={true}
+      />
+    </Content>
+  );
+};
+
+export default Statistics;

--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -9,10 +9,9 @@ import {
   YAxis,
 } from 'recharts';
 import Card from 'app/components/Card';
-import ChartLabel from 'app/components/Chart/ChartLabel';
-import DistributionPieChart from 'app/components/Chart/PieChart';
+import PieChartWithLabel from 'app/components/Chart/PieChartWithLabel';
 import type { DistributionDataPoint } from 'app/components/Chart/utils';
-import { Flex } from 'app/components/Layout';
+import { addGenericDataPoint } from 'app/components/Statistics/aggregationUtils';
 import type { Dateish, EventRegistration } from 'app/models';
 import styles from './Event.css';
 
@@ -32,45 +31,10 @@ interface AttendeeStatistics {
   registrationTimeDistribution: RegistrationDateDataPoint[];
 }
 
-const PieChartWithLabel = ({
-  label,
-  distributionData,
-}: {
-  label: string;
-  distributionData: DistributionDataPoint[];
-}) => {
-  return (
-    <>
-      <h4>{label}</h4>
-      <Flex alignItems="center" style={{ marginBottom: '3rem' }} wrap={true}>
-        <DistributionPieChart
-          dataKey="count"
-          distributionData={distributionData}
-        />
-        <ChartLabel distributionData={distributionData} />
-      </Flex>
-    </>
-  );
-};
-
 const toLocalizedGender = (gender: string) => {
   if (gender === 'male') return 'Mann';
   if (gender === 'female') return 'Kvinne';
   return 'Annet';
-};
-
-const addGenericDataPoint = (
-  selectedDistribution: DistributionDataPoint[],
-  selectedDataPoint: string
-) => {
-  const dataPointEntry = selectedDistribution.find(
-    (entry) => entry.name === selectedDataPoint
-  );
-  if (dataPointEntry) {
-    dataPointEntry.count++;
-  } else {
-    selectedDistribution.push({ name: selectedDataPoint, count: 1 });
-  }
 };
 
 const addGroupDataPoint = (

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -32,7 +32,7 @@ export const eventTypeToString = (eventType: EventType): string => {
   return EVENT_CONSTANTS[eventType] || EVENT_CONSTANTS['other'];
 };
 // Colors for different event types
-const COLOR_CONSTANTS: Record<EventType, string> = {
+export const COLOR_CONSTANTS: Record<EventType, string> = {
   company_presentation: '#A1C34A',
   lunch_presentation: '#A1C34A',
   alternative_presentation: '#8A2BE2',

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -34,14 +34,14 @@ export const eventTypeToString = (eventType: EventType): string => {
 // Colors for different event types
 export const COLOR_CONSTANTS: Record<EventType, string> = {
   company_presentation: '#A1C34A',
-  lunch_presentation: '#A1C34A',
+  lunch_presentation: '#98f942',
   alternative_presentation: '#8A2BE2',
   course: '#52B0EC',
   breakfast_talk: '#86D1D0',
   party: '#FCD748',
-  social: 'var(--color-event-red)',
+  social: '#ff87eb',
   event: 'var(--color-event-red)',
-  kid_event: 'var(--color-event-black)',
+  kid_event: '#144e9d',
   other: 'var(--color-event-black)',
 } as const;
 // Returns the color code of an EventType

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -33,6 +33,7 @@ const UserValidator = loadable(() => import('./userValidator'));
 const Polls = loadable(() => import('./polls'));
 const Events = loadable(() => import('./events'));
 const Overview = loadable(() => import('./overview'));
+const Statistics = loadable(() => import('./statistics'));
 
 const RouterConfig = () => (
   <>
@@ -83,7 +84,8 @@ const AppWrapper = (props) => (
           <Route path="/companyInterest" component={CompanyInterest} />
           <Route path="/bdb" component={Bdb} />
           <Route path="/articles" component={Articles} />
-          {/* 
+          <Route path="/statistics" component={Statistics} />
+          {/*
         This will eat all routes that are written after this 
         So one cant put any routes after pageNotFound
         */}

--- a/app/routes/statistics/StatisticsRoute.tsx
+++ b/app/routes/statistics/StatisticsRoute.tsx
@@ -29,7 +29,7 @@ function fetchEventsFromSelectedPeriod(
   semester: string
 ) {
   const startMonth = semester === 'autumn' ? 6 : 0;
-  const durationInMonths = semester ? 6 : 12;
+  const durationInMonths = semester === 'year' ? 12 : 6;
   const fromDate = moment(year).startOf('year').add(startMonth, 'months');
   const toDate = moment(year)
     .startOf('year')
@@ -67,8 +67,10 @@ export default compose(
       dispatch(fetchAllWithType(GroupType.Revue)),
       fetchEventsFromSelectedPeriod(
         dispatch,
-        (year as string) ?? currentYear,
-        (semester as string) || currentSemester
+        typeof year === 'string' ? year : currentYear,
+        typeof semester === 'string' && semester.length > 0
+          ? semester
+          : currentSemester
       ),
     ]);
   }),

--- a/app/routes/statistics/StatisticsRoute.tsx
+++ b/app/routes/statistics/StatisticsRoute.tsx
@@ -1,0 +1,76 @@
+import { push } from 'connected-react-router';
+import moment from 'moment-timezone';
+import qs from 'qs';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { fetchList } from 'app/actions/EventActions';
+import { fetchAllWithType } from 'app/actions/GroupActions';
+import Statistics from 'app/components/Statistics';
+import { GroupType } from 'app/models';
+import { selectEvents } from 'app/reducers/events';
+import { selectGroupsWithType } from 'app/reducers/groups';
+import withPreparedDispatch from 'app/utils/withPreparedDispatch';
+
+const mapStateToProps = (state) => {
+  return {
+    committees: selectGroupsWithType(state, {
+      groupType: GroupType.Committee,
+    }),
+    revueGroups: selectGroupsWithType(state, {
+      groupType: GroupType.Revue,
+    }),
+    previousEvents: selectEvents(state),
+  };
+};
+
+function fetchEventsFromSelectedPeriod(
+  dispatch,
+  year: string,
+  semester: string
+) {
+  const startMonth = semester === 'autumn' ? 6 : 0;
+  const durationInMonths = semester ? 6 : 12;
+  const fromDate = moment(year).startOf('year').add(startMonth, 'months');
+  const toDate = moment(year)
+    .startOf('year')
+    .add(startMonth + durationInMonths, 'months');
+
+  dispatch(
+    push(`/statistics?year=${year}${semester ? '&semester=' + semester : ''}`)
+  );
+
+  return dispatch(
+    fetchList({
+      dateAfter: fromDate.format('YYYY-MM-DD'),
+      dateBefore: toDate.format('YYYY-MM-DD'),
+      refresh: true,
+      usePagination: false,
+    })
+  );
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  onSelect: (year: string, semester: string) =>
+    fetchEventsFromSelectedPeriod(dispatch, year, semester),
+});
+
+export default compose(
+  withPreparedDispatch('fetchStatisticsGroups', (props, dispatch) => {
+    const currentYear = String(moment().year());
+    const currentSemester = moment().month() < 6 ? 'spring' : 'autumn';
+    const { year, semester } = qs.parse(props.location.search, {
+      ignoreQueryPrefix: true,
+    });
+
+    return Promise.all([
+      dispatch(fetchAllWithType(GroupType.Committee)),
+      dispatch(fetchAllWithType(GroupType.Revue)),
+      fetchEventsFromSelectedPeriod(
+        dispatch,
+        (year as string) ?? currentYear,
+        (semester as string) || currentSemester
+      ),
+    ]);
+  }),
+  connect(mapStateToProps, mapDispatchToProps)
+)(Statistics);

--- a/app/routes/statistics/index.tsx
+++ b/app/routes/statistics/index.tsx
@@ -1,0 +1,33 @@
+import { Route, Switch } from 'react-router-dom';
+import RouteWrapper from 'app/components/RouteWrapper';
+import { UserContext } from 'app/routes/app/AppRoute';
+import StatisticsRoute from 'app/routes/statistics/StatisticsRoute';
+import PageNotFound from '../pageNotFound';
+
+const statisticsRoute = ({
+  match,
+}: {
+  match: {
+    path: string;
+  };
+}) => (
+  <UserContext.Consumer>
+    {({ currentUser, loggedIn }) => (
+      <Switch>
+        <RouteWrapper
+          path={match.path}
+          passedProps={{
+            currentUser,
+            loggedIn,
+          }}
+          Component={StatisticsRoute}
+        />
+        <Route component={PageNotFound} />
+      </Switch>
+    )}
+  </UserContext.Consumer>
+);
+
+export default function Statistics() {
+  return <Route path="/statistics" component={statisticsRoute} />;
+}


### PR DESCRIPTION
# Description

A new route showing statistics for event. It is possible to view statistics for each year, or for specific specific semesters.

# Result
<img width="848" alt="Screenshot 2023-04-25 at 20 58 30" src="https://user-images.githubusercontent.com/26925695/234376269-b6ccee97-4d79-40c9-9846-5e7392a33f05.png">
<img width="848" alt="Screenshot 2023-04-25 at 20 58 55" src="https://user-images.githubusercontent.com/26925695/234376275-9304a48e-4ed5-4261-9654-ee88d9a2677b.png">



# Testing

- [X] I have thoroughly tested my changes.

Only tested manually, no changes to existing pages or components tho. 

---

Resolves ABA-157