### PR TITLE
Extend Card component with a `danger` prop

### DIFF
--- a/app/actions/GalleryPictureActions.ts
+++ b/app/actions/GalleryPictureActions.ts
@@ -138,7 +138,7 @@ function uploadGalleryPicturesInTurn(files, galleryId, dispatch) {
   };
 
   const uploadPictureWithErrorhandler = (file) =>
-    uploadPicture(file).catch((error) => {
+    uploadPicture(file).catch(() => {
       dispatch({
         type: GalleryPicture.UPLOAD.FAILURE,
         error: true,

--- a/app/components/Card/Card.css
+++ b/app/components/Card/Card.css
@@ -16,3 +16,36 @@
   transition: box-shadow var(--easing-medium);
   box-shadow: var(--shadow-md);
 }
+
+.danger {
+  background-color: var(--color-red-1);
+  border: 3px solid var(--danger-color);
+  color: var(--danger-color);
+}
+
+html[data-theme='dark'] .danger {
+  color: var(--color-red-8);
+  border-color: var(--color-red-8);
+}
+
+.warningIcon {
+  color: var(--danger-color);
+}
+
+.danger a {
+  color: var(--color-red-8);
+  text-decoration: underline;
+
+  &:hover {
+    color: var(--color-red-7);
+  }
+}
+
+html[data-theme='dark'] .danger a:hover {
+  color: var(--color-red-3);
+}
+
+.header {
+  font-weight: 600;
+  font-size: var(--font-size-large);
+}

--- a/app/components/Card/index.tsx
+++ b/app/components/Card/index.tsx
@@ -1,6 +1,12 @@
 import cx from 'classnames';
+import Icon from 'app/components/Icon';
+import Flex from 'app/components/Layout/Flex';
 import styles from './Card.css';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
+
+const CardHeader = ({ children }: { children: ReactNode }) => (
+  <div className={styles.header}>{children}</div>
+);
 
 type Props = {
   className?: string;
@@ -8,6 +14,7 @@ type Props = {
   shadow?: boolean;
   hideOverflow?: boolean;
   isHoverable?: boolean;
+  danger?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
 function Card({
@@ -17,6 +24,7 @@ function Card({
   shadow = true,
   hideOverflow = false,
   isHoverable = false,
+  danger = false,
   ...htmlAttributes
 }: Props) {
   return (
@@ -26,16 +34,22 @@ function Card({
         styles.card,
         tight && styles.tight,
         shadow && styles.shadow,
-        isHoverable && styles.isHoverable
+        isHoverable && styles.isHoverable,
+        danger && styles.danger
       )}
       style={{
         overflow: hideOverflow ? 'hidden' : 'initial',
       }}
       {...htmlAttributes}
     >
-      {children}
+      <Flex gap={20}>
+        {danger && <Icon name="warning" className={styles.warningIcon} />}
+        <Flex column>{children}</Flex>
+      </Flex>
     </div>
   );
 }
+
+Card.Header = CardHeader;
 
 export default Card;

--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -73,37 +73,6 @@
   margin-bottom: 1rem;
 }
 
-.eventWarning {
-  padding: 10px;
-  border-radius: var(--border-radius-lg);
-  background: var(--danger-color);
-  text-align: center;
-  margin-bottom: 0.5rem;
-}
-
-.eventWarning > p {
-  color: white;
-  font-weight: bold;
-  margin: 0;
-}
-
-.eventWarning a {
-  font-weight: 600;
-  color: var(--color-red-9);
-
-  &:hover {
-    color: var(--color-red-8);
-  }
-}
-
-html[data-theme='dark'] .eventWarning a {
-  color: var(--color-red-1);
-
-  &:hover {
-    color: var(--color-red-2);
-  }
-}
-
 .eventPrice {
   text-align: center;
   width: 100%;

--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -8,10 +8,10 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import Card from 'app/components/Card';
 import ChartLabel from 'app/components/Chart/ChartLabel';
 import DistributionPieChart from 'app/components/Chart/PieChart';
 import type { DistributionDataPoint } from 'app/components/Chart/utils';
-import Icon from 'app/components/Icon';
 import { Flex } from 'app/components/Layout';
 import type { Dateish, EventRegistration } from 'app/models';
 import styles from './Event.css';
@@ -246,15 +246,14 @@ const EventAttendeeStatistics = ({
   return (
     <>
       {isEventFromPreviousSemester(eventStartTime) && (
-        <Flex alignItems="center" className={styles.eventWarning}>
-          <Icon name="warning" />
+        <Card danger>
           <span>
             Dette arrangementet er fra et tidligere semester, og kan derfor ha
             feil fordeling av klassetrinn og gruppetilhørighet. Dette er fordi
             dataen om deltakerne bruker <i>nåværende</i> klassetrinn og
             gruppemedlemskap.
           </span>
-        </Flex>
+        </Card>
       )}
       {registrations.length === 0 ? (
         <p className={styles.noRegistrationsText}>Ingen er påmeldt enda.</p>

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -3,6 +3,7 @@ import { Component, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import mazemapLogo from 'app/assets/mazemap.png';
 import Button from 'app/components/Button';
+import Card from 'app/components/Card';
 import CommentView from 'app/components/Comments/CommentView';
 import {
   Content,
@@ -497,17 +498,11 @@ export default class EventDetail extends Component<Props, State> {
                 {event.unansweredSurveys &&
                 event.unansweredSurveys.length > 0 &&
                 !event.isAdmitted ? (
-                  <div className={sharedStyles.eventWarning}>
+                  <Card danger>
                     <p>
                       Du kan ikke melde deg på dette arrangementet fordi du har
-                      ubesvarte spørreundersøkelser.
-                    </p>
-                    <br />
-                    <p>
-                      Man må svare på alle spørreundersøkelser for tidligere
-                      arrangementer før man kan melde seg på nye arrangementer.
-                      Du kan svare på undersøkelsene dine ved å trykke på
-                      følgende linker:
+                      ubesvarte spørreundersøkelser. Gå til lenkene under for å
+                      svare:
                     </p>
                     <ul>
                       {event.unansweredSurveys.map((surveyId, i) => (
@@ -518,7 +513,7 @@ export default class EventDetail extends Component<Props, State> {
                         </li>
                       ))}
                     </ul>
-                  </div>
+                  </Card>
                 ) : (
                   <div>
                     <JoinEventForm

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -354,9 +354,9 @@ const JoinEventForm = (props: Props) => {
               <div>Du kan ikke melde deg på dette arrangementet.</div>
             )}
             {sumPenalties(penalties) > 0 && event.heedPenalties && (
-              <div className={styles.eventWarning}>
+              <Card danger>
+                <Card.Header>NB!</Card.Header>
                 <p>
-                  NB!{' '}
                   {sumPenalties(penalties) > 2
                     ? `Du blir lagt rett på venteliste hvis du melder deg på`
                     : `Påmeldingen din er forskjøvet
@@ -367,13 +367,13 @@ const JoinEventForm = (props: Props) => {
                 <Link to="/pages/arrangementer/26-arrangementsregler">
                   Les mer om prikker her
                 </Link>
-              </div>
+              </Card>
             )}
             {!disabledForUser &&
               event.useContactTracing &&
               !currentUser.phoneNumber && (
-                <div className={styles.eventWarning}>
-                  <p>NB!</p>
+                <Card danger>
+                  <Card.Header>NB!</Card.Header>
                   <p>
                     Du må legge til telefonnummer for å melde deg på dette
                     arrangementet.
@@ -381,20 +381,20 @@ const JoinEventForm = (props: Props) => {
                   <Link to={`/users/me/settings/profile`}>
                     Gå til innstillinger
                   </Link>
-                </div>
+                </Card>
               )}
             {!disabledForUser &&
               event.useConsent &&
               !hasRegisteredConsentForSemester && (
-                <div className={styles.eventWarning}>
-                  <p>NB!</p>
+                <Card>
+                  <Card.Header>NB!</Card.Header>
                   <p>
                     Du må ta stilling til bildesamtykke for semesteret{' '}
                     {toReadableSemester(eventSemester)} for å melde deg på dette
                     arrangement.
                   </p>
                   <Link to={`/users/me/`}>Gå til min profil</Link>
-                </div>
+                </Card>
               )}
             {formOpen &&
               hasRegisteredConsentIfRequired &&


### PR DESCRIPTION
# Description

Replaces our current use of the `eventWarning` css class across the webapp.

Probably going to iterate on the styling later when extending the component further soon with `info`, `success` and `warning`.

# Result

Top card is the current look, while the bottom is with the change.
<p align="center">
	<img width="294" alt="Screenshot 2023-03-29 at 00 12 04" src="https://user-images.githubusercontent.com/69514187/228380826-5da7995a-cd5c-43ca-9ccf-3c71d1fc0414.png">
	<img width="294" alt="Screenshot 2023-03-29 at 00 11 45" src="https://user-images.githubusercontent.com/69514187/228380834-cd80b062-afa4-4dfd-8cbf-9f636c84c026.png">
</p>

# Testing

- [x] I have thoroughly tested my changes.

Went through all uses of `styles.eventWarning`. The danger card might be applicable to other places, but that can come later.