### PR TITLE
Stop survey creator page from crashing on load

### DIFF
--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
@@ -130,7 +130,6 @@ const renderQuestions = ({
             fields={fields}
           />
         ))}
-        <span>{error}</span>
       </ul>
 
       <Link

--- a/app/routes/surveys/utils.tsx
+++ b/app/routes/surveys/utils.tsx
@@ -50,6 +50,7 @@ export const graphMappings = Object.keys(displayTypeStrings).map((key) => ({
 }>;
 export const ListNavigation = ({ title }: { title: ReactNode }) => (
   <NavigationTab title={title}>
+    <NavigationLink to="/surveys">Undersøkelser</NavigationLink>
     <NavigationLink to="/surveys/add">Ny undersøkelse</NavigationLink>
     <NavigationLink to="/surveys/templates">Maler</NavigationLink>
   </NavigationTab>


### PR DESCRIPTION
# Description

The `error` object was not a valid child of the span. Since it did not work as intended and I do not see the value in fixing it, I simply removed it.

Also add a navigation tab back to the survey list, as it was much needed.

# Testing

- [x] I have thoroughly tested my changes.

It now does not crash.