### PR TITLE
Only calculate penalty reg time if heedPenalties

### DIFF
--- a/app/components/UserAttendance/withModal.tsx
+++ b/app/components/UserAttendance/withModal.tsx
@@ -64,7 +64,7 @@ const ChildrenWithProps = ({
   children,
   ...restProps
 }: WithModalProps & {
-  children: ReactElement;
+  children: ReactElement[];
 }) => (
   <div>
     {Children.map(children, (child) => cloneElement(child, { ...restProps }))}

--- a/app/models.ts
+++ b/app/models.ts
@@ -243,6 +243,7 @@ export type Event = EventBase & {
   totalCapacity: number;
   thumbnail: string | null | undefined;
   company: Company;
+  spotsLeft: number;
   comments: Comment[];
   contentTarget: string;
   pools: Array<EventPool>;

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -212,17 +212,19 @@ export default class EventDetail extends Component<Props, State> {
     const color = colorForEvent(event.eventType);
 
     const onRegisterClick = event.following
-      ? () => unfollow(event.following, event.id)
+      ? () => unfollow(event.following as number, event.id)
       : () => follow(currentUser.id, event.id);
 
     const currentMoment = moment();
 
     const activationTimeMoment = moment(event.activationTime);
 
-    const eventRegistrationTime = activationTimeMoment.subtract(
-      penaltyHours(penalties),
-      'hours'
-    );
+    // Get the actual activation time.
+    // The time from LEGO is with penalties applied.
+    // This "unapplies" the penalties again
+    const eventRegistrationTime = event.heedPenalties
+      ? activationTimeMoment.subtract(penaltyHours(penalties), 'hours')
+      : activationTimeMoment;
 
     const registrationCloseTimeMoment = registrationCloseTime(event);
 

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -17,6 +17,8 @@ import type {
   User,
   EventRegistration,
   EventRegistrationStatus,
+  Penalty,
+  Event,
 } from 'app/models';
 import { selectPenaltyByUserId } from 'app/reducers/penalties';
 import { selectUserByUsername } from 'app/reducers/users';
@@ -34,7 +36,6 @@ import styles from './Event.css';
 import withCountdown from './JoinEventFormCountdownProvider';
 import PaymentRequestForm from './StripeElement';
 
-type Event = Record<string, any>;
 export type Props = {
   title?: string;
   event: Event;
@@ -54,7 +55,7 @@ export type Props = {
   captchaOpen: boolean;
   buttonOpen: boolean;
   registrationOpensIn: string | null | undefined;
-  penalties: Array<Record<string, any>>;
+  penalties: Penalty[];
   touch: (field: string) => void;
 };
 type SpotsLeftProps = {
@@ -159,7 +160,7 @@ const PaymentForm = ({
   currentUser,
   registration,
 }: {
-  createPaymentIntent: () => Promise<any>;
+  createPaymentIntent: () => Promise<void>;
   event: Event;
   currentUser: User;
   registration: EventRegistration;
@@ -344,9 +345,7 @@ const JoinEventForm = (props: Props) => {
           <>
             {!formOpen && event.activationTime && (
               <div>
-                {new Date(event.activationTime) < new Date()
-                  ? 'Åpnet '
-                  : 'Åpner '}
+                {moment(event.activationTime) < moment() ? 'Åpnet ' : 'Åpner '}
                 <Time time={event.activationTime} format="nowToTimeInWords" />
               </div>
             )}
@@ -477,7 +476,6 @@ const JoinEventForm = (props: Props) => {
                       component={TextInput.Field}
                       label={feedbackLabel}
                       className={styles.feedbackText}
-                      fieldClassName={styles.feedbackField}
                       rows={1}
                     />
                     {registration && (

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -293,7 +293,7 @@ export const penaltyHours = (penalties: Array<AddPenalty>) => {
       return 1337;
 
     default:
-      return -1;
+      return 0;
   }
 };
 


### PR DESCRIPTION
# Description

We don't check if the event uses penalties before calculating the
activation time. Also the calculation subtracted hours instead of adding
for some reason.

Also fixes random type errors in the mix here.


# Result

The correct time is shown

# Testing

- [x] I have thoroughly tested my changes. I have not tested anything :)). Probably flawless :tm:.

---

Resolves ABA-356
