### PR TITLE
Fix check for special day

### DIFF
--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -140,9 +140,10 @@ export default class EventDetail extends Component<Props, State> {
   }
   static isCorrectDate() {
     // The year doesn't matter, as it only check month and day of the month
-    const aprilFoolsDate = moment('2023-04-01 11:00', 'YYYY-MM-DD HH:mm');
+    const aprilFoolsDateStart = moment('2023-04-01 11:00', 'YYYY-MM-DD HH:mm');
+    const aprilFoolsDateEnd = moment('2023-04-01 18:00', 'YYYY-MM-DD HH:mm');
     const now = moment();
-    return aprilFoolsDate.isBefore(now);
+    return aprilFoolsDateStart.isBefore(now) && aprilFoolsDateEnd.isAfter(now);
   }
 
   handleRegistration = ({


### PR DESCRIPTION
# Description

The current check only checks if the time is after 11:00 April 1st. This means that april fools is active after April 1st. This commit makes it so that "special day" is between 11:00 and 18:00 on April 1st.

# Result

No visual changes

# Testing

- [X] I have thoroughly tested my changes.

---
