### PR TITLE
add more padding to bottom of quicklinks

### DIFF
--- a/app/components/Search/Search.css
+++ b/app/components/Search/Search.css
@@ -116,7 +116,7 @@
   flex: 1;
   background-color: var(--lego-card-color);
   color: var(--color-white);
-  padding: 2rem;
+  padding: 2rem 2rem 3rem;
 }
 
 .quickLinks::after {


### PR DESCRIPTION
readme overflows on the quicklinks dropdown menu on my iphone 12 pro (in google chrome):
![337782690_1253395138885401_2802626941147422091_n](https://user-images.githubusercontent.com/17336846/229463106-6c087a76-db29-4635-85e4-fc237e647703.jpg)

This pull request adds a bit more padding to the bottom of the menu (32px->48px), a safe margin is ~50px https://developer.apple.com/documentation/apple_news/margin
