### PR TITLE
Bump `ionicons` to v7

### DIFF
--- a/server/pageRenderer.ts
+++ b/server/pageRenderer.ts
@@ -158,8 +158,8 @@ export default function pageRenderer({
            window.__IS_SSR__ = ${isSSR};
            ${preparedStateCode}
         </script>
-        <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
+        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
+        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
         ${dllPlugin}
         ${scripts}
       </body>


### PR DESCRIPTION
# Description

Two major versions up, but no breaking changes that affect us. Nice to do every now and then.

Mostly `ariaHidden` -> `aria-hidden`, but read on the changes here: 
v6: https://github.com/ionic-team/ionicons/releases/tag/v6.0.0
v7: https://github.com/ionic-team/ionicons/releases/tag/v7.0.0

# Result

No visual changes.

# Testing

- [x] I have thoroughly tested my changes.

Icons still work as expected.