### PR TITLE
Show correct status on registration pill

### DIFF
--- a/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
@@ -100,6 +100,11 @@ export const getRegistrationInfo = (registration) => {
     className: styles.orangePill,
   };
 
+  if (registration.pool) {
+    registrationInfo.status = 'Påmeldt';
+    registrationInfo.className = styles.greenPill;
+  }
+
   if (registration.adminRegistrationReason !== '') {
     registrationInfo.className = styles.bluePill;
 
@@ -111,16 +116,11 @@ export const getRegistrationInfo = (registration) => {
         registrationInfo.className = styles.webkomPill;
         registrationInfo.reason = `Webkompåmeldt av ${registration.createdBy.username}: ${registration.adminRegistrationReason}`;
       } else {
-        registrationInfo.status = 'Påmeldt';
         registrationInfo.reason = `Adminpåmeldt av ${registration.createdBy.username}: ${registration.adminRegistrationReason}`;
       }
     } else {
-      registrationInfo.status = 'Påmeldt';
       registrationInfo.reason = `Adminpåmeldt: ${registration.adminRegistrationReason}`;
     }
-  } else if (registration.pool) {
-    registrationInfo.status = 'Påmeldt';
-    registrationInfo.className = styles.greenPill;
   }
 
   return registrationInfo;


### PR DESCRIPTION
# Description

Currently, it would always show "Venteliste" when being admin
registered by someone in Webkom. All the if/else statements made
it difficult to work with. This is better.

# Result

| Before | After |
:------------------:|:-----------------------------:
<img width="416" alt="image" src="https://user-images.githubusercontent.com/69514187/230609903-7f942dd9-7c58-4f88-96ce-e21a0cd8a317.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/69514187/230609825-f12b78d0-bfb3-40fa-903b-4d45f9a2f900.png">

# Testing

- [x] I have thoroughly tested my changes.

Tested all different statuses, with and without "Webkom register".