### PR TITLE
Stop default card content from being flex aligned

### DIFF
--- a/app/components/Card/index.tsx
+++ b/app/components/Card/index.tsx
@@ -42,10 +42,14 @@ function Card({
       }}
       {...htmlAttributes}
     >
-      <Flex gap={20}>
-        {danger && <Icon name="warning" className={styles.warningIcon} />}
-        <Flex column>{children}</Flex>
-      </Flex>
+      {danger ? (
+        <Flex gap={20}>
+          {danger && <Icon name="warning" className={styles.warningIcon} />}
+          <Flex column>{children}</Flex>
+        </Flex>
+      ) : (
+        <>{children}</>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# Description

Kind of an ugly fix imo., but it'll be cleaned up in the soon-to-be iteration. Nevertheless good to get this fixed in the meantime.

# Result

| Before | After |
:-----------------------:|:--------------------------:
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/69514187/230679534-f64b2ee6-709f-44b5-a8d0-0c27539a8881.png"> | <img width="1003" alt="image" src="https://user-images.githubusercontent.com/69514187/230679502-858ed53f-3e05-46a8-be5a-37bac6698214.png">
<img width="1147" alt="image" src="https://user-images.githubusercontent.com/69514187/230679604-25e78299-2a9c-4b25-a5d0-d263c851ef8b.png"> | <img width="1147" alt="image" src="https://user-images.githubusercontent.com/69514187/230679633-ccbb667a-8e21-4564-9d04-5fe28e454516.png">


# Testing

- [x] I have thoroughly tested my changes.

`danger` card still works.