### PR TITLE
Support changing group roles in the membership table

### DIFF
--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -157,6 +157,7 @@ export const CompanyInterestForm = {
 };
 export const Membership = {
   CREATE: generateStatuses('Membership.CREATE') as AAT,
+  UPDATE: generateStatuses('Membership.UPDATE') as AAT,
   REMOVE: generateStatuses('Membership.REMOVE') as AAT,
   JOIN_GROUP: generateStatuses('Membership.JOIN_GROUP') as AAT,
   LEAVE_GROUP: generateStatuses('Membership.LEAVE_GROUP') as AAT,

--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -2,12 +2,13 @@ import { push } from 'connected-react-router';
 import callAPI from 'app/actions/callAPI';
 import { groupSchema, membershipSchema } from 'app/reducers';
 import type MembershipType from 'app/store/models/Membership';
+import type { ID } from 'app/store/models/index';
 import type { Thunk } from 'app/types';
 import { Group, Membership } from './ActionTypes';
 
 export type AddMemberArgs = {
-  groupId: number;
-  userId: number;
+  groupId: ID;
+  userId: ID;
   role: string;
 };
 export function addMember({

--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -1,6 +1,7 @@
 import { push } from 'connected-react-router';
 import callAPI from 'app/actions/callAPI';
 import { groupSchema, membershipSchema } from 'app/reducers';
+import type MembershipType from 'app/store/models/Membership';
 import type { Thunk } from 'app/types';
 import { Group, Membership } from './ActionTypes';
 
@@ -30,7 +31,7 @@ export function addMember({
     },
   });
 }
-export function removeMember(membership: Record<string, any>): Thunk<any> {
+export function removeMember(membership: MembershipType): Thunk<any> {
   return callAPI({
     types: Membership.REMOVE,
     endpoint: `/groups/${membership.abakusGroup}/memberships/${membership.id}/`,

--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -4,12 +4,13 @@ import { groupSchema, membershipSchema } from 'app/reducers';
 import type MembershipType from 'app/store/models/Membership';
 import type { ID } from 'app/store/models/index';
 import type { Thunk } from 'app/types';
+import type { RoleType } from 'app/utils/constants';
 import { Group, Membership } from './ActionTypes';
 
 export type AddMemberArgs = {
   groupId: ID;
   userId: ID;
-  role: string;
+  role: RoleType;
 };
 export function addMember({
   groupId,

--- a/app/components/GroupForm/index.tsx
+++ b/app/components/GroupForm/index.tsx
@@ -9,21 +9,22 @@ import {
   legoForm,
 } from 'app/components/Form';
 import Tooltip from 'app/components/Tooltip';
+import type { DetailedGroup } from 'app/store/models/Group';
 import { createValidator, required } from 'app/utils/validation';
 import styles from './index.css';
 import type { FormProps } from 'redux-form';
 
 type OwnProps = {
   handleSubmitCallback: (arg0: Record<string, any>) => Promise<any>;
-  group: Record<string, any>;
+  group: DetailedGroup;
 };
+
 type Props = OwnProps & FormProps;
 
 const logoValidator = (value) => (value ? undefined : 'Bilde er påkrevd');
 
 function GroupForm({
   handleSubmit,
-  handleSubmitCallback,
   group,
   submitting,
   invalid,

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -55,6 +55,7 @@ type Props = {
   onChange?: (filters: Record<string, any>, sort: sortProps) => void;
   onLoad?: (filters: Record<string, any>, sort: sortProps) => void;
   filters?: Record<string, any>;
+  className?: string;
 };
 
 type State = {
@@ -387,7 +388,7 @@ export default class Table extends Component<Props, State> {
   }, 170);
 
   render() {
-    const { columns, data, rowKey, hasMore, loading } = this.props;
+    const { columns, data, rowKey, hasMore, loading, className } = this.props;
     let sorter = this.state.sort.sorter;
     const { direction, dataIndex } = this.state.sort;
     if (typeof sorter == 'boolean')
@@ -401,7 +402,7 @@ export default class Table extends Component<Props, State> {
     if (direction === 'desc') sortedData.reverse();
 
     return (
-      <div className={styles.wrapper}>
+      <div className={cx(styles.wrapper, className)}>
         <table>
           <thead>
             <tr>

--- a/app/models.ts
+++ b/app/models.ts
@@ -1,4 +1,5 @@
 import type Comment from 'app/store/models/Comment';
+import type { RoleType } from 'app/utils/constants';
 import type { ReactionsGrouped } from './store/models/Reaction';
 import type { Moment } from 'moment';
 // TODO: Id handling could be opaque
@@ -41,14 +42,14 @@ export type EventSemester = {
 
 export type GroupMembership = {
   user: User;
-  role: string;
+  role: RoleType;
 };
 
 export type UserMembership = {
   id: ID;
   user: User;
   abakusGroup: ID;
-  role: string;
+  role: RoleType;
   isActive: boolean;
   emailListsEnabled: boolean;
   createdAt: Dateish;

--- a/app/routes/admin/email/EmailListRoute.ts
+++ b/app/routes/admin/email/EmailListRoute.ts
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetchEmailList, editEmailList } from 'app/actions/EmailListActions';
 import { selectEmailListById } from 'app/reducers/emailLists';
-import { ROLES } from 'app/utils/constants';
+import { ROLES, type RoleType } from 'app/utils/constants';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import EmailListEditor from './components/EmailListEditor';
@@ -22,7 +22,7 @@ const mapStateToProps = (state, { match: { params } }) => {
         value: groups.id,
       })),
       // $FlowFixMe
-      groupRoles: (emailList.groupRoles || []).map((groupRoles) => ({
+      groupRoles: (emailList.groupRoles || []).map((groupRoles: RoleType) => ({
         label: ROLES[groupRoles],
         value: groupRoles,
       })),

--- a/app/routes/admin/groups/components/AddGroupMember.tsx
+++ b/app/routes/admin/groups/components/AddGroupMember.tsx
@@ -1,22 +1,19 @@
 import { Field, SubmissionError } from 'redux-form';
+import type { AddMemberArgs } from 'app/actions/GroupActions';
 import { legoForm, Button, Form } from 'app/components/Form';
 import SelectInput from 'app/components/Form/SelectInput';
-import { ROLES } from 'app/utils/constants';
+import type { ID } from 'app/store/models';
+import { ROLES, type RoleType } from 'app/utils/constants';
 import { createValidator, required } from 'app/utils/validation';
 import type { FormProps } from 'redux-form';
-import type { $Keys } from 'utility-types';
 
 type Props = FormProps & {
   groupId: number;
-  addMember: (arg0: {
-    role: $Keys<typeof ROLES>;
-    userId: number;
-    groupId: number;
-  }) => Promise<any>;
+  addMember: (arg0: AddMemberArgs) => Promise<any>;
 };
 const roles = Object.keys(ROLES)
   .sort()
-  .map((role) => ({
+  .map((role: RoleType) => ({
     value: role,
     label: ROLES[role],
   }));
@@ -65,10 +62,10 @@ export default legoForm({
       role,
     }: {
       user: {
-        id: number;
+        id: ID;
       };
       role: {
-        value: $Keys<typeof ROLES>;
+        value: RoleType;
       };
     },
     dispatch,

--- a/app/routes/admin/groups/components/GroupMembers.css
+++ b/app/routes/admin/groups/components/GroupMembers.css
@@ -1,3 +1,0 @@
-.groupMembers h3 {
-  margin-top: 20px;
-}

--- a/app/routes/admin/groups/components/GroupMembers.tsx
+++ b/app/routes/admin/groups/components/GroupMembers.tsx
@@ -12,9 +12,9 @@ import type { AddMemberArgs } from 'app/actions/GroupActions';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
 import { selectPaginationNext } from 'app/reducers/selectors';
+import type Membership from 'app/store/models/Membership';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import AddGroupMember from './AddGroupMember';
-import styles from './GroupMembers.css';
 import GroupMembersList from './GroupMembersList';
 
 type Props = {
@@ -34,10 +34,10 @@ type Props = {
       numberOfUsers?: number;
     }
   >;
-  memberships: Array<Record<string, any>>;
+  memberships: Membership[];
   showDescendants: boolean;
   addMember: (arg0: AddMemberArgs) => Promise<any>;
-  removeMember: (arg0: Record<string, any>) => Promise<any>;
+  removeMember: (membership: Membership) => Promise<void>;
   push: (arg0: any) => void;
   pathname: string;
   search: string;
@@ -60,7 +60,7 @@ export const GroupMembers = ({
   query,
   filters,
 }: Props) => (
-  <div className={styles.groupMembers}>
+  <>
     <>
       Antall medlemmer (inkl. undergrupper):{' '}
       {groupsById[groupId.toString()].numberOfUsers}
@@ -69,7 +69,7 @@ export const GroupMembers = ({
       <AddGroupMember addMember={addMember} groupId={groupId} />
     )}
     <LoadingIndicator loading={!memberships}>
-      <h3 className={styles.subTitle}>Brukere</h3>
+      <h3>Brukere</h3>
       <GroupMembersList
         key={groupId + showDescendants}
         groupId={groupId}
@@ -87,7 +87,7 @@ export const GroupMembers = ({
         memberships={memberships}
       />
     </LoadingIndicator>
-  </div>
+  </>
 );
 
 function loadData({ query, match: { params }, location }, dispatch) {

--- a/app/routes/admin/groups/components/GroupMembers.tsx
+++ b/app/routes/admin/groups/components/GroupMembers.tsx
@@ -10,9 +10,11 @@ import {
 } from 'app/actions/GroupActions';
 import type { AddMemberArgs } from 'app/actions/GroupActions';
 import LoadingIndicator from 'app/components/LoadingIndicator';
+import { selectCurrentUser } from 'app/reducers/auth';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
 import { selectPaginationNext } from 'app/reducers/selectors';
 import type Membership from 'app/store/models/Membership';
+import type { CurrentUser } from 'app/store/models/User';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import AddGroupMember from './AddGroupMember';
 import GroupMembersList from './GroupMembersList';
@@ -43,6 +45,7 @@ type Props = {
   search: string;
   query: Record<string, any>;
   filters: Record<string, any>;
+  currentUser: CurrentUser;
 };
 export const GroupMembers = ({
   addMember,
@@ -59,6 +62,7 @@ export const GroupMembers = ({
   search,
   query,
   filters,
+  currentUser,
 }: Props) => (
   <>
     <>
@@ -71,7 +75,7 @@ export const GroupMembers = ({
     <LoadingIndicator loading={!memberships}>
       <h3>Brukere</h3>
       <GroupMembersList
-        key={groupId + showDescendants}
+        key={groupId + Number(showDescendants)}
         groupId={groupId}
         filters={filters}
         query={query}
@@ -83,8 +87,10 @@ export const GroupMembers = ({
         fetch={fetch}
         fetching={fetching}
         showDescendants={showDescendants}
+        addMember={addMember}
         removeMember={removeMember}
         memberships={memberships}
+        currentUser={currentUser}
       />
     </LoadingIndicator>
   </>
@@ -122,6 +128,7 @@ function mapStateToProps(state, props) {
     descendants: showDescendants,
     pagination,
   });
+  const currentUser = selectCurrentUser(state);
   return {
     memberships,
     groupId,
@@ -133,6 +140,7 @@ function mapStateToProps(state, props) {
     search,
     query,
     filters,
+    currentUser,
   };
 }
 
@@ -142,6 +150,7 @@ const mapDispatchToProps = {
   fetch: fetchMembershipsPagination,
   push,
 };
+
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
   withPreparedDispatch('fetchGroupMemberships', loadData, (props) => [

--- a/app/routes/admin/groups/components/GroupMembersList.css
+++ b/app/routes/admin/groups/components/GroupMembersList.css
@@ -1,10 +1,35 @@
-.removeIcon {
+.list {
+  /* Padding must be added to the table, to prevent the select 
+  options from "falling behind" the table, making it difficult
+  to change the role of the users at the bottom */
+  padding-bottom: 300px;
+}
+
+.editIcon {
   cursor: pointer;
-  padding-right: 10px;
-  color: var(--color-gray-4);
+  color: var(--color-orange-6);
   transition: color var(--easing-fast);
 
   &:hover {
-    color: var(--color-gray-5);
+    color: var(--color-orange-7);
+  }
+}
+
+.removeIcon {
+  cursor: pointer;
+  color: var(--danger-color);
+  transition: color var(--easing-fast);
+
+  &:hover {
+    color: var(--color-red-7);
+  }
+}
+
+.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+
+  &:hover {
+    color: var(--color-orange-6);
   }
 }

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -1,8 +1,16 @@
+import cx from 'classnames';
 import qs from 'qs';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import Select from 'react-select';
+import type { AddMemberArgs } from 'app/actions/GroupActions';
+import Icon from 'app/components/Icon';
+import Flex from 'app/components/Layout/Flex';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import Table from 'app/components/Table';
+import { isCurrentUser as checkIfCurrentUser } from 'app/routes/users/utils';
 import type Membership from 'app/store/models/Membership';
+import type { CurrentUser } from 'app/store/models/User';
 import { ROLES } from 'app/utils/constants';
 import styles from './GroupMembersList.css';
 
@@ -11,6 +19,7 @@ type Props = {
   hasMore: boolean;
   groupId: number;
   memberships: Membership[];
+  addMember: (arg0: AddMemberArgs) => Promise<any>;
   removeMember: (membership: Membership) => Promise<void>;
   showDescendants: boolean;
   groupsById: Record<
@@ -31,11 +40,13 @@ type Props = {
   search: string;
   query: Record<string, any>;
   filters: Record<string, any>;
+  currentUser: CurrentUser;
 };
 
 const GroupMembersList = ({
   memberships,
   groupId,
+  addMember,
   removeMember,
   showDescendants,
   fetch,
@@ -47,22 +58,17 @@ const GroupMembersList = ({
   search,
   query,
   filters,
+  currentUser,
 }: Props) => {
-  const GroupMembersListColumns = (fullName, membership) => {
-    const { user, abakusGroup } = membership;
+  // State for keeping track of which memberships are being edited
+  const [membershipsInEditMode, setMembershipsInEditMode] = useState({});
+
+  const GroupMembersListColumns = (fullName, membership: Membership) => {
+    const { user } = membership;
     return (
-      <>
-        <ConfirmModalWithParent
-          title="Bekreft utmelding"
-          message={`Er du sikker på at du vil melde ut "${user.fullName}" fra gruppen "${groupsById[abakusGroup].name}"?`}
-          onConfirm={() => removeMember(membership)}
-        >
-          <i key="icon" className={`fa fa-times ${styles.removeIcon}`} />
-        </ConfirmModalWithParent>
-        <Link key="link" to={`/users/${user.username}`}>
-          {user.fullName} ({user.username})
-        </Link>
-      </>
+      <Link key={user.id} to={`/users/${user.username}`}>
+        {user.fullName} ({user.username})
+      </Link>
     );
   };
 
@@ -72,8 +78,74 @@ const GroupMembersList = ({
     </Link>
   );
 
-  const RoleRender = (role: string) =>
-    role !== 'member' && <i>{ROLES[role] || role} </i>;
+  const RoleRender = (fullName, membership: Membership) => {
+    const { id, role } = membership;
+
+    if (membershipsInEditMode[id]) {
+      return (
+        <Select
+          value={{
+            value: role,
+            label: ROLES[role],
+          }}
+          placeholder="tre"
+          options={Object.keys(ROLES).map((key) => ({
+            value: key,
+            label: ROLES[key],
+          }))}
+          onChange={async (value: { label: string; value: string }) => {
+            setMembershipsInEditMode((prev) => ({
+              ...prev,
+              [id]: false,
+            }));
+            await removeMember(membership).then(() =>
+              addMember({
+                userId: membership.user.id,
+                groupId: membership.abakusGroup,
+                role: value.value,
+              })
+            );
+          }}
+        />
+      );
+    }
+
+    return role !== 'member' && <i>{ROLES[role] || role} </i>;
+  };
+
+  const EditRender = (fullName, membership: Membership) => {
+    const { id, user, abakusGroup } = membership;
+    const isCurrentUser = checkIfCurrentUser(
+      user.username,
+      currentUser.username
+    );
+
+    return (
+      <Flex justifyContent="center" alignItems="center" gap={5}>
+        {!membershipsInEditMode[id] && (
+          <Icon
+            name="pencil"
+            size={20}
+            className={cx(styles.editIcon, isCurrentUser && styles.disabled)}
+            onClick={() =>
+              !isCurrentUser &&
+              setMembershipsInEditMode((prev) => ({
+                ...prev,
+                [id]: true,
+              }))
+            }
+          />
+        )}
+        <ConfirmModalWithParent
+          title="Bekreft utmelding"
+          message={`Er du sikker på at du vil melde ut "${user.fullName}" fra gruppen "${groupsById[abakusGroup].name}"?`}
+          onConfirm={() => removeMember(membership)}
+        >
+          <Icon name="trash" size={20} className={styles.removeIcon} />
+        </ConfirmModalWithParent>
+      </Flex>
+    );
+  };
 
   const columns = [
     {
@@ -105,6 +177,9 @@ const GroupMembersList = ({
       filterMapping: (role) =>
         role === 'member' || !ROLES[role] ? '' : ROLES[role],
       render: RoleRender,
+    },
+    {
+      render: EditRender,
     },
   ].filter(Boolean);
 
@@ -138,6 +213,7 @@ const GroupMembersList = ({
         loading={fetching}
         data={memberships}
         filters={filters}
+        className={styles.list}
       />
       {!memberships.length && !fetching && <div>Ingen brukere</div>}
     </>

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -2,6 +2,7 @@ import qs from 'qs';
 import { Link } from 'react-router-dom';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import Table from 'app/components/Table';
+import type Membership from 'app/store/models/Membership';
 import { ROLES } from 'app/utils/constants';
 import styles from './GroupMembersList.css';
 
@@ -9,8 +10,8 @@ type Props = {
   fetching: boolean;
   hasMore: boolean;
   groupId: number;
-  memberships: Array<Record<string, any>>;
-  removeMember: (arg0: Record<string, any>) => Promise<any>;
+  memberships: Membership[];
+  removeMember: (membership: Membership) => Promise<void>;
   showDescendants: boolean;
   groupsById: Record<
     string,

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -11,7 +11,7 @@ import Table from 'app/components/Table';
 import { isCurrentUser as checkIfCurrentUser } from 'app/routes/users/utils';
 import type Membership from 'app/store/models/Membership';
 import type { CurrentUser } from 'app/store/models/User';
-import { ROLES } from 'app/utils/constants';
+import { ROLES, type RoleType } from 'app/utils/constants';
 import styles from './GroupMembersList.css';
 
 type Props = {
@@ -89,11 +89,11 @@ const GroupMembersList = ({
             label: ROLES[role],
           }}
           placeholder="tre"
-          options={Object.keys(ROLES).map((key) => ({
+          options={Object.keys(ROLES).map((key: RoleType) => ({
             value: key,
             label: ROLES[key],
           }))}
-          onChange={async (value: { label: string; value: string }) => {
+          onChange={async (value: { label: string; value: RoleType }) => {
             setMembershipsInEditMode((prev) => ({
               ...prev,
               [id]: false,
@@ -168,7 +168,7 @@ const GroupMembersList = ({
     {
       title: 'Rolle',
       dataIndex: 'role',
-      filter: Object.keys(ROLES).map((value) => ({
+      filter: Object.keys(ROLES).map((value: RoleType) => ({
         value,
         label: ROLES[value],
       })),

--- a/app/routes/admin/groups/components/GroupPermissions.tsx
+++ b/app/routes/admin/groups/components/GroupPermissions.tsx
@@ -7,7 +7,6 @@ import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import type { ID } from 'app/models';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import AddGroupPermission from './AddGroupPermission';
-import styles from './GroupMembers.css';
 
 type PermissionListProps = {
   permissions: Array<string>;
@@ -132,7 +131,7 @@ export const GroupPermissions = ({
 }: GroupPermissionsProps) => {
   const { permissions, parentPermissions } = group;
   return (
-    <div className={styles.groupMembers}>
+    <div>
       <PermissionList
         group={group}
         permissions={permissions}

--- a/app/routes/admin/groups/components/GroupSettings.tsx
+++ b/app/routes/admin/groups/components/GroupSettings.tsx
@@ -2,10 +2,11 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { editGroup } from 'app/actions/GroupActions';
 import GroupForm from 'app/components/GroupForm';
+import type { DetailedGroup } from 'app/store/models/Group';
 import loadingIndicator from 'app/utils/loadingIndicator';
 
 type Props = {
-  group: Record<string, any>;
+  group: DetailedGroup;
   editGroup: (arg0: any) => Promise<any>;
 };
 

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
 import AnnouncementInLine from 'app/components/AnnouncementInLine';
 import Button from 'app/components/Button';
 import {
@@ -8,34 +9,14 @@ import {
   ContentSidebar,
 } from 'app/components/Content';
 import DisplayContent from 'app/components/DisplayContent';
+import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
-import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import NavigationTab from 'app/components/NavigationTab';
 import UserGrid from 'app/components/UserGrid';
 import type { Group, User, GroupMembership, ID } from 'app/models';
 import styles from './InterestGroup.css';
 import InterestGroupMemberList from './InterestGroupMemberList';
-
-type TitleProps = {
-  group: Group;
-  showEdit: boolean;
-};
-
-const Title = ({ group: { name, id }, showEdit }: TitleProps) => (
-  <NavigationTab
-    title={name}
-    back={{
-      label: 'Tilbake',
-      path: '/interest-groups',
-    }}
-  >
-    {showEdit && (
-      <NavigationLink to={`/interest-groups/${id}/edit`}>
-        Rediger
-      </NavigationLink>
-    )}
-  </NavigationTab>
-);
 
 type MembersProps = {
   members: Array<GroupMembership>;
@@ -44,7 +25,7 @@ type MembersProps = {
 
 const Members = ({ group, members }: MembersProps) => (
   <Flex column>
-    <h4>Medlemmer {group.numberOfUsers}</h4>
+    <h4>{group.numberOfUsers} medlemmer</h4>
     <UserGrid
       users={members && members.slice(0, 14).map((reg) => reg.user)}
       maxRows={2}
@@ -127,12 +108,18 @@ type Props = {
 
 function InterestGroupDetail(props: Props) {
   const { group } = props;
-  const canEdit = group.actionGrant && group.actionGrant.includes('edit');
+  const canEdit = group.actionGrant?.includes('edit');
   const logo = group.logo || 'https://i.imgur.com/Is9VKjb.jpg';
   return (
     <Content>
       <Helmet title={group.name} />
-      <Title group={group} showEdit={canEdit} />
+      <NavigationTab
+        title={group.name}
+        back={{
+          label: 'Tilbake',
+          path: '/interest-groups',
+        }}
+      />
       <ContentSection>
         <ContentMain>
           <p className={styles.description}>{group.description}</p>
@@ -148,6 +135,17 @@ function InterestGroupDetail(props: Props) {
           />
           <Members group={group} members={group.memberships} />
           <Contact group={group} />
+
+          <h3>Admin</h3>
+          {canEdit && (
+            <Link to={`/interest-groups/${group.id}/edit`}>
+              <Button>
+                <Icon name="create-outline" size={19} />
+                Rediger
+              </Button>
+            </Link>
+          )}
+
           <AnnouncementInLine group={group} />
         </ContentSidebar>
       </ContentSection>

--- a/app/routes/interestgroups/components/InterestGroupMemberList.tsx
+++ b/app/routes/interestgroups/components/InterestGroupMemberList.tsx
@@ -9,10 +9,11 @@ import Modal from 'app/components/Modal';
 import Tooltip from 'app/components/Tooltip';
 import shared from 'app/components/UserAttendance/AttendanceModal.css';
 import type { User, GroupMembership } from 'app/models';
+import type { RoleType } from 'app/utils/constants';
 import styles from './InterestGroupMemberList.css';
 import type { ReactNode } from 'react';
 
-const Name = ({ user, role }: { user: User; role: string }) => {
+const Name = ({ user, role }: { user: User; role: RoleType }) => {
   if (role === 'member') {
     return <span>{user.fullName}</span>;
   }
@@ -33,7 +34,7 @@ const Name = ({ user, role }: { user: User; role: string }) => {
   return <span className={roleStyle}>{user.fullName} </span>;
 };
 
-const RoleIcon = ({ role }: { role: string }) => {
+const RoleIcon = ({ role }: { role: RoleType }) => {
   if (role === 'member') {
     return null;
   }
@@ -64,7 +65,7 @@ const RoleIcon = ({ role }: { role: string }) => {
   );
 };
 
-const ListedUser = ({ user, role }: { user: User; role: string }) => (
+const ListedUser = ({ user, role }: { user: User; role: RoleType }) => (
   <li>
     <Flex alignItems="center" gap={10} className={shared.row}>
       <ProfilePicture size={30} user={user} />

--- a/app/routes/interestgroups/components/InterestGroupMemberList.tsx
+++ b/app/routes/interestgroups/components/InterestGroupMemberList.tsx
@@ -118,14 +118,12 @@ export default class InterestGroupMemberList extends Component<Props, State> {
             className={shared.modal}
           >
             <h2>Medlemmer</h2>
-            <Flex alignItems="center" className={shared.search}>
-              <Icon name="search" size={16} />
-              <TextInput
-                type="text"
-                placeholder="Søk etter navn"
-                onChange={(e) => this.setState({ filter: e.target.value })}
-              />
-            </Flex>
+            <TextInput
+              type="text"
+              prefix="search"
+              placeholder="Søk etter navn"
+              onChange={(e) => this.setState({ filter: e.target.value })}
+            />
 
             <ul className={shared.list}>
               {sorted.map((membership) => (

--- a/app/store/models/Membership.d.ts
+++ b/app/store/models/Membership.d.ts
@@ -1,12 +1,13 @@
 import type { Dateish } from 'app/models';
 import type { PublicUser } from 'app/store/models/User';
 import type { ID } from 'app/store/models/index';
+import type { RoleType } from 'app/utils/constants';
 
 export default interface Membership {
   id: ID;
   user: PublicUser;
   abakusGroup: ID;
-  role: string;
+  role: RoleType;
   isActive: boolean;
   emailListsEnabled: boolean;
   createdAt: Dateish;

--- a/app/store/models/Membership.d.ts
+++ b/app/store/models/Membership.d.ts
@@ -1,10 +1,10 @@
 import type { Dateish } from 'app/models';
-import type User from 'app/store/models/User';
+import type { PublicUser } from 'app/store/models/User';
 import type { ID } from 'app/store/models/index';
 
 export default interface Membership {
   id: ID;
-  user: User;
+  user: PublicUser;
   abakusGroup: ID;
   role: string;
   isActive: boolean;

--- a/app/store/models/PastMembership.d.ts
+++ b/app/store/models/PastMembership.d.ts
@@ -1,11 +1,12 @@
 import type { Dateish } from 'app/models';
 import type Group from 'app/store/models/Group';
 import type { ID } from 'app/store/models/index';
+import type { RoleType } from 'app/utils/constants';
 
 export default interface PastMembership {
   id: ID;
   abakusGroup: Group;
-  role: string;
+  role: RoleType;
   startDate: Dateish;
   endDate?: Dateish;
 }

--- a/app/store/models/User.d.ts
+++ b/app/store/models/User.d.ts
@@ -14,7 +14,7 @@ export interface PhotoConsent {
 }
 
 interface User {
-  id: number;
+  id: ID;
   username: string;
   firstName: string;
   lastName: string;

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -8,6 +8,7 @@ export const Keyboard = {
   UP: 38,
   DOWN: 40,
 };
+
 export const ROLES = {
   member: 'Medlem (standard)',
   leader: 'Leder',
@@ -30,14 +31,17 @@ export const ROLES = {
   sponsor_admin: 'Sponsoransvarlig',
   social_admin: 'Sosialansvarlig',
 };
+
+export type RoleType = keyof typeof ROLES;
+
 export const roleOptions = Object.keys(ROLES)
   .sort()
   .map((role) => ({
     value: role,
     label: ROLES[role],
   })) as Array<{
-  value: string;
-  label: string;
+  value: RoleType;
+  label: (typeof ROLES)[RoleType];
 }>;
 
 /*


### PR DESCRIPTION
# Description

[Minor changes to (interest) groups page](https://github.com/webkom/lego-webapp/pull/3757/commits/e469ee2c8ce41b4f67b04a0058efcef50b47208e)

---

[Support changing group roles in the membership table](https://github.com/webkom/lego-webapp/pull/3757/commits/e9956ced3c931e9b7aa378679fd69e5f521f4216) 
Previously, you had to remove the user from the group and re-add them
back with a different role. You may now simply change the user's role
directly in the membership table.

---

[Type group roles correctly](https://github.com/webkom/lego-webapp/pull/3757/commits/00dff1856cbb61f7d178a7e359ee77cf7c47ef71)

# Result

**Before**
<img width="698" alt="image" src="https://user-images.githubusercontent.com/69514187/230738166-ce91613f-600d-4d3f-aa4e-52d0e614178e.png">

**After**

https://user-images.githubusercontent.com/69514187/230737973-c19d4003-72e3-4ec2-bf9d-64e00d22c788.mov

# Testing

- [x] I have thoroughly tested my changes.

I have tested it thoroughly, but I plan on testing it even more ... Might even write an E2E spec for it 😨

---

Resolves https://github.com/webkom/lego/issues/3051