### PR TITLE
Recognize broken interest groups links as valid

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -59,7 +59,10 @@ const AppWrapper = (props) => (
           <Route path="/events" component={Events} />
           <Route path="/companies" component={Companies} />
           <Route path={['/contact', '/kontakt']} component={Contact} />
-          <Route path="/interest-groups" component={InterestGroups} />
+          <Route
+            path={['/interest-groups', '/interestgroups']}
+            component={InterestGroups}
+          />
           <Route path="/joblistings" component={Joblistings} />
           <Route path="/meetings" component={Meetings} />
           <Route path="/pages" component={Pages} />

--- a/app/routes/interestgroups/index.tsx
+++ b/app/routes/interestgroups/index.tsx
@@ -59,5 +59,10 @@ const interestGroupRoute = ({
 );
 
 export default function InterestGroups() {
-  return <Route path="/interest-groups" component={interestGroupRoute} />;
+  return (
+    <Route
+      path={['/interest-groups', '/interestgroups']}
+      component={interestGroupRoute}
+    />
+  );
 }


### PR DESCRIPTION
# Description

Some time ago "interestgroups" were changed to "interest-groups", which caused broken links. These are fixed by recognizing both "/interest-groups" and "/interestgroups" as being valid paths.

# Result

https://user-images.githubusercontent.com/69514187/230785932-e12d5221-0d63-4f0a-8d9c-c66d3513fe90.mov

# Testing

- [x] I have thoroughly tested my changes.

See video above.