### PR TITLE
Fix usage of query params in quotes-list

### DIFF
--- a/app/routes/quotes/components/QuoteList.tsx
+++ b/app/routes/quotes/components/QuoteList.tsx
@@ -12,7 +12,6 @@ type Props = {
   actionGrant: ActionGrant;
   currentUser: any;
   loggedIn: boolean;
-  reactions: Record<string, any>;
   addReaction: (arg0: { emoji: string; contentTarget: string }) => Promise<any>;
   deleteReaction: (arg0: {
     reactionId: ID;
@@ -52,7 +51,6 @@ export default class QuoteList extends Component<Props, State> {
       deleteQuote,
       currentUser,
       loggedIn,
-      reactions,
       addReaction,
       deleteReaction,
       emojis,
@@ -73,7 +71,6 @@ export default class QuoteList extends Component<Props, State> {
             displayAdmin={quote.id === this.state.displayAdminId}
             currentUser={currentUser}
             loggedIn={loggedIn}
-            reactions={reactions}
             addReaction={addReaction}
             deleteReaction={deleteReaction}
             emojis={emojis}

--- a/app/routes/quotes/components/QuotePage.tsx
+++ b/app/routes/quotes/components/QuotePage.tsx
@@ -1,4 +1,5 @@
 import cx from 'classnames';
+import qs from 'qs';
 import { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useHistory } from 'react-router-dom';
@@ -14,7 +15,6 @@ import QuoteList from './QuoteList';
 import styles from './Quotes.css';
 
 type Props = {
-  reactions: Array<Record<string, any>>;
   query: {
     approved: string;
     ordering: string;
@@ -28,6 +28,7 @@ type Props = {
     arg0: {
       query: {
         approved: string;
+        ordering: string;
       };
     },
     next?: boolean
@@ -35,7 +36,6 @@ type Props = {
   showFetchMore: boolean;
   currentUser: any;
   loggedIn: boolean;
-  reactions: Record<string, any>;
   addReaction: (arg0: { emoji: string; contentTarget: string }) => Promise<any>;
   deleteReaction: (arg0: {
     reactionId: ID;
@@ -71,7 +71,6 @@ export default function QuotePage({
   showFetchMore,
   currentUser,
   loggedIn,
-  reactions,
   addReaction,
   deleteReaction,
   emojis,
@@ -100,10 +99,15 @@ export default function QuotePage({
   };
 
   useEffect(() => {
+    // Update url with the new filtering/ordering params while ignoring the default values
+    const searchObject = qs.parse(ordering.value, { ignoreQueryPrefix: true });
+    if (query.approved === 'false') searchObject['approved'] = query.approved;
+    const searchString = qs.stringify(searchObject, { addQueryPrefix: true });
     history.replace({
-      search: ordering.value,
+      search: searchString,
     });
-  }, [history, ordering]);
+  }, [history, ordering, query.approved]);
+
   return (
     <div className={cx(styles.root, styles.quoteContainer)}>
       <Helmet title="Overhørt" />
@@ -131,7 +135,6 @@ export default function QuotePage({
           quotes={quotes}
           currentUser={currentUser}
           loggedIn={loggedIn}
-          reactions={reactions}
           addReaction={addReaction}
           deleteReaction={deleteReaction}
           emojis={emojis}


### PR DESCRIPTION
# Description

In the quotes-list, the query params are overridden every time the state of the ordering-select changes it's values. As this happens not only when the user changes it, but also on page load, any other query params were overridden.

Currently this was a problem because the useEffect only updated one of the two possible query params.

# Result

This still happens, but now the useEffect that does the overriding takes both the query params into account, enabling filtering in the list of non-approved quotes and navigating freely between the three pages and directly to the non-approved quotes page.

Also removed the reactions prop as it was not used.

# Testing

- [x] I have thoroughly tested my changes.

Tested locally and with staging, navigating through the pages and using sorting on all pages.

---

Resolves ABA-272
