### PR TITLE
Replace pill in survey result with tag

### DIFF
--- a/app/components/Tags/Tag.css
+++ b/app/components/Tags/Tag.css
@@ -12,6 +12,7 @@
 }
 
 .tag {
+  /* The default red color */
   --label-r: 192;
   --label-g: 57;
   --label-b: 43;
@@ -165,4 +166,13 @@ html[data-theme='dark'] .active {
   --label-h: 256;
   --label-s: 81;
   --label-l: 50;
+}
+
+.orange {
+  --label-r: 242;
+  --label-g: 92;
+  --label-b: 5;
+  --label-h: 22;
+  --label-s: 96;
+  --label-l: 48;
 }

--- a/app/components/Tags/Tag.tsx
+++ b/app/components/Tags/Tag.tsx
@@ -2,18 +2,23 @@ import cx from 'classnames';
 import { Link } from 'react-router-dom';
 import styles from './Tag.css';
 
+const tagColors = [
+  'red',
+  'gray',
+  'pink',
+  'yellow',
+  'green',
+  'cyan',
+  'blue',
+  'purple',
+  'orange',
+] as const;
+
+export type TagColors = (typeof tagColors)[number];
+
 type Props = {
-  /** The tag value - the text */
   tag: string;
-  color?:
-    | 'gray'
-    | 'pink'
-    | 'yellow'
-    | 'green'
-    | 'cyan'
-    | 'blue'
-    | 'purple'
-    | '';
+  color?: TagColors;
   link?: string;
   className?: string;
   active?: boolean;

--- a/app/routes/surveys/components/Submissions/Results.tsx
+++ b/app/routes/surveys/components/Submissions/Results.tsx
@@ -5,7 +5,7 @@ import DistributionPieChart from 'app/components/Chart/PieChart';
 import { CHART_COLORS } from 'app/components/Chart/utils';
 import { selectTheme, selectStyles } from 'app/components/Form/SelectInput';
 import InfoBubble from 'app/components/InfoBubble';
-import Pill from 'app/components/Pill';
+import Tag, { type TagColors } from 'app/components/Tags/Tag';
 import type { SurveyEntity, QuestionEntity } from 'app/reducers/surveys';
 import {
   QuestionTypes,
@@ -143,12 +143,7 @@ const Results = ({
     return ((value - start) * (newEnd - newStart)) / (end - start) + newStart;
   };
 
-  const averagePillColors = [
-    'var(--color-red-6)',
-    'var(--color-orange-6)',
-    'var(--color-yellow)',
-    'var(--color-green-6)',
-  ];
+  const averageTagColors: TagColors[] = ['red', 'orange', 'yellow', 'green'];
 
   const averagePill = (options, data) => {
     const average = getAverage(data);
@@ -158,13 +153,14 @@ const Results = ({
       optionMin,
       optionMax,
       0,
-      averagePillColors.length - 1
+      averageTagColors.length - 1
     );
 
     return (
-      <Pill color={averagePillColors[Math.round(mappedAverage)]}>
-        {average}
-      </Pill>
+      <Tag
+        color={averageTagColors[Math.round(mappedAverage)]}
+        tag={Number.isNaN(average) ? '?' : String(average)}
+      />
     );
   };
 

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -97,9 +97,6 @@
 
   --color-yellow: #fcd703;
 
-  --color-select-hover: rgb(178, 212, 255);
-  --color-select-multi-bg: rgb(230, 230, 230);
-
   --color-red-hover-alpha: 5%;
 
   --font-size: 16px;
@@ -206,9 +203,6 @@
   --color-red-9: #e9494a;
 
   --color-yellow: #fcd703;
-
-  --color-select-hover: var(--color-gray-4);
-  --color-select-multi-bg: var(--color-gray-5);
 
   --color-red-hover-alpha: 10%;
 }


### PR DESCRIPTION
# Description

The colors in the tags are more "supported", and the design on the pills are outdated.

"orange" had to be introduced as a tag color.

Also fix an issue where it would print "NaN" during fetching.

# Result

| Before | After |
:-----------------------:|:--------------------------:
![image](https://user-images.githubusercontent.com/69514187/232047103-a13c7b45-58d4-4d05-bd61-25f621028411.png) | ![image](https://user-images.githubusercontent.com/69514187/232048369-50973b41-467c-44f1-8114-0e3abdd07f68.png) ![image](https://user-images.githubusercontent.com/69514187/232046962-38a3c35d-9f8c-4b11-8a12-6bfc942ec477.png)
![image](https://user-images.githubusercontent.com/69514187/232047538-cee53179-96cd-4c27-9094-0a7be442c6a1.png) | ![image](https://user-images.githubusercontent.com/69514187/232046744-70f778b5-c39f-4551-bfce-1ab973852d94.png)![image](https://user-images.githubusercontent.com/69514187/232046851-6ccf51bc-cfc3-474c-a119-45625a1403a7.png)
![image](https://user-images.githubusercontent.com/69514187/232048224-aef442e2-99fc-42da-8e70-df5b4a963221.png) | ![image](https://user-images.githubusercontent.com/69514187/232048129-a4d36c0f-7a75-411b-a430-6e3a6c9e5028.png) ![image](https://user-images.githubusercontent.com/69514187/232048528-7f52bf4d-f505-492f-bcec-45cc350e0451.png)
![image](https://user-images.githubusercontent.com/69514187/232049252-aedb593b-2f32-489c-a5e7-b1d59383bd9f.png) | ![image](https://user-images.githubusercontent.com/69514187/232049000-47432cb1-ca4f-4e4a-80bc-bb60d8de2edd.png) ![image](https://user-images.githubusercontent.com/69514187/232048937-ed5f1ce7-b6ba-4a9a-9082-de832067246b.png)

# Testing

- [x] I have thoroughly tested my changes.

See images above.