### PR TITLE
Render fields correctly on the server

### DIFF
--- a/app/components/Form/CheckBox.tsx
+++ b/app/components/Form/CheckBox.tsx
@@ -48,7 +48,7 @@ const CheckBox = ({
   );
 };
 
-const RawField = createField(CheckBox);
+const RawField = createField(CheckBox, { inlineLabel: true });
 
 const StyledField = ({ fieldClassName, ...props }: FormProps) => (
   <RawField fieldClassName={fieldClassName} {...props} />

--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -77,6 +77,8 @@ export type FormProps = {
 type Options = {
   // Removes the html <label> around the component
   noLabel?: boolean;
+  // Sets the label to be inline with the component
+  inlineLabel?: boolean;
 };
 
 /**
@@ -105,9 +107,7 @@ export function createField(Component: ComponentType<any>, options?: Options) {
     const hasError = showErrors && touched && anyError?.length > 0;
     const hasWarning = showErrors && touched && warning?.length > 0;
     const fieldName = input?.name;
-    // CheckBox and RadioButton should have an inline label
-    const inlineLabel =
-      Component.name === 'CheckBox' || Component.name === 'RadioButton';
+    const inlineLabel = options?.inlineLabel;
 
     const labelComponent = (
       <Flex>

--- a/app/components/Form/RadioButton.tsx
+++ b/app/components/Form/RadioButton.tsx
@@ -44,7 +44,7 @@ function RadioButton({
   );
 }
 
-const RawField = createField(RadioButton);
+const RawField = createField(RadioButton, { inlineLabel: true });
 
 const StyledField = ({ fieldClassName, ...props }: FormProps) => (
   <RawField fieldClassName={cx(fieldClassName, styles.radioField)} {...props} />


### PR DESCRIPTION
# Description

On the server, the component name would be undefined, resulting in the label not being inline. But, on the client side this would actually work, resulting in an error stating that the rendered content did not match what was server-rendered.

# Result

The labels still align as expected.
<p align="center">
<img src="https://user-images.githubusercontent.com/69514187/232095313-f02e9d8b-4496-4e12-8c5e-340d83108cdb.png" />

<img src="https://user-images.githubusercontent.com/69514187/232095397-a880a00a-a85f-43cb-a850-b1160360f6da.png" />
</p>

# Testing

- [x] I have thoroughly tested my changes.

For some reason I don't get to test this through `yarn ssr`, but the cypress test passed without errors so we're all good.