### PR TITLE
Refactor public frontpage

### DIFF
--- a/app/components/AuthSection/AuthSection.css
+++ b/app/components/AuthSection/AuthSection.css
@@ -1,0 +1,4 @@
+.toggleButton {
+  color: var(--lego-link-color);
+  font-size: var(--font-size-small);
+}

--- a/app/components/AuthSection/AuthSection.tsx
+++ b/app/components/AuthSection/AuthSection.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { Flex } from 'app/components/Layout';
+import {
+  ForgotPasswordForm,
+  LoginForm,
+  RegisterForm,
+} from 'app/components/LoginForm';
+import styles from './AuthSection.css';
+import type { ReactNode, MouseEvent } from 'react';
+
+enum AuthMode {
+  LOGIN,
+  REGISTER,
+  FORGOT_PASSWORD,
+}
+
+const titles: { [M in AuthMode]: string } = {
+  [AuthMode.LOGIN]: 'Logg inn',
+  [AuthMode.REGISTER]: 'Registrer bruker',
+  [AuthMode.FORGOT_PASSWORD]: 'Glemt passord',
+};
+
+const forms: { [M in AuthMode]: ReactNode } = {
+  [AuthMode.LOGIN]: <LoginForm />,
+  [AuthMode.REGISTER]: <RegisterForm />,
+  [AuthMode.FORGOT_PASSWORD]: <ForgotPasswordForm />,
+};
+
+const AuthSection = () => {
+  const [authMode, setAuthMode] = useState<AuthMode>(AuthMode.LOGIN);
+
+  const title = titles[authMode];
+  const form = forms[authMode];
+
+  const createModeSelector = (mode: AuthMode) => (e: MouseEvent) => {
+    setAuthMode(mode);
+    e.stopPropagation();
+  };
+
+  return (
+    <>
+      <Flex
+        component="h2"
+        justifyContent="space-between"
+        alignItems="center"
+        className="u-mb"
+        style={{
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {title}
+        {authMode === AuthMode.LOGIN ? (
+          <div>
+            <button
+              onClick={createModeSelector(AuthMode.FORGOT_PASSWORD)}
+              className={styles.toggleButton}
+            >
+              Glemt passord
+            </button>
+            <span className={styles.toggleButton}>&bull;</span>
+            <button
+              onClick={createModeSelector(AuthMode.REGISTER)}
+              className={styles.toggleButton}
+            >
+              Jeg er ny
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={createModeSelector(AuthMode.LOGIN)}
+            className={styles.toggleButton}
+          >
+            Tilbake
+          </button>
+        )}
+      </Flex>
+      {form}
+    </>
+  );
+};
+
+export default AuthSection;

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -4,6 +4,7 @@ import { Modal } from 'react-overlays';
 import { Link, NavLink, withRouter } from 'react-router-dom';
 import logoLightMode from 'app/assets/logo-dark.png';
 import logoDarkMode from 'app/assets/logo.png';
+import AuthSection from 'app/components/AuthSection/AuthSection';
 import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import {
@@ -42,16 +43,9 @@ type Props = {
   updateUserTheme: (username: string, theme: string) => Promise<void>;
 };
 
-enum LoginMode {
-  LOGIN = 'login',
-  REGISTER = 'register',
-  FORGOT_PASSWORD = 'forgotPassword',
-}
-
 type State = {
   accountOpen: boolean;
   shake: boolean;
-  mode: LoginMode;
 };
 
 type AccountDropdownItemsProps = {
@@ -128,34 +122,10 @@ class Header extends Component<Props, State> {
   state = {
     accountOpen: false,
     shake: false,
-    mode: LoginMode.LOGIN,
-  };
-
-  toggleRegisterUser: MouseEventHandler<HTMLButtonElement> = (e) => {
-    this.setState({
-      mode: LoginMode.REGISTER,
-    });
-    e.stopPropagation();
-  };
-
-  toggleForgotPassword: MouseEventHandler<HTMLButtonElement> = (e) => {
-    this.setState({
-      mode: LoginMode.FORGOT_PASSWORD,
-    });
-    e.stopPropagation();
-  };
-
-  toggleBack: MouseEventHandler<HTMLButtonElement> = (e) => {
-    this.setState({
-      mode: LoginMode.LOGIN,
-    });
-    e.stopPropagation();
   };
 
   render() {
     const { loggedIn, currentUser, loading } = this.props;
-    const isLogin = this.state.mode === LoginMode.LOGIN;
-    let title, form;
 
     if (
       __CLIENT__ &&
@@ -167,26 +137,6 @@ class Header extends Component<Props, State> {
         : getTheme() !== currentUser.selectedTheme)
     ) {
       applySelectedTheme(currentUser.selectedTheme || 'light');
-    }
-
-    switch (this.state.mode) {
-      case LoginMode.LOGIN:
-        title = 'Logg inn';
-        form = <LoginForm />;
-        break;
-
-      case LoginMode.REGISTER:
-        title = 'Register';
-        form = <RegisterForm />;
-        break;
-
-      case LoginMode.FORGOT_PASSWORD:
-        title = 'Glemt passord';
-        form = <ForgotPasswordForm />;
-        break;
-
-      default:
-        break;
     }
 
     const MeetingButton = withRouter(({ history }) => (
@@ -313,50 +263,7 @@ class Header extends Component<Props, State> {
                   )}
                   triggerComponent={<Icon name="person-circle-outline" />}
                 >
-                  <div
-                    style={{
-                      padding: 10,
-                    }}
-                  >
-                    <Flex
-                      component="h2"
-                      justifyContent="space-between"
-                      alignItems="center"
-                      className="u-mb"
-                      style={{
-                        whitespace: 'nowrap',
-                      }}
-                    >
-                      {title}
-                      {isLogin && (
-                        <div>
-                          <button
-                            onClick={this.toggleForgotPassword}
-                            className={styles.toggleButton}
-                          >
-                            Glemt passord
-                          </button>
-                          <span className={styles.toggleButton}>&bull;</span>
-                          <button
-                            onClick={this.toggleRegisterUser}
-                            className={styles.toggleButton}
-                          >
-                            Jeg er ny
-                          </button>
-                        </div>
-                      )}
-
-                      {!isLogin && (
-                        <button
-                          onClick={this.toggleBack}
-                          className={styles.toggleButton}
-                        >
-                          Tilbake
-                        </button>
-                      )}
-                    </Flex>
-                    {form}
-                  </div>
+                  <AuthSection />
                 </Dropdown>
               )}
 

--- a/app/components/LoginForm/LoginPage.tsx
+++ b/app/components/LoginForm/LoginPage.tsx
@@ -1,86 +1,10 @@
-import { useState } from 'react';
+import AuthSection from 'app/components/AuthSection/AuthSection';
 import { Content } from 'app/components/Content';
-import { Flex } from 'app/components/Layout';
-import {
-  LoginForm,
-  RegisterForm,
-  ForgotPasswordForm,
-} from 'app/components/LoginForm';
-import styles from './Login.css';
-import type { ReactNode, MouseEvent } from 'react';
 
-const LoginPage = () => {
-  const [mode, setMode] = useState<'login' | 'register' | 'forgotPassword'>(
-    'login'
-  );
-  const isLogin = mode === 'login';
-
-  const toggleRegisterUser = (e: MouseEvent) => {
-    setMode('register');
-    e.stopPropagation();
-  };
-  const toggleForgotPassword = (e: MouseEvent) => {
-    setMode('forgotPassword');
-    e.stopPropagation();
-  };
-  const toggleBack = (e: MouseEvent) => {
-    setMode('login');
-    e.stopPropagation();
-  };
-
-  let title: string;
-  let form: ReactNode;
-
-  switch (mode) {
-    case 'login': {
-      title = 'Logg inn';
-      form = <LoginForm />;
-      break;
-    }
-    case 'register': {
-      title = 'Register';
-      form = <RegisterForm />;
-      break;
-    }
-    case 'forgotPassword': {
-      title = 'Glemt passord';
-      form = <ForgotPasswordForm />;
-      break;
-    }
-    default:
-      break;
-  }
-
-  return (
-    <Content>
-      <Flex justifyContent="space-between" alignItems="center">
-        <h2>{title}</h2>
-        {isLogin && (
-          <div>
-            <button
-              onClick={toggleForgotPassword}
-              className={styles.toggleButton}
-            >
-              Glemt passord
-            </button>
-            <span className={styles.toggleButton}>&bull;</span>
-            <button
-              onClick={toggleRegisterUser}
-              className={styles.toggleButton}
-            >
-              Jeg er ny
-            </button>
-          </div>
-        )}
-        {!isLogin && (
-          <button onClick={toggleBack} className={styles.toggleButton}>
-            Tilbake
-          </button>
-        )}
-      </Flex>
-      {form}
-    </Content>
-  );
-};
+const LoginPage = () => (
+  <Content>
+    <AuthSection />
+  </Content>
+);
 
 export default LoginPage;

--- a/app/reducers/articles.ts
+++ b/app/reducers/articles.ts
@@ -2,11 +2,15 @@ import { orderBy } from 'lodash';
 import { createSelector } from 'reselect';
 import { mutateComments } from 'app/reducers/comments';
 import { mutateReactions } from 'app/reducers/reactions';
+import { selectUserById } from 'app/reducers/users';
 import { typeable } from 'app/reducers/utils';
-import type { UnknownArticle } from 'app/store/models/Article';
+import type { ArticleWithAuthorDetails } from 'app/routes/articles/ArticleListRoute';
+import type { RootState } from 'app/store/createRootReducer';
+import type { PublicArticle, UnknownArticle } from 'app/store/models/Article';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
 import { Article } from '../actions/ActionTypes';
+import type { Selector } from 'reselect';
 
 export default createEntityReducer({
   key: 'articles',
@@ -37,6 +41,25 @@ export const selectArticles = typeable(
       )
   )
 );
+
+export const selectArticlesWithAuthorDetails: Selector<
+  RootState,
+  ArticleWithAuthorDetails[],
+  [
+    {
+      pagination: any;
+    }
+  ]
+> = (state, props) =>
+  selectArticles<PublicArticle[]>(state, props).map((article) => ({
+    ...article,
+    authors: article.authors.map((e) => {
+      return selectUserById(state, {
+        userId: e,
+      });
+    }),
+  }));
+
 export const selectArticlesByTag = createSelector(
   selectArticles,
   (state, props) => props.tag,

--- a/app/reducers/frontpage.ts
+++ b/app/reducers/frontpage.ts
@@ -5,7 +5,7 @@ import { Frontpage } from 'app/actions/ActionTypes';
 import type { Event } from 'app/models';
 import type { UnknownArticle } from 'app/store/models/Article';
 import { fetching } from 'app/utils/createEntityReducer';
-import { selectArticles } from './articles';
+import { selectArticlesWithAuthorDetails } from './articles';
 import { selectEvents } from './events';
 
 export type WithDocumentType<T> = T & {
@@ -22,7 +22,7 @@ export const isArticle = <T extends UnknownArticle>(
 
 export default fetching(Frontpage.FETCH);
 export const selectFrontpage = createSelector(
-  selectArticles,
+  selectArticlesWithAuthorDetails,
   selectEvents,
   (articles, events) => {
     const articlesWithType = articles.map((article) => ({

--- a/app/routes/articles/ArticleListRoute.ts
+++ b/app/routes/articles/ArticleListRoute.ts
@@ -3,7 +3,10 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetchAll } from 'app/actions/ArticleActions';
 import { fetchPopular } from 'app/actions/TagActions';
-import { selectArticles } from 'app/reducers/articles';
+import {
+  selectArticles,
+  selectArticlesWithAuthorDetails,
+} from 'app/reducers/articles';
 import { selectPaginationNext } from 'app/reducers/selectors';
 import { selectPopularTags } from 'app/reducers/tags';
 import { selectUserById } from 'app/reducers/users';
@@ -27,19 +30,9 @@ const mapStateToProps = (state, props) => {
     query,
     entity: 'articles',
   })(state);
-  const articles: ArticleWithAuthorDetails[] = selectArticles<PublicArticle[]>(
-    state,
-    {
-      pagination,
-    }
-  ).map((article) => ({
-    ...article,
-    authors: article.authors.map((e) => {
-      return selectUserById(state, {
-        userId: e,
-      });
-    }),
-  }));
+  const articles = selectArticlesWithAuthorDetails(state, {
+    pagination,
+  });
 
   return {
     articles,

--- a/app/routes/articles/components/Overview.tsx
+++ b/app/routes/articles/components/Overview.tsx
@@ -14,26 +14,35 @@ import styles from './Overview.css';
 
 const HEADLINE_EVENTS = 2;
 
-const OverviewItem = ({ article }: { article: ArticleWithAuthorDetails }) => (
+export const OverviewItem = ({
+  article,
+}: {
+  article: ArticleWithAuthorDetails;
+}) => (
   <div className={styles.item}>
     <Link to={`/articles/${article.id}`} className={styles.imageLink}>
-      <Image src={article.cover} placeholder={article.coverPlaceholder} />
+      <Image
+        src={article.cover}
+        alt="Article cover"
+        placeholder={article.coverPlaceholder}
+      />
     </Link>
     <h2 className={styles.itemTitle}>
       <Link to={`/articles/${article.id}`}>{article.title}</Link>
     </h2>
 
     <span className={styles.itemInfo}>
-      {article.authors.map((e) => {
-        return (
-          <span key={e.username}>
-            <Link to={`/users/${e.username}`} className={styles.overviewAuthor}>
-              {' '}
-              {e.fullName}
-            </Link>{' '}
-          </span>
-        );
-      })}
+      {article.authors.map((author) => (
+        <span key={author.username}>
+          <Link
+            to={`/users/${author.username}`}
+            className={styles.overviewAuthor}
+          >
+            {' '}
+            {author.fullName}
+          </Link>{' '}
+        </span>
+      ))}
 
       <Time time={article.createdAt} format="DD.MM.YYYY HH:mm" />
       <Tags className={styles.tagline}>

--- a/app/routes/overview/components/LatestReadme.tsx
+++ b/app/routes/overview/components/LatestReadme.tsx
@@ -7,13 +7,21 @@ import { Flex } from 'app/components/Layout';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import type { Readme } from 'app/models';
 import styles from './LatestReadme.css';
+import type { CSSProperties } from 'react';
 
 type Props = {
   expandedInitially: boolean;
+  collapsible?: boolean;
   readmes: Array<Readme>;
+  style?: CSSProperties;
 };
 
-const LatestReadme = ({ readmes, expandedInitially }: Props) => {
+const LatestReadme = ({
+  readmes,
+  expandedInitially,
+  collapsible = true,
+  style,
+}: Props) => {
   const [expanded, setExpanded] = useState(expandedInitially);
 
   useEffect(() => {
@@ -21,13 +29,20 @@ const LatestReadme = ({ readmes, expandedInitially }: Props) => {
   }, [expandedInitially]);
 
   return (
-    <Card className={styles.latestReadme}>
-      <button className={styles.heading} onClick={() => setExpanded(!expanded)}>
-        <Flex justifyContent="space-between" alignItems="center">
-          {readmeIfy('readme')}
-          <Icon name={expanded ? 'close' : 'arrow-down'} />
-        </Flex>
-      </button>
+    <Card className={styles.latestReadme} style={style}>
+      {collapsible ? (
+        <button
+          className={styles.heading}
+          onClick={() => setExpanded(!expanded)}
+        >
+          <Flex justifyContent="space-between" alignItems="center">
+            {readmeIfy('readme')}
+            <Icon name={expanded ? 'close' : 'arrow-down'} />
+          </Flex>
+        </button>
+      ) : (
+        <div className={styles.heading}>{readmeIfy('readme')}</div>
+      )}
 
       <Collapse isOpened={expanded}>
         <Flex

--- a/app/routes/overview/components/PublicFrontpage.css
+++ b/app/routes/overview/components/PublicFrontpage.css
@@ -24,19 +24,7 @@
   }
 }
 
-.welcome {
-  composes: rootCardStyle;
-  grid-area: welcome;
-}
-
-.events {
-  composes: rootCardStyle;
-  grid-area: events;
-}
-
 .hsp {
-  composes: rootCardStyle;
-  grid-area: hsp;
   text-align: center;
 }
 
@@ -45,26 +33,6 @@
   height: auto;
   display: block;
   margin: auto;
-}
-
-.article {
-  composes: rootCardStyle;
-  grid-area: article;
-}
-
-.readme {
-  composes: rootCardStyle;
-  grid-area: readme;
-}
-
-.links {
-  composes: rootCardStyle;
-  grid-area: links;
-}
-
-.facebook {
-  composes: rootCardStyle;
-  grid-area: facebook;
 }
 
 .facebookIframeContainer {
@@ -78,12 +46,6 @@
   overflow: hidden;
   height: 500px;
   width: 340px;
-}
-
-.articleTitle {
-  display: flex;
-  overflow: hidden;
-  justify-content: space-between;
 }
 
 .usefulLinks {

--- a/app/routes/overview/components/PublicFrontpage.css
+++ b/app/routes/overview/components/PublicFrontpage.css
@@ -29,16 +29,6 @@
   grid-area: welcome;
 }
 
-.login {
-  composes: rootCardStyle;
-  grid-area: login;
-}
-
-.toggleButton {
-  color: var(--lego-link-color);
-  font-size: 14px;
-}
-
 .events {
   composes: rootCardStyle;
   grid-area: events;

--- a/app/routes/overview/components/PublicFrontpage.css
+++ b/app/routes/overview/components/PublicFrontpage.css
@@ -5,12 +5,12 @@
   grid-gap: 30px;
   grid-template-columns: 1fr 1fr 1.3fr;
   grid-auto-rows: auto;
-  grid-template-areas: 'welcome welcome login' 'events events hsp' 'article article readme' 'links links facebook';
+  grid-template-areas: 'welcome welcome login' 'events events hsp' 'article article readme' 'links links links';
 
   @media (--mobile-device) {
     grid-gap: 10px;
     grid-template-columns: 1fr;
-    grid-template-areas: 'welcome' 'login' 'events' 'hsp' 'article' 'readme' 'links' 'facebook';
+    grid-template-areas: 'welcome' 'login' 'events' 'hsp' 'article' 'readme' 'links';
   }
 }
 

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -70,9 +70,6 @@ const PublicFrontpage = ({ frontpage, readmes }: Props) => {
         <Card style={{ gridArea: 'links' }}>
           <UsefulLinks />
         </Card>
-        <Card style={{ gridArea: 'facebook' }}>
-          <Facebook />
-        </Card>
       </Container>
     </Container>
   );
@@ -172,21 +169,6 @@ const UsefulLinks = () => (
         </div>
       </li>
     </ul>
-  </>
-);
-
-const Facebook = () => (
-  <>
-    <h2 className="u-mb">Vår Facebook side</h2>
-    <div className={styles.facebookIframeContainer}>
-      <iframe
-        src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FAbakusNTNU%2F&amp;tabs=timeline&amp;small_header=true&amp;adapt_container_width=true&amp;hide_cover=false&amp;show_facepile=true&amp;appId=1717809791769695"
-        className={styles.facebookIframe}
-        title="facebook"
-        scrolling="no"
-        frameBorder="0"
-      />
-    </div>
   </>
 );
 

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -1,13 +1,9 @@
-import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import netcompany from 'app/assets/netcompany_dark.png';
+import AuthSection from 'app/components/AuthSection/AuthSection';
+import Card from 'app/components/Card';
 import { Image } from 'app/components/Image';
-import { Container, Flex } from 'app/components/Layout';
-import {
-  LoginForm,
-  RegisterForm,
-  ForgotPasswordForm,
-} from 'app/components/LoginForm';
+import { Container } from 'app/components/Layout';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import Time from 'app/components/Time';
 import truncateString from 'app/utils/truncateString';
@@ -18,239 +14,160 @@ type Props = {
   frontpage: Array<Record<string, any>>;
   readmes: Array<Record<string, any>>;
 };
-type State = {
-  registerUser: boolean;
-  forgotPassword: boolean;
-};
 
-class PublicFrontpage extends Component<Props, State> {
-  state = {
-    registerUser: false,
-    forgotPassword: false,
-  };
-  toggleRegisterUser = () =>
-    this.setState({
-      registerUser: true,
-    });
-  toggleForgotPassword = () =>
-    this.setState({
-      forgotPassword: true,
-    });
-  toggleBack = () =>
-    this.setState({
-      registerUser: false,
-      forgotPassword: false,
-    });
+const PublicFrontpage = ({ frontpage, readmes }: Props) => {
+  const isEvent = (item) => item.documentType === 'event';
 
-  render() {
-    const { registerUser, forgotPassword } = this.state;
+  const isArticle = (item) => item.documentType === 'article';
 
-    const isEvent = (item) => item.documentType === 'event';
-
-    const isArticle = (item) => item.documentType === 'article';
-
-    const topArticle = this.props.frontpage
-      .filter(isArticle)
-      .slice(0, 1)
-      .map((item) => (
-        <div key={item.id} className={styles.innerArticle}>
-          <div className={styles.articleTitle}>
-            <h4>{truncateString(item.title, 60)}</h4>
-            <h5
-              style={{
-                whitespace: 'pre',
-              }}
-            >
-              <Time format="dd D.MM" time={item.createdAt} />
-            </h5>
-          </div>
-          <Link to={`/articles/${item.id}`}>
-            <Image src={item.cover} placeholder={item.coverPlaceholder} />
-          </Link>
-          {truncateString(item.description, 500)}
+  const topArticle = frontpage
+    .filter(isArticle)
+    .slice(0, 1)
+    .map((item) => (
+      <div key={item.id} className={styles.innerArticle}>
+        <div className={styles.articleTitle}>
+          <h4>{truncateString(item.title, 60)}</h4>
+          <h5
+            style={{
+              whitespace: 'pre',
+            }}
+          >
+            <Time format="dd D.MM" time={item.createdAt} />
+          </h5>
         </div>
-      ));
-    const title = registerUser
-      ? 'Registrer bruker'
-      : forgotPassword
-      ? 'Glemt passord'
-      : 'Logg inn';
-    const form = registerUser ? (
-      <RegisterForm />
-    ) : forgotPassword ? (
-      <ForgotPasswordForm />
-    ) : (
-      <LoginForm />
-    );
-    const [latestReadme] = this.props.readmes || [];
-    return (
-      <Container>
-        {/* <Banner
-         header="Abakusrevyen har opptak!"
-         subHeader="Søk her"
-         link="https://opptak.abakus.no"
-         color={COLORS.red}
-        /> */}
-        <Container className={styles.container}>
-          <div className={styles.welcome}>
-            <h2 className="u-mb">Velkommen til Abakus</h2>
-            <p>
-              Abakus er linjeforeningen for studentene ved <i>Datateknologi</i>{' '}
-              og
-              <i> Kommunikasjonsteknologi og digital sikkerhet</i> på NTNU, og
-              drives av studenter ved disse studiene.
-            </p>
-            <p>
-              Abakus
-              {"'"} formål er å gi disse studentene veiledning i
-              studiesituasjonen, arrangere kurs som utfyller fagtilbudet ved
-              NTNU, fremme kontakten med næringslivet og bidra med sosiale
-              aktiviteter.
-            </p>
-          </div>
-          <div className={styles.login}>
-            <Flex
-              component="h2"
-              justifyContent="space-between"
-              alignItems="center"
-              className="u-mb"
-              style={{
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {title}
-              {!(registerUser || forgotPassword) && (
-                <div>
-                  <button
-                    onClick={this.toggleForgotPassword}
-                    className={styles.toggleButton}
-                  >
-                    Glemt passord
-                  </button>
-                  <span className={styles.toggleButton}>&bull;</span>
-                  <button
-                    onClick={this.toggleRegisterUser}
-                    className={styles.toggleButton}
-                  >
-                    Jeg er ny
-                  </button>
-                </div>
-              )}
-              {(registerUser || forgotPassword) && (
-                <button
-                  onClick={this.toggleBack}
-                  className={styles.toggleButton}
-                >
-                  Tilbake
-                </button>
-              )}
-            </Flex>
-            {form}
-          </div>
-          <div className={styles.events}>
-            <CompactEvents
-              events={this.props.frontpage.filter(isEvent)}
-              frontpageHeading
+        <Link to={`/articles/${item.id}`}>
+          <Image src={item.cover} placeholder={item.coverPlaceholder} />
+        </Link>
+        {truncateString(item.description, 500)}
+      </div>
+    ));
+
+  const [latestReadme] = readmes || [];
+  return (
+    <Container>
+      {/* <Banner
+           header="Abakusrevyen har opptak!"
+           subHeader="Søk her"
+           link="https://opptak.abakus.no"
+           color={COLORS.red}
+          /> */}
+      <Container className={styles.container}>
+        <div className={styles.welcome}>
+          <h2 className="u-mb">Velkommen til Abakus</h2>
+          <p>
+            Abakus er linjeforeningen for studentene ved <i>Datateknologi</i> og
+            <i> Kommunikasjonsteknologi og digital sikkerhet</i> på NTNU, og
+            drives av studenter ved disse studiene.
+          </p>
+          <p>
+            Abakus{"'"} formål er å gi disse studentene veiledning i
+            studiesituasjonen, arrangere kurs som utfyller fagtilbudet ved NTNU,
+            fremme kontakten med næringslivet og bidra med sosiale aktiviteter.
+          </p>
+        </div>
+        <Card style={{ gridArea: 'login' }}>
+          <AuthSection />
+        </Card>
+        <div className={styles.events}>
+          <CompactEvents events={frontpage.filter(isEvent)} frontpageHeading />
+        </div>
+        <div className={styles.hsp}>
+          <a href="https://www.netcompany.com/no" target="blank">
+            <Image
+              className={styles.hspImage}
+              src={netcompany}
+              alt="NETCOMPANY"
+            />
+          </a>
+          Hovedsamarbeidspartneren vår er Netcompany. Hos Netcompany står fag,
+          innovasjon og samhold sterkt, og de er opptatt av å ta ansvar – både
+          for egne leveranser, for kundene og for sine ansatte.
+        </div>
+        <div className={styles.article}>
+          <h2 className="u-mb">Siste artikkel</h2>
+          {topArticle}
+        </div>
+        <div className={styles.readme}>
+          <h2 className="u-mb">Siste utgave av {readmeIfy('readme')} </h2>
+          <a
+            href={latestReadme && latestReadme.pdf}
+            className={styles.thumb}
+            style={{
+              display: 'block',
+            }}
+          >
+            <Image src={latestReadme && latestReadme.image} />
+          </a>
+        </div>
+        <div className={styles.links}>
+          <h2 className="u-mb">Nyttige linker</h2>
+          <ul>
+            <li>
+              <Link to="/articles/414">
+                <i className="fa fa-caret-right" /> Fadderperioden 2022
+              </Link>
+              <div className={styles.linkDescription}>
+                Informasjon om fadderperioden 2022
+              </div>
+            </li>
+            <li>
+              <a href="https://www.ntnu.no/studier/mtdt" target="blank">
+                <i className="fa fa-caret-right" /> Datateknologi
+              </a>
+              <div className={styles.linkDescription}>
+                Datateknologi er en helt sentral del av alle fremtidsrettede
+                teknologier, som for eksempel kunstig intelligens, medisinsk
+                teknologi og søkemotorteknologi.
+              </div>
+            </li>
+            <li>
+              <a href="http://www.ntnu.no/studier/mtkom" target="blank">
+                <i className="fa fa-caret-right" /> Kommunikasjonsteknologi og
+                digital sikkerhet
+              </a>
+              <div className={styles.linkDescription}>
+                Vi bruker stadig mer av livene våre på nett, på jobb som i
+                fritid. Kommunikasjonsteknologi og digital sikkerhet blir stadig
+                viktigere i en digital verden.
+              </div>
+            </li>
+            <li>
+              <Link to="/pages/bedrifter/for-bedrifter">
+                <i className="fa fa-caret-right" /> For bedrifter
+              </Link>
+              <div className={styles.linkDescription}>
+                Her finner du som bedriftsrepresentant informasjon om Abakus
+                {"' "} prosedyrer for bedriftspresentasjoner og andre nyttige
+                fakta.
+              </div>
+            </li>
+            <li>
+              <a href="https://readme.abakus.no">
+                <i className="fa fa-caret-right" /> {readmeIfy('readme')}
+              </a>
+              <div className={styles.linkDescription}>
+                Abakus har sitt eget magasin skrevet av {readmeIfy('readme')}.
+                Her kan du lese om hva abakus driver med og få et innblikk i
+                abakus som organisasjon.
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div className={styles.facebook}>
+          <h2 className="u-mb">Vår Facebook side</h2>
+          <div className={styles.facebookIframeContainer}>
+            <iframe
+              src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FAbakusNTNU%2F&amp;tabs=timeline&amp;small_header=true&amp;adapt_container_width=true&amp;hide_cover=false&amp;show_facepile=true&amp;appId=1717809791769695"
+              className={styles.facebookIframe}
+              title="facebook"
+              scrolling="no"
+              frameBorder="0"
             />
           </div>
-          <div className={styles.hsp}>
-            <a href="https://www.netcompany.com/no" target="blank">
-              <Image
-                className={styles.hspImage}
-                src={netcompany}
-                alt="NETCOMPANY"
-              />
-            </a>
-            Hovedsamarbeidspartneren vår er Netcompany. Hos Netcompany står fag,
-            innovasjon og samhold sterkt, og de er opptatt av å ta ansvar – både
-            for egne leveranser, for kundene og for sine ansatte.
-          </div>
-          <div className={styles.article}>
-            <h2 className="u-mb">Siste artikkel</h2>
-            {topArticle}
-          </div>
-          <div className={styles.readme}>
-            <h2 className="u-mb">Siste utgave av {readmeIfy('readme')} </h2>
-            <a
-              href={latestReadme && latestReadme.pdf}
-              className={styles.thumb}
-              style={{
-                display: 'block',
-              }}
-            >
-              <Image src={latestReadme && latestReadme.image} />
-            </a>
-          </div>
-          <div className={styles.links}>
-            <h2 className="u-mb">Nyttige linker</h2>
-            <ul>
-              <li>
-                <Link to="/articles/414">
-                  <i className="fa fa-caret-right" /> Fadderperioden 2022
-                </Link>
-                <div className={styles.linkDescription}>
-                  Informasjon om fadderperioden 2022
-                </div>
-              </li>
-              <li>
-                <a href="https://www.ntnu.no/studier/mtdt" target="blank">
-                  <i className="fa fa-caret-right" /> Datateknologi
-                </a>
-                <div className={styles.linkDescription}>
-                  Datateknologi er en helt sentral del av alle fremtidsrettede
-                  teknologier, som for eksempel kunstig intelligens, medisinsk
-                  teknologi og søkemotorteknologi.
-                </div>
-              </li>
-              <li>
-                <a href="http://www.ntnu.no/studier/mtkom" target="blank">
-                  <i className="fa fa-caret-right" /> Kommunikasjonsteknologi og
-                  digital sikkerhet
-                </a>
-                <div className={styles.linkDescription}>
-                  Vi bruker stadig mer av livene våre på nett, på jobb som i
-                  fritid. Kommunikasjonsteknologi og digital sikkerhet blir
-                  stadig viktigere i en digital verden.
-                </div>
-              </li>
-              <li>
-                <Link to="/pages/bedrifter/for-bedrifter">
-                  <i className="fa fa-caret-right" /> For bedrifter
-                </Link>
-                <div className={styles.linkDescription}>
-                  Her finner du som bedriftsrepresentant informasjon om Abakus
-                  {"' "}
-                  prosedyrer for bedriftspresentasjoner og andre nyttige fakta.
-                </div>
-              </li>
-              <li>
-                <a href="https://readme.abakus.no">
-                  <i className="fa fa-caret-right" /> {readmeIfy('readme')}
-                </a>
-                <div className={styles.linkDescription}>
-                  Abakus har sitt eget magasin skrevet av {readmeIfy('readme')}.
-                  Her kan du lese om hva abakus driver med og få et innblikk i
-                  abakus som organisasjon.
-                </div>
-              </li>
-            </ul>
-          </div>
-          <div className={styles.facebook}>
-            <h2 className="u-mb">Vår Facebook side</h2>
-            <div className={styles.facebookIframeContainer}>
-              <iframe
-                src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FAbakusNTNU%2F&amp;tabs=timeline&amp;small_header=true&amp;adapt_container_width=true&amp;hide_cover=false&amp;show_facepile=true&amp;appId=1717809791769695"
-                className={styles.facebookIframe}
-                title="facebook"
-                scrolling="no"
-                frameBorder="0"
-              />
-            </div>
-          </div>
-        </Container>
+        </div>
       </Container>
-    );
-  }
-}
+    </Container>
+  );
+};
 
 export default PublicFrontpage;

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -5,44 +5,38 @@ import Card from 'app/components/Card';
 import { Image } from 'app/components/Image';
 import { Container } from 'app/components/Layout';
 import { readmeIfy } from 'app/components/ReadmeLogo';
-import Time from 'app/components/Time';
-import truncateString from 'app/utils/truncateString';
+import type { Readme } from 'app/models';
+import type { WithDocumentType } from 'app/reducers/frontpage';
+import type { ArticleWithAuthorDetails } from 'app/routes/articles/ArticleListRoute';
+import { OverviewItem as Article } from 'app/routes/articles/components/Overview';
+import LatestReadme from 'app/routes/overview/components/LatestReadme';
+import type { PublicEvent } from 'app/store/models/Event';
 import CompactEvents from './CompactEvents';
 import styles from './PublicFrontpage.css';
 // import Banner, { COLORS } from 'app/components/Banner';
+
 type Props = {
-  frontpage: Array<Record<string, any>>;
-  readmes: Array<Record<string, any>>;
+  frontpage: (
+    | WithDocumentType<ArticleWithAuthorDetails>
+    | WithDocumentType<PublicEvent>
+  )[];
+  readmes: Array<Readme>;
 };
 
+const isEvent = (
+  item:
+    | WithDocumentType<ArticleWithAuthorDetails>
+    | WithDocumentType<PublicEvent>
+): item is WithDocumentType<PublicEvent> => item.documentType === 'event';
+
+const isArticle = (
+  item:
+    | WithDocumentType<ArticleWithAuthorDetails>
+    | WithDocumentType<PublicEvent>
+): item is WithDocumentType<ArticleWithAuthorDetails> =>
+  item.documentType === 'article';
+
 const PublicFrontpage = ({ frontpage, readmes }: Props) => {
-  const isEvent = (item) => item.documentType === 'event';
-
-  const isArticle = (item) => item.documentType === 'article';
-
-  const topArticle = frontpage
-    .filter(isArticle)
-    .slice(0, 1)
-    .map((item) => (
-      <div key={item.id} className={styles.innerArticle}>
-        <div className={styles.articleTitle}>
-          <h4>{truncateString(item.title, 60)}</h4>
-          <h5
-            style={{
-              whitespace: 'pre',
-            }}
-          >
-            <Time format="dd D.MM" time={item.createdAt} />
-          </h5>
-        </div>
-        <Link to={`/articles/${item.id}`}>
-          <Image src={item.cover} placeholder={item.coverPlaceholder} />
-        </Link>
-        {truncateString(item.description, 500)}
-      </div>
-    ));
-
-  const [latestReadme] = readmes || [];
   return (
     <Container>
       {/* <Banner
@@ -52,122 +46,148 @@ const PublicFrontpage = ({ frontpage, readmes }: Props) => {
            color={COLORS.red}
           /> */}
       <Container className={styles.container}>
-        <div className={styles.welcome}>
-          <h2 className="u-mb">Velkommen til Abakus</h2>
-          <p>
-            Abakus er linjeforeningen for studentene ved <i>Datateknologi</i> og
-            <i> Kommunikasjonsteknologi og digital sikkerhet</i> på NTNU, og
-            drives av studenter ved disse studiene.
-          </p>
-          <p>
-            Abakus{"'"} formål er å gi disse studentene veiledning i
-            studiesituasjonen, arrangere kurs som utfyller fagtilbudet ved NTNU,
-            fremme kontakten med næringslivet og bidra med sosiale aktiviteter.
-          </p>
-        </div>
+        <Card style={{ gridArea: 'welcome' }}>
+          <Welcome />
+        </Card>
         <Card style={{ gridArea: 'login' }}>
           <AuthSection />
         </Card>
-        <div className={styles.events}>
+        <Card style={{ gridArea: 'events' }}>
           <CompactEvents events={frontpage.filter(isEvent)} frontpageHeading />
-        </div>
-        <div className={styles.hsp}>
-          <a href="https://www.netcompany.com/no" target="blank">
-            <Image
-              className={styles.hspImage}
-              src={netcompany}
-              alt="NETCOMPANY"
-            />
-          </a>
-          Hovedsamarbeidspartneren vår er Netcompany. Hos Netcompany står fag,
-          innovasjon og samhold sterkt, og de er opptatt av å ta ansvar – både
-          for egne leveranser, for kundene og for sine ansatte.
-        </div>
-        <div className={styles.article}>
-          <h2 className="u-mb">Siste artikkel</h2>
-          {topArticle}
-        </div>
-        <div className={styles.readme}>
-          <h2 className="u-mb">Siste utgave av {readmeIfy('readme')} </h2>
-          <a
-            href={latestReadme && latestReadme.pdf}
-            className={styles.thumb}
-            style={{
-              display: 'block',
-            }}
-          >
-            <Image src={latestReadme && latestReadme.image} />
-          </a>
-        </div>
-        <div className={styles.links}>
-          <h2 className="u-mb">Nyttige linker</h2>
-          <ul>
-            <li>
-              <Link to="/articles/414">
-                <i className="fa fa-caret-right" /> Fadderperioden 2022
-              </Link>
-              <div className={styles.linkDescription}>
-                Informasjon om fadderperioden 2022
-              </div>
-            </li>
-            <li>
-              <a href="https://www.ntnu.no/studier/mtdt" target="blank">
-                <i className="fa fa-caret-right" /> Datateknologi
-              </a>
-              <div className={styles.linkDescription}>
-                Datateknologi er en helt sentral del av alle fremtidsrettede
-                teknologier, som for eksempel kunstig intelligens, medisinsk
-                teknologi og søkemotorteknologi.
-              </div>
-            </li>
-            <li>
-              <a href="http://www.ntnu.no/studier/mtkom" target="blank">
-                <i className="fa fa-caret-right" /> Kommunikasjonsteknologi og
-                digital sikkerhet
-              </a>
-              <div className={styles.linkDescription}>
-                Vi bruker stadig mer av livene våre på nett, på jobb som i
-                fritid. Kommunikasjonsteknologi og digital sikkerhet blir stadig
-                viktigere i en digital verden.
-              </div>
-            </li>
-            <li>
-              <Link to="/pages/bedrifter/for-bedrifter">
-                <i className="fa fa-caret-right" /> For bedrifter
-              </Link>
-              <div className={styles.linkDescription}>
-                Her finner du som bedriftsrepresentant informasjon om Abakus
-                {"' "} prosedyrer for bedriftspresentasjoner og andre nyttige
-                fakta.
-              </div>
-            </li>
-            <li>
-              <a href="https://readme.abakus.no">
-                <i className="fa fa-caret-right" /> {readmeIfy('readme')}
-              </a>
-              <div className={styles.linkDescription}>
-                Abakus har sitt eget magasin skrevet av {readmeIfy('readme')}.
-                Her kan du lese om hva abakus driver med og få et innblikk i
-                abakus som organisasjon.
-              </div>
-            </li>
-          </ul>
-        </div>
-        <div className={styles.facebook}>
-          <h2 className="u-mb">Vår Facebook side</h2>
-          <div className={styles.facebookIframeContainer}>
-            <iframe
-              src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FAbakusNTNU%2F&amp;tabs=timeline&amp;small_header=true&amp;adapt_container_width=true&amp;hide_cover=false&amp;show_facepile=true&amp;appId=1717809791769695"
-              className={styles.facebookIframe}
-              title="facebook"
-              scrolling="no"
-              frameBorder="0"
-            />
-          </div>
-        </div>
+        </Card>
+        <Card style={{ gridArea: 'hsp' }}>
+          <HspInfo />
+        </Card>
+        <Card style={{ gridArea: 'article' }}>
+          <LatestArticle frontpage={frontpage} />
+        </Card>
+        <LatestReadme
+          readmes={readmes}
+          expandedInitially
+          collapsible={false}
+          style={{ gridArea: 'readme' }}
+        />
+        <Card style={{ gridArea: 'links' }}>
+          <UsefulLinks />
+        </Card>
+        <Card style={{ gridArea: 'facebook' }}>
+          <Facebook />
+        </Card>
       </Container>
     </Container>
   );
 };
+
+const Welcome = () => (
+  <>
+    <h2 className="u-mb">Velkommen til Abakus</h2>
+    <p>
+      Abakus er linjeforeningen for studentene ved <i>Datateknologi</i> og
+      <i> Kommunikasjonsteknologi og digital sikkerhet</i> på NTNU, og drives av
+      studenter ved disse studiene.
+    </p>
+    <p>
+      Abakus{"'"} formål er å gi disse studentene veiledning i
+      studiesituasjonen, arrangere kurs som utfyller fagtilbudet ved NTNU,
+      fremme kontakten med næringslivet og bidra med sosiale aktiviteter.
+    </p>
+  </>
+);
+
+const HspInfo = () => (
+  <div className={styles.hsp}>
+    <h3>
+      <a href="https://www.netcompany.com/no" target="blank">
+        <Image className={styles.hspImage} src={netcompany} alt="NETCOMPANY" />
+      </a>
+    </h3>
+    Hovedsamarbeidspartneren vår er Netcompany. Hos Netcompany står fag,
+    innovasjon og samhold sterkt, og de er opptatt av å ta ansvar – både for
+    egne leveranser, for kundene og for sine ansatte.
+  </div>
+);
+
+const LatestArticle = ({ frontpage }: Pick<Props, 'frontpage'>) => (
+  <>
+    <h2 className="u-mb">Siste artikkel</h2>
+    {frontpage
+      .filter(isArticle)
+      .slice(0, 1)
+      .map((item) => (
+        <Article article={item} key={item.id} />
+      ))}
+  </>
+);
+
+const UsefulLinks = () => (
+  <>
+    <h2 className="u-mb">Nyttige lenker</h2>
+    <ul>
+      <li>
+        <Link to="/articles/414">
+          <i className="fa fa-caret-right" /> Fadderperioden 2022
+        </Link>
+        <div className={styles.linkDescription}>
+          Informasjon om fadderperioden 2022
+        </div>
+      </li>
+      <li>
+        <a href="https://www.ntnu.no/studier/mtdt" target="blank">
+          <i className="fa fa-caret-right" /> Datateknologi
+        </a>
+        <div className={styles.linkDescription}>
+          Datateknologi er en helt sentral del av alle fremtidsrettede
+          teknologier, som for eksempel kunstig intelligens, medisinsk teknologi
+          og søkemotorteknologi.
+        </div>
+      </li>
+      <li>
+        <a href="http://www.ntnu.no/studier/mtkom" target="blank">
+          <i className="fa fa-caret-right" /> Kommunikasjonsteknologi og digital
+          sikkerhet
+        </a>
+        <div className={styles.linkDescription}>
+          Vi bruker stadig mer av livene våre på nett, på jobb som i fritid.
+          Kommunikasjonsteknologi og digital sikkerhet blir stadig viktigere i
+          en digital verden.
+        </div>
+      </li>
+      <li>
+        <Link to="/pages/bedrifter/for-bedrifter">
+          <i className="fa fa-caret-right" /> For bedrifter
+        </Link>
+        <div className={styles.linkDescription}>
+          Her finner du som bedriftsrepresentant informasjon om Abakus{"' "}
+          prosedyrer for bedriftspresentasjoner og andre nyttige fakta.
+        </div>
+      </li>
+      <li>
+        <a href="https://readme.abakus.no">
+          <i className="fa fa-caret-right" /> {readmeIfy('readme')}
+        </a>
+        <div className={styles.linkDescription}>
+          Abakus har sitt eget magasin skrevet av {readmeIfy('readme')}. Her kan
+          du lese om hva abakus driver med og få et innblikk i abakus som
+          organisasjon.
+        </div>
+      </li>
+    </ul>
+  </>
+);
+
+const Facebook = () => (
+  <>
+    <h2 className="u-mb">Vår Facebook side</h2>
+    <div className={styles.facebookIframeContainer}>
+      <iframe
+        src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FAbakusNTNU%2F&amp;tabs=timeline&amp;small_header=true&amp;adapt_container_width=true&amp;hide_cover=false&amp;show_facepile=true&amp;appId=1717809791769695"
+        className={styles.facebookIframe}
+        title="facebook"
+        scrolling="no"
+        frameBorder="0"
+      />
+    </div>
+  </>
+);
 
 export default PublicFrontpage;


### PR DESCRIPTION
# Description

Refactor `PublicFrontpage` component, splitting it into smaller components and reusing shared components instead of implementing the same thing in multiple places.

Notable changes:
- Public frontpage is now only composed of functional components
- Make use of `Card` component
- Create a shared component for the login/register/forgot-password section used in frontpage, header and login-page
- Use `LatestReadme` component (from logged-in frontpage) instead of custom code on public frontpage
- Use article component from articles page on public frontpage
- Remove facebook page widget

# Result

Mostly just refactoring, but some small visual changes can be seen here:

Before:
<img width="571" alt="Screenshot 2023-04-15 at 18 34 35" src="https://user-images.githubusercontent.com/8343002/232238287-db172f7b-21b6-41b6-8d38-a3e922a59ec5.png">

After:
<img width="571" alt="Screenshot 2023-04-15 at 18 32 04" src="https://user-images.githubusercontent.com/8343002/232238166-4e8aa5df-db8d-4491-a8e8-94fc1fa2a327.png">

# Poem

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e8d8947</samp>

> _We're breaking down the walls of code_
> _Refactoring the components of doom_
> _We're simplifying the logic and UI_
> _Using `AuthSection` and `OverviewItem` to rule_

# Testing

- [x] I have thoroughly tested my changes.

The frontpage still loads, and shows the same information as before. The login forms still work on both front page, in header and on login-page.