### PR TITLE
Stop gallery modal from overflowing on mobile

### DIFF
--- a/app/routes/photos/components/GalleryPictureModal.css
+++ b/app/routes/photos/components/GalleryPictureModal.css
@@ -4,14 +4,6 @@
   padding: 0;
   width: var(--lego-max-width);
   max-height: calc(100vh - 100px);
-
-  @media (width <= 800px) {
-    position: fixed;
-    top: 0;
-    max-height: 100vh;
-    height: 100vh;
-    width: 100vw;
-  }
 }
 
 .pictureContainer {


### PR DESCRIPTION
# Description

The media query was not needed.

# Result

| Before | After |
:-----------------------:|:--------------------------:
<img width="506" alt="image" src="https://user-images.githubusercontent.com/69514187/232302546-22969cf6-faaf-4787-8e78-078d73ed235e.png"> | <img width="506" alt="image" src="https://user-images.githubusercontent.com/69514187/232302540-ef861dee-1cca-4a66-b73c-ef06693ed735.png">


# Testing

- [x] I have thoroughly tested my changes.

Tested on mobile view, as shown above.