### PR TITLE
Fix readme sizing on public frontpage

### DIFF
--- a/app/routes/overview/components/LatestReadme.tsx
+++ b/app/routes/overview/components/LatestReadme.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import { useEffect, useState } from 'react';
 import { Collapse } from 'react-collapse';
 import Card from 'app/components/Card';
@@ -14,6 +15,7 @@ type Props = {
   collapsible?: boolean;
   readmes: Array<Readme>;
   style?: CSSProperties;
+  imageClassName?: string;
 };
 
 const LatestReadme = ({
@@ -21,6 +23,7 @@ const LatestReadme = ({
   expandedInitially,
   collapsible = true,
   style,
+  imageClassName,
 }: Props) => {
   const [expanded, setExpanded] = useState(expandedInitially);
 
@@ -53,7 +56,11 @@ const LatestReadme = ({
           }}
         >
           {readmes.slice(0, 4).map(({ image, pdf, title }) => (
-            <a key={title} href={pdf} className={styles.thumb}>
+            <a
+              key={title}
+              href={pdf}
+              className={cx(styles.thumb, imageClassName)}
+            >
               <Image src={image} alt={`Cover of ${title}`} />
             </a>
           ))}

--- a/app/routes/overview/components/PublicFrontpage.css
+++ b/app/routes/overview/components/PublicFrontpage.css
@@ -65,3 +65,9 @@
 .linkDescription {
   margin-left: 30px;
 }
+
+.latestReadme {
+  min-height: 410px;
+  max-width: 330px;
+  width: 100%;
+}

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -62,6 +62,7 @@ const PublicFrontpage = ({ frontpage, readmes }: Props) => {
           <LatestArticle frontpage={frontpage} />
         </Card>
         <LatestReadme
+          imageClassName={styles.latestReadme}
           readmes={readmes}
           expandedInitially
           collapsible={false}


### PR DESCRIPTION
# Description

Fix readme sizing on public frontpage.

# Result

**before**

![image](https://user-images.githubusercontent.com/42850232/232328621-9726a227-ae17-4354-8724-8266fbda9923.png)


**after**
![image](https://user-images.githubusercontent.com/42850232/232328599-427b335f-063d-420d-8c1f-2c0061ccc925.png)


# Testing

- [x] I have thoroughly tested my changes.

Tested public and logged in pages on desktop and different mobile sizes.

---

Resolves ABA-397
