### PR TITLE
Update react-meter-bar to v2

### DIFF
--- a/app/routes/users/components/PasswordStrengthMeter.tsx
+++ b/app/routes/users/components/PasswordStrengthMeter.tsx
@@ -1,7 +1,7 @@
 import loadable from '@loadable/component';
 import Bar from '@webkom/react-meter-bar';
+import '@webkom/react-meter-bar/style.css';
 import moment from 'moment-timezone';
-import '@webkom/react-meter-bar/dist/Bar.css';
 import type { UserEntity } from 'app/reducers/users';
 import styles from './PasswordStrengthMeter.css';
 import {
@@ -84,7 +84,7 @@ const PasswordStrengthBar = ({ strengthScore }: { strengthScore: number }) => {
         labelColor="#000"
         progress={strengthScore * 25}
         barColor={barColor[strengthScore]}
-        seperatorColor="#fff"
+        separatorColor="#fff"
       />
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@stripe/react-stripe-js": "^1.14.2",
     "@stripe/stripe-js": "^1.46.0",
     "@webkom/lego-editor": "^2.1.0",
-    "@webkom/react-meter-bar": "^1.0.3",
+    "@webkom/react-meter-bar": "^2.0.0",
     "@webkom/react-prepare": "^1.0.0",
     "animate.css": "^4.1.1",
     "buffer": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2804,13 +2804,10 @@
     slate-hyperscript "^0.77.0"
     slate-react "^0.82.0"
 
-"@webkom/react-meter-bar@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@webkom/react-meter-bar/-/react-meter-bar-1.0.3.tgz#cf21ac7ae4f9524fe84567e1d5929082968641eb"
-  integrity sha512-tF5Ohd5MoyKSAK4xj6ekV4tmprNoPCdXsL6+6GoyC/89vjDCXsz46+xUKebDvWnvTy/TJ/d3LrLpZ/b5o6o/ow==
-  dependencies:
-    react "^16.4.0"
-    react-dom "^16.4.0"
+"@webkom/react-meter-bar@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@webkom/react-meter-bar/-/react-meter-bar-2.0.0.tgz#edfde3fbb2d93ded384bcd81acb56473a1994ea8"
+  integrity sha512-eWyr1qcKIwmsMwm4oaUez7qUpEQl9u2r94k3myZS31eeSyJ0nxa+bDhc8lKFXXXzR6BWq+q9tDktvQAjJtggZQ==
 
 "@webkom/react-prepare@^1.0.0":
   version "1.0.0"
@@ -9000,16 +8997,6 @@ react-cropper@^2.3.3:
   dependencies:
     cropperjs "^1.5.13"
 
-react-dom@^16.4.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -9342,15 +9329,6 @@ react-youtube@^10.1.0:
     fast-deep-equal "3.1.3"
     prop-types "15.8.1"
     youtube-player "5.5.2"
-
-react@^16.4.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
# Description

Use the new version of react-meter-bar I just merged here: https://github.com/webkom/react-meter-bar/pull/2

# Result

We no longer install React 16, as the peer-dependency in react-meter-bar is updated to support React 18. We also get the new typescript types for react-meter-bar.

# Testing

- [x] I have thoroughly tested my changes.

The meter bar component still works.
---

Resolves ABA-398
