### PR TITLE
Add tooltip explaining anonymous attendees events

### DIFF
--- a/app/components/UserAttendance/AttendanceStatus.tsx
+++ b/app/components/UserAttendance/AttendanceStatus.tsx
@@ -1,5 +1,6 @@
 import Button from 'app/components/Button';
 import Flex from 'app/components/Layout/Flex';
+import Tooltip from 'app/components/Tooltip';
 import styles from './AttendanceStatus.css';
 import withModal from './withModal';
 import type { Pool } from './AttendanceModal';
@@ -65,10 +66,12 @@ const AttendanceStatus = ({
       ))}
       {!!legacyRegistrationCount && (
         <div className={styles.poolBox}>
-          <strong>Anonyme</strong>
-          <strong>
-            <p>{`${legacyRegistrationCount}/∞`}</p>
-          </strong>
+          <Tooltip content="Disse brukerne har blitt slettet etter de deltok på arrangementet">
+            <strong>Anonyme</strong>
+            <strong>
+              <p>{`${legacyRegistrationCount}/∞`}</p>
+            </strong>
+          </Tooltip>
         </div>
       )}
     </div>


### PR DESCRIPTION
# Description

For the overview of registrations on events we add an anonymous pool when a registered user has been deleted (so that one can get accurate numbers for registrations for old events without breaking any GDPR rules). This PR just adds a tooltip explaing that this anonymous pool represents deleted users.

# Result
Before (when hovering over the anonymoys-text):
*Exactly the same as after, just without the tooltip*

After (when hovering over the anonymoys-text):
![image](https://user-images.githubusercontent.com/69513864/232870399-4177eb43-6e14-4646-8bfc-4968df0d72d2.png)


# Testing

- [ x] I have thoroughly tested my changes.

---

Resolves ABA-404
