### PR TITLE
Fix big readme style on public frontpage

### DIFF
--- a/app/routes/overview/components/LatestReadme.css
+++ b/app/routes/overview/components/LatestReadme.css
@@ -11,7 +11,6 @@
 }
 
 .thumb {
-  width: 150px;
   height: 200px;
   transition: transform var(--easing-medium);
   display: block;

--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -45,6 +45,10 @@
   }
 }
 
+.smallReadme {
+  width: 150px;
+}
+
 .showMore {
   display: flex;
   justify-content: center;

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -87,6 +87,7 @@ const Overview = (props: Props) => {
   const readMe = (
     <Flex className={styles.readMe}>
       <LatestReadme
+        imageClassName={styles.smallReadme}
         readmes={readmes}
         expandedInitially={frontpage.length === 0 && !fetchingFrontpage}
       />


### PR DESCRIPTION
# Description

Fixes the styling of the large readme on the frontpage

# Result

By moving the style to a new class smallReadme, now looks as in #3794 

# Testing

- [x] I have thoroughly tested my changes.


---

Resolves ABA-419
