### PR TITLE
Temporarily disable event slug rerouting

### DIFF
--- a/app/routes/events/EventDetailRoute.ts
+++ b/app/routes/events/EventDetailRoute.ts
@@ -42,9 +42,12 @@ const mapStateToProps = (state, props) => {
     ? selectEventById(state, { eventId: eventIdOrSlug })
     : selectEventBySlug(state, { eventSlug: eventIdOrSlug });
 
-  if (event && event.slug && eventIdOrSlug !== event.slug) {
+  /*
+    * FIXME: This produces an insane amount of location change events for some reason
+  if (event?.slug && eventIdOrSlug !== event.slug) {
     props.history.replace(`/events/${event.slug}`);
   }
+  */
 
   const eventId = event.id;
 


### PR DESCRIPTION
It causes big issues with loading. For some reason the history
replacement produces hundreds of LOCATION.CHANGE events.

# Description

Please write a summary of the changes, and please include relevant motivation and context. Remember to label your pull request properly; e.g. **bug-fix**, **new-feature** or **docs**.

# Result

If you've made visual changes, please include **before** and **after** images, preferably with a description. Make sure they do not contain any real user information.

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
