### PR TITLE
Fix crash on survey results page

### DIFF
--- a/app/routes/surveys/SubmissionsRoute.ts
+++ b/app/routes/surveys/SubmissionsRoute.ts
@@ -18,11 +18,13 @@ import {
 import { LoginPage } from 'app/components/LoginForm';
 import { selectSurveySubmissions } from 'app/reducers/surveySubmissions';
 import { selectSurveyById } from 'app/reducers/surveys';
+import type { RootState } from 'app/store/createRootReducer';
 import loadingIndicator from 'app/utils/loadingIndicator';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import SubmissionPage from './components/Submissions/SubmissionPage';
 import { getCsvUrl } from './utils';
+import type { RouteChildrenProps } from 'react-router';
 
 const loadData = (props, dispatch) => {
   const { surveyId } = props.match.params;
@@ -32,7 +34,10 @@ const loadData = (props, dispatch) => {
   ]);
 };
 
-const mapStateToProps = (state, props) => {
+const mapStateToProps = (
+  state: RootState,
+  props: RouteChildrenProps<{ surveyId: string }>
+) => {
   const surveyId = Number(props.match.params.surveyId);
   const locationStrings = props.location.pathname.split('/');
   const isSummary =

--- a/app/routes/surveys/components/AdminSideBar.tsx
+++ b/app/routes/surveys/components/AdminSideBar.tsx
@@ -1,4 +1,3 @@
-import cx from 'classnames';
 import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
@@ -7,15 +6,15 @@ import { CheckBox } from 'app/components/Form';
 import Icon from 'app/components/Icon';
 import config from 'app/config';
 import type { ActionGrant } from 'app/models';
-import styles from './surveys.css';
+import type { ID } from 'app/store/models';
 
 type Props = {
-  surveyId: number;
+  surveyId: ID;
   actionGrant: ActionGrant;
   token?: string;
-  shareSurvey: (arg0: number) => Promise<any>;
-  hideSurvey: (arg0: number) => Promise<any>;
-  exportSurvey?: (arg0: number) => Promise<any>;
+  shareSurvey: (id: ID) => Promise<void>;
+  hideSurvey: (id: ID) => Promise<void>;
+  exportSurvey?: (id: ID) => Promise<void>;
 };
 type State = {
   copied: boolean;

--- a/app/routes/surveys/components/Submissions/SubmissionPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionPage.tsx
@@ -1,24 +1,24 @@
-import { cloneElement } from 'react';
 import { Link } from 'react-router-dom';
 import { Content, ContentSection, ContentMain } from 'app/components/Content';
 import type { ActionGrant } from 'app/models';
 import type { SubmissionEntity } from 'app/reducers/surveySubmissions';
 import type { SurveyEntity } from 'app/reducers/surveys';
+import type { ID } from 'app/store/models';
 import { DetailNavigation } from '../../utils';
 import AdminSideBar from '../AdminSideBar';
 import styles from '../surveys.css';
-import type { Element } from 'react';
+import type { ReactNode } from 'react';
 
 type Props = {
   submissions: Array<SubmissionEntity>;
-  addSubmission: (arg0: SubmissionEntity) => Promise<any>;
+  addSubmission: (submission: SubmissionEntity) => Promise<void>;
   survey: SurveyEntity;
-  children: Array<Element<any>>;
+  children: (props: Omit<Props, 'children'>) => ReactNode;
   actionGrant: ActionGrant;
   isSummary: boolean;
-  shareSurvey: (arg0: number) => Promise<any>;
-  hideSurvey: (arg0: number) => Promise<any>;
-  exportSurvey: (arg0: number) => Promise<any>;
+  shareSurvey: (id: ID) => Promise<void>;
+  hideSurvey: (id: ID) => Promise<void>;
+  exportSurvey: (id: ID) => Promise<void>;
 };
 
 const SubmissionPage = (props: Props) => {
@@ -31,7 +31,7 @@ const SubmissionPage = (props: Props) => {
     exportSurvey,
   } = props;
   return (
-    <Content className={styles.surveyDetail} banner={survey.event.cover}>
+    <Content banner={survey.event.cover}>
       <DetailNavigation title={survey.title} surveyId={Number(survey.id)} />
 
       <ContentSection>
@@ -52,9 +52,7 @@ const SubmissionPage = (props: Props) => {
             </Link>
           </div>
 
-          {props.children.map((child, i) =>
-            cloneElement(child, { ...props, children: undefined })
-          )}
+          {props.children(props)}
         </ContentMain>
 
         <AdminSideBar

--- a/app/routes/surveys/index.tsx
+++ b/app/routes/surveys/index.tsx
@@ -87,24 +87,30 @@ const surveysRoute = ({
                 location,
               }}
             >
-              <RouteWrapper
-                exact
-                path={`${match.path}/summary`}
-                passedProps={{
-                  currentUser,
-                  loggedIn,
-                }}
-                Component={SubmissionSummary}
-              />
-              <RouteWrapper
-                exact
-                path={`${match.path}/individual`}
-                passedProps={{
-                  currentUser,
-                  loggedIn,
-                }}
-                Component={SubmissionIndividual}
-              />
+              {(props) => (
+                <>
+                  <RouteWrapper
+                    exact
+                    path={`${match.path}/summary`}
+                    passedProps={{
+                      currentUser,
+                      loggedIn,
+                      ...props,
+                    }}
+                    Component={SubmissionSummary}
+                  />
+                  <RouteWrapper
+                    exact
+                    path={`${match.path}/individual`}
+                    passedProps={{
+                      currentUser,
+                      loggedIn,
+                      ...props,
+                    }}
+                    Component={SubmissionIndividual}
+                  />
+                </>
+              )}
             </SubmissionsRoute>
           )}
         </Route>


### PR DESCRIPTION
# Description

The exact same problem as in this PR: https://github.com/webkom/lego-webapp/pull/3803

# Result

It no longer crashes.

Before:
![Screenshot 2023-04-23 at 14 14 19](https://user-images.githubusercontent.com/8343002/233839196-b6460061-9d52-437d-9266-60cac326968c.png)

After:
![Screenshot 2023-04-23 at 14 14 01](https://user-images.githubusercontent.com/8343002/233839174-758c1bad-f347-4bbe-bc79-e8b8fbd20fa1.png)

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-425
