### PR TITLE
Link to arrangementskalender page from checkbox

### DIFF
--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
 import { Field, FieldArray } from 'redux-form';
 import {
   Content,
@@ -566,10 +567,28 @@ function EventEditor({
             style={{
               marginLeft: '3px',
             }}
-            content="Jeg er kjent med at jeg kun kan bruke rettighetene mine til å opprette abakusarrangement som er i tråd med arrangementskalenderen og Abakus sine blesteregler, og at jeg må ta kontakt med hs@abakus.no dersom jeg er usikker eller ønsker å opprette et annet/eksternt arrangement."
+            content={
+              <>
+                Jeg er kjent med at jeg kun kan bruke rettighetene mine til å
+                opprette et Abakusarrangement som er i tråd med{' '}
+                <Link to="/pages/arrangementer/86-arrangementskalender">
+                  arrangementskalenderen
+                </Link>{' '}
+                og Abakus sine blesteregler, og at jeg må ta kontakt med{' '}
+                <a href="mailto:hs@abakus.no">hs@abakus.no</a> dersom jeg er
+                usikker eller ønsker å opprette et annet/eksternt arrangement.
+              </>
+            }
           >
             <Field
-              label="Arrangementet er avklart i arrangementskalenderen"
+              label={
+                <>
+                  Arrangementet er avklart i{' '}
+                  <Link to="/pages/arrangementer/86-arrangementskalender">
+                    arrangementskalenderen
+                  </Link>
+                </>
+              }
               name="isClarified"
               component={CheckBox.Field}
               fieldClassName={styles.metaFieldInformation}


### PR DESCRIPTION
# Description
Link to the [arrangementskalender](https://abakus.no/pages/arrangementer/86-arrangementskalender) page from checkbox in `EventEditor` for easy access. Links are added both in the label and tooltip.

# Result
**Before**
![image](https://user-images.githubusercontent.com/43182025/233842199-668091dd-784b-4f0d-9a9b-929441a836fe.png)

**After**
![image](https://user-images.githubusercontent.com/43182025/233842220-b07d47d9-d6e6-44dc-a341-96186eb493f2.png)

**Before**
![image](https://user-images.githubusercontent.com/43182025/233842230-7ff4c394-ccc4-43b6-8a46-b9d995141d5c.png)

**After**
![image](https://user-images.githubusercontent.com/43182025/233842250-a98a14b6-a40e-41a0-a417-668b15f2db54.png)

# Testing

- [x] I have thoroughly tested my changes.

Clicked the links and created an event just to be sure, even though the only changes are in the label and tooltip.

---

Resolves ABA-383
