### PR TITLE
Extend Icon component with more props

### DIFF
--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -74,20 +74,12 @@ type TimeStampProps = {
 const TimeStamp = ({ event }: TimeStampProps) => {
   return (
     <div className={styles.eventTime}>
-      <Flex alignItems="center">
-        <Icon
-          name="calendar-number-outline"
-          size={20}
-          style={{ cursor: 'pointer', marginRight: '10px' }}
-        />
+      <Flex alignItems="center" gap={10}>
+        <Icon name="calendar-number-outline" size={20} />
         <Time time={event.startTime} format="ll" />
       </Flex>
-      <Flex alignItems="center">
-        <Icon
-          name="time-outline"
-          size={20}
-          style={{ cursor: 'pointer', marginRight: '10px' }}
-        />
+      <Flex alignItems="center" gap={10}>
+        <Icon name="time-outline" size={20} />
         <Time time={event.startTime} format="HH:mm" />
       </Flex>
     </div>
@@ -102,7 +94,7 @@ const RegistrationIcon = ({ event }: TimeStampProps) => {
         <Icon
           name={iconStyle.icon}
           size={23}
-          style={{ cursor: 'pointer', color: iconStyle.color }}
+          style={{ color: iconStyle.color }}
         />
       </Tooltip>
     </Flex>

--- a/app/components/Icon/Icon.css
+++ b/app/components/Icon/Icon.css
@@ -11,3 +11,42 @@
   opacity: 0.9;
   z-index: 1;
 }
+
+.danger {
+  color: var(--danger-color);
+  transition: color var(--easing-fast);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-red-7);
+  }
+}
+
+.success {
+  color: var(--color-green-6);
+  transition: color var(--easing-fast);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-green-7);
+  }
+}
+
+.edit {
+  color: var(--color-orange-6);
+  transition: color var(--easing-fast);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-orange-7);
+  }
+}
+
+.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+
+  &:hover {
+    color: var(--color-orange-6);
+  }
+}

--- a/app/components/Icon/index.tsx
+++ b/app/components/Icon/index.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import { Flex } from 'app/components/Layout';
 import styles from './Icon.css';
 import type { ComponentProps } from 'react';
@@ -8,6 +9,10 @@ type Props = {
   scaleOnHover?: boolean;
   className?: string;
   size?: number;
+  danger?: boolean; // name: trash
+  success?: boolean; // name: checkmark
+  edit?: boolean; // name: pencil
+  disabled?: boolean;
 } & ComponentProps<typeof Flex>;
 
 /**
@@ -24,11 +29,21 @@ const Icon = ({
   className,
   style = {},
   size = 24,
+  danger = false,
+  success = false,
+  edit = false,
+  disabled = false,
   ...props
 }: Props) => {
   return (
     <Flex
-      className={className}
+      className={cx(
+        className,
+        danger && styles.danger,
+        success && styles.success,
+        edit && styles.edit,
+        disabled && styles.disabled
+      )}
       style={{
         fontSize: `${size.toString()}px`,
         ...style,

--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -65,12 +65,7 @@ const FilePreview = ({ file, onRemove }: FilePreviewProps) => {
     >
       <img alt="preview" className={styles.previewImage} src={previewUrl} />
       <div className={styles.fileName}>{file.name}</div>
-      <Icon
-        onClick={onRemove}
-        name="trash"
-        size={28}
-        className={styles.removeIcon}
-      />
+      <Icon onClick={onRemove} name="trash" danger />
     </Flex>
   );
 };

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -90,13 +90,3 @@
   font-size: 14px;
   font-weight: 500;
 }
-
-.removeIcon {
-  cursor: pointer;
-  color: var(--danger-color);
-  transition: color var(--easing-fast);
-
-  &:hover {
-    color: var(--color-red-7);
-  }
-}

--- a/app/components/UserValidator/Validator.css
+++ b/app/components/UserValidator/Validator.css
@@ -37,11 +37,6 @@
   margin-right: 0.2rem;
 }
 
-.overlay i {
-  font-size: 10em;
-  color: var(--color-green-6);
-}
-
 .shown {
   visibility: visible;
   opacity: 1;

--- a/app/components/UserValidator/index.tsx
+++ b/app/components/UserValidator/index.tsx
@@ -105,7 +105,7 @@ const Validator = (props: Props) => {
             😀
           </span>
         </h3>
-        <i className="fa fa-check" />
+        <Icon name="checkmark" success size={160} />
       </div>
       <Modal
         contentClassName={styles.scannerModal}

--- a/app/routes/admin/groups/components/GroupMembersList.css
+++ b/app/routes/admin/groups/components/GroupMembersList.css
@@ -4,32 +4,3 @@
   to change the role of the users at the bottom */
   padding-bottom: 300px;
 }
-
-.editIcon {
-  cursor: pointer;
-  color: var(--color-orange-6);
-  transition: color var(--easing-fast);
-
-  &:hover {
-    color: var(--color-orange-7);
-  }
-}
-
-.removeIcon {
-  cursor: pointer;
-  color: var(--danger-color);
-  transition: color var(--easing-fast);
-
-  &:hover {
-    color: var(--color-red-7);
-  }
-}
-
-.disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-
-  &:hover {
-    color: var(--color-orange-6);
-  }
-}

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -126,7 +126,8 @@ const GroupMembersList = ({
           <Icon
             name="pencil"
             size={20}
-            className={cx(styles.editIcon, isCurrentUser && styles.disabled)}
+            edit
+            disabled={isCurrentUser}
             onClick={() =>
               !isCurrentUser &&
               setMembershipsInEditMode((prev) => ({
@@ -141,7 +142,7 @@ const GroupMembersList = ({
           message={`Er du sikker på at du vil melde ut "${user.fullName}" fra gruppen "${groupsById[abakusGroup].name}"?`}
           onConfirm={() => removeMember(membership)}
         >
-          <Icon name="trash" size={20} className={styles.removeIcon} />
+          <Icon name="trash" size={20} danger />
         </ConfirmModalWithParent>
       </Flex>
     );

--- a/app/routes/admin/groups/components/GroupPermissions.tsx
+++ b/app/routes/admin/groups/components/GroupPermissions.tsx
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { compose } from 'redux';
 import { editGroup } from 'app/actions/GroupActions';
+import Icon from 'app/components/Icon';
+import { Flex } from 'app/components/Layout';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import type { ID } from 'app/models';
 import loadingIndicator from 'app/utils/loadingIndicator';
@@ -88,15 +90,19 @@ const PermissionList = ({
         {permissions.length ? (
           permissions.map((permission) => (
             <li key={permission}>
-              <ConfirmModalWithParent
-                title="Bekreft fjerning av rettighet"
-                message={`Er du sikker på at du vil fjerne tilgangen ${permission}?`}
-                closeOnConfirm={true}
-                onConfirm={() => removePermission(permission, group, editGroup)}
-              >
-                <i className={`fa fa-times`} />
-              </ConfirmModalWithParent>
-              {permission}
+              <Flex>
+                <ConfirmModalWithParent
+                  title="Bekreft fjerning av rettighet"
+                  message={`Er du sikker på at du vil fjerne tilgangen ${permission}?`}
+                  closeOnConfirm={true}
+                  onConfirm={() =>
+                    removePermission(permission, group, editGroup)
+                  }
+                >
+                  <Icon name="trash" danger />
+                </ConfirmModalWithParent>
+                {permission}
+              </Flex>
             </li>
           ))
         ) : (

--- a/app/routes/bdb/components/BdbDetail.tsx
+++ b/app/routes/bdb/components/BdbDetail.tsx
@@ -4,8 +4,10 @@ import { Link } from 'react-router-dom';
 import Button from 'app/components/Button';
 import CommentView from 'app/components/Comments/CommentView';
 import { Content } from 'app/components/Content';
+import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import InfoBubble from 'app/components/InfoBubble';
+import { Flex } from 'app/components/Layout';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import Time from 'app/components/Time';
@@ -203,13 +205,7 @@ export default class BdbDetail extends Component<Props, State> {
                       contact.id
                     )}`}
                   >
-                    <i
-                      className="fa fa-pencil"
-                      style={{
-                        marginRight: '5px',
-                        color: 'orange',
-                      }}
-                    />
+                    <Icon name="pencil" edit size={20} />
                   </Link>
                   <ConfirmModalWithParent
                     title="Slett bedriftskontakt"
@@ -217,14 +213,7 @@ export default class BdbDetail extends Component<Props, State> {
                     onConfirm={() => this.deleteCompanyContact(contact.id)}
                     closeOnConfirm
                   >
-                    <i
-                      className="fa fa-times"
-                      style={{
-                        color: '#d13c32',
-                        position: 'relative',
-                        top: '5px',
-                      }}
-                    />
+                    <Icon name="trash" danger size={20} />
                   </ConfirmModalWithParent>
                 </span>
               </div>
@@ -266,7 +255,7 @@ export default class BdbDetail extends Component<Props, State> {
           </tr>
         ));
     const title = (
-      <span>
+      <Flex alignItems="center" gap={5}>
         {company.name}
         {!company.active && (
           <span
@@ -279,16 +268,9 @@ export default class BdbDetail extends Component<Props, State> {
           </span>
         )}
         <Link to={`/bdb/${company.id}/edit`}>
-          <i
-            className="fa fa-pencil"
-            style={{
-              marginLeft: '15px',
-              color: 'orange',
-              fontSize: '20px',
-            }}
-          />
+          <Icon name="pencil" edit size={20} />
         </Link>
-      </span>
+      </Flex>
     );
     return (
       <Content>

--- a/app/routes/bdb/components/SemesterStatusContent.tsx
+++ b/app/routes/bdb/components/SemesterStatusContent.tsx
@@ -3,6 +3,7 @@ import { Component } from 'react';
 import Button from 'app/components/Button';
 import Dropdown from 'app/components/Dropdown';
 import Icon from 'app/components/Icon';
+import { Flex } from 'app/components/Layout';
 import type { CompanySemesterContactedStatus } from 'app/models';
 import {
   sortStatusesByProminence,
@@ -52,29 +53,11 @@ export default class SemesterStatusContent extends Component<Props, State> {
         {statusCodes.map((statusString, j) => (
           <Dropdown.ListItem key={j} className={styles.dropDownItem}>
             <Button flat onClick={(e) => editFunction(statusString)}>
-              <div>
-                {semesterStatus.contactedStatus.indexOf(statusString) !== -1 ? (
-                  <Icon
-                    name="checkmark"
-                    style={{
-                      color: 'var(--color-green-6)',
-                      marginRight: '5px',
-                      position: 'relative',
-                      top: '5px',
-                    }}
-                    size={25}
-                  />
-                ) : (
-                  <div
-                    style={{
-                      width: '10px',
-                      height: '1px',
-                      display: 'inline-block',
-                    }}
-                  />
-                )}
+              <Flex>
                 {getStatusString(statusString)}
-              </div>
+                {semesterStatus.contactedStatus.indexOf(statusString) !==
+                  -1 && <Icon name="checkmark" success size={25} />}
+              </Flex>
               <div
                 className={cx(
                   styles[selectColorCode(statusString)],

--- a/app/routes/bdb/components/SemesterStatusDetail.tsx
+++ b/app/routes/bdb/components/SemesterStatusDetail.tsx
@@ -1,6 +1,6 @@
-import cx from 'classnames';
 import { Component } from 'react';
 import Button from 'app/components/Button';
+import Icon from 'app/components/Icon';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import { ConfirmModalWithParent } from 'app/components/Modal/ConfirmModal';
 import FileUpload from 'app/components/Upload/FileUpload';
@@ -119,13 +119,7 @@ export default class SemesterStatusDetail extends Component<Props, State> {
                 }))
               }
             >
-              <i
-                className="fa fa-pencil"
-                style={{
-                  marginRight: '5px',
-                  color: 'orange',
-                }}
-              />
+              <Icon name="pencil" edit size={20} />
             </Button>
             <ConfirmModalWithParent
               title="Slett semesterstatus"
@@ -133,7 +127,7 @@ export default class SemesterStatusDetail extends Component<Props, State> {
               onConfirm={this.deleteSemesterStatus}
               closeOnConfirm
             >
-              <i className={cx('fa fa-times', styles.deleteIcon)} />
+              <Icon name="trash" danger size={20} />
             </ConfirmModalWithParent>
           </span>
         </td>
@@ -179,12 +173,7 @@ const RenderFile = (props: RenderFileProps) => {
           onConfirm={() => removeFile(type)}
           closeOnConfirm
         >
-          <i
-            className="fa fa-times"
-            style={{
-              color: '#d13c32',
-            }}
-          />
+          <Icon name="trash" danger />
         </ConfirmModalWithParent>
       </span>
     );

--- a/app/routes/bdb/components/bdb.css
+++ b/app/routes/bdb/components/bdb.css
@@ -173,14 +173,6 @@
   }
 }
 
-.deleteIcon {
-  color: var(--danger-color);
-
-  &:hover {
-    cursor: pointer;
-  }
-}
-
 .showAscending .upArrow,
 .showDescending .downArrow {
   display: block !important;

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -61,7 +61,7 @@ const renderOptions = ({ fields }: any): ReactNode => (
             className={styles.deleteOption}
           >
             <Tooltip content="Fjern">
-              <Icon name="trash" className={styles.deleteOption} />
+              <Icon name="trash" danger />
             </Tooltip>
           </ConfirmModalWithParent>
         </li>

--- a/app/routes/surveys/components/SurveyEditor/Question.tsx
+++ b/app/routes/surveys/components/SurveyEditor/Question.tsx
@@ -162,7 +162,7 @@ const Question = ({
             closeOnConfirm
             className={styles.deleteQuestion}
           >
-            <Icon name="trash" />
+            <Icon name="trash" danger />
           </ConfirmModalWithParent>
         </div>
       </div>

--- a/app/routes/users/components/UserSettingsOAuth2.css
+++ b/app/routes/users/components/UserSettingsOAuth2.css
@@ -1,18 +1,3 @@
 .copyIcon {
   cursor: pointer;
 }
-
-.copied {
-  color: var(--color-green-6);
-}
-
-.deleteIcon {
-  justify-content: center;
-  cursor: pointer;
-  color: var(--danger-color);
-  transition: color var(--easing-fast);
-
-  &:hover {
-    color: var(--color-red-7);
-  }
-}

--- a/app/routes/users/components/UserSettingsOAuth2.tsx
+++ b/app/routes/users/components/UserSettingsOAuth2.tsx
@@ -1,4 +1,3 @@
-import cx from 'classnames';
 import keys from 'lodash/keys';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -51,7 +50,8 @@ const UserSettingsOAuth2 = (props: Props) => {
               <Icon
                 name={copied ? 'copy' : 'copy-outline'}
                 size={20}
-                className={cx(styles.copyIcon, copied && styles.copied)}
+                success={copied}
+                className={styles.copyIcon}
                 onClick={() => {
                   navigator.clipboard.writeText(application.clientId);
                   setCopiedClientId(application.clientId);
@@ -98,11 +98,9 @@ const UserSettingsOAuth2 = (props: Props) => {
           closeOnCancel
         >
           <Tooltip content="Fjern" style={{ marginTop: '-7px' }}>
-            <Icon
-              name="trash-outline"
-              size={18}
-              className={styles.deleteIcon}
-            />
+            <Flex justifyContent="center">
+              <Icon name="trash" size={19} danger />
+            </Flex>
           </Tooltip>
         </ConfirmModalWithParent>
       ),


### PR DESCRIPTION
# Description
There is a lot of custom styling for different looks of icons. Now we have the option of using the danger, edit or success prop, which adds common styling for the icons with this prop.

# Result
Mostly, the changes are not visual except some changes of sizes and the fact that the icons in FontAwesome and IonIcons are different. Some of the visual changes are provided below, but check out the branch if you want to see them all, or let me know in the comments.

The following change affects Abacard:
**Before**
![image](https://user-images.githubusercontent.com/43182025/233861276-f918873a-f34e-4a5b-a025-3ade1d628fec.png)

**After**
![image](https://user-images.githubusercontent.com/43182025/233861250-a7ab14d1-3e66-430b-ae39-8f71ab3348dc.png)

**Before**
![image](https://user-images.githubusercontent.com/43182025/233861544-35a6e0d1-f8e1-4f04-a4aa-cb8c5dcb2876.png)

**After**
![image](https://user-images.githubusercontent.com/43182025/233861511-f88c79a9-9d7d-45e1-b602-0c27d9c756d3.png)

Examples of changes because of the icon library used:
**Before**
![image](https://user-images.githubusercontent.com/43182025/233861415-db32a9d4-5cb6-4fee-9bbc-cd5a7940338f.png)

**After**
![image](https://user-images.githubusercontent.com/43182025/233861395-3badf379-238a-42fe-894c-cd09b17ab27a.png)

**Before**
![image](https://user-images.githubusercontent.com/43182025/233861979-c98e6fdc-c163-4d9e-b0b1-0913d7d98078.png)

**After**
![image](https://user-images.githubusercontent.com/43182025/233943004-58358fea-d89a-493e-b3eb-61e2a3d3543b.png)

This pencil icon is not the nicest imo., but the only other possible option I find on IonIcons is this one:
![image](https://user-images.githubusercontent.com/43182025/233861948-11a9b18c-1f04-4d01-b3d5-b5552f92736c.png)



# Testing

- [x] I have thoroughly tested my changes.

I have visually compared all the changes with prod.
---

Resolves ABA-367
