### PR TITLE
Move meeting end when setting start time after end

### DIFF
--- a/app/routes/meetings/MeetingCreateRoute.ts
+++ b/app/routes/meetings/MeetingCreateRoute.ts
@@ -26,8 +26,8 @@ const mapStateToProps = (state, props) => {
   return {
     user: props.currentUser,
     initialValues: {
-      startTime: time(17, 15),
-      endTime: time(20),
+      startTime: time(16, 15),
+      endTime: time(18),
       report: EDITOR_EMPTY,
       useMazemap: true,
     },

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -1,5 +1,6 @@
 import { unionBy } from 'lodash';
-import { Field } from 'react-final-form';
+import moment from 'moment-timezone';
+import { Field, FormSpy } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { useHistory } from 'react-router-dom';
 import { Content } from 'app/components/Content';
@@ -162,7 +163,7 @@ const MeetingEditor = ({
         validate={validate}
         subscription={{}}
       >
-        {({ handleSubmit }) => {
+        {({ handleSubmit, form }) => {
           return (
             <Form onSubmit={handleSubmit}>
               <Field
@@ -183,6 +184,23 @@ const MeetingEditor = ({
                 component={TextArea.Field}
               />
               <div className={styles.sideBySideBoxes}>
+                <FormSpy
+                  subscription={{ values: true }}
+                  onChange={({ values }) => {
+                    const startTime = moment(values.startTime);
+                    const endTime = moment(values.endTime);
+                    if (endTime.isBefore(startTime)) {
+                      form.change(
+                        'endTime',
+                        startTime
+                          .clone()
+                          .add(1, 'hour')
+                          .add(45, 'minutes')
+                          .toISOString()
+                      );
+                    }
+                  }}
+                />
                 <Field
                   name="startTime"
                   label="Starttidspunkt"

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -46,10 +46,10 @@ describe('Create meeting', () => {
     fieldError('endTime').should('not.exist');
     fieldError('description').should('not.exist');
 
-    setDatePickerTime('startTime', '20', '00');
     setDatePickerTime('endTime', '19', '30');
+    setDatePickerTime('startTime', '20', '00');
 
-    fieldError('endTime').should('be.visible');
+    fieldError('endTime').should('not.exist');
 
     setDatePickerTime('endTime', '20', '30');
 


### PR DESCRIPTION
# Description

When creating a new meeting one often have to set the date multiple times, both for the end time field and start time field. This commit changes the form to work similar to a lot of other meeting forms in changing the end time if one moves the start time past the end time. Also changes the default time to something more probable.


# Result
![Peek 2023-04-25 20-12](https://user-images.githubusercontent.com/7977650/234365391-7ac65a6e-ab6d-452a-9fa2-8c3b0488969f.gif)


# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-438
