### PR TITLE
Add slugs to joblistings and articles and use them in common places

### DIFF
--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -122,7 +122,7 @@ const EventItem = ({
           className={styles.eventItem}
         >
           <div>
-            <Link to={`/events/${event.id}`}>
+            <Link to={`/events/${event.slug}`}>
               <h4 className={styles.eventItemTitle}>{event.title}</h4>
             </Link>
             <Time
@@ -149,7 +149,7 @@ const EventItem = ({
           className={styles.eventItemCompact}
         >
           <Flex width="100%">
-            <Link to={`/events/${event.id}`}>
+            <Link to={`/events/${event.slug}`}>
               <h3 className={styles.eventItemTitle}>{event.title}</h3>
             </Link>
           </Flex>
@@ -157,7 +157,7 @@ const EventItem = ({
             <Flex width="72%">
               <Flex className={styles.companyLogoCompact}>
                 {event.cover && (
-                  <Link to={`/events/${event.id}`}>
+                  <Link to={`/events/${event.slug}`}>
                     <Image
                       src={event.cover}
                       placeholder={event.coverPlaceholder}
@@ -195,7 +195,7 @@ const EventItem = ({
           className={styles.eventItem}
         >
           <div>
-            <Link to={`/events/${event.id}`}>
+            <Link to={`/events/${event.slug}`}>
               <h3 className={styles.eventItemTitle}>{event.title}</h3>
               {event.totalCapacity > 0 && <Attendance event={event} />}
             </Link>

--- a/app/components/JoblistingItem/index.tsx
+++ b/app/components/JoblistingItem/index.tsx
@@ -13,7 +13,10 @@ type JobListingItemProps = {
 };
 
 const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
-  <Link to={`/joblistings/${joblisting.id}/`} className={styles.joblistingItem}>
+  <Link
+    to={`/joblistings/${joblisting.slug}/`}
+    className={styles.joblistingItem}
+  >
     {joblisting.company.logo && (
       <Image
         className={styles.companyLogo}

--- a/app/models.ts
+++ b/app/models.ts
@@ -151,6 +151,7 @@ export type Group = {
 type EventBase = {
   id: ID;
   title: string;
+  slug: string;
   cover: string;
   coverPlaceholder: string;
   description: string;

--- a/app/reducers/articles.ts
+++ b/app/reducers/articles.ts
@@ -76,6 +76,17 @@ export const selectArticleById = createSelector(
   (state, props) => props.articleId,
   (articlesById, articleId) => transformArticle(articlesById[articleId])
 );
+export const selectArticleBySlug = createSelector(
+  (state) => state.articles.byId,
+  (state, props) => props.articleSlug,
+  (articlesById, articleSlug) =>
+    transformArticle(
+      Object.values(articlesById).find(
+        (article) => article.slug === articleSlug
+      )
+    )
+);
+
 export const selectCommentsForArticle = createSelector(
   selectArticleById,
   (state) => state.comments.byId,

--- a/app/reducers/joblistings.ts
+++ b/app/reducers/joblistings.ts
@@ -21,3 +21,13 @@ export const selectJoblistingById = createSelector(
   (state, props) => props.joblistingId,
   (joblistingsById, joblistingId) => joblistingsById[joblistingId]
 );
+export const selectJoblistingBySlug = createSelector(
+  (state) => state.joblistings.byId,
+  (state, props) => props.joblistingSlug,
+  (joblistingsById, joblistingSlug) => {
+    const joblisting = Object.values(joblistingsById).find(
+      (joblisting) => joblisting.slug === joblistingSlug
+    );
+    return joblisting;
+  }
+);

--- a/app/routes/announcements/components/AnnouncementItem.tsx
+++ b/app/routes/announcements/components/AnnouncementItem.tsx
@@ -50,7 +50,7 @@ const AnnouncementItem = ({
               <Link
                 key={i}
                 className={styles.recipients}
-                to={`/events/${event.id}/`}
+                to={`/events/${event.slug}/`}
               >
                 {event.title}
               </Link>

--- a/app/routes/articles/ArticleDetailRoute.ts
+++ b/app/routes/articles/ArticleDetailRoute.ts
@@ -25,7 +25,6 @@ type Params = {
 
 const mapStateToProps = (state, props) => {
   const { articleIdOrSlug } = props.match.params;
-  console.log('articleIdOrSlug', articleIdOrSlug);
   const article = !isNaN(articleIdOrSlug)
     ? selectArticleById(state, {
         articleId: articleIdOrSlug,
@@ -44,11 +43,7 @@ const mapStateToProps = (state, props) => {
     });
   });
   const emojis = selectEmojis(state);
-  setTimeout(() => {
-    if (article?.slug && articleIdOrSlug !== article.slug) {
-      props.history.replace(`/articles/${article.slug}`);
-    }
-  }, 0);
+
   return {
     fetching: state.articles.fetching,
     fetchingEmojis: state.emojis.fetching,

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Link, useHistory } from 'react-router-dom';
 import CommentView from 'app/components/Comments/CommentView';
 import { Content } from 'app/components/Content';
 import DisplayContent from 'app/components/DisplayContent';
@@ -54,6 +55,10 @@ const ArticleDetail = ({
   fetchEmojis,
   fetchingEmojis,
 }: Props) => {
+  const history = useHistory();
+  useEffect(() => {
+    history.replace(`/articles/${article.slug}`);
+  }, [article.slug, history]);
   return (
     <Content
       banner={article.cover}

--- a/app/routes/articles/index.tsx
+++ b/app/routes/articles/index.tsx
@@ -37,7 +37,7 @@ const articleRoute = ({
         />
         <RouteWrapper
           exact
-          path={`${match.path}/:articleId`}
+          path={`${match.path}/:articleIdOrSlug`}
           passedProps={{
             currentUser,
             loggedIn,

--- a/app/routes/events/EventDetailRoute.ts
+++ b/app/routes/events/EventDetailRoute.ts
@@ -42,6 +42,7 @@ const mapStateToProps = (state, props) => {
     ? selectEventById(state, { eventId: eventIdOrSlug })
     : selectEventBySlug(state, { eventSlug: eventIdOrSlug });
 
+  // TODO: Use a hook for this when EventDetail is converted, like in ArticleDetail
   setTimeout(() => {
     if (event?.slug && eventIdOrSlug !== event.slug) {
       props.history.replace(`/events/${event.slug}`);

--- a/app/routes/events/EventDetailRoute.ts
+++ b/app/routes/events/EventDetailRoute.ts
@@ -42,12 +42,11 @@ const mapStateToProps = (state, props) => {
     ? selectEventById(state, { eventId: eventIdOrSlug })
     : selectEventBySlug(state, { eventSlug: eventIdOrSlug });
 
-  /*
-    * FIXME: This produces an insane amount of location change events for some reason
-  if (event?.slug && eventIdOrSlug !== event.slug) {
-    props.history.replace(`/events/${event.slug}`);
-  }
-  */
+  setTimeout(() => {
+    if (event?.slug && eventIdOrSlug !== event.slug) {
+      props.history.replace(`/events/${event.slug}`);
+    }
+  }, 0);
 
   const eventId = event.id;
 
@@ -82,7 +81,7 @@ const mapStateToProps = (state, props) => {
         : normalPools;
     return {
       actionGrant,
-      notLoading: !state.events.fetching,
+      notLoading: !!event,
       event,
       eventId,
       pools,
@@ -138,7 +137,7 @@ const mapStateToProps = (state, props) => {
   return {
     comments,
     actionGrant,
-    notLoading: !state.events.fetching,
+    notLoading: !!event,
     event,
     eventId,
     pools,

--- a/app/routes/events/components/Admin.tsx
+++ b/app/routes/events/components/Admin.tsx
@@ -119,7 +119,7 @@ const Admin = ({ actionGrant, event, deleteEvent }: Props) => {
           )}
 
           {canEdit && (
-            <Link to={`/events/${event.id}/edit`}>
+            <Link to={`/events/${event.slug}/edit`}>
               <Button>
                 <Icon name="create-outline" size={19} />
                 Rediger

--- a/app/routes/events/components/EventAdministrate/index.tsx
+++ b/app/routes/events/components/EventAdministrate/index.tsx
@@ -30,7 +30,7 @@ const EventAdministrateIndex = (props: Props) => {
         title={props.event ? props.event.title : ''}
         back={{
           label: 'Tilbake',
-          path: '/events/' + props.event.id,
+          path: '/events/' + props.event?.slug,
         }}
       >
         <NavigationLink to={`${base}/attendees`}>Påmeldinger</NavigationLink>

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
-import { Component, Fragment } from 'react';
-import { Link } from 'react-router-dom';
+import { Component, Fragment, useEffect } from 'react';
+import { Link, useHistory } from 'react-router-dom';
 import mazemapLogo from 'app/assets/mazemap.png';
 import Card from 'app/components/Card';
 import CommentView from 'app/components/Comments/CommentView';

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -117,7 +117,7 @@ function EventEditor({
         title={isEditPage ? `Redigerer: ${event.title}` : 'Nytt arrangement'}
         back={{
           label: 'Tilbake',
-          path: isEditPage ? `/events/${event.id}` : '/events',
+          path: isEditPage ? `/events/${event.slug}` : '/events',
         }}
       />
       <Form onSubmit={handleSubmit}>
@@ -590,7 +590,7 @@ function EventEditor({
 
         <Flex wrap>
           {isEditPage && (
-            <Button flat onClick={() => push(`/events/${event.id}`)}>
+            <Button flat onClick={() => push(`/events/${event.slug}`)}>
               Avbryt
             </Button>
           )}

--- a/app/routes/joblistings/JoblistingDetailedRoute.ts
+++ b/app/routes/joblistings/JoblistingDetailedRoute.ts
@@ -22,11 +22,6 @@ const mapStateToProps = (state, props) => {
   const { fetching } = state.joblistings;
   const joblistingId = joblisting && joblisting.id;
   const actionGrant = (joblisting && joblisting.actionGrant) || [];
-  setTimeout(() => {
-    if (joblisting?.slug && joblistingIdOrSlug !== joblisting?.slug) {
-      props.history.replace(`/joblistings/${joblisting.slug}`);
-    }
-  }, 0);
   return {
     joblisting,
     joblistingId,
@@ -50,7 +45,7 @@ const propertyGenerator = ({ joblisting }, config) => {
     {
       element: 'link',
       rel: 'canonical',
-      href: `${config.webUrl}/joblistings/${joblisting.slug}`,
+      href: `${config.webUrl}/joblistings/${joblisting.id}`,
     },
     {
       property: 'og:description',
@@ -70,7 +65,7 @@ const propertyGenerator = ({ joblisting }, config) => {
     },
     {
       property: 'og:url',
-      content: `${config.webUrl}/joblistings/${joblisting.slug}`,
+      content: `${config.webUrl}/joblistings/${joblisting.id}`,
     },
     {
       property: 'og:image',

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -1,6 +1,7 @@
 import { LoadingIndicator, Button } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Link, useHistory } from 'react-router-dom';
 import {
   Content,
   ContentSection,
@@ -21,23 +22,18 @@ type Props = {
   joblisting: DetailedJoblisting;
   actionGrant: ActionGrant;
   fetching: boolean;
-  match: {
-    params: {
-      joblistingIdOrSlug: string;
-    };
-  };
-  history: History;
 };
 
 const JoblistingDetail = ({
   joblisting,
   actionGrant,
   fetching = false,
-  match: {
-    params: { joblistingIdOrSlug },
-  },
-  history,
 }: Props) => {
+  const history = useHistory();
+  useEffect(() => {
+    history.replace(`/joblistings/${joblisting.slug}`);
+  }, [joblisting.slug, history]);
+
   if (fetching || !joblisting) {
     return <LoadingIndicator loading />;
   }

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -1,6 +1,6 @@
 import { LoadingIndicator, Button } from '@webkom/lego-bricks';
-import { Helmet } from 'react-helmet-async';
 import { useEffect } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { Link, useHistory } from 'react-router-dom';
 import {
   Content,
@@ -31,8 +31,10 @@ const JoblistingDetail = ({
 }: Props) => {
   const history = useHistory();
   useEffect(() => {
-    history.replace(`/joblistings/${joblisting.slug}`);
-  }, [joblisting.slug, history]);
+    joblisting &&
+      joblisting.slug &&
+      history.replace(`/joblistings/${joblisting.slug}`);
+  }, [joblisting?.slug, history]);
 
   if (fetching || !joblisting) {
     return <LoadingIndicator loading />;

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -21,12 +21,22 @@ type Props = {
   joblisting: DetailedJoblisting;
   actionGrant: ActionGrant;
   fetching: boolean;
+  match: {
+    params: {
+      joblistingIdOrSlug: string;
+    };
+  };
+  history: History;
 };
 
 const JoblistingDetail = ({
   joblisting,
   actionGrant,
   fetching = false,
+  match: {
+    params: { joblistingIdOrSlug },
+  },
+  history,
 }: Props) => {
   if (fetching || !joblisting) {
     return <LoadingIndicator loading />;

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -130,7 +130,7 @@ class JoblistingEditor extends Component<Props, State> {
           back={{
             label: 'Tilbake',
             path: !isNew
-              ? `/joblistings/${this.props.joblisting.id}`
+              ? `/joblistings/${this.props.joblisting.slug}`
               : '/joblistings',
           }}
         />
@@ -256,7 +256,9 @@ class JoblistingEditor extends Component<Props, State> {
           />
           <Flex wrap>
             <Button
-              onClick={() => push(`/joblistings/${this.props.joblisting.id}`)}
+              onClick={() =>
+                push(`/joblistings/${isNew ? '' : this.props.joblisting.id}`)
+              }
             >
               Avbryt
             </Button>

--- a/app/routes/joblistings/index.tsx
+++ b/app/routes/joblistings/index.tsx
@@ -28,7 +28,7 @@ const jobListingRoute = ({
         />
         <Route
           exact
-          path={`${match.path}/:joblistingId`}
+          path={`${match.path}/:joblistingIdOrSlug`}
           component={JoblistingDetailedRoute}
         />
         <RouteWrapper

--- a/app/routes/overview/components/CompactEvents.tsx
+++ b/app/routes/overview/components/CompactEvents.tsx
@@ -37,7 +37,7 @@ export default class CompactEvents extends Component<Props> {
             >
               <i className="fa fa-circle" />
             </span>
-            <Link to={`/events/${event.id}`}>{event.title}</Link>
+            <Link to={`/events/${event.slug}`}>{event.title}</Link>
             {event.pinned && (
               <Tooltip content="Dette arrangementet er festet til forsiden">
                 <i

--- a/app/routes/overview/components/utils.tsx
+++ b/app/routes/overview/components/utils.tsx
@@ -15,7 +15,9 @@ import styles from './Overview.css';
 export const itemUrl = (
   item: WithDocumentType<ArticleWithAuthorDetails | PublicArticle | PublicEvent>
 ) => {
-  return `/${item.documentType === 'event' ? 'events' : 'articles'}/${item.id}`;
+  return `/${item.documentType === 'event' ? 'events' : 'articles'}/${
+    item.slug
+  }`;
 };
 
 export const renderMeta = (

--- a/app/store/models/Article.d.ts
+++ b/app/store/models/Article.d.ts
@@ -8,6 +8,7 @@ import type { ContentTarget } from 'app/store/utils/contentTarget';
 interface CompleteArticle {
   id: ID;
   title: string;
+  slug: string;
   cover: string;
   coverPlaceholder: string;
   authors: Array<ID>;
@@ -26,6 +27,7 @@ export type DetailedArticle = Pick<
   CompleteArticle,
   | 'id'
   | 'title'
+  | 'slug'
   | 'cover'
   | 'coverPlaceholder'
   | 'authors'
@@ -52,6 +54,7 @@ export type PublicArticle = Pick<
   CompleteArticle,
   | 'id'
   | 'title'
+  | 'slug'
   | 'cover'
   | 'coverPlaceholder'
   | 'authors'

--- a/app/store/models/Event.d.ts
+++ b/app/store/models/Event.d.ts
@@ -22,6 +22,7 @@ export enum EventType {
 interface Event {
   id: ID;
   title: string;
+  slug: string;
   description: string;
   cover: string;
   coverPlaceholder: string;
@@ -98,6 +99,7 @@ export type ListEvent = Pick<
   Event,
   | 'id'
   | 'title'
+  | 'slug'
   | 'description'
   | 'cover'
   | 'coverPlaceholder'
@@ -121,6 +123,7 @@ export type DetailedEvent = Pick<
   Event,
   | 'id'
   | 'title'
+  | 'slug'
   | 'description'
   | 'cover'
   | 'coverPlaceholder'

--- a/app/store/models/Event.d.ts
+++ b/app/store/models/Event.d.ts
@@ -86,6 +86,7 @@ interface Event {
 export type PublicEvent = Pick<
   Event,
   | 'id'
+  | 'slug'
   | 'title'
   | 'description'
   | 'eventType'

--- a/app/store/models/Joblisting.ts
+++ b/app/store/models/Joblisting.ts
@@ -20,6 +20,7 @@ export interface Workplace {
 interface Joblisting {
   id: ID;
   title: string;
+  slug: string;
   text: string;
   company: ListCompany; // TODO: normalize?
   responsible: CompanyContact | null;
@@ -41,6 +42,7 @@ export type ListJoblisting = Pick<
   Joblisting,
   | 'id'
   | 'title'
+  | 'slug'
   | 'company'
   | 'deadline'
   | 'jobType'
@@ -54,6 +56,7 @@ export type DetailedJoblisting = Pick<
   Joblisting,
   | 'id'
   | 'title'
+  | 'slug'
   | 'text'
   | 'company'
   | 'responsible'


### PR DESCRIPTION
# Description

- Fix the infinite loop when redirecting from /{id}
- Add slugs to joblistings and articles
- Use slugs in common links and on frontpage

# Result

No visual changes except for url

# Testing

- [x] I have thoroughly tested my changes.
Seems to work fine now

---

Resolves ABA-212
