### PR TITLE
Fix frontpage not loading correctly after logging in

### DIFF
--- a/app/routes/overview/IndexRoute.ts
+++ b/app/routes/overview/IndexRoute.ts
@@ -44,12 +44,17 @@ export default compose(
   //   loggedIn ? dispatch(fetchPersonalFeed()) : Promise.resolve()
   // ),
   connect(mapStateToProps, mapDispatchToProps),
-  withPreparedDispatch('fetchIndex', (props, dispatch) =>
-    Promise.all([
-      props.loggedIn && props.shouldFetchQuote && dispatch(fetchRandomQuote()),
-      dispatch(fetchReadmes(props.loggedIn ? 4 : 1)),
-      dispatch(fetchData()),
-    ])
+  withPreparedDispatch(
+    'fetchIndex',
+    (props, dispatch) =>
+      Promise.all([
+        props.loggedIn &&
+          props.shouldFetchQuote &&
+          dispatch(fetchRandomQuote()),
+        dispatch(fetchReadmes(props.loggedIn ? 4 : 1)),
+        dispatch(fetchData()),
+      ]),
+    (props) => [props.loggedIn, props.shouldFetchQuote]
   ),
   replaceUnlessLoggedIn(PublicFrontpage)
 )(Overview);


### PR DESCRIPTION
# Description

There is a bug where the frontpage doesn't reload after logging in, so some data is missing. The poll doesn't show results, and the quotes-component looks like it is perpetually loading.
<img width="1122" alt="Screenshot 2023-05-06 at 18 52 41" src="https://user-images.githubusercontent.com/8343002/236637174-16c81dd0-a849-4057-bb59-5a0fa02fd7ca.png">

This fixes it by adding `props.loggedIn` to the dependency array of the `withPreparedEffect` responsible for loading the frontpage. This means the frontpage will reload every time that prop changes.

# Result

After the fix, the frontpage loads normally after logging in:)
<img width="1122" alt="Screenshot 2023-05-06 at 18 53 08" src="https://user-images.githubusercontent.com/8343002/236637158-2a15969d-b74b-4cec-9fd0-3d4892d26073.png">

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ... (either GitHub issue or Linear task)
