### PR TITLE
Fix survey template picker

### DIFF
--- a/app/components/Modal/ConfirmModal.tsx
+++ b/app/components/Modal/ConfirmModal.tsx
@@ -8,8 +8,8 @@ import styles from './ConfirmModal.css';
 import type { ComponentType, ReactElement, ReactNode } from 'react';
 
 type ConfirmModalProps = {
-  onConfirm?: () => Promise<any>;
-  onCancel?: () => Promise<any>;
+  onConfirm?: () => Promise<void>;
+  onCancel?: () => Promise<void>;
   message: ReactNode;
   title: string;
   disabled?: boolean;

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -191,8 +191,11 @@
 }
 
 .templateDropdown {
-  position: absolute;
   color: transparent;
+  position: absolute;
+  bottom: 0;
+  height: 0;
+  width: 0;
 }
 
 .freeText {

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -2,12 +2,13 @@ import { merge } from 'lodash';
 import moment from 'moment-timezone';
 import config from 'app/config';
 import { EDITOR_EMPTY } from 'app/utils/constants';
+import type { ValidationErrors } from 'final-form';
 
 type Validator<T = any, C = any> = (
   message?: string
 ) => (value: T, context?: C) => Readonly<[boolean, string]>;
 
-export type ValidatorResult = { [field: string]: string[] };
+export type ValidatorResult = ValidationErrors;
 
 export const EMAIL_REGEX = /.+@.+\..+/;
 const YOUTUBE_URL_REGEX =


### PR DESCRIPTION
# Description

This was very buggy. It was calling a function `destroy()` that didn't exist, that I couldn't even find it in old code, so idk how that has ever worked. The template picker dropdown also has a hidden button, that it was still possible to hit, causing the dropdown to be toggled twice and instantly close again. This is a super hacky workaround and should definitely be refactored later on, but for now I set the height and width to 0 so that it is impossible to hit.

# Result

It is actually possible to use the survey templates again.

# Testing

- [x] I have thoroughly tested my changes.

Seems to work locally:)
---

Resolves ABA-465
