### PR TITLE
Fix theme toggle button bugs

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -21,9 +21,13 @@
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
+  transition: background-color var(--linear-medium);
 
   & button {
     padding: 0;
+  }
+  &:hover {
+   background-color: var(--color-gray-1);
   }
 }
 

--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -27,7 +27,7 @@
     padding: 0;
   }
   &:hover {
-   background-color: var(--color-gray-1);
+    background-color: var(--color-gray-1);
   }
 }
 

--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -26,6 +26,7 @@
   & button {
     padding: 0;
   }
+
   &:hover {
     background-color: var(--color-gray-1);
   }

--- a/app/components/Header/ToggleTheme.tsx
+++ b/app/components/Header/ToggleTheme.tsx
@@ -1,4 +1,5 @@
 import cx from 'classnames';
+import { debounce } from 'lodash';
 import { useCallback, useState, useEffect } from 'react';
 import { applySelectedTheme, getTheme } from 'app/utils/themeUtils';
 import Icon from '../Icon';
@@ -32,6 +33,10 @@ const ToggleTheme = ({
     setIcon(getIcon());
   }, []);
 
+  window.addEventListener('themeChange', () => {
+    setIcon(getIcon());
+  });
+
   const handleThemeChange = useCallback(
     (e) => {
       e.preventDefault();
@@ -50,7 +55,7 @@ const ToggleTheme = ({
   const props = {
     name: 'Endre tema',
     className: classN,
-    onClick: handleThemeChange,
+    onClick: debounce(handleThemeChange, 200),
   };
   return isButton ? (
     <button {...props}>

--- a/app/components/Header/ToggleTheme.tsx
+++ b/app/components/Header/ToggleTheme.tsx
@@ -31,11 +31,16 @@ const ToggleTheme = ({
   // update to the correct icon once on the client.
   useEffect(() => {
     setIcon(getIcon());
-  }, []);
 
-  window.addEventListener('themeChange', () => {
-    setIcon(getIcon());
-  });
+    function handleChangeEvent() {
+      setIcon(getIcon());
+    }
+
+    window.addEventListener('themeChange', handleChangeEvent);
+    return () => {
+      window.removeEventListener('themeChange', handleChangeEvent);
+    };
+  }, []);
 
   const handleThemeChange = useCallback(
     (e) => {


### PR DESCRIPTION
# Description

- Adds background hover effect to the theme change button in the drop down menu.
- Fixes clicking on the toggle theme button in the header not changing the icon of the button in the drop down and vice versa.
- Adds debounce to theme changing to prevent "glitchy" behaviour.

# Result

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/33326578/236696847-69148430-d9bc-40f9-96ab-f62f3e1a9405.png) | ![image](https://user-images.githubusercontent.com/33326578/236696824-bdc0133b-e890-4d14-9093-5684e7c53297.png) |
| Without background hover | With background hover |
| ![image](https://user-images.githubusercontent.com/33326578/236696963-50b69161-2b83-4239-abb9-7410ae99fefe.png) | ![image](https://user-images.githubusercontent.com/33326578/236696890-b5cd6163-165a-4987-8d49-0b211295bca1.png) |
| Not synchronised icons | Synchronised icons

# Testing

- [x] I have thoroughly tested my changes.

1. Click on your profile picture to open the drop down menu.
2. Hover over the change theme button and verify that there's a hover effect present.
3. Click on the change theme button and verify that the icon in the header also changes.
4. Spam click the header change theme button and verify that the site doesn't change theme after spamming has ended.

Resolves: [#2926](https://github.com/webkom/lego/issues/2926)
