### PR TITLE
Fix bug where added reactions could not be removed before reloading

### DIFF
--- a/app/reducers/__tests__/reactions.spec.ts
+++ b/app/reducers/__tests__/reactions.spec.ts
@@ -39,7 +39,8 @@ describe('reducers', () => {
           unicodeString: '123',
         },
         payload: {
-          result: 33,
+          id: 33,
+          emoji: ':pizza:',
         },
       };
       expect(reducer(prevState, action)).toEqual({
@@ -87,7 +88,8 @@ describe('reducers', () => {
           unicodeString: '123',
         },
         payload: {
-          result: 33,
+          id: 33,
+          emoji: ':pizza:',
         },
       };
       expect(reducer(prevState, action)).toEqual({
@@ -172,7 +174,8 @@ describe('reducers', () => {
           unicodeString: '123',
         },
         payload: {
-          result: 33,
+          id: 33,
+          emoji: ':pizza:',
         },
       };
       const newState = reducer(prevState, action);

--- a/app/reducers/reactions.ts
+++ b/app/reducers/reactions.ts
@@ -21,7 +21,7 @@ export function mutateReactions<T, S = EntityReducerState<T>>(
           action.meta.contentTarget.split('-');
         const reactionEmoji = action.meta.emoji;
         const unicodeString = action.meta.unicodeString;
-        const reactionId = action.payload.result;
+        const reactionId = action.payload.id;
         const targetType = getEntityType(serverTargetType);
 
         if (targetType !== forTargetType) {


### PR DESCRIPTION
# Description

The added reaction didn't get the correct ID in the redux store. This made it impossible to un-react before reloading the page. 

# Result

It works now

# Testing

- [x] I have thoroughly tested my changes.

Reacted and un-reacted
---

Resolves ABA-461
