### PR TITLE
Add support for dark theme source on images.

### DIFF
--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -4,6 +4,7 @@ import forCompaniesGraphic from 'app/assets/frontpage-graphic-for-companies.png'
 import komtekGraphic from 'app/assets/frontpage-graphic-komtek.png';
 import readmeGraphic from 'app/assets/frontpage-graphic-readme.png';
 import netcompany from 'app/assets/netcompany_dark.png';
+import netcompanyLight from 'app/assets/netcompany_white.svg';
 import AuthSection from 'app/components/AuthSection/AuthSection';
 import Button from 'app/components/Button';
 import Card from 'app/components/Card';
@@ -99,7 +100,12 @@ const HspInfo = () => (
   <div className={styles.hsp}>
     <h3>
       <a href="https://www.netcompany.com/no" target="blank">
-        <Image className={styles.hspImage} src={netcompany} alt="NETCOMPANY" />
+        <Image
+          className={styles.hspImage}
+          src={netcompany}
+          alt="NETCOMPANY"
+          darkThemeSource={netcompanyLight}
+        />
       </a>
     </h3>
     Hovedsamarbeidspartneren vår er Netcompany. Hos Netcompany står fag,


### PR DESCRIPTION
# Description

Add support for dark theme source on the custom Image component using the new "darkThemeSource" argument.
Implement this for the Public Frontpage on the main sponsor.

# Result

![image](https://github.com/webkom/lego-webapp/assets/113468143/9c0209cd-eba7-4052-8a9a-5698dc0c5dc9)

![image](https://github.com/webkom/lego-webapp/assets/113468143/7d4e8df7-11c4-435d-b12f-129dd363eb53)


# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-390
