### PR TITLE
Refactor DatePicker- and TimePicker-component

### DIFF
--- a/app/components/Form/DatePicker.css
+++ b/app/components/Form/DatePicker.css
@@ -6,13 +6,14 @@
   display: flex;
   width: 100%;
   flex-wrap: wrap;
-  margin: 0;
+  margin: 0 0 10px;
 }
 
 .dropdown {
   width: auto;
   max-width: 320px;
-  padding: 0 20px;
+  padding: 0 20px 10px;
+  flex: 1;
 }
 
 .inputField {

--- a/app/components/Form/DatePicker.tsx
+++ b/app/components/Form/DatePicker.tsx
@@ -1,7 +1,8 @@
 import cx from 'classnames';
 import moment from 'moment-timezone';
-import { Component } from 'react';
+import { useState } from 'react';
 import Dropdown from 'app/components/Dropdown';
+import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
 import createMonthlyCalendar from 'app/utils/createMonthlyCalendar';
 import parseDateValue from 'app/utils/parseDateValue';
@@ -9,146 +10,93 @@ import styles from './DatePicker.css';
 import { createField } from './Field';
 import TextInput from './TextInput';
 import TimePicker from './TimePicker';
+import type { Moment } from 'moment';
 
 type Props = {
-  onChange: (arg0: string) => void;
+  onChange: (selectedDate: string) => void;
   className?: string;
-  value: string | null | undefined;
+  value?: string;
   showTimePicker?: boolean;
   dateFormat?: string;
   name?: string;
 };
-type State = {
-  pickerOpen: boolean;
-  date: moment$Moment;
-  value: moment$Moment;
-};
 
-class DatePicker extends Component<Props, State> {
-  static defaultProps = {
-    value: '',
-    showTimePicker: true,
-    dateFormat: 'lll',
-  };
-  static Field: any;
-  state = {
-    pickerOpen: false,
-    date: moment(),
-    value: parseDateValue(this.props.value),
-  };
-  onNext = () => {
-    this.setState((prevState) => ({
-      date: prevState.date.clone().add(1, 'month'),
-    }));
-  };
-  onPrev = () => {
-    this.setState((prevState) => ({
-      date: prevState.date.clone().subtract(1, 'month'),
-    }));
-  };
-  onChange = (day: moment$Moment) => {
-    this.setState((prevState) => {
-      const value = day
-        .clone()
-        .hour(prevState.value.hour())
-        .minute(prevState.value.minute());
-      return {
-        value,
-        pickerOpen: false,
-      };
-    }, this._notifyParent);
-  };
-  onChangeTime = (time: moment$Moment) => {
-    this.setState((prevState) => {
-      const value = prevState.value
-        .clone()
-        .hour(time.hour())
-        .minute(time.minute());
-      return {
-        value,
-      };
-    }, this._notifyParent);
-  };
-  _notifyParent = () => this.props.onChange(this.state.value.toISOString());
-  toggleDropdown = () => {
-    this.setState((prevState) => ({
-      pickerOpen: !prevState.pickerOpen,
-    }));
+const DatePicker = ({
+  onChange,
+  className,
+  value,
+  showTimePicker = true,
+  dateFormat = 'lll',
+  name,
+}: Props) => {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [date, setDate] = useState(moment());
+  const parsedValue = parseDateValue(value);
+
+  const onNext = () => setDate(date.clone().add(1, 'month'));
+  const onPrev = () => setDate(date.clone().subtract(1, 'month'));
+
+  const changeDay = (day: Moment) => {
+    const value = day
+      .clone()
+      .hour(parsedValue.hour())
+      .minute(parsedValue.minute());
+    onChange(value.toISOString());
+    setPickerOpen(false);
   };
 
-  componentDidUpdate(prevProps: Props) {
-    if (prevProps.value !== this.props.value) {
-      this.setState({
-        value: parseDateValue(this.props.value),
-      });
-    }
-  }
+  return (
+    <Dropdown
+      show={pickerOpen}
+      toggle={() => setPickerOpen(!pickerOpen)}
+      triggerComponent={
+        <TextInput
+          className={cx(styles.inputField, className)}
+          value={parsedValue.format(dateFormat)}
+          name={name}
+          readOnly
+        />
+      }
+      componentClass="div"
+      contentClassName={styles.dropdown}
+    >
+      <div onClick={(e) => e.stopPropagation()}>
+        <Flex
+          justifyContent="space-between"
+          alignItems="center"
+          className={styles.header}
+        >
+          <button onClick={onPrev} className={styles.arrowIcon}>
+            <Icon name="arrow-back-outline" />
+          </button>
+          <span>{date.format('MMMM YYYY')}</span>
+          <button onClick={onNext} className={styles.arrowIcon}>
+            <Icon name="arrow-forward-outline" />
+          </button>
+        </Flex>
 
-  render() {
-    const { showTimePicker, className, name } = this.props;
-    const { date } = this.state;
-    return (
-      <Dropdown
-        show={this.state.pickerOpen}
-        toggle={this.toggleDropdown}
-        triggerComponent={
-          <TextInput
-            className={cx(styles.inputField, className)}
-            value={this.state.value.format(this.props.dateFormat)}
-            name={name}
-            readOnly
-          />
-        }
-        componentClass="div"
-        contentClassName={styles.dropdown}
-        style={{
-          flex: 1,
-        }}
-      >
-        <div className={styles.datePicker} onClick={(e) => e.stopPropagation()}>
-          <Flex
-            justifyContent="space-between"
-            alignItems="center"
-            className={styles.header}
-          >
-            <button onClick={this.onPrev} className={styles.arrowIcon}>
-              <i className="fa fa-long-arrow-left" />
+        <div className={styles.calendar}>
+          {createMonthlyCalendar(date).map((dateProps, i) => (
+            <button
+              key={i}
+              className={cx(
+                styles.calendarItem,
+                dateProps.prevOrNextMonth && styles.prevOrNextMonth,
+                dateProps.day.isSame(parsedValue, 'day') && styles.selectedDate
+              )}
+              onClick={() => changeDay(dateProps.day)}
+              disabled={dateProps.prevOrNextMonth}
+            >
+              {dateProps.day.date()}
             </button>
-            <span>{date.format('MMMM YYYY')}</span>
-            <button onClick={this.onNext} className={styles.arrowIcon}>
-              <i className="fa fa-long-arrow-right" />
-            </button>
-          </Flex>
-
-          <div className={styles.calendar}>
-            {createMonthlyCalendar(date).map((dateProps, i) => (
-              <button
-                key={i}
-                className={cx(
-                  styles.calendarItem,
-                  dateProps.prevOrNextMonth && styles.prevOrNextMonth,
-                  dateProps.day.isSame(this.state.value, 'day') &&
-                    styles.selectedDate
-                )}
-                onClick={() => this.onChange(dateProps.day)}
-                disabled={dateProps.prevOrNextMonth}
-              >
-                {dateProps.day.date()}
-              </button>
-            ))}
-          </div>
-
-          {showTimePicker && (
-            <TimePicker
-              value={this.state.value.toISOString()}
-              onChange={this.onChangeTime}
-            />
-          )}
+          ))}
         </div>
-      </Dropdown>
-    );
-  }
-}
+
+        {showTimePicker && <TimePicker value={value} onChange={onChange} />}
+      </div>
+    </Dropdown>
+  );
+};
 
 DatePicker.Field = createField(DatePicker);
 export default DatePicker;

--- a/app/components/Form/DatePicker.tsx
+++ b/app/components/Form/DatePicker.tsx
@@ -14,6 +14,8 @@ import type { Moment } from 'moment';
 
 type Props = {
   onChange: (selectedDate: string) => void;
+  onBlur: (selectedDate?: string) => void;
+  onFocus: () => void;
   className?: string;
   value?: string;
   showTimePicker?: boolean;
@@ -23,6 +25,8 @@ type Props = {
 
 const DatePicker = ({
   onChange,
+  onFocus,
+  onBlur,
   className,
   value,
   showTimePicker = true,
@@ -36,19 +40,25 @@ const DatePicker = ({
   const onNext = () => setDate(date.clone().add(1, 'month'));
   const onPrev = () => setDate(date.clone().subtract(1, 'month'));
 
+  const togglePicker = (open = !pickerOpen) => {
+    setPickerOpen(open);
+    open ? onFocus() : onBlur(value);
+  };
+
   const changeDay = (day: Moment) => {
     const value = day
       .clone()
       .hour(parsedValue.hour())
       .minute(parsedValue.minute());
     onChange(value.toISOString());
+    onBlur(value.toISOString());
     setPickerOpen(false);
   };
 
   return (
     <Dropdown
       show={pickerOpen}
-      toggle={() => setPickerOpen(!pickerOpen)}
+      toggle={() => togglePicker()}
       triggerComponent={
         <TextInput
           className={cx(styles.inputField, className)}

--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -147,7 +147,7 @@ export function createField(Component: ComponentType<any>, options?: Options) {
         {...input}
         {...props}
         onChange={(value) => {
-          input.onChange(value);
+          input.onChange?.(value);
           onChange?.(value);
         }}
         className={cx(

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -184,23 +184,6 @@ const MeetingEditor = ({
                 component={TextArea.Field}
               />
               <div className={styles.sideBySideBoxes}>
-                <FormSpy
-                  subscription={{ values: true }}
-                  onChange={({ values }) => {
-                    const startTime = moment(values.startTime);
-                    const endTime = moment(values.endTime);
-                    if (endTime.isBefore(startTime)) {
-                      form.change(
-                        'endTime',
-                        startTime
-                          .clone()
-                          .add(1, 'hour')
-                          .add(45, 'minutes')
-                          .toISOString()
-                      );
-                    }
-                  }}
-                />
                 <Field
                   name="startTime"
                   label="Starttidspunkt"

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -184,11 +184,29 @@ const MeetingEditor = ({
                 component={TextArea.Field}
               />
               <div className={styles.sideBySideBoxes}>
-                <Field
-                  name="startTime"
-                  label="Starttidspunkt"
-                  component={DatePicker.Field}
-                />
+                <FormSpy subscription={{ values: true }}>
+                  {({ values }) => (
+                    <Field
+                      name="startTime"
+                      label="Starttidspunkt"
+                      component={DatePicker.Field}
+                      onBlur={(value: string) => {
+                        const startTime = moment(value);
+                        const endTime = moment(values.endTime);
+                        if (endTime.isBefore(startTime)) {
+                          form.change(
+                            'endTime',
+                            startTime
+                              .clone()
+                              .add(2, 'hours')
+                              .set('minute', 0)
+                              .toISOString()
+                          );
+                        }
+                      }}
+                    />
+                  )}
+                </FormSpy>
                 <Field
                   name="endTime"
                   label="Sluttidspunkt"

--- a/app/utils/parseDateValue.ts
+++ b/app/utils/parseDateValue.ts
@@ -1,7 +1,8 @@
 import moment from 'moment-timezone';
 import config from 'app/config';
+import type { Moment } from 'moment';
 
-const parseDateValue = (value) => {
+const parseDateValue = (value?: string): Moment => {
   if (value) return moment(value).tz(config.timezone);
   return moment().tz(config.timezone);
 };

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -6,7 +6,7 @@ import type { ValidationErrors } from 'final-form';
 
 type Validator<T = any, C = any> = (
   message?: string
-) => (value: T, context?: C) => Readonly<[boolean, string]>;
+) => (value: T, context?: C) => Readonly<[false, string] | [true, string?]>;
 
 export type ValidatorResult = ValidationErrors;
 

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -50,6 +50,7 @@ describe('Create meeting', () => {
     setDatePickerTime('startTime', '20', '00');
 
     fieldError('endTime').should('not.exist');
+    field('endTime').should('contain', '22:00');
 
     setDatePickerTime('endTime', '20', '30');
 

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -50,7 +50,7 @@ describe('Create meeting', () => {
     setDatePickerTime('startTime', '20', '00');
 
     fieldError('endTime').should('not.exist');
-    field('endTime').should('contain', '22:00');
+    field('endTime').should('contain.value', '22:00');
 
     setDatePickerTime('endTime', '20', '30');
 

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -44,21 +44,16 @@ export const selectEditor = (name) =>
     ? cy.get(`[name="${name}"] div[data-slate-editor="true"]`).click().click()
     : cy.get('div[data-slate-editor="true"]').click().click();
 
+const selectDatePickerHours = () =>
+  cy.get(c('TimePicker__timePickerInput')).first().find('input');
+
+const selectDatePickerMinutes = () =>
+  cy.get(c('TimePicker__timePickerInput')).last().find('input');
+
 export const setDatePickerTime = (name, hours, minutes) => {
   field(name).click();
-  cy.get(c('TimePicker__timePickerInput'))
-    .first()
-    .find('input')
-    .click()
-    .clear()
-    .type(hours);
-
-  cy.get(c('TimePicker__timePickerInput'))
-    .last()
-    .find('input')
-    .click()
-    .clear()
-    .type(minutes);
+  selectDatePickerHours().click().clear().type(hours);
+  selectDatePickerMinutes().click().clear().type(minutes);
   field(name).click();
 };
 


### PR DESCRIPTION
# Description

Small refactor of the DatePicker thingy. Shouldn't change too much, but rewrote to functional components and simplified the logic a bit. ~100 fewer lines of code:)

# Result

Some minor changes in appearance:

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td><img width="351" alt="Screenshot 2023-05-27 at 18 54 41" src="https://github.com/webkom/lego-webapp/assets/8343002/edc577da-6a80-4ed7-a05b-737699d7ff54"></td>
 <td><img width="351" alt="Screenshot 2023-06-10 at 10 25 07" src="https://github.com/webkom/lego-webapp/assets/8343002/287e7b3a-fbf0-4e59-86c4-08b8e7828ef1"></td>
</table>

~~I have changed the behaviour slightly to simplify the logic. In the meeting editor we would previously automatically move the end time forward if it was set before the start time, but this didn't play well with the simplified component. Now it will simply show a form validation error (which is how it works in f.ex. the event-editor).~~
<img width="527" alt="Screenshot 2023-06-10 at 09 54 58" src="https://github.com/webkom/lego-webapp/assets/8343002/47ba72fd-3cb8-4928-8706-2111b299c1dc">

The end-time auto-moving is kept intact! It now moved the end time to ~two hours after the start time when blurring (deselecting) the start time field.

# Testing

- [x] I have thoroughly tested my changes.

I've gone through every usage of the component in the webapp, and checked manually that it still works as expected.