### PR TITLE
Update the chart and password bar colors

### DIFF
--- a/app/components/Chart/utils.tsx
+++ b/app/components/Chart/utils.tsx
@@ -4,18 +4,15 @@ export interface DistributionDataPoint {
 }
 
 export const CHART_COLORS = [
-  'var(--lego-red-color)',
-  'var(--color-blue-4)',
-  'var(--color-orange-7)',
-  'var(--color-green-8)',
-  'var(--lego-chart-purple)',
-  'var(--lego-chart-yellow)',
-  '#ff87eb',
-  'var(--lego-chart-black)',
-  'var(--lego-chart-green)',
-  'var(--lego-chart-blue)',
-  'var(--lego-chart-salmon)',
-  'var(--lego-chart-navajo)',
+  'var(--color-blue-6)',
+  'var(--color-orange-6)',
+  'var(--color-green-7)',
+  'var(--color-red-4)',
+  'var(--color-purple-5)',
+  'var(--color-blue-5)',
+  'var(--color-orange-5)',
+  'var(--color-green-6)',
+  'var(--color-purple-7)',
 ];
 
 type GraphProps = {

--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -284,12 +284,12 @@ const Analytics = ({ eventId }: { eventId: ID }) => {
             <linearGradient id="colorView" x1="0" y1="0" x2="0" y2="1">
               <stop
                 offset="30%"
-                stopColor="var(--color-blue-5)"
+                stopColor="var(--color-blue-6)"
                 stopOpacity={0.4}
               />
               <stop
                 offset="75%"
-                stopColor="var(--color-blue-4)"
+                stopColor="var(--color-blue-5)"
                 stopOpacity={0.3}
               />
               <stop
@@ -325,7 +325,7 @@ const Analytics = ({ eventId }: { eventId: ID }) => {
             name="Besøkende"
             dataKey="visitors"
             type="monotone"
-            stroke="var(--color-blue-5)"
+            stroke="var(--color-blue-6)"
             strokeWidth={3}
             strokeOpacity={1}
             fill="url(#colorView)"

--- a/app/routes/users/components/passwordStrengthVariables.ts
+++ b/app/routes/users/components/passwordStrengthVariables.ts
@@ -6,11 +6,11 @@ export const passwordLabel = {
   4: 'Sterkt',
 };
 export const barColor = {
-  0: '#F25F5C',
-  1: '#F25F5C',
-  2: '#FFE066',
-  3: '#70C1B3',
-  4: '#006600',
+  0: 'var(--danger-color)',
+  1: 'var(--color-orange-6)',
+  2: 'var(--color-yellow-6)',
+  3: 'var(--color-green-6)',
+  4: 'var(--color-green-7)',
 };
 export const passwordFeedbackMessages = {
   'Add another word or two. Uncommon words are better.':

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -22,15 +22,6 @@
   --lego-header-height: 120px;
   --lego-main-nav-height: 50px;
 
-  --lego-chart-purple: #c73aea;
-  --lego-chart-yellow: #f4ee42;
-  --lego-chart-green: #98e442;
-  --lego-chart-pink: #ff87eb;
-  --lego-chart-blue: #145bd4;
-  --lego-chart-black: #000;
-  --lego-chart-salmon: #fa8072;
-  --lego-chart-navajo: #ffdead;
-
   --color-event-red: #b11c11;
   --color-event-black: #111;
 
@@ -95,7 +86,25 @@
   --color-red-8: #730202;
   --color-red-9: #400101;
 
-  --color-yellow: #fcd703;
+  --color-purple-1: #f4eaff;
+  --color-purple-2: #e8d4fe;
+  --color-purple-3: #dba7fd;
+  --color-purple-4: #cc79fc;
+  --color-purple-5: #b94cfb;
+  --color-purple-6: #a020fa;
+  --color-purple-7: #8120c9;
+  --color-purple-8: #62189b;
+  --color-purple-9: #440d66;
+
+  --color-yellow-1: #fffbe6;
+  --color-yellow-2: #fff9cc;
+  --color-yellow-3: #fff7b2;
+  --color-yellow-4: #fff595;
+  --color-yellow-5: #fff368;
+  --color-yellow-6: #ffea00;
+  --color-yellow-7: #b3a300;
+  --color-yellow-8: #807300;
+  --color-yellow-9: #403600;
 
   --color-red-hover-alpha: 5%;
 
@@ -135,15 +144,6 @@
   --secondary-font-color: #aaa;
 
   --lego-red-color: var(--color-red-7);
-
-  --lego-chart-purple: #c73aea;
-  --lego-chart-yellow: #f4ee42;
-  --lego-chart-green: #98e442;
-  --lego-chart-pink: #ff87eb;
-  --lego-chart-blue: #145bd4;
-  --lego-chart-black: #000;
-  --lego-chart-salmon: #fa8072;
-  --lego-chart-navajo: #ffdead;
 
   --color-event-black: #ddd;
   --color-white: #181818;
@@ -204,7 +204,25 @@
   --color-red-8: #e52d2e;
   --color-red-9: #e9494a;
 
-  --color-yellow: #fcd703;
+  --color-purple-1: #440d66;
+  --color-purple-2: #62189b;
+  --color-purple-3: #8120c9;
+  --color-purple-4: #a020fa;
+  --color-purple-5: #b94cfb;
+  --color-purple-6: #cc79fc;
+  --color-purple-7: #dba7fd;
+  --color-purple-8: #e8d4fe;
+  --color-purple-9: #f4eaff;
+
+  --color-yellow-1: #403600;
+  --color-yellow-2: #807300;
+  --color-yellow-3: #b3a300;
+  --color-yellow-4: #ffea00;
+  --color-yellow-5: #fff368;
+  --color-yellow-6: #fff595;
+  --color-yellow-7: #fff7b2;
+  --color-yellow-8: #fff9cc;
+  --color-yellow-9: #fffbe6;
 
   --color-red-hover-alpha: 10%;
 }


### PR DESCRIPTION
# Description

[Update the chart colors](https://github.com/webkom/lego-webapp/pull/3977/commits/c1f5d38efe8de906c847c8eaf79a221ed7b15bc3)

They are now based entirely on our color palette, and will therefore both match the rest of the webapp better and work better on dark mode.

Also introduce a yellow and purple color palette. I did not spend too much time picking out these colors, so they might need to be iterated on. Nevertheless they seem fine.

---

[Update colors on the password strength bar](https://github.com/webkom/lego-webapp/pull/3977/commits/14ba5d8ab60d1ad7dde835e66dc8b1e1fa103fe6)

# Result

Overall I think it looks better - here's an average example:

| Before | After |
:-----------------------:|:--------------------------:
<img width="649" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/338e5a17-af17-4bfa-9741-ae4b5707a1b5"> | <img width="649" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/64c6fcab-16c7-4551-8851-0e2659d78662">
<video src="https://github.com/webkom/lego-webapp/assets/69514187/d0bb36e5-ff32-41cd-9ef0-6099b2714e94" /> | <video src="https://github.com/webkom/lego-webapp/assets/69514187/797b379c-cdd9-465f-a249-bc9f407318ad" />

# Testing

- [x] I have thoroughly tested my changes.

They are only used on event statistics and survey results. Both were tested.