### PR TITLE
Stop attendance box from growing

### DIFF
--- a/app/components/UserAttendance/AttendanceStatus.css
+++ b/app/components/UserAttendance/AttendanceStatus.css
@@ -3,7 +3,6 @@
   flex-flow: row wrap;
   justify-content: flex-start;
   width: 100%;
-  height: 100%;
   text-align: center;
   border-radius: var(--border-radius-md);
   margin: 10px 0;


### PR DESCRIPTION
# Description

Somehow introduced in https://github.com/webkom/lego-webapp/pull/3876

But the weird part is that it only affects this one event shown below, and I can't find any other event where the bug occurs ... Nevertheless, this change fixes the bug and does not introduce any other bug, so ...

# Result



| Before | After |
:-----------------------:|:--------------------------:
<img width="270" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/39d97f02-fc86-4ae0-8867-141e41fae942"> | <img width="270" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/80b6fdfb-f320-4ca4-a74f-8455c5b244ef"> 
<img width="270" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/1a094a50-c18f-4ecb-902e-61ae96e892bc"> | <img width="270" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/1a094a50-c18f-4ecb-902e-61ae96e892bc">

# Testing

- [x] I have thoroughly tested my changes.

Tested on mobile, tablet and computer viewports.