### PR TITLE
Greatly improve the tooltip component

### DIFF
--- a/app/components/PhotoUploadStatus/index.tsx
+++ b/app/components/PhotoUploadStatus/index.tsx
@@ -56,7 +56,6 @@ const UploadStatusCard = ({
       )}
       {hasFailedUploads && (
         <Tooltip
-          list
           content={
             <Flex column>
               {uploadStatus.failedImages.map(

--- a/app/components/Poll/index.tsx
+++ b/app/components/Poll/index.tsx
@@ -115,17 +115,11 @@ class Poll extends Component<Props, State> {
               <span className={styles.pollHeader}>{title}</span>
             </Flex>
           </Link>
-          <Tooltip content="Avstemningen er anonym." renderDirection="left">
-            <Flex>
-              <Icon
-                name="information-circle-outline"
-                size={20}
-                style={{
-                  cursor: 'pointer',
-                }}
-              />
-            </Flex>
-          </Tooltip>
+          <div>
+            <Tooltip content="Avstemningen er anonym.">
+              <Icon name="information-circle-outline" size={20} />
+            </Tooltip>
+          </div>
         </Flex>
         {details && (
           <div>

--- a/app/components/Tooltip/Tooltip.css
+++ b/app/components/Tooltip/Tooltip.css
@@ -1,63 +1,65 @@
+:root {
+  --tooltip-background: var(--lego-font-color);
+}
+
 .tooltip {
-  display: none;
+  opacity: 0;
+  visibility: hidden;
 }
 
 .baseTooltipHover {
-  text-align: center;
-  display: block;
+  opacity: 1;
+  visibility: visible;
+  transition: var(--easing-medium);
+  transition-property: opacity, visibility;
   position: absolute;
-  background: var(--color-gray-8);
-  color: var(--color-white);
+  background: var(--tooltip-background);
+  color: var(--inverted-font-color);
   border-radius: var(--border-radius-md);
-  padding: 5px 15px;
+  box-shadow: var(--shadow-md);
   z-index: 1;
+
+  /* A 1 pixel border in case of sub-pixels
+  rendering in the browser or rounding errors
+  when positioning the arrow */
+  border: 1px solid var(--tooltip-background);
 }
 
-.baseTooltipHover::after {
-  content: '';
-  position: absolute;
+.content {
+  display: flex;
+  align-items: center;
+  padding: 4px 9px;
+  line-height: 1.3;
+}
+
+.arrow {
   width: 0;
   height: 0;
-  border-width: 5px;
   border-style: solid;
+  position: absolute;
 }
 
-.showTooltip::after {
-  top: 100%;
-  border-color: var(--color-gray-8) transparent transparent;
+/* stylelint-disable shorthand-property-no-redundant-values */
+[data-popper-placement^='top'] > .arrow {
+  bottom: -7px;
+  border-width: 7px 7px 0 7px;
+  border-color: var(--tooltip-background) transparent transparent transparent;
 }
 
-.renderDirectionLeft {
-  transform: translate(-90%, -100%);
+[data-popper-placement^='bottom'] > .arrow {
+  top: -7px;
+  border-width: 0 7px 7px 7px;
+  border-color: transparent transparent var(--tooltip-background) transparent;
 }
 
-.renderDirectionLeft::after {
-  left: 90%;
+[data-popper-placement^='left'] > .arrow {
+  right: -7px;
+  border-width: 7px 0 7px 7px;
+  border-color: transparent transparent transparent var(--tooltip-background);
 }
 
-.renderDirectionRight {
-  transform: translate(-10%, -100%);
-}
-
-.renderDirectionRight::after {
-  left: 10%;
-}
-
-.renderFromCenter {
-  transform: translate(-50%, -100%);
-}
-
-.renderFromCenter::after {
-  left: 50%;
-}
-
-.listTooltip {
-  flex-direction: column;
-  margin-top: 30px;
-  transform: translateX(-50%);
-}
-
-.listTooltip::after {
-  border-color: transparent transparent var(--color-gray-8);
-  bottom: 100%;
+[data-popper-placement^='right'] > .arrow {
+  left: -7px;
+  border-width: 7px 7px 7px 0;
+  border-color: transparent var(--tooltip-background) transparent transparent;
 }

--- a/app/components/Tooltip/index.tsx
+++ b/app/components/Tooltip/index.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { Component } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import styles from './Tooltip.css';
 import type { ReactNode, CSSProperties } from 'react';
 
@@ -13,10 +13,7 @@ type Props = {
   renderDirection?: string;
   pointerPosition?: string;
 };
-type State = {
-  hovered: boolean;
-  childrenContainerWidth: number;
-};
+
 /**
  * A tooltip that appears when you hover over the component placed within.
  * The tooltip will by default be centered, however it supports a 'renderDirection'
@@ -25,111 +22,83 @@ type State = {
  * also default to center, and it can be adjusted with the 'pointerPosition' prop.
  * Both props can be set as either 'left' or 'right'.
  */
+const Tooltip = ({
+  children,
+  content,
+  className,
+  list = false,
+  style,
+  onClick,
+  renderDirection,
+  pointerPosition,
+}: Props) => {
+  const [hovered, setHovered] = useState(false);
+  const [childrenContainerWidth, setChildrenContainerWidth] = useState(0);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
 
-export default class Tooltip extends Component<Props, State> {
-  static defaultProps = {
-    list: false,
+  const measure = () => {
+    if (tooltipRef.current) {
+      setChildrenContainerWidth(tooltipRef.current.offsetWidth);
+    }
   };
-  tooltip: HTMLDivElement | null | undefined;
 
-  measure() {
-    if (!this.tooltip) {
-      return;
+  useEffect(() => {
+    measure();
+  }, []);
+
+  let renderDirectionClass = styles.renderFromCenter;
+  let startPointChildren = 2;
+
+  if (!list) {
+    switch (renderDirection) {
+      case 'left':
+        renderDirectionClass = styles.renderDirectionLeft;
+        break;
+
+      case 'right':
+        renderDirectionClass = styles.renderDirectionRight;
+        break;
+
+      default:
+        break;
     }
 
-    const width = this.tooltip.offsetWidth;
-    this.setState({
-      childrenContainerWidth: width,
-    });
-  }
+    switch (pointerPosition) {
+      case 'left':
+        startPointChildren = 9;
+        break;
 
-  state = {
-    hovered: false,
-    childrenContainerWidth: 0,
-  };
-  onMouseEnter = () => {
-    this.setState({
-      hovered: true,
-    });
-  };
-  onMouseLeave = () => {
-    this.setState({
-      hovered: false,
-    });
-  };
+      case 'right':
+        startPointChildren = 10 / 9;
+        break;
 
-  componentDidMount() {
-    this.measure();
-  }
-
-  render() {
-    const {
-      content,
-      children,
-      className,
-      list,
-      style,
-      onClick,
-      renderDirection,
-      pointerPosition,
-    } = this.props;
-    let renderDirectionClass = styles.renderFromCenter;
-    let startPointChildren = 2;
-
-    if (!list) {
-      switch (renderDirection) {
-        case 'left':
-          renderDirectionClass = styles.renderDirectionLeft;
-          break;
-
-        case 'right':
-          renderDirectionClass = styles.renderDirectionRight;
-          break;
-
-        default:
-          break;
-      }
-
-      switch (pointerPosition) {
-        case 'left':
-          startPointChildren = 9;
-          break;
-
-        case 'right':
-          startPointChildren = 10 / 9;
-          break;
-
-        default:
-          break;
-      }
+      default:
+        break;
     }
+  }
 
-    const tooltipClass = this.state.hovered
-      ? styles.baseTooltipHover
-      : styles.tooltip;
-    const tooltip = list ? styles.listTooltip : styles.showTooltip;
-    return (
-      <div className={className} onClick={onClick}>
+  const tooltipClass = hovered ? styles.baseTooltipHover : styles.tooltip;
+  const tooltip = list ? styles.listTooltip : styles.showTooltip;
+  return (
+    <div className={className} onClick={onClick}>
+      <div
+        ref={tooltipRef}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
         <div
-          ref={(ref) => {
-            this.tooltip = ref;
+          className={cx(tooltipClass, tooltip, renderDirectionClass)}
+          style={{
+            ...style,
+            marginLeft: childrenContainerWidth / startPointChildren - 5,
           }}
-          onMouseEnter={this.onMouseEnter}
-          onMouseLeave={this.onMouseLeave}
         >
-          <div
-            className={cx(tooltipClass, tooltip, renderDirectionClass)}
-            style={{
-              ...style,
-              marginLeft:
-                this.state.childrenContainerWidth / startPointChildren - 5,
-            }}
-          >
-            {content}
-          </div>
-          {children}
+          {content}
         </div>
+        {children}
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/app/components/UserGrid/index.tsx
+++ b/app/components/UserGrid/index.tsx
@@ -45,12 +45,7 @@ const UserGrid = ({
 );
 
 const RegisteredUserCell = ({ user }: { user: User }) => (
-  <Tooltip
-    style={{
-      marginTop: '-7px',
-    }}
-    content={user.fullName}
-  >
+  <Tooltip content={user.fullName}>
     <Link to={`/users/${user.username}`}>
       <ProfilePicture
         alt={`${user.username}'s profile picture`}

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -88,19 +88,8 @@ const ArticleEditor = ({
                     marginLeft: '5px',
                   }}
                 >
-                  <Tooltip
-                    style={{
-                      marginLeft: '3px',
-                    }}
-                    content="Valgfritt felt. Videoen erstatter ikke coveret i listen over artikler."
-                  >
-                    <Icon
-                      name="information-circle-outline"
-                      size={20}
-                      style={{
-                        cursor: 'pointer',
-                      }}
-                    />
+                  <Tooltip content="Valgfritt felt. Videoen erstatter ikke coveret i listen over artikler.">
+                    <Icon name="information-circle-outline" size={20} />
                   </Tooltip>
                 </div>
               </Flex>

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -264,7 +264,9 @@ class CompanyInterestList extends Component<Props, State> {
           ) : (
             <Tooltip
               style={
-                this.props.selectedSemesterOption.year && { display: 'none' }
+                this.props.selectedSemesterOption.year
+                  ? { display: 'none' }
+                  : undefined
               }
               content={'Vennligst velg semester'}
             >

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -730,7 +730,6 @@ const CompanyInterestPage = (props: Props) => {
                     {labels.companyCourseThemes[language]}
                     <Tooltip
                       className={styles.tooltip}
-                      renderDirection="right"
                       content={
                         <span>
                           {language === 'norwegian'

--- a/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
+++ b/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
@@ -129,7 +129,7 @@ export const Unregister = ({
           closeOnCancel
         >
           {({ openConfirmModal }) => (
-            <Tooltip content="Meld av bruker" style={{ marginTop: '-7px' }}>
+            <Tooltip content="Meld av bruker">
               <Icon
                 onClick={openConfirmModal}
                 name="person-remove-outline"

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -67,14 +67,11 @@ const InterestedButton = ({ isInterested }: InterestedButtonProps) => {
       }}
     >
       <Tooltip
-        style={{
-          lineHeight: '1.3rem',
-        }}
         content={
           <span
             style={{
-              fontSize: '1rem',
-              fontWeight: '100',
+              fontSize: 'var(--font-size-md)',
+              fontWeight: '400',
               padding: '0',
             }}
           >

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -136,13 +136,7 @@ function EventEditor({
               <Flex alignItems="center" gap={6}>
                 <div>Erstatt cover-bildet med video fra YouTube</div>
                 <Tooltip content="Valgfritt felt. Videoen erstatter ikke coveret i listen over arrangementer.">
-                  <Icon
-                    name="information-circle-outline"
-                    size={20}
-                    style={{
-                      cursor: 'pointer',
-                    }}
-                  />
+                  <Icon name="information-circle-outline" size={20} />
                 </Tooltip>
               </Flex>
             }
@@ -564,9 +558,6 @@ function EventEditor({
         </ContentSection>
         {!isEditPage && (
           <Tooltip
-            style={{
-              marginLeft: '3px',
-            }}
             content={
               <>
                 Jeg er kjent med at jeg kun kan bruke rettighetene mine til å

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -152,7 +152,6 @@ const RegistrationPending = ({
             på slack for eventuelle oppdateringer.
           </span>
         }
-        renderDirection="center"
       >
         <Icon name="information-circle-outline" size={20} />
       </Tooltip>

--- a/app/routes/events/components/RegisteredSummary.tsx
+++ b/app/routes/events/components/RegisteredSummary.tsx
@@ -52,7 +52,6 @@ const RegistrationList = ({
 }: RegistrationListProps) => (
   <Tooltip
     content={renderNameList(registrations)}
-    list
     className={styles.registrationList}
     onClick={onClick}
   >

--- a/app/routes/photos/components/GalleryPictureEditModal.tsx
+++ b/app/routes/photos/components/GalleryPictureEditModal.tsx
@@ -88,17 +88,8 @@ const GalleryPictureEditModal = ({
                     marginLeft: '5px',
                   }}
                 >
-                  <Tooltip
-                    content="Om bildet skal være synlig for brukere som ikke har tilgang til å redigere albumet."
-                    renderDirection="right"
-                  >
-                    <Icon
-                      name="information-circle-outline"
-                      size={20}
-                      style={{
-                        cursor: 'pointer',
-                      }}
-                    />
+                  <Tooltip content="Om bildet skal være synlig for brukere som ikke har tilgang til å redigere albumet.">
+                    <Icon name="information-circle-outline" size={20} />
                   </Tooltip>
                 </div>
               </Flex>

--- a/app/routes/polls/components/PollEditor.css
+++ b/app/routes/polls/components/PollEditor.css
@@ -2,15 +2,8 @@
 
 .optionField {
   display: flex;
-}
-
-.deleteOption {
-  display: flex;
-  justify-content: center;
   align-items: center;
-  cursor: pointer;
-  width: 2rem;
-  padding-top: 5px;
+  gap: 15px;
 }
 
 .actionButtons {

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -60,7 +60,7 @@ const renderOptions = ({ fields }: any): ReactNode => (
             closeOnConfirm
           >
             {({ openConfirmModal }) => (
-              <Tooltip className={styles.deleteOption} content="Fjern">
+              <Tooltip className="deleteOption" content="Fjern">
                 <Icon onClick={openConfirmModal} name="trash" danger />
               </Tooltip>
             )}

--- a/app/routes/users/components/StudentConfirmation.tsx
+++ b/app/routes/users/components/StudentConfirmation.tsx
@@ -107,28 +107,11 @@ const StudentConfirmation = ({
           <RadioButtonGroup
             name="isTwoYears"
             label={
-              <Flex>
+              <Flex alignItems="center" gap={5}>
                 <div>Begynner du på 2-årig eller 5-årig master?</div>
-                <div
-                  style={{
-                    marginLeft: '5px',
-                  }}
-                >
-                  <Tooltip
-                    style={{
-                      marginLeft: '3px',
-                    }}
-                    content="Huk av 2-årig master her kun hvis du begynner på to-arig master studiet på din respektive linje. Dvs. du har en bachelor fra før av. Begynner du i første klasse og skal studere i 5 år, huk av 5-årig master."
-                  >
-                    <Icon
-                      name="information-circle-outline"
-                      size={20}
-                      style={{
-                        cursor: 'pointer',
-                      }}
-                    />
-                  </Tooltip>
-                </div>
+                <Tooltip content="Huk av 2-årig master her kun hvis du begynner på to-arig master studiet på din respektive linje. Dvs. du har en bachelor fra før av. Begynner du i første klasse og skal studere i 5 år, huk av 5-årig master.">
+                  <Icon name="information-circle-outline" size={20} />
+                </Tooltip>
               </Flex>
             }
           >

--- a/app/routes/users/components/UserSettingsOAuth2.tsx
+++ b/app/routes/users/components/UserSettingsOAuth2.tsx
@@ -46,7 +46,7 @@ const UserSettingsOAuth2 = (props: Props) => {
         return (
           <Flex wrap gap={10}>
             {application.clientId}
-            <Tooltip content="Kopier client ID" renderDirection="right">
+            <Tooltip content="Kopier client ID">
               <Icon
                 name={copied ? 'copy' : 'copy-outline'}
                 size={20}
@@ -98,7 +98,7 @@ const UserSettingsOAuth2 = (props: Props) => {
           closeOnCancel
         >
           {({ openConfirmModal }) => (
-            <Tooltip content="Fjern" style={{ marginTop: '-7px' }}>
+            <Tooltip content="Fjern">
               <Flex justifyContent="center">
                 <Icon
                   onClick={openConfirmModal}

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -9,6 +9,7 @@
   --lego-card-color: #fff;
 
   --lego-font-color: var(--color-gray-9);
+  --inverted-font-color: var(--color-gray-1);
   --secondary-font-color: #606060;
 
   --lego-red-color: var(--color-red-5);

--- a/cypress/e2e/poll_spec.js
+++ b/cypress/e2e/poll_spec.js
@@ -51,7 +51,7 @@ describe('Polls', () => {
 
     // Add new option and remove it
     cy.contains('button', 'Legg til alternativ').click();
-    cy.get(c('PollEditor__deleteOption')).last().click();
+    cy.get(c('deleteOption')).last().click();
     cy.get(c('Modal__content')).should('be.visible').contains('Ja').click();
 
     field('description').type(poll_form.description).blur();
@@ -94,13 +94,13 @@ describe('Polls', () => {
     field('title').clear().type(poll_form.title);
     field('pinned').check();
 
-    cy.get(c('PollEditor__deleteOption')).first().click();
+    cy.get(c('deleteOption')).first().click();
     cy.get(c('Modal__content')).should('be.visible').contains('Ja').click();
-    cy.get(c('PollEditor__deleteOption')).first().click();
+    cy.get(c('deleteOption')).first().click();
     cy.get(c('Modal__content')).should('be.visible').contains('Ja').click();
-    cy.get(c('PollEditor__deleteOption')).first().click();
+    cy.get(c('deleteOption')).first().click();
     cy.get(c('Modal__content')).should('be.visible').contains('Ja').click();
-    cy.get(c('PollEditor__deleteOption')).first().click();
+    cy.get(c('deleteOption')).first().click();
     cy.get(c('Modal__content')).should('be.visible').contains('Ja').click();
 
     cy.contains('button', 'Legg til alternativ').click();

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-notification": "^6.8.5",
     "react-overlays": "5.2.1",
     "react-phone-number-input": "^3.2.23",
+    "react-popper": "^2.3.0",
     "react-qr-reader": "^3.0.0-beta-1",
     "react-qrcode-logo": "^2.9.0",
     "react-redux": "^8.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9219,6 +9219,11 @@ react-dropzone@^14.2.2:
     file-selector "^0.6.0"
     prop-types "^15.8.1"
 
+react-fast-compare@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
 react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
@@ -9319,6 +9324,14 @@ react-phone-number-input@^3.2.23:
     input-format "^0.3.8"
     libphonenumber-js "^1.10.30"
     prop-types "^15.8.1"
+
+react-popper@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
+  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-qr-reader@^3.0.0-beta-1:
   version "3.0.0-beta-1"
@@ -11120,7 +11133,7 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-warning@^4.0.3:
+warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
# Description

It is now no longer super buggy!

Firstly it will not overflow out of view when there is no space.
Through the `popper` library, it will find the most suitable postion.
No more need for the `renderDirection` prop and hacky calculations.

Another nice feature is that it will point to the right direction even
when the trigger component is flexed, which it often is. This is most
noticeable on tables.

Some minor styling changes as well, but that's not really the important
part of this change. Worth noting that there is no longer an annoying
buggy line between the arrow and the tooltip whenever there's a bad
render.

# Result

https://github.com/webkom/lego-webapp/assets/69514187/9a7480c8-7a5c-4220-8008-8252171098a0

# Testing

- [x] I have thoroughly tested my changes.

Went through all uses of tooltips. Tried all viewports, hard refreshes and other "stress testing".

---

Resolves https://github.com/webkom/lego/issues/2849