### PR TITLE
Remove broken webpack hot reload from server

### DIFF
--- a/config/webpack.server.js
+++ b/config/webpack.server.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const webpack = require('webpack');
 const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
@@ -14,10 +13,7 @@ module.exports = (env, argv) => {
     devtool: 'source-map',
     stats: isProduction ? 'normal' : 'errors-only',
     entry: {
-      server: [
-        !isProduction && 'webpack/hot/poll?1000',
-        path.resolve(__dirname, '..', 'server/index.ts'),
-      ].filter(Boolean),
+      server: path.resolve(__dirname, '..', 'server/index.ts'),
     },
     optimization: {
       minimize: false,
@@ -39,8 +35,6 @@ module.exports = (env, argv) => {
     },
 
     plugins: [
-      !isProduction && new webpack.HotModuleReplacementPlugin(),
-      !isProduction && new ReactRefreshWebpackPlugin(),
       new webpack.optimize.LimitChunkCountPlugin({
         maxChunks: 1,
       }),

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,7 +30,6 @@ const server = config.https
     )
   : http.createServer(app);
 
-let currentApp = app;
 const log = app.get('log');
 
 server.on('error', (err) => {
@@ -48,11 +47,3 @@ server.listen({ port: app.get('port'), host: app.get('host') }, () => {
     'app_started'
   );
 });
-
-if (module.hot) {
-  module.hot.accept('./server', () => {
-    server.removeListener('request', currentApp);
-    server.on('request', app);
-    currentApp = app;
-  });
-}


### PR DESCRIPTION
# Description

The main point of this is to remove the ReactRefreshWebpackPlugin that I unnecessarily added to the webpack server config a while back, but I figured I could also remove the hot reloading code from the server as it doesn't seem to be working. I removed instead of fixing it as I don't really see the need to have hot reload on the server, it is rarely changed much.

# Result

Removed some code from webpack config and server code

# Testing

- [x] I have thoroughly tested my changes.

Hot reload still works in client-code.