### PR TITLE
Replace `global` with `window` and ensure its existence

### DIFF
--- a/app/components/Header/FancyNodesCanvas.tsx
+++ b/app/components/Header/FancyNodesCanvas.tsx
@@ -14,15 +14,23 @@ const FancyNodesCanvas = ({ height = 160 }: Props) => {
   const theme = useTheme();
 
   useEffect(() => {
-    setWidth(global.innerWidth);
+    setWidth(window.innerWidth);
   }, []);
 
   useEffect(() => {
     const handleResize = debounce((e: UIEvent) => {
       setWidth((e.target as Window).innerWidth);
     }, 70);
-    global.addEventListener('resize', handleResize);
-    return () => global.removeEventListener('resize', handleResize);
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', handleResize);
+    }
+
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('resize', handleResize);
+      }
+    };
   }, [width]);
 
   useEffect(() => {


### PR DESCRIPTION
# Description

`addEventListener` and `removeEventListener` are methods provided by the `window` object in the browser, but not on the `global` object in a Node environment. This was causing a TypeError.

# Testing

- [x] I have thoroughly tested my changes.

The fancy nodes still work.

---

Resolves https://github.com/webkom/lego/issues/3434