### PR TITLE
Slightly improve the public overview

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -82,7 +82,10 @@
   align-items: center;
   flex-direction: row;
   height: var(--lego-header-height);
-  padding: 0 20px;
+
+  @media (--mobile-device) {
+    padding: 0 10px;
+  }
 }
 
 .logo {

--- a/app/routes/overview/IndexRoute.ts
+++ b/app/routes/overview/IndexRoute.ts
@@ -51,7 +51,7 @@ export default compose(
         props.loggedIn &&
           props.shouldFetchQuote &&
           dispatch(fetchRandomQuote()),
-        dispatch(fetchReadmes(props.loggedIn ? 4 : 1)),
+        dispatch(fetchReadmes(props.loggedIn ? 4 : 2)),
         dispatch(fetchData()),
       ]),
     (props) => [props.loggedIn, props.shouldFetchQuote]

--- a/app/routes/overview/components/CompactEvents.tsx
+++ b/app/routes/overview/components/CompactEvents.tsx
@@ -6,14 +6,16 @@ import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
 import { colorForEvent } from 'app/routes/events/utils';
 import styles from './CompactEvents.css';
+import type { CSSProperties } from 'react';
 
 type Props = {
   events: Array<Record<string, any>>;
-  frontpageHeading?: boolean;
+  style?: CSSProperties;
 };
+
 export default class CompactEvents extends Component<Props> {
   render() {
-    const { events, frontpageHeading } = this.props;
+    const { events, style } = this.props;
 
     const mapEvents = (eventTypes) => {
       return events
@@ -43,7 +45,7 @@ export default class CompactEvents extends Component<Props> {
                   style={{
                     transform: 'rotate(-20deg)',
                     marginRight: '4px',
-                    color: '#BE1600',
+                    color: 'var(--lego-red-color)',
                   }}
                 />
               </Tooltip>
@@ -76,9 +78,8 @@ export default class CompactEvents extends Component<Props> {
       return null;
     }
 
-    const headerStyle = frontpageHeading ? 'u-mb' : 'u-ui-heading';
     return (
-      <Flex column>
+      <Flex column style={style}>
         <Flex wrap className={styles.compactEvents}>
           <Flex column className={styles.compactLeft}>
             <Link
@@ -89,7 +90,7 @@ export default class CompactEvents extends Component<Props> {
                 },
               }}
             >
-              <h3 className={headerStyle}>Bedpres og kurs</h3>
+              <h3 className="u-ui-heading">Bedpres og kurs</h3>
             </Link>
             <ul className={styles.innerList}>{leftEvents}</ul>
           </Flex>
@@ -102,7 +103,7 @@ export default class CompactEvents extends Component<Props> {
                 },
               }}
             >
-              <h3 className={headerStyle}>Arrangementer</h3>
+              <h3 className="u-ui-heading">Arrangementer</h3>
             </Link>
             <ul className={styles.innerList}>{rightEvents}</ul>
           </Flex>

--- a/app/routes/overview/components/LatestReadme.css
+++ b/app/routes/overview/components/LatestReadme.css
@@ -11,8 +11,8 @@
 }
 
 .thumb {
-  height: 200px;
-  transition: transform var(--easing-medium);
+  width: 150px;
+  transition: transform var(--easing-fast);
   display: block;
   object-fit: contain;
 

--- a/app/routes/overview/components/LatestReadme.tsx
+++ b/app/routes/overview/components/LatestReadme.tsx
@@ -1,4 +1,3 @@
-import cx from 'classnames';
 import { useEffect, useState } from 'react';
 import { Collapse } from 'react-collapse';
 import Card from 'app/components/Card';
@@ -11,19 +10,17 @@ import styles from './LatestReadme.css';
 import type { CSSProperties } from 'react';
 
 type Props = {
-  expandedInitially: boolean;
+  expandedInitially?: boolean;
   collapsible?: boolean;
   readmes: Array<Readme>;
   style?: CSSProperties;
-  imageClassName?: string;
 };
 
 const LatestReadme = ({
   readmes,
-  expandedInitially,
+  expandedInitially = true,
   collapsible = true,
   style,
-  imageClassName,
 }: Props) => {
   const [expanded, setExpanded] = useState(expandedInitially);
 
@@ -52,15 +49,11 @@ const LatestReadme = ({
           wrap
           justifyContent="space-around"
           style={{
-            paddingTop: 20,
+            paddingTop: 15,
           }}
         >
           {readmes.slice(0, 4).map(({ image, pdf, title }) => (
-            <a
-              key={title}
-              href={pdf}
-              className={cx(styles.thumb, imageClassName)}
-            >
+            <a key={title} href={pdf} className={styles.thumb}>
               <Image src={image} alt={`Cover of ${title}`} />
             </a>
           ))}

--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -45,10 +45,6 @@
   }
 }
 
-.smallReadme {
-  width: 150px;
-}
-
 .showMore {
   display: flex;
   justify-content: center;

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -11,6 +11,7 @@ import type { WithDocumentType } from 'app/reducers/frontpage';
 import { isArticle, isEvent } from 'app/reducers/frontpage';
 import type { PollEntity } from 'app/reducers/polls';
 import type { PublicArticle } from 'app/store/models/Article';
+import type { FrontpageEvent } from 'app/store/models/Event';
 import ArticleItem from './ArticleItem';
 import CompactEvents from './CompactEvents';
 import EventItem from './EventItem';
@@ -18,20 +19,16 @@ import LatestReadme from './LatestReadme';
 import NextEvent from './NextEvent';
 import styles from './Overview.css';
 import Pinned from './Pinned';
-import { renderMeta } from './utils';
+import { itemUrl, renderMeta } from './utils';
 // import Banner, { COLORS } from 'app/components/Banner';
 
 type Props = {
-  frontpage: WithDocumentType<PublicArticle | Event>[];
+  frontpage: WithDocumentType<PublicArticle | FrontpageEvent>[];
   fetchingFrontpage: boolean;
   readmes: Readme[];
   poll: PollEntity | null | undefined;
   votePoll: () => Promise<void>;
   loggedIn: boolean;
-};
-
-const itemUrl = (item: WithDocumentType<PublicArticle | Event>) => {
-  return `/${item.documentType === 'event' ? 'events' : 'articles'}/${item.id}`;
 };
 
 const Overview = (props: Props) => {
@@ -55,7 +52,9 @@ const Overview = (props: Props) => {
       events
         .filter(
           (item) =>
-            item.id !== pinned.id && moment(item.startTime).isAfter(moment())
+            item.id !== pinned.id &&
+            isEvent(item) &&
+            moment(item.startTime).isAfter(moment())
         )
         .slice(0, eventsToShow),
     [events, eventsToShow, pinned]
@@ -87,7 +86,6 @@ const Overview = (props: Props) => {
   const readMe = (
     <Flex className={styles.readMe}>
       <LatestReadme
-        imageClassName={styles.smallReadme}
         readmes={readmes}
         expandedInitially={frontpage.length === 0 && !fetchingFrontpage}
       />

--- a/app/routes/overview/components/Pinned.tsx
+++ b/app/routes/overview/components/Pinned.tsx
@@ -2,19 +2,20 @@ import { Link } from 'react-router-dom';
 import Card from 'app/components/Card';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
-import type { Event } from 'app/models';
 import type { PublicArticle } from 'app/store/models/Article';
+import type { FrontpageEvent } from 'app/store/models/Event';
 import styles from './Pinned.css';
-import type { ReactElement } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
 
 type Props = {
-  item: Event | PublicArticle;
+  item: FrontpageEvent | PublicArticle;
   url: string;
   meta: ReactElement<'span'> | null;
+  style?: CSSProperties;
 };
 
-const Pinned = ({ item, url, meta }: Props) => (
-  <Flex column className={styles.pinned}>
+const Pinned = ({ item, url, meta, style }: Props) => (
+  <Flex column style={style} className={styles.pinned}>
     <h3 className="u-ui-heading">Festet oppslag</h3>
     <Card hideOverflow className={styles.body}>
       <Link to={url} className={styles.innerLinks}>

--- a/app/routes/overview/components/PublicFrontpage.css
+++ b/app/routes/overview/components/PublicFrontpage.css
@@ -2,26 +2,25 @@
 
 .container {
   display: grid;
-  grid-gap: 30px;
-  grid-template-columns: 1fr 1fr 1.3fr;
+  grid-gap: 40px;
+  grid-template-columns: 1fr 1fr 1fr;
   grid-auto-rows: auto;
   grid-template-areas: 'welcome welcome login' 'events events hsp' 'article article readme' 'links links links';
 
   @media (--mobile-device) {
-    grid-gap: 10px;
+    grid-gap: 20px;
     grid-template-columns: 1fr;
     grid-template-areas: 'welcome' 'login' 'events' 'hsp' 'article' 'readme' 'links';
   }
 }
 
-.rootCardStyle {
-  composes: withShadow from '~app/styles/utilities.css';
-  background: var(--lego-card-color);
-  padding: 30px;
+.login {
+  height: fit-content;
+}
 
-  @media (--mobile-device) {
-    padding: 15px;
-  }
+.welcome,
+.links {
+  padding: 0 10px 10px;
 }
 
 .hsp {
@@ -54,10 +53,4 @@
   margin: 0 auto;
   width: auto;
   height: 40%;
-}
-
-.latestReadme {
-  min-height: 410px;
-  max-width: 330px;
-  width: 100%;
 }

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import buddyWeekGraphic from 'app/assets/frontpage-graphic-buddyweek.png';
 import dataGraphic from 'app/assets/frontpage-graphic-data.png';
 import forCompaniesGraphic from 'app/assets/frontpage-graphic-for-companies.png';
@@ -14,8 +15,9 @@ import { readmeIfy } from 'app/components/ReadmeLogo';
 import type { Readme } from 'app/models';
 import type { WithDocumentType } from 'app/reducers/frontpage';
 import type { ArticleWithAuthorDetails } from 'app/routes/articles/ArticleListRoute';
-import { OverviewItem as Article } from 'app/routes/articles/components/Overview';
 import LatestReadme from 'app/routes/overview/components/LatestReadme';
+import Pinned from 'app/routes/overview/components/Pinned';
+import { itemUrl, renderMeta } from 'app/routes/overview/components/utils';
 import type { PublicEvent } from 'app/store/models/Event';
 import CompactEvents from './CompactEvents';
 import styles from './PublicFrontpage.css';
@@ -43,32 +45,38 @@ const isArticle = (
   item.documentType === 'article';
 
 const PublicFrontpage = ({ frontpage, readmes }: Props) => {
+  const pinned = frontpage[0];
+  const pinnedComponent = pinned && (
+    <Pinned
+      style={{ gridArea: 'article' }}
+      item={pinned}
+      url={itemUrl(pinned)}
+      meta={renderMeta(pinned)}
+    />
+  );
+
   return (
     <Container>
       {/* <Banner
-           header="Abakusrevyen har opptak!"
-           subHeader="Søk her"
-           link="https://opptak.abakus.no"
-           color={COLORS.red}
-          /> */}
+        header="Abakusrevyen har opptak!"
+        subHeader="Søk her"
+        link="https://opptak.abakus.no"
+        color={COLORS.red}
+      /> */}
       <Container className={styles.container}>
-        <Card style={{ gridArea: 'welcome' }}>
-          <Welcome />
-        </Card>
-        <Card style={{ gridArea: 'login' }}>
+        <Welcome />
+        <Card className={styles.login} style={{ gridArea: 'login' }}>
           <AuthSection />
         </Card>
-        <Card style={{ gridArea: 'events' }}>
-          <CompactEvents events={frontpage.filter(isEvent)} frontpageHeading />
-        </Card>
+        <CompactEvents
+          style={{ gridArea: 'events' }}
+          events={frontpage.filter(isEvent)}
+        />
         <Card style={{ gridArea: 'hsp' }}>
           <HspInfo />
         </Card>
-        <Card style={{ gridArea: 'article' }}>
-          <LatestArticle frontpage={frontpage} />
-        </Card>
+        {pinnedComponent}
         <LatestReadme
-          imageClassName={styles.latestReadme}
           readmes={readmes}
           expandedInitially
           collapsible={false}
@@ -81,8 +89,8 @@ const PublicFrontpage = ({ frontpage, readmes }: Props) => {
 };
 
 const Welcome = () => (
-  <>
-    <h2 className="u-mb">Velkommen til Abakus</h2>
+  <div className={styles.welcome} style={{ gridArea: 'welcome' }}>
+    <h1 className="u-mb">Velkommen til Abakus</h1>
     <p>
       Abakus er linjeforeningen for studentene ved <i>Datateknologi</i> og
       <i> Kommunikasjonsteknologi og digital sikkerhet</i> på NTNU, og drives av
@@ -93,7 +101,10 @@ const Welcome = () => (
       studiesituasjonen, arrangere kurs som utfyller fagtilbudet ved NTNU,
       fremme kontakten med næringslivet og bidra med sosiale aktiviteter.
     </p>
-  </>
+    <Link to="/pages/info-om-abakus">
+      <Button dark>Les mer om oss</Button>
+    </Link>
+  </div>
 );
 
 const HspInfo = () => (
@@ -112,18 +123,6 @@ const HspInfo = () => (
     innovasjon og samhold sterkt, og de er opptatt av å ta ansvar – både for
     egne leveranser, for kundene og for sine ansatte.
   </div>
-);
-
-const LatestArticle = ({ frontpage }: Pick<Props, 'frontpage'>) => (
-  <>
-    <h2 className="u-mb">Siste artikkel</h2>
-    {frontpage
-      .filter(isArticle)
-      .slice(0, 1)
-      .map((item) => (
-        <Article article={item} key={item.id} />
-      ))}
-  </>
 );
 
 const usefulLinksConf = [
@@ -175,8 +174,8 @@ const usefulLinksConf = [
 ];
 
 const UsefulLinks = () => (
-  <>
-    <h2 className="u-mb">Nyttige lenker</h2>
+  <div className={styles.links}>
+    <h3 className="u-ui-heading">Nyttige lenker</h3>
 
     <Flex wrap justifyContent="center" gap={40}>
       {usefulLinksConf.map((item) => (
@@ -201,7 +200,7 @@ const UsefulLinks = () => (
         </a>
       ))}
     </Flex>
-  </>
+  </div>
 );
 
 export default PublicFrontpage;

--- a/app/routes/overview/components/utils.tsx
+++ b/app/routes/overview/components/utils.tsx
@@ -2,16 +2,30 @@ import moment from 'moment-timezone';
 import Tags from 'app/components/Tags';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';
-import type { Event } from 'app/models';
 import type { WithDocumentType } from 'app/reducers/frontpage';
-import { isEvent } from 'app/reducers/frontpage';
+import { isArticle, isEvent } from 'app/reducers/frontpage';
+import type { ArticleWithAuthorDetails } from 'app/routes/articles/ArticleListRoute';
 import { eventTypeToString } from 'app/routes/events/utils';
 import type { PublicArticle } from 'app/store/models/Article';
+import type { PublicEvent } from 'app/store/models/Event';
 import truncateString from 'app/utils/truncateString';
 import styles from './Overview.css';
 
-export const renderMeta = (item: WithDocumentType<Event | PublicArticle>) => {
-  const itemTime = isEvent(item) ? item.startTime : item.createdAt;
+export const itemUrl = (
+  item: WithDocumentType<ArticleWithAuthorDetails | PublicArticle | PublicEvent>
+) => {
+  return `/${item.documentType === 'event' ? 'events' : 'articles'}/${item.id}`;
+};
+
+export const renderMeta = (
+  item: WithDocumentType<ArticleWithAuthorDetails | PublicArticle | PublicEvent>
+) => {
+  let itemTime;
+  if (isEvent(item)) {
+    itemTime = item.startTime;
+  } else if (isArticle(item)) {
+    itemTime = item.createdAt;
+  }
 
   let format =
     moment().year() === moment(itemTime).year() ? 'DD. MMM' : 'DD. MMM YYYY';

--- a/app/styles/overlay.css
+++ b/app/styles/overlay.css
@@ -11,11 +11,6 @@
   @media (--small-viewport) {
     width: calc(100% - 10px);
   }
-
-  & h2 {
-    margin: 0;
-    font-size: var(--font-size-lg);
-  }
 }
 
 .arrow {

--- a/cypress/e2e/home_page_spec.js
+++ b/cypress/e2e/home_page_spec.js
@@ -16,10 +16,9 @@ describe('The Home Page and Login', () => {
     cy.contains('h3', 'Arrangementer');
     cy.contains('li', 'Sikkerhet og Sårbarhet');
 
-    cy.contains('h2', 'Siste artikkel');
-    cy.contains('h2', 'Siste utgave av');
-    cy.contains('h2', 'Nyttige linker');
-    cy.contains('h2', 'Vår Facebook side');
+    cy.contains('h3', 'Festet oppslag');
+    cy.contains('span', 'readme');
+    cy.contains('h3', 'Nyttige lenker');
   });
 
   it('can log in from homepage', () => {


### PR DESCRIPTION
# Description

Small changes here and there that I believe improves it. Firstly it resembles the "private" overview page a lot more by using the same components. It feels less "square" without the heavy use of cards. I do not think this is perfect, but I thought the page needed some love, especially before next semester. I don't want to spend too much time on it right now.

# Result

| Before | After |
:-----------------------:|:--------------------------:
<img width="868" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/8771bbbe-da87-4d63-b13c-b09ed3c178ed"> | <img width="868" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/b038c290-d7dc-4e20-88fb-fc63c1f271b9">


# Testing

- [x] I have thoroughly tested my changes.

Tested on different viewports. It now actually works better on mobile imo.