### PR TITLE
Add banner and update public frontpage for fp-23

### DIFF
--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -2,6 +2,7 @@ import moment from 'moment-timezone';
 import { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
+import Banner from 'app/components/Banner';
 import Icon from 'app/components/Icon';
 import { Container, Flex } from 'app/components/Layout';
 import Poll from 'app/components/Poll';
@@ -20,7 +21,6 @@ import NextEvent from './NextEvent';
 import styles from './Overview.css';
 import Pinned from './Pinned';
 import { itemUrl, renderMeta } from './utils';
-// import Banner, { COLORS } from 'app/components/Banner';
 
 type Props = {
   frontpage: WithDocumentType<PublicArticle | FrontpageEvent>[];
@@ -95,12 +95,12 @@ const Overview = (props: Props) => {
   return (
     <Container>
       <Helmet title="Hjem" />
-      {/* <Banner
-         header="Abakusrevyen har opptak!"
-         subHeader="Søk her"
-         link="https://opptak.abakus.no"
-         color={COLORS.red}
-        /> */}
+      <Banner
+        header="Velkommen til fadderperioden 2023!"
+        subHeader="Trykk her for mer informasjon til nye studenter"
+        link="https://ny.abakus.no"
+        color="red"
+      />
       <Flex className={styles.desktopContainer}>
         <Flex column className={styles.leftColumn}>
           <CompactEvents events={events} />

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -7,6 +7,7 @@ import readmeGraphic from 'app/assets/frontpage-graphic-readme.png';
 import netcompany from 'app/assets/netcompany_dark.png';
 import netcompanyLight from 'app/assets/netcompany_white.svg';
 import AuthSection from 'app/components/AuthSection/AuthSection';
+import Banner from 'app/components/Banner';
 import Button from 'app/components/Button';
 import Card from 'app/components/Card';
 import { Image } from 'app/components/Image';
@@ -21,7 +22,6 @@ import { itemUrl, renderMeta } from 'app/routes/overview/components/utils';
 import type { PublicEvent } from 'app/store/models/Event';
 import CompactEvents from './CompactEvents';
 import styles from './PublicFrontpage.css';
-// import Banner, { COLORS } from 'app/components/Banner';
 
 type Props = {
   frontpage: (
@@ -57,12 +57,12 @@ const PublicFrontpage = ({ frontpage, readmes }: Props) => {
 
   return (
     <Container>
-      {/* <Banner
-        header="Abakusrevyen har opptak!"
-        subHeader="Søk her"
-        link="https://opptak.abakus.no"
-        color={COLORS.red}
-      /> */}
+      <Banner
+        header="Velkommen til fadderperioden 2023!"
+        subHeader="Trykk her for mer informasjon til nye studenter"
+        link="https://ny.abakus.no"
+        color="red"
+      />
       <Container className={styles.container}>
         <Welcome />
         <Card className={styles.login} style={{ gridArea: 'login' }}>
@@ -127,13 +127,13 @@ const HspInfo = () => (
 
 const usefulLinksConf = [
   {
-    title: 'Fadderperioden 2022',
+    title: 'Fadderperioden 2023',
     image: buddyWeekGraphic,
     description:
-      'Abakus arrangerer fadderperioden for alle nye studenter, og her finner du informasjon om fadderperioden 2022.',
+      'Abakus arrangerer fadderperioden for alle nye studenter, og her kan du lese mer om den og finne annen nyttig informasjon til studiestart.',
     buttonText: 'Les deg opp',
-    link: '/articles/414',
-    isInternalLink: true,
+    link: 'https://ny.abakus.no',
+    isInternalLink: false,
   },
   {
     title: 'Datateknologi',


### PR DESCRIPTION
# Description

Add banner for fp-23, and change public fb-card from linking to an article to linking to ny.abakus.no.

I believe that the site is now good enough that it is better to publish it than wait, and rather iterate on the minor stuff later. Also starting to be about time that new students can find some sort of info.

# Result

Banner is now visible

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ... (either GitHub issue or Linear task)
