### PR TITLE
Set default tooltip placement to be top

### DIFF
--- a/app/components/Tooltip/index.tsx
+++ b/app/components/Tooltip/index.tsx
@@ -22,8 +22,14 @@ const Tooltip = ({ children, content, className, style, onClick }: Props) => {
     attributes,
     update,
   } = usePopper(triggerRef.current, tooltipRef.current, {
-    placement: 'auto',
+    placement: 'top',
     modifiers: [
+      {
+        name: 'flip',
+        options: {
+          fallbackPlacements: ['bottom', 'left', 'right'],
+        },
+      },
       {
         name: 'arrow',
         options: {

--- a/app/components/Tooltip/index.tsx
+++ b/app/components/Tooltip/index.tsx
@@ -8,10 +8,18 @@ type Props = {
   content: ReactNode;
   className?: string;
   onClick?: () => void;
+  placement?: 'top' | 'bottom' | 'left' | 'right';
   style?: CSSProperties;
 };
 
-const Tooltip = ({ children, content, className, style, onClick }: Props) => {
+const Tooltip = ({
+  children,
+  content,
+  className,
+  onClick,
+  placement,
+  style,
+}: Props) => {
   const [hovered, setHovered] = useState(false);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -22,12 +30,12 @@ const Tooltip = ({ children, content, className, style, onClick }: Props) => {
     attributes,
     update,
   } = usePopper(triggerRef.current, tooltipRef.current, {
-    placement: 'top',
+    placement: placement || 'top',
     modifiers: [
       {
         name: 'flip',
         options: {
-          fallbackPlacements: ['bottom', 'left', 'right'],
+          fallbackPlacements: ['top', 'bottom', 'left', 'right'],
         },
       },
       {


### PR DESCRIPTION
# Description

When there is space, I prefer to have it on top. It's also the more "common" placement.

# Result

https://github.com/webkom/lego-webapp/assets/69514187/da5203d5-2db7-40f1-87a5-942ea8aee087


# Testing

- [x] I have thoroughly tested my changes.

It still works. See video above.