### PR TITLE
Show a loading indicator when fetching notifications

### DIFF
--- a/app/components/Feed/types.ts
+++ b/app/components/Feed/types.ts
@@ -1,10 +1,13 @@
 export type Activity = {
+  activityId: string;
   time: string;
+  verb: number;
   extraContext: Record<string, any>;
   actor: string;
   object: string;
   target: string;
 };
+
 export type AggregatedActivity = {
   id: number;
   verb: string;
@@ -16,11 +19,18 @@ export type AggregatedActivity = {
   actorIds: Array<string>;
   read: boolean;
   seen: boolean;
+  orderingKey: string;
   context: Record<string, any>;
 };
+
 export type TagInfo = {
   link: string;
   text: string;
   notLink: boolean;
   linkableContent: boolean;
+};
+
+export type NotificationData = {
+  unreadCount: number;
+  unseenCount: number;
 };

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -5,6 +5,10 @@ import { Link, NavLink, useHistory } from 'react-router-dom';
 import logoLightMode from 'app/assets/logo-dark.png';
 import logoDarkMode from 'app/assets/logo.png';
 import AuthSection from 'app/components/AuthSection/AuthSection';
+import type {
+  AggregatedActivity,
+  NotificationData,
+} from 'app/components/Feed/types';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import type { UserEntity } from 'app/reducers/users';
 import type { ID } from 'app/store/models';
@@ -27,9 +31,9 @@ type Props = {
   loggedIn: boolean;
   login: () => Promise<any>;
   logout: () => void;
-  notificationsData: Record<string, any>;
+  notificationsData: NotificationData;
   fetchNotifications: () => void;
-  notifications: Array<Record<string, any>>;
+  notifications: AggregatedActivity[];
   markAllNotifications: () => Promise<void>;
   fetchNotificationData: () => Promise<void>;
   upcomingMeeting: string;

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -33,6 +33,7 @@ type Props = {
   logout: () => void;
   notificationsData: NotificationData;
   fetchNotifications: () => void;
+  fetchingNotifications: boolean;
   notifications: AggregatedActivity[];
   markAllNotifications: () => Promise<void>;
   fetchNotificationData: () => Promise<void>;
@@ -198,6 +199,7 @@ const Header = ({ loggedIn, currentUser, loading, ...props }: Props) => {
               <NotificationsDropdown
                 notificationsData={props.notificationsData}
                 fetchNotifications={props.fetchNotifications}
+                fetchingNotifications={props.fetchingNotifications}
                 notifications={props.notifications}
                 markAllNotifications={props.markAllNotifications}
                 fetchNotificationData={props.fetchNotificationData}

--- a/app/components/HeaderNotifications/HeaderNotifications.css
+++ b/app/components/HeaderNotifications/HeaderNotifications.css
@@ -1,7 +1,12 @@
 @import url('~app/styles/variables.css');
 
 .notifications {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 400px;
+  min-height: 200px;
+  transition: height 3s ease-in-out;
 
   @media (--small-viewport) {
     width: 100%;

--- a/app/routes/app/AppRoute.tsx
+++ b/app/routes/app/AppRoute.tsx
@@ -142,6 +142,7 @@ class App extends PureComponent<AppProps> {
             login={this.props.login}
             notificationsData={this.props.notificationsData}
             fetchNotifications={this.props.fetchNotificationFeed}
+            fetchingNotifications={this.props.fetchingNotifications}
             notifications={this.props.notifications}
             markAllNotifications={this.props.markAllNotifications}
             fetchNotificationData={this.props.fetchNotificationData}
@@ -183,6 +184,7 @@ const mapStateToProps = (state) => {
     notifications: selectFeedActivitesByFeedId(state, {
       feedId: 'notifications',
     }),
+    fetchingNotifications: state.feedActivities.fetching,
     statusCode: state.router.statusCode,
     upcomingMeeting: upcomingMeetings.length ? upcomingMeetings[0] : undefined,
     loading: state.frontpage.fetching,


### PR DESCRIPTION
# Description

[Rewrite NotificationsDropdown to a functional component](https://github.com/webkom/lego-webapp/commit/fda94f290f7671b00b05e21e515d79351a8ef465) 

And correctly type its props.

---

[Show a loading indicator when fetching notifications](https://github.com/webkom/lego-webapp/commit/332989da97f088aa47f5b187c2706ec62c619daa) 

Gives better feedback to the user, than stating that there are no
notifications. The content is now also centered properly.

# Result

https://github.com/webkom/lego-webapp/assets/69514187/4db47b0c-1381-46ce-9343-50d318c83983

# Testing

- [x] I have thoroughly tested my changes.

See video above.