### PR TITLE
Give comments a retouch

### DIFF
--- a/app/components/Card/Card.css
+++ b/app/components/Card/Card.css
@@ -4,10 +4,6 @@
   border-radius: var(--border-radius-lg);
 }
 
-.tight {
-  padding: 0;
-}
-
 .shadow {
   box-shadow: var(--shadow-sm);
 }

--- a/app/components/Card/index.tsx
+++ b/app/components/Card/index.tsx
@@ -43,7 +43,6 @@ const CardContent = ({ children, danger, info }: CardContentProps) => {
 
 type Props = {
   className?: string;
-  tight?: boolean;
   shadow?: boolean;
   hideOverflow?: boolean;
   isHoverable?: boolean;
@@ -54,7 +53,6 @@ type Props = {
 function Card({
   children,
   className,
-  tight = false,
   shadow = true,
   hideOverflow = false,
   isHoverable = false,
@@ -67,7 +65,6 @@ function Card({
       className={cx(
         className,
         styles.card,
-        tight && styles.tight,
         shadow && styles.shadow,
         isHoverable && styles.isHoverable,
         danger && styles.danger,

--- a/app/components/CommentForm/CommentForm.css
+++ b/app/components/CommentForm/CommentForm.css
@@ -1,22 +1,12 @@
-.form {
-  :global {
-    /* stylelint-disable-next-line selector-class-pattern */
-    .md-RichEditor-editor:not(.md-RichEditor-readonly) {
-      padding: 10px 0;
-      border: 0;
-
-      &:focus-within {
-        box-shadow: none;
-      }
-    }
-
-    /* stylelint-disable-next-line selector-class-pattern */
-    .md-RichEditor-editor .public-DraftEditor-content {
-      min-height: 0;
-    }
-  }
-}
-
 .field {
   flex: 1;
+}
+
+.field > div {
+  margin: 0;
+}
+
+.submittable {
+  opacity: 0;
+  transition: opacity var(--easing-medium);
 }

--- a/app/components/CommentForm/CommentForm.css
+++ b/app/components/CommentForm/CommentForm.css
@@ -1,13 +1,4 @@
 .form {
-  background-color: var(--lego-card-color);
-  box-shadow: var(--shadow-sm);
-  border-radius: var(--border-radius-lg);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 20px;
-  margin-bottom: 15px;
-
   :global {
     /* stylelint-disable-next-line selector-class-pattern */
     .md-RichEditor-editor:not(.md-RichEditor-readonly) {
@@ -26,50 +17,6 @@
   }
 }
 
-.inlineForm {
-  flex-direction: row;
-  display: flex;
-  margin-top: 20px;
-  width: 100%;
-}
-
-.activeForm {
-  flex-direction: column;
-  align-items: flex-start;
-}
-
-.header {
-  flex-direction: row;
-  display: flex;
-  align-items: center;
-}
-
-.fields {
-  display: flex;
-  flex-direction: column;
+.field {
   flex: 1;
-  margin-left: 15px;
-}
-
-.author {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  margin-left: 25px;
-  font-weight: 500;
-  color: var(--lego-red-color);
-}
-
-.activeFields {
-  margin-top: 10px;
-  margin-left: 0;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  flex: 2;
-}
-
-.submit {
-  max-width: 150px;
-  margin-top: 30px;
 }

--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -55,6 +55,7 @@ const CommentForm = ({
   return (
     <Card>
       <LegoFinalForm
+        validateOnSubmitOnly
         initialValues={{
           commentKey: Math.random(),
         }}

--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -3,11 +3,13 @@ import { useEffect, useState } from 'react';
 import { Field } from 'react-final-form';
 import { addComment } from 'app/actions/CommentActions';
 import Button from 'app/components/Button';
+import Card from 'app/components/Card';
 import DisplayContent from 'app/components/DisplayContent';
 import { EditorField } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { ProfilePicture } from 'app/components/Image';
+import Flex from 'app/components/Layout/Flex';
 import { useAppDispatch } from 'app/store/hooks';
 import type { ID } from 'app/store/models';
 import type { CurrentUser } from 'app/store/models/User';
@@ -23,6 +25,7 @@ type Props = {
   inlineMode?: boolean;
   autoFocus?: boolean;
   parent?: ID;
+  placeholder?: string;
 };
 
 const validate = createValidator({
@@ -37,6 +40,7 @@ const CommentForm = ({
   inlineMode = false,
   autoFocus = false,
   parent,
+  placeholder = 'Skriv en kommentar ...',
 }: Props) => {
   const dispatch = useAppDispatch();
   // editor must be disabled while server-side rendering
@@ -48,81 +52,77 @@ const CommentForm = ({
   const className = inlineMode ? styles.inlineForm : styles.form;
 
   if (!loggedIn) {
-    return <div>Vennligst logg inn for å kommentere.</div>;
+    return <div>Vennligst logg inn for å kommentere</div>;
   }
 
   return (
-    <LegoFinalForm
-      initialValues={{
-        text: EDITOR_EMPTY,
-        commentKey: Math.random(),
-      }}
-      validate={validate}
-      onSubmit={({ text }) => {
-        return dispatch(
-          addComment({
-            contentTarget,
-            text,
-            parent,
-          })
-        );
-      }}
-    >
-      {({
-        handleSubmit,
-        pristine,
-        submitting,
-        form,
-        // $FlowFixMe
-        values,
-      }) => {
-        const textValue = form.getFieldState('text')?.value;
-        const fieldActive = form.getFieldState('text')?.active;
-        const isOpen = fieldActive || (textValue && textValue !== EDITOR_EMPTY);
-        return (
-          <form
-            onSubmit={handleSubmit}
-            className={cx(className, isOpen && styles.activeForm)}
-          >
-            <div className={styles.header}>
-              <ProfilePicture size={40} user={user} />
+    <Card>
+      <LegoFinalForm
+        initialValues={{
+          text: EDITOR_EMPTY,
+          commentKey: Math.random(),
+        }}
+        validate={validate}
+        onSubmit={({ text }) => {
+          return dispatch(
+            addComment({
+              contentTarget,
+              text,
+              parent,
+            })
+          );
+        }}
+      >
+        {({
+          handleSubmit,
+          pristine,
+          submitting,
+          form,
+          // $FlowFixMe
+          values,
+        }) => {
+          const textValue = form.getFieldState('text')?.value;
+          const fieldActive = form.getFieldState('text')?.active;
+          const isOpen =
+            fieldActive || (textValue && textValue !== EDITOR_EMPTY);
 
-              {isOpen && <div className={styles.author}>{user.fullName}</div>}
-            </div>
-            <div className={cx(styles.fields, isOpen && styles.activeFields)}>
-              {editorSsrDisabled ? (
-                <DisplayContent
-                  id="comment-text"
-                  content=""
-                  placeholder="Skriv en kommentar"
-                />
-              ) : (
-                <Field
-                  key={values.commentKey}
-                  autoFocus={autoFocus}
-                  name="text"
-                  placeholder="Skriv en kommentar"
-                  component={EditorField.AutoInitialized}
-                  simple
-                />
-              )}
+          return (
+            <form onSubmit={handleSubmit} className={cx(className)}>
+              <Flex alignItems="center" gap="1rem">
+                <ProfilePicture size={40} user={user} />
 
-              {isOpen && (
-                <Button
-                  flat
-                  submit
-                  disabled={pristine || submitting}
-                  className={styles.submit}
-                >
-                  {submitText}
-                </Button>
-              )}
+                <div className={styles.field}>
+                  {editorSsrDisabled ? (
+                    <DisplayContent
+                      id="comment-text"
+                      content=""
+                      placeholder={placeholder}
+                    />
+                  ) : (
+                    <Field
+                      key={values.commentKey}
+                      autoFocus={autoFocus}
+                      name="text"
+                      placeholder={placeholder}
+                      component={EditorField.AutoInitialized}
+                      simple
+                    />
+                  )}
+                </div>
+
+                {isOpen && (
+                  <Button submit disabled={pristine || submitting}>
+                    {submitText}
+                  </Button>
+                )}
+              </Flex>
+
               <SubmissionError />
-            </div>
-          </form>
-        );
-      }}
-    </LegoFinalForm>
+            </form>
+          );
+        }}
+      </LegoFinalForm>
+    </Card>
   );
 };
 

--- a/app/components/Comments/Comment.css
+++ b/app/components/Comments/Comment.css
@@ -1,25 +1,7 @@
 @import url('~app/styles/variables.css');
 
-.container {
-  background-color: var(--lego-card-color);
-  box-shadow: var(--shadow-sm);
-  border-radius: var(--border-radius-lg);
-  margin-bottom: 15px;
-  padding: 25px;
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-
-  @media (--mobile-device) {
-    padding: 8px;
-  }
-}
-
 .comment {
-  display: flex;
-  align-items: flex-start;
-  flex-direction: column;
-  width: 100%;
+  padding: 1rem;
 
   :global {
     /* stylelint-disable-next-line selector-class-pattern */
@@ -29,67 +11,19 @@
   }
 }
 
-.profileImage {
-  margin-right: 45px;
-
-  @media (--mobile-device) {
-    margin-right: 5px;
-  }
-}
-
-.content {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-}
-
-.header {
-  display: flex;
-  align-items: center;
-  margin-bottom: 10px;
-  width: inherit;
-}
-
-.username {
-  align-items: center;
-
-  @media (--mobile-device) {
-    flex-direction: column;
-    padding-top: 16px;
-    margin-right: 10px;
-  }
-}
-
-.bullet {
-  color: var(--secondary-font-color);
-  padding: 0 8px;
-
-  @media (--mobile-device) {
-    display: none;
-  }
+.username a {
+  color: var(--lego-font-color);
+  font-weight: 500;
 }
 
 .timestamp {
+  font-size: var(--font-size-sm);
   color: var(--secondary-font-color);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-
-  @media (--mobile-device) {
-    padding: none;
-    font-size: var(--font-size-sm);
-  }
 }
 
 .text {
-  margin: 0;
-}
-
-.links {
-  flex-grow: 1;
-  justify-content: space-between;
-}
-
-.delete {
-  margin-left: 10px;
+  margin: 1rem 0;
 }

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -6,6 +6,7 @@ import DisplayContent from 'app/components/DisplayContent';
 import Icon from 'app/components/Icon';
 import { ProfilePicture } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
+import { Tag } from 'app/components/Tags';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
 import type { ID } from 'app/store/models';
@@ -24,6 +25,7 @@ type Props = {
   deleteComment: (id: ID, contentTarget: ContentTarget) => Promise<void>;
   user: CurrentUser;
   contentTarget: ContentTarget;
+  contentAuthors?: ID[];
 };
 
 const Comment = ({
@@ -32,6 +34,7 @@ const Comment = ({
   commentFormProps,
   deleteComment,
   user,
+  contentAuthors,
 }: Props) => {
   const [replyOpen, setReplyOpen] = useState(false);
   const { createdAt, text, author } = comment;
@@ -49,7 +52,18 @@ const Comment = ({
               />
 
               <Flex column className={styles.username}>
-                <Link to={`/users/${author.username}`}>{author.fullName}</Link>
+                <Flex alignItems="center" gap={10}>
+                  <Link to={`/users/${author.username}`}>
+                    {author.fullName}
+                  </Link>
+                  {contentAuthors?.includes(author.id) && (
+                    <Tag
+                      icon="shield-checkmark-outline"
+                      tag="Forfatter"
+                      color="blue"
+                    />
+                  )}
+                </Flex>
                 <Time className={styles.timestamp} time={createdAt} wordsAgo />
               </Flex>
             </Flex>

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import Button from 'app/components/Button';
 import CommentForm from 'app/components/CommentForm';
 import DisplayContent from 'app/components/DisplayContent';
+import Icon from 'app/components/Icon';
 import { ProfilePicture } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import Time from 'app/components/Time';
+import Tooltip from 'app/components/Tooltip';
 import type { ID } from 'app/store/models';
 import type CommentType from 'app/store/models/Comment';
 import type { CurrentUser } from 'app/store/models/User';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
-import Button from '../Button';
 import styles from './Comment.css';
 
 type Props = {
@@ -35,48 +37,56 @@ const Comment = ({
   const { createdAt, text, author } = comment;
 
   return (
-    <div className={styles.container}>
+    <>
       <div className={styles.comment}>
         {author && (
-          <div className={styles.header}>
-            <ProfilePicture
-              size={40}
-              user={author}
-              alt={`${author.username}'s profile picture`}
-              className={styles.profileImage}
-            />
-            <Flex className={styles.username}>
-              <Link to={`/users/${author.username}`}>{author.fullName}</Link>
-              <span className={styles.bullet}>•</span>
-              <Time className={styles.timestamp} time={createdAt} wordsAgo />
-              <span className={styles.bullet}>•</span>
+          <Flex alignItems="center" justifyContent="space-between">
+            <Flex alignItems="center" gap="1rem">
+              <ProfilePicture
+                size={40}
+                user={author}
+                alt={`${author.username}'s profile picture`}
+              />
+
+              <Flex column className={styles.username}>
+                <Link to={`/users/${author.username}`}>{author.fullName}</Link>
+                <Time className={styles.timestamp} time={createdAt} wordsAgo />
+              </Flex>
             </Flex>
-            <Flex className={styles.links}>
-              <Button flat onClick={() => setReplyOpen(!replyOpen)}>
-                {replyOpen ? 'Lukk svar' : 'Svar'}
-              </Button>
-              {user && author.id === user.id && (
-                <Button
-                  flat
-                  onClick={() => deleteComment(comment.id, contentTarget)}
-                  className={styles.delete}
-                >
-                  Slett
-                </Button>
+
+            <Flex justifyContent="flex-end">
+              {user?.id === author.id && (
+                <Tooltip content="Slett kommentar">
+                  <Icon
+                    danger
+                    name="trash"
+                    size={20}
+                    onClick={() => deleteComment(comment.id, contentTarget)}
+                  />
+                </Tooltip>
               )}
             </Flex>
-          </div>
+          </Flex>
         )}
-        <div className={styles.content}>
-          <DisplayContent
-            id="comment-text"
-            className={styles.text}
-            style={{
-              fontStyle: replyOpen && 'italic',
-            }}
-            content={text ? text : '<p>Slettet</p>'}
-          />
-        </div>
+
+        <DisplayContent
+          id="comment-text"
+          className={styles.text}
+          content={text ? text : '<p>Slettet</p>'}
+        />
+
+        {author && (
+          <Button flat onClick={() => setReplyOpen(!replyOpen)}>
+            {replyOpen ? (
+              'Avbryt'
+            ) : (
+              <>
+                <Icon name="return-up-back" size={20} />
+                Svar
+              </>
+            )}
+          </Button>
+        )}
       </div>
 
       {replyOpen && (
@@ -86,9 +96,10 @@ const Comment = ({
           inlineMode
           autoFocus
           parent={comment.id}
+          placeholder={`Svar ${author.fullName} ...`}
         />
       )}
-    </div>
+    </>
   );
 };
 

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -93,7 +93,6 @@ const Comment = ({
         <CommentForm
           {...commentFormProps}
           submitText="Send svar"
-          inlineMode
           autoFocus
           parent={comment.id}
           placeholder={`Svar ${author.fullName} ...`}

--- a/app/components/Comments/CommentTree.css
+++ b/app/components/Comments/CommentTree.css
@@ -1,5 +1,9 @@
 @import url('~app/styles/variables.css');
 
+.commentTree {
+  margin-bottom: 1rem;
+}
+
 .nested {
   margin-left: 50px;
 

--- a/app/components/Comments/CommentTree.tsx
+++ b/app/components/Comments/CommentTree.tsx
@@ -32,6 +32,7 @@ function CommentTree({
 }: Props) {
   const tree = comments.map((comment) => {
     const className = cx(
+      styles.commentTree,
       isChild && level < 3 && styles.nested,
       isChild ? styles.child : styles.root
     );
@@ -73,6 +74,7 @@ function CommentTree({
       </div>
     );
   });
+
   return <div>{tree}</div>;
 }
 

--- a/app/components/Comments/CommentTree.tsx
+++ b/app/components/Comments/CommentTree.tsx
@@ -19,6 +19,7 @@ type Props = {
   deleteComment: (id: ID, contentTarget: ContentTarget) => Promise<void>;
   user: CurrentUser;
   contentTarget: ContentTarget;
+  contentAuthors?: ID[];
 };
 
 function CommentTree({
@@ -29,6 +30,7 @@ function CommentTree({
   deleteComment,
   user,
   contentTarget,
+  contentAuthors,
 }: Props) {
   const tree = comments.map((comment) => {
     const className = cx(
@@ -46,6 +48,7 @@ function CommentTree({
             deleteComment={deleteComment}
             user={user}
             contentTarget={contentTarget}
+            contentAuthors={contentAuthors}
           />
 
           <CommentTree
@@ -56,6 +59,7 @@ function CommentTree({
             deleteComment={deleteComment}
             user={user}
             contentTarget={contentTarget}
+            contentAuthors={contentAuthors}
           />
         </div>
       );
@@ -70,6 +74,7 @@ function CommentTree({
           deleteComment={deleteComment}
           user={user}
           contentTarget={contentTarget}
+          contentAuthors={contentAuthors}
         />
       </div>
     );

--- a/app/components/Comments/CommentView.tsx
+++ b/app/components/Comments/CommentView.tsx
@@ -19,6 +19,7 @@ type Props = {
   style?: CSSProperties;
   newOnTop?: boolean;
   deleteComment: (id: ID, contentTarget: ContentTarget) => Promise<void>;
+  contentAuthors?: ID[];
 };
 
 const Title = ({ displayTitle }: { displayTitle: boolean }) =>
@@ -35,6 +36,7 @@ const CommentView = (props: Props) => {
     displayTitle = true,
     newOnTop = false,
     deleteComment,
+    contentAuthors,
   } = props;
   const commentFormProps = {
     contentTarget,
@@ -61,6 +63,7 @@ const CommentView = (props: Props) => {
               deleteComment={deleteComment}
               user={user}
               contentTarget={contentTarget}
+              contentAuthors={contentAuthors}
             />
           )}
         </LoadingIndicator>

--- a/app/components/Comments/CommentView.tsx
+++ b/app/components/Comments/CommentView.tsx
@@ -46,10 +46,13 @@ const CommentView = (props: Props) => {
     <div style={style}>
       <Title displayTitle={displayTitle} />
       <Flex
+        gap="1rem"
         style={{
           flexDirection: newOnTop ? 'column-reverse' : 'column',
         }}
       >
+        {!formDisabled && <CommentForm {...commentFormProps} />}
+
         <LoadingIndicator loading={!comments}>
           {comments && (
             <CommentTree
@@ -61,12 +64,6 @@ const CommentView = (props: Props) => {
             />
           )}
         </LoadingIndicator>
-
-        {!formDisabled && (
-          <div>
-            <CommentForm {...commentFormProps} />
-          </div>
-        )}
       </Flex>
     </div>
   );

--- a/app/components/Form/LegoFinalForm.tsx
+++ b/app/components/Form/LegoFinalForm.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import createFocusOnErrorDecorator from 'final-form-focus';
 import { isEqual } from 'lodash';
+import { useState } from 'react';
 import { Form } from 'react-final-form';
 import { handleSubmissionErrorFinalForm } from 'app/components/Form/utils';
 import type { FormProps } from 'react-final-form';
@@ -16,6 +17,9 @@ interface Props<FormValues> extends FormProps<FormValues> {
 
   /* Move the screen to the first error in the list on SubmissionError */
   enableFocusOnError?: boolean;
+
+  /* Only validate on submit, instead of giving real-time feedback on user input */
+  validateOnSubmitOnly?: boolean;
 }
 
 const LegoFinalForm = <FormValues,>({
@@ -24,34 +28,54 @@ const LegoFinalForm = <FormValues,>({
   enableSubmissionError = true,
   enableFocusOnError = true,
   decorators = [],
+  validateOnSubmitOnly = false,
   ...rest
 }: Props<FormValues>) => {
   if (enableFocusOnError) {
     decorators = [focusOnError, ...decorators];
   }
 
+  const [submitting, setSubmitting] = useState(false);
+
+  const validate = (values) => {
+    if (validateOnSubmitOnly && !submitting) {
+      return {};
+    } else {
+      return rest.validate ? rest.validate(values) : {};
+    }
+  };
+
   return (
     <Form
       {...rest}
+      validate={validate}
       initialValuesEqual={isEqual}
       decorators={decorators}
       onSubmit={(values, form) => {
+        setSubmitting(true);
         const res = onSubmit(values, form);
 
         if (!res || !('then' in res)) {
+          setSubmitting(false);
           return res;
         }
 
-        return res.catch((error) => {
-          Sentry.captureException(error);
-          if (__DEV__) console.error(error);
+        return res
+          .then((result) => {
+            setSubmitting(false);
+            return result;
+          })
+          .catch((error) => {
+            setSubmitting(false);
+            Sentry.captureException(error);
+            if (__DEV__) console.error(error);
 
-          if (!enableSubmissionError) {
-            throw error;
-          }
+            if (!enableSubmissionError) {
+              throw error;
+            }
 
-          return handleSubmissionErrorFinalForm(error);
-        });
+            return handleSubmissionErrorFinalForm(error);
+          });
       }}
     >
       {children}

--- a/app/components/Tags/Tag.css
+++ b/app/components/Tags/Tag.css
@@ -48,8 +48,7 @@
     calc((var(--label-l) - 25) * 1%),
     var(--border-alpha)
   );
-  display: inline-block;
-  padding: 1px 7px;
+  padding: 2.5px 7px;
   border: 1px solid transparent;
   border-radius: var(--border-radius-lg);
   font-size: var(--font-size-xs);

--- a/app/components/Tags/Tag.tsx
+++ b/app/components/Tags/Tag.tsx
@@ -1,5 +1,7 @@
 import cx from 'classnames';
 import { Link } from 'react-router-dom';
+import Icon from 'app/components/Icon';
+import Flex from 'app/components/Layout/Flex';
 import styles from './Tag.css';
 
 const tagColors = [
@@ -18,6 +20,7 @@ export type TagColors = (typeof tagColors)[number];
 
 type Props = {
   tag: string;
+  icon: string;
   color?: TagColors;
   link?: string;
   className?: string;
@@ -27,7 +30,7 @@ type Props = {
 /**
  * A basic tag component for displaying tags
  */
-const Tag = ({ tag, color, link, className, active }: Props) => (
+const Tag = ({ tag, icon, color = 'red', link, className, active }: Props) => (
   <div className={styles.linkSpacing}>
     {link ? (
       <Link
@@ -43,7 +46,14 @@ const Tag = ({ tag, color, link, className, active }: Props) => (
         {tag}
       </Link>
     ) : (
-      <span className={cx(styles.tag, styles[color], className)}>{tag}</span>
+      <Flex
+        gap={5}
+        alignItems="center"
+        className={cx(styles.tag, styles[color], className)}
+      >
+        {icon && <Icon name={icon} size={16} />}
+        {tag}
+      </Flex>
     )}
   </div>
 );

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -116,6 +116,7 @@ const ArticleDetail = ({
           loggedIn={loggedIn}
           comments={comments}
           deleteComment={deleteComment}
+          contentAuthors={article.authors}
         />
       )}
     </Content>

--- a/app/routes/events/components/Event.css
+++ b/app/routes/events/components/Event.css
@@ -14,11 +14,6 @@
   resize: vertical;
 }
 
-.feedbackUpdateButton {
-  margin-left: 10px;
-  height: 40px;
-}
-
 .registeredThumbnails {
   flex-wrap: wrap;
   max-height: 130px;

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -43,7 +43,6 @@ import {
   registrationCloseTime,
 } from '../../utils';
 import Admin from '../Admin';
-import sharedStyles from '../Event.css';
 import JoinEventForm from '../JoinEventForm';
 import RegisteredSummary from '../RegisteredSummary';
 import RegistrationMeta from '../RegistrationMeta';
@@ -577,6 +576,7 @@ export default class EventDetail extends Component<Props, State> {
             loggedIn={loggedIn}
             comments={comments}
             deleteComment={deleteComment}
+            contentAuthors={[event.createdBy.id]}
           />
         )}
       </Content>

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -472,6 +472,7 @@ const JoinEventForm = (props: Props) => {
 
                   <Flex
                     alignItems="center"
+                    gap={10}
                     style={{
                       margin: '20px 0',
                     }}
@@ -493,8 +494,6 @@ const JoinEventForm = (props: Props) => {
                           feedbackName,
                           'feedback'
                         )}
-                        success
-                        className={styles.feedbackUpdateButton}
                         disabled={pristine}
                       >
                         Oppdater

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -260,6 +260,7 @@ const MeetingDetails = ({
                 loggedIn={loggedIn}
                 comments={comments}
                 deleteComment={deleteComment}
+                contentAuthors={[meeting.createdBy]}
               />
             </>
           )}

--- a/cypress/e2e/event_visit_spec.js
+++ b/cypress/e2e/event_visit_spec.js
@@ -63,16 +63,18 @@ describe('View event', () => {
     cy.contains('button', 'Kommenter').should('not.be.disabled').click();
 
     // We should see the comment and be able to delete it
-    cy.get(c('Comment__comment')).within(($c) => {
-      cy.contains('This event will be awesome');
-      cy.contains('button', 'Svar').should('exist').and('not.be.disabled');
-      cy.contains('button', 'Slett')
-        .should('exist')
-        .and('not.be.disabled')
-        .click();
-      cy.contains('Slettet');
-      cy.contains('button', 'svar').should('not.exist');
-    });
+    cy.get(c('Comment__comment'))
+      .last()
+      .within(() => {
+        cy.contains('This event will be awesome');
+        cy.contains('button', 'Svar').should('exist').and('not.be.disabled');
+        cy.get('ion-icon[name=trash]')
+          .should('exist')
+          .and('not.be.disabled')
+          .click();
+        cy.contains('Slettet');
+        cy.contains('button', 'svar').should('not.exist');
+      });
 
     // Nested comments should work as expected
     // TODO fix form clearing

--- a/cypress/e2e/event_visit_spec.js
+++ b/cypress/e2e/event_visit_spec.js
@@ -51,16 +51,14 @@ describe('View event', () => {
   it('Should be possible to comment', () => {
     cy.visit('/events/20');
 
-    cy.contains('button', 'Kommenter').should('not.exist');
+    cy.contains('button', 'Kommenter').should('not.be.visible');
 
-    cy.wait(2000);
-    cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
+    cy.get(c('CommentForm__field'))
+      .find('input')
       .last()
       .click()
-      .wait(100);
-    cy.contains('button', 'Kommenter').should('be.disabled');
-    cy.focused().click().type('This event will be awesome');
-    cy.contains('button', 'Kommenter').should('not.be.disabled').click();
+      .type('This event will be awesome');
+    cy.contains('button', 'Kommenter').should('be.visible').click();
 
     // We should see the comment and be able to delete it
     cy.get(c('Comment__comment'))
@@ -76,26 +74,21 @@ describe('View event', () => {
         cy.contains('button', 'svar').should('not.exist');
       });
 
-    // Nested comments should work as expected
-    // TODO fix form clearing
-    cy.reload();
-    cy.wait(2000);
-    cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
+    cy.get(c('CommentForm'))
+      .find('input')
       .last()
       .click()
-      .wait(100);
-    cy.contains('button', 'Kommenter').should('be.disabled');
-    cy.focused().click().type('This is the top comment');
-    cy.contains('button', 'Kommenter').should('not.be.disabled').click();
+      .type('This is the top comment');
+    cy.contains('button', 'Kommenter').should('be.visible').click();
 
     cy.get(c('Comment__comment')).last().contains('This is the top comment');
     cy.contains('button', 'Svar').click();
 
-    cy.get(c('CommentForm') + ' [data-slate-editor="true"]')
+    cy.get(c('CommentForm'))
+      .find('input')
       .should('have.lengthOf', 2)
-      .first()
-      .click()
-      .wait(100);
+      .last()
+      .click();
     cy.focused().type('This is a child comment');
     cy.contains('button', 'Send svar').click();
     cy.get(c('CommentTree__nested')).contains('This is a child comment');


### PR DESCRIPTION
# Description

[Improve the styling of comments](https://github.com/webkom/lego-webapp/commit/0ef2005375e97d2d8c693618119c9e0c7303eaeb) 

Reposition and align elements, slightly change some styling and also greatly clean up the css.

---

[Replace editor in comment form with text input](https://github.com/webkom/lego-webapp/commit/73ad4225258954c79237087d79953294bfdfb0b8) 

It's less buggy, and will probably work on mobile .. once and for all.

---

[Allow LegoFinalForm to only validate on submit](https://github.com/webkom/lego-webapp/commit/60fa7989c8d9ec3b3fcd0a21272d896a7c6c8649) 

Useful for forms that don't really need to give users real-time
feedback on inputs, such as on comments.

---

[Ability to add icons to tags through props](https://github.com/webkom/lego-webapp/commit/edc4b20a1f6d93225902fbf1bb87c23b4f6dbcf7) 

I still want the `tag` prop to only be used for strings. Better to
separate these than allow all kinds of types to be passed into the tag.

---

[Highlight content author (creator) on comments](https://github.com/webkom/lego-webapp/commit/86ed9ea0dd1d04c4a9fbfd14bef11ff403b98f62) 

Not _that_ useful, but a nice feature imo.

Implemented for events, articles and meetings. BDB and gallery also
has comments, but this feature doesn't really make sense on the BDB and the gallery creator is unknown on the client side.

# Result

The styling isn't perfect, but it's an improvement in my opinion. The comments never looked good as cards. I tried to follow industry norms, such as moving the comment form to the top instead of bottom.

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td><img width="1079" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/0f5048b4-d481-4c7e-ac14-5d0f5cf1be73"></td>
		<td><img width="1075" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/8c2965c3-2e4a-4fea-8ed3-adc06691dafb"></td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Comments (including nested comments) still look "good" on smaller viewports.

Form validation still works like normal for other forms that don't use the new `validateOnSubmitOnly` prop.

Author highlighting has been tested for all implementations.

---

Resolves ABA-504