### PR TITLE
Refactor Sidebar

### DIFF
--- a/app/routes/pages/components/Sidebar.css
+++ b/app/routes/pages/components/Sidebar.css
@@ -1,108 +1,49 @@
 @import url('~app/styles/variables.css');
 
-.side {
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  box-sizing: border-box;
-  background-color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 2%);
-  margin-bottom: 5em;
-  width: 290px;
-}
-
 .sidebar {
-  margin: 0 1.1em;
-  width: 100%;
-  padding-top: 20px;
   display: flex;
   flex-direction: column;
-
-  @media (--mobile-device) {
-    margin: 0;
-    padding-right: 1.5rem;
-  }
+  width: 290px;
+  flex-shrink: 0;
+  padding: 1.1em;
+  padding-bottom: 4.4em;
+  background-color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 2%);
+  border-radius: var(--border-radius-lg) 0 0 var(--border-radius-lg);
+  z-index: 11;
 }
 
 .sidebarHeader {
-  margin-top: 20px;
-  width: 95%;
+  margin: 1em 0 1.4em;
+  align-self: center;
   text-align: center;
-  border-bottom: 2px solid var(--border-gray);
   padding-bottom: 0.6em;
+  width: 93%;
+  border-bottom: 2px solid var(--border-gray);
 }
 
-.sidebarPicture {
-  margin-top: 30px;
+.sidebarCloseButton {
   display: none;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-}
-
-.sidebarTop {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.sidebarBottom {
-  margin-top: 2em;
-}
-
-.oldImg {
-  filter: grayscale(100%);
-}
-
-.pictureInfo {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.sidebarCloseBtn {
-  width: 40px;
-  height: 25px;
-  display: none;
-  align-items: right;
-  justify-content: flex-end;
-  color: var(--lego-font-color);
-  z-index: 10;
-
-  @media (--mobile-device) {
-    display: inline-block;
-    position: absolute;
-    right: 0.7em;
-    top: 0.5em;
-  }
 }
 
 @media (--mobile-device) {
-  .side,
-  .sidebarPicture {
+  .sidebar {
+    position: fixed;
+    top: 0;
+    width: 100%;
+    height: 100vh;
+    border-radius: 0;
+    background-color: var(--lego-card-color);
+    overflow-y: auto;
+    overscroll-behavior: none;
+  }
+
+  .sidebarClosed {
     display: none;
   }
 
-  .side.isOpen {
-    display: block;
-    position: absolute;
-    z-index: 11;
-    width: 100%;
-    box-shadow: var(--shadow-lg);
-    height: 100%;
-  }
-
-  .sidebar {
-    width: 100%;
-    max-width: 100%;
-    background-color: var(--lego-card-color);
-    height: 100%;
-  }
-
-  .sidebarWrapper {
-    width: 100%;
-    position: absolute;
-    height: 100%;
-    background-color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 7%);
-    z-index: 10;
+  .sidebarCloseButton {
+    display: flex;
+    align-self: flex-end;
+    color: var(--lego-font-color);
   }
 }

--- a/app/routes/pages/components/Sidebar.tsx
+++ b/app/routes/pages/components/Sidebar.tsx
@@ -1,13 +1,9 @@
 import cx from 'classnames';
-import { Component } from 'react';
 import Icon from 'app/components/Icon';
 import PageHierarchy from './PageHierarchy';
 import styles from './Sidebar.css';
 import type { HierarchySectionEntity } from './PageHierarchy';
 
-type State = {
-  isOpen: boolean;
-};
 type Props = {
   categorySelected: string;
   currentUrl: string;
@@ -16,49 +12,27 @@ type Props = {
   handleClose: () => void;
 };
 
-class Sidebar extends Component<Props, State> {
-  render() {
-    const {
-      categorySelected,
-      currentUrl,
-      pageHierarchy,
-      isOpen,
-      handleClose,
-    }: Props = this.props;
-    // const pictureLabel = 'Hemmelig bilde';
-    return (
-      <div
-        className={isOpen ? styles.sidebarWrapper : undefined}
-        onClick={handleClose}
-      >
-        <div
-          className={cx(styles.side, isOpen && styles.isOpen)}
-          onClick={(event) => {
-            // Just werkz
-            event.stopPropagation();
-          }}
-        >
-          <aside className={styles.sidebar}>
-            <div className={styles.sidebarTop}>
-              <button className={styles.sidebarCloseBtn} onClick={handleClose}>
-                <Icon name="close" size={50} />
-              </button>
-              <h2 className={styles.sidebarHeader}>Om Abakus</h2>
-            </div>
-
-            <div className={styles.sidebarBottom}>
-              <PageHierarchy
-                pageHierarchy={pageHierarchy}
-                currentUrl={currentUrl}
-                currentCategory={categorySelected}
-                handleCloseSidebar={handleClose}
-              />
-            </div>
-          </aside>
-        </div>
-      </div>
-    );
-  }
-}
+const Sidebar = ({
+  categorySelected,
+  currentUrl,
+  pageHierarchy,
+  isOpen,
+  handleClose,
+}: Props) => {
+  return (
+    <div className={cx(styles.sidebar, isOpen || styles.sidebarClosed)}>
+      <button className={styles.sidebarCloseButton} onClick={handleClose}>
+        <Icon name="close" size={30} />
+      </button>
+      <h2 className={styles.sidebarHeader}>Om Abakus</h2>
+      <PageHierarchy
+        pageHierarchy={pageHierarchy}
+        currentUrl={currentUrl}
+        currentCategory={categorySelected}
+        handleCloseSidebar={handleClose}
+      />
+    </div>
+  );
+};
 
 export default Sidebar;


### PR DESCRIPTION
# Description
- Refactor the Sidebar component to utilize a hook
- The previous JSX and CSS was a mess. This looks much cleaner imo <3
- Make the sidebar fixed in mobile view in order to remove dead space.
- Fix a bug where the sidebar in mobile view would overflow vertically if too many tabs where opened

This sidebar looks basically the same for desktop view.

# Result

## Desktop view

Proof that they look about the same:

**Before**
![before](https://github.com/webkom/lego-webapp/assets/66320400/6883ebf3-0784-4546-8ab6-bbbc84d960a2)

**After**
![after](https://github.com/webkom/lego-webapp/assets/66320400/6d70ef5c-6ceb-4d18-920e-3951fa05da4a)

## Mobile view

By making the sidebar fixed, you remove the "dead space" that would appear if a page was too long. This makes it so that the user doesn't have to scroll to the top of the page when opening the sidebar. It preserves the scroll of the page between opening and closing the sidebar.

**Before**

[Screencast1](https://github.com/webkom/lego-webapp/assets/66320400/c7b820ee-d9e4-4405-9bbe-5be017478d12)


**After**

[Screencast2](https://github.com/webkom/lego-webapp/assets/66320400/79c0df30-28c2-427e-8d69-983a7b1b4ecb)


It also fixes this overflow bug as described earlier:
![Screenshot_20230704_221345](https://github.com/webkom/lego-webapp/assets/66320400/7f083df0-c41e-40a6-b159-d83069e99252)

# Testing

- [x] I have thoroughly tested my changes.

I have tested it with many different window sizes and tabs in the sidebar collapsed.

---