### PR TITLE
Introduce a `secondary` button type and update buttons

### DIFF
--- a/app/components/Button/Button.css
+++ b/app/components/Button/Button.css
@@ -1,7 +1,9 @@
 @import url('~app/styles/variables.css');
 
 :root {
-  --button-color: var(--inverted-font-color);
+  --button-color: var(--lego-font-color);
+  --button-color-white: var(--inverted-font-color);
+  --button-background: var(--additive-background);
   --button-background-hover: var(--color-gray-2);
 
   --button-dark-background: var(--color-red-6);
@@ -15,6 +17,7 @@
 
 [data-theme='dark'] {
   --button-color: var(--lego-font-color);
+  --button-color-white: var(--lego-font-color);
   --button-background-hover: var(--color-gray-3);
 
   --button-dark-box-shadow-focus: #ff737344;
@@ -34,8 +37,8 @@
   padding: 0 1rem;
   font-family: Inter, sans-serif;
   font-weight: 600;
-  background-color: var(--additive-background);
-  color: var(--lego-font-color);
+  background-color: var(--button-background);
+  color: var(--button-color);
   outline: none;
   border-radius: 2rem;
   transition: var(--easing-fast);
@@ -75,6 +78,12 @@
   }
 }
 
+.secondary {
+  --button-color: var(--inverted-font-color);
+  --button-background: var(--lego-font-color);
+  --button-background-hover: var(--color-gray-8);
+}
+
 .loading {
   margin-left: 8px;
   color: var(--secondary-font-color);
@@ -82,7 +91,7 @@
 
 .dark {
   background-color: var(--button-dark-background);
-  color: var(--button-color);
+  color: var(--button-color-white);
   box-shadow: none;
 
   &.fa {
@@ -116,13 +125,13 @@
   &:hover:not(:disabled) {
     background-color: var(--danger-color);
     border-color: var(--danger-color);
-    color: var(--button-color);
+    color: var(--button-color-white);
   }
 }
 
 .success {
   background-color: var(--button-success-background);
-  color: var(--button-color);
+  color: var(--button-color-white);
   box-shadow: none;
 
   &:focus-visible {
@@ -136,6 +145,7 @@
 
 .flat {
   background: none;
+  --button-color: var(--lego-font-color);
 
   &:hover:not(:disabled) {
     background-color: var(--additive-background);
@@ -145,17 +155,16 @@
 .ghost {
   background: none;
   box-shadow: none;
-  border: 1.5px solid var(--button-dark-background);
-  color: var(--button-dark-background);
+  border: 1.5px solid var(--lego-font-color);
+  --button-color: var(--lego-font-color);
 
   &:focus-visible {
     box-shadow: 0 0 0 3px var(--button-dark-box-shadow-focus);
   }
 
   &:hover:not(:disabled) {
-    background-color: var(--button-dark-background);
-    border-color: var(--button-dark-background);
-    color: var(--button-color);
+    background-color: var(--lego-font-color);
+    --button-color: var(--inverted-font-color);
   }
 }
 

--- a/app/components/Button/index.tsx
+++ b/app/components/Button/index.tsx
@@ -19,11 +19,11 @@ type Props = {
   /** is the button action pending? */
   pending?: boolean;
 
+  /** Secondary button styling */
+  secondary?: boolean;
+
   /** Dark background (red button)*/
   dark?: boolean;
-
-  /** Primary button styling */
-  primary?: boolean;
 
   /** Danger button styling */
   danger?: boolean;
@@ -44,6 +44,7 @@ function Button({
   size = 'normal',
   submit,
   pending = false,
+  secondary = false,
   dark = false,
   danger = false,
   success = false,
@@ -56,6 +57,7 @@ function Button({
       className={cx(
         styles.button,
         styles[size],
+        (submit || secondary) && styles.secondary,
         dark && styles.dark,
         danger && styles.danger,
         success && styles.success,

--- a/app/components/Modal/ConfirmModal.tsx
+++ b/app/components/Modal/ConfirmModal.tsx
@@ -36,7 +36,7 @@ const ConfirmModalContent = ({
     </Flex>
     <span>{message}</span>
     <div>
-      <Button disabled={disabled} onClick={onCancel}>
+      <Button flat disabled={disabled} onClick={onCancel}>
         {cancelText}
       </Button>
       <Button danger={danger} disabled={disabled} onClick={onConfirm}>

--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -281,14 +281,16 @@ export default class ImageUpload extends Component<Props, State> {
               </Flex>
             )}
             <Flex wrap gap={35}>
+              <Button flat onClick={() => this.closeModal()}>
+                Avbryt
+              </Button>
               <Button
-                success
+                secondary
                 disabled={files.length === 0 && !preview}
                 onClick={this.onSubmit}
               >
                 Last opp
               </Button>
-              <Button onClick={() => this.closeModal()}>Avbryt</Button>
             </Flex>
           </Flex>
         </Modal>

--- a/app/routes/admin/email/components/RestrictedMailEditor.tsx
+++ b/app/routes/admin/email/components/RestrictedMailEditor.tsx
@@ -2,6 +2,7 @@ import { reduxForm, Form, Field } from 'redux-form';
 import Button from 'app/components/Button';
 import { TextInput, SelectInput } from 'app/components/Form';
 import CheckBox from 'app/components/Form/CheckBox';
+import Icon from 'app/components/Icon';
 import config from 'app/config';
 import { isEmail, createValidator, required } from 'app/utils/validation';
 
@@ -163,7 +164,10 @@ const RestrictedMailEditor = ({
           href={`${config.serverUrl}/restricted-mail/${restrictedMailId}/token?auth=${restrictedMail.tokenQueryParam}`}
           download
         >
-          <Button>Last ned e-post token</Button>
+          <Button>
+            <Icon name="download-outline" size={19} />
+            Last ned e-post token
+          </Button>
         </a>
       )}
     </Form>

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -163,12 +163,13 @@ const ArticleEditor = ({
           initialized={initialized}
         />
         <Flex wrap>
-          <Button onClick={() => push(`/articles/${isNew ? '' : articleId}`)}>
+          <Button
+            flat
+            onClick={() => push(`/articles/${isNew ? '' : articleId}`)}
+          >
             Avbryt
           </Button>
-          <Button submit success>
-            {!isNew ? 'Lagre endringer' : 'Opprett'}
-          </Button>
+          <Button submit>{!isNew ? 'Lagre endringer' : 'Opprett'}</Button>
           {!isNew && (
             <ConfirmModal
               title="Slett artikkelen"

--- a/app/routes/bdb/components/AddSemester.tsx
+++ b/app/routes/bdb/components/AddSemester.tsx
@@ -188,7 +188,6 @@ export default class AddSemester extends Component<Props, State> {
                 })
               }
               submit
-              success
             >
               Lagre
             </Button>

--- a/app/routes/bdb/components/CompanyContactEditor.tsx
+++ b/app/routes/bdb/components/CompanyContactEditor.tsx
@@ -102,15 +102,7 @@ class CompanyContactEditor extends Component<Props> {
               component={TextInput.Field}
             />
 
-            <div className={styles.clear} />
-            <Button
-              disabled={submitting}
-              submit
-              style={{
-                marginBottom: '0!important',
-              }}
-              success
-            >
+            <Button disabled={submitting} submit>
               Lagre
             </Button>
           </form>

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -233,7 +233,7 @@ const CompanyEditor = ({
           </div>
 
           <div className={styles.clear} />
-          <Button disabled={submitting} submit success>
+          <Button disabled={submitting} submit>
             Lagre
           </Button>
         </form>

--- a/app/routes/brand/components/BrandPage.tsx
+++ b/app/routes/brand/components/BrandPage.tsx
@@ -2,6 +2,7 @@ import logosDonts from 'app/assets/logos-donts.png';
 import logosDos from 'app/assets/logos-dos.png';
 import Button from 'app/components/Button';
 import { Content } from 'app/components/Content';
+import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import NavigationTab from 'app/components/NavigationTab';
@@ -80,14 +81,15 @@ const BrandPage = () => (
         </Flex>
         <div>
           <h2 className={styles.h2Padding}>Logoer i vektorformat</h2>
-          <Button>
-            <a
-              href="https://github.com/abakus-ntnu/grafisk-profil/archive/master.zip"
-              download="proposed_file_name"
-            >
+          <a
+            href="https://github.com/abakus-ntnu/grafisk-profil/archive/master.zip"
+            download="proposed_file_name"
+          >
+            <Button>
+              <Icon name="download-outline" size={19} />
               Last ned
-            </a>
-          </Button>
+            </Button>
+          </a>
           <h2 className={styles.h2Padding}>Abakusfarger</h2>
           <ul>
             <li>Hvit: CMYK(0,0,0,0)</li>
@@ -101,14 +103,15 @@ const BrandPage = () => (
           <p>
             Denne malen skal brukes for presentasjoner som holdes i Abakus-regi
           </p>
-          <Button>
-            <a
-              href="https://github.com/abakus-ntnu/grafisk-profil/blob/master/maler/Abakus%20-%20Presentasjonsmal.pptx?raw=true"
-              download="proposed_file_name"
-            >
+          <a
+            href="https://github.com/abakus-ntnu/grafisk-profil/blob/master/maler/Abakus%20-%20Presentasjonsmal.pptx?raw=true"
+            download="proposed_file_name"
+          >
+            <Button>
+              <Icon name="download-outline" size={19} />
               Last ned
-            </a>
-          </Button>
+            </Button>
+          </a>
         </div>
       </Flex>
     </section>

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -1073,7 +1073,7 @@ const CompanyInterestPage = (props: Props) => {
             </div>
 
             {spySubmittable((submittable) => (
-              <Button success disabled={!submittable} submit>
+              <Button secondary disabled={!submittable} submit>
                 {props.edit
                   ? 'Oppdater bedriftsinteresse'
                   : labels.create[language]}

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -591,9 +591,11 @@ function EventEditor({
 
         <Flex wrap>
           {isEditPage && (
-            <Button onClick={() => push(`/events/${event.id}`)}>Avbryt</Button>
+            <Button flat onClick={() => push(`/events/${event.id}`)}>
+              Avbryt
+            </Button>
           )}
-          <Button success={isEditPage} disabled={pristine || submitting} submit>
+          <Button disabled={pristine || submitting} submit>
             {isEditPage ? 'Lagre endringer' : 'Opprett'}
           </Button>
         </Flex>

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -471,6 +471,7 @@ const JoinEventForm = (props: Props) => {
                   </Form>
 
                   <Flex
+                    alignItems="center"
                     style={{
                       margin: '20px 0',
                     }}

--- a/app/routes/events/components/Toolbar.tsx
+++ b/app/routes/events/components/Toolbar.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames';
 import { Link, NavLink } from 'react-router-dom';
+import Button from 'app/components/Button';
 import Time from 'app/components/Time';
 import type { ActionGrant } from 'app/models';
 import styles from './Toolbar.css';
@@ -31,7 +32,9 @@ const Toolbar = ({ actionGrant }: Props) => (
 
     <div className={styles.create}>
       {actionGrant?.includes('create') && (
-        <Link to="/events/create">Lag nytt</Link>
+        <Link to="/events/create">
+          <Button flat>Lag nytt</Button>
+        </Link>
       )}
     </div>
   </div>

--- a/app/routes/events/components/UpdateAllergies.tsx
+++ b/app/routes/events/components/UpdateAllergies.tsx
@@ -56,7 +56,6 @@ const UpdateAllergies = ({
         component={TextInput.Field}
       />
       <Button
-        success
         className={styles.button}
         submit
         disabled={invalid || pristine || submitting}

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -261,7 +261,7 @@ class JoblistingEditor extends Component<Props, State> {
             >
               Avbryt
             </Button>
-            <Button success={!isNew} disabled={invalid || submitting} submit>
+            <Button disabled={invalid || submitting} submit>
               {isNew ? 'Opprett' : 'Lagre endringer'}
             </Button>
             {!isNew && (

--- a/app/routes/joblistings/components/JoblistingRightNav.tsx
+++ b/app/routes/joblistings/components/JoblistingRightNav.tsx
@@ -123,8 +123,7 @@ const JoblistingsRightNav = (props: Props) => {
 
   return (
     <div className={styles.joblistingRightNav}>
-      <Button
-        flat
+      <button
         onClick={() => setDisplayOptions(!displayOptions)}
         className={styles.optionsTitle}
       >
@@ -137,7 +136,7 @@ const JoblistingsRightNav = (props: Props) => {
             )}
           />
         </h2>
-      </Button>
+      </button>
 
       <div
         className={styles.options}

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -303,6 +303,7 @@ const MeetingEditor = ({
               <SubmissionError />
               <Flex wrap>
                 <Button
+                  flat
                   onClick={() =>
                     push(`/meetings/${isEditPage ? meeting.id : ''}`)
                   }
@@ -310,7 +311,7 @@ const MeetingEditor = ({
                   Avbryt
                 </Button>
                 {spySubmittable((submittable) => (
-                  <Button success disabled={!submittable} submit>
+                  <Button disabled={!submittable} submit>
                     {isEditPage ? 'Lagre endringer' : 'Opprett møte'}
                   </Button>
                 ))}

--- a/app/routes/pages/components/PageButtons.tsx
+++ b/app/routes/pages/components/PageButtons.tsx
@@ -9,11 +9,11 @@ type Props = {
 
 const PageButtons = ({ isEditing, toggleEditing, handleSave }: Props) => (
   <div>
-    <Button size="small" onClick={toggleEditing}>
+    <Button flat={isEditing} onClick={toggleEditing}>
       {isEditing ? 'Avbryt' : 'Rediger'}
     </Button>
     {isEditing && (
-      <Button size="small" onClick={handleSave} className={styles.last}>
+      <Button secondary onClick={handleSave} className={styles.last}>
         Lagre
       </Button>
     )}

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -6,6 +6,7 @@ import Button from 'app/components/Button';
 import { Content } from 'app/components/Content';
 import EmptyState from 'app/components/EmptyState';
 import Gallery from 'app/components/Gallery';
+import Icon from 'app/components/Icon';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
 import ImageUpload from 'app/components/Upload/ImageUpload';
@@ -13,6 +14,7 @@ import type { DropFile } from 'app/components/Upload/ImageUpload';
 import type { ID, ActionGrant } from 'app/models';
 import type { GalleryPictureEntity } from 'app/reducers/galleryPictures';
 import GalleryDetailsRow from './GalleryDetailsRow';
+import type { Push } from 'connected-react-router';
 import type { Element } from 'react';
 
 type Props = {
@@ -30,7 +32,7 @@ type Props = {
     }
   ) => Promise<any>;
   clear: (galleryId: number) => Promise<any>;
-  push: (arg0: string) => Promise<any>;
+  push: Push;
   uploadAndCreateGalleryPicture: (
     arg0: ID,
     arg1: File | Array<DropFile>
@@ -151,7 +153,8 @@ export default class GalleryDetail extends Component<Props, State> {
                 {this.state.downloading ? (
                   <LoadingIndicator loading={true} small margin={0} />
                 ) : (
-                  <Button flat={true} onClick={this.downloadGallery}>
+                  <Button onClick={this.downloadGallery}>
+                    <Icon name="download-outline" size={19} />
                     Last ned album
                   </Button>
                 )}

--- a/app/routes/photos/components/GalleryEditor.tsx
+++ b/app/routes/photos/components/GalleryEditor.tsx
@@ -29,6 +29,7 @@ import type { GalleryEntity } from 'app/reducers/galleries';
 import type { GalleryPictureEntity } from 'app/reducers/galleryPictures';
 import GalleryEditorActions from './GalleryEditorActions';
 import styles from './Overview.css';
+import type { Push } from 'connected-react-router';
 
 type Props = {
   isNew: boolean;
@@ -36,7 +37,7 @@ type Props = {
   pictures: Array<GalleryPictureEntity>;
   submitFunction: (arg0: GalleryEntity) => Promise<any>;
   handleSubmit: (arg0: any) => void;
-  push: (arg0: string) => Promise<any>;
+  push: Push;
   submitting: boolean;
   fetch: (
     galleryId: number,
@@ -170,6 +171,7 @@ class GalleryEditor extends Component<Props, State> {
       handleSubmit,
       gallery,
       submitting,
+      push,
     } = this.props;
     const { selected } = this.state;
     return (
@@ -250,6 +252,12 @@ class GalleryEditor extends Component<Props, State> {
           />
 
           <Flex className={styles.buttonRow} justifyContent="flex-end">
+            <Button flat onClick={() => push(`/photos/${gallery.id}`)}>
+              Avbryt
+            </Button>
+            <Button disabled={submitting} submit>
+              {isNew ? 'Opprett' : 'Lagre'}
+            </Button>
             {!isNew && (
               <ConfirmModal
                 title="Slett album"
@@ -257,16 +265,13 @@ class GalleryEditor extends Component<Props, State> {
                 onConfirm={this.onDeleteGallery}
               >
                 {({ openConfirmModal }) => (
-                  <Button onClick={openConfirmModal} danger>
+                  <Button danger onClick={openConfirmModal}>
                     <Icon name="trash" size={19} />
                     Slett album
                   </Button>
                 )}
               </ConfirmModal>
             )}
-            <Button success={!isNew} disabled={submitting} type="submit">
-              {isNew ? 'Opprett' : 'Lagre'}
-            </Button>
           </Flex>
         </Form>
         <GalleryEditorActions

--- a/app/routes/photos/components/GalleryEditorActions.tsx
+++ b/app/routes/photos/components/GalleryEditorActions.tsx
@@ -28,11 +28,15 @@ const GalleryEditorActions = ({
         <Flex alignItems="center" justifyContent="space-between">
           <div className={styles.selectedElements}>{selectedCount} valgt</div>
           <div>
+            <Button flat onClick={onDeselect}>
+              Avbryt
+            </Button>
             {selectedCount === 1 && (
               <Button onClick={onUpdateGalleryCover}>Sett album cover</Button>
             )}
             {newPicutureStatus !== -1 && (
               <Button
+                danger={newPicutureStatus === 0}
                 onClick={() => onTogglePicturesStatus(!!newPicutureStatus)}
               >
                 {newPicutureStatus === 0 && 'Skjul'}
@@ -42,7 +46,6 @@ const GalleryEditorActions = ({
             <Button danger onClick={onDeletePictures}>
               Slett {selectedCount > 1 ? 'valgte' : 'valgt'}
             </Button>
-            <Button onClick={onDeselect}>Avbryt</Button>
           </div>
         </Flex>
       </Card>

--- a/app/routes/photos/components/GalleryPictureEditModal.tsx
+++ b/app/routes/photos/components/GalleryPictureEditModal.tsx
@@ -112,15 +112,14 @@ const GalleryPictureEditModal = ({
           />
           <Flex justifyContent="flex-end">
             <Button
+              flat
               onClick={() =>
                 push(`/photos/${gallery.id}/picture/${picture.id}`)
               }
             >
               Avbryt
             </Button>
-            <Button success type="submit">
-              Lagre
-            </Button>
+            <Button submit>Lagre</Button>
             <Button
               danger
               onClick={() =>

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -183,11 +183,7 @@ const EditPollForm = ({
               rerenderOnEveryChange={true}
             />
             <Flex className={styles.actionButtons}>
-              <Button
-                disabled={pristine || submitting}
-                success={editing}
-                submit
-              >
+              <Button disabled={pristine || submitting} submit>
                 {editing ? 'Lagre endringer' : 'Lag ny avstemning'}
               </Button>
               {editing && (

--- a/app/routes/surveys/components/SubmissionEditor/SubmissionEditor.tsx
+++ b/app/routes/surveys/components/SubmissionEditor/SubmissionEditor.tsx
@@ -100,7 +100,7 @@ const SubmissionEditor = ({
           ))}
         </ul>
 
-        <Button success disabled={submitting} submit>
+        <Button disabled={submitting} submit>
           Send svar
         </Button>
       </form>

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
@@ -321,12 +321,13 @@ const SurveyEditor = ({
 
             <Flex>
               {spySubmittable((submittable) => (
-                <Button success disabled={submitting || !submittable} submit>
+                <Button disabled={submitting || !submittable} submit>
                   {editing ? 'Lagre' : 'Opprett'}
                 </Button>
               ))}
 
               <Button
+                flat
                 onClick={() =>
                   push(editing ? `/surveys/${survey.id}` : '/surveys')
                 }

--- a/app/routes/users/components/GroupChange.tsx
+++ b/app/routes/users/components/GroupChange.tsx
@@ -74,7 +74,7 @@ class GroupChange extends Component<Props, State> {
           instanceId="profile-group"
         />
         {this.state.selectedOption && (
-          <Button onClick={this.handleOnClick} success>
+          <Button secondary onClick={this.handleOnClick}>
             Lagre endring
           </Button>
         )}

--- a/app/routes/users/components/StudentConfirmation.tsx
+++ b/app/routes/users/components/StudentConfirmation.tsx
@@ -180,7 +180,7 @@ const StudentConfirmation = ({
             }}
             component={Captcha.Field}
           />
-          <Button submit success disabled={disabledButton}>
+          <Button submit disabled={disabledButton}>
             Verifiser
           </Button>
         </Form>

--- a/app/routes/users/components/UserProfile.tsx
+++ b/app/routes/users/components/UserProfile.tsx
@@ -436,7 +436,7 @@ const UserProfile = (props: Props) => {
               {renderFields()}
               {showSettings ? (
                 <Link to={`/users/${user.username}/settings/profile`}>
-                  Innstillinger
+                  <Button>Innstillinger</Button>
                 </Link>
               ) : (
                 ''

--- a/app/routes/users/components/__tests__/UserProfile.spec.tsx
+++ b/app/routes/users/components/__tests__/UserProfile.spec.tsx
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
+import Button from 'app/components/Button';
 import UserProfile from '../UserProfile';
 
 const user = {
@@ -17,7 +18,9 @@ describe('<UserProfile />', () => {
     const wrapper = shallow(<UserProfile user={user} showSettings />);
     expect(
       wrapper.containsMatchingElement(
-        <Link to="/users/webkom/settings/profile">Innstillinger</Link>
+        <Link to="/users/webkom/settings/profile">
+          <Button>Innstillinger</Button>
+        </Link>
       )
     ).toBe(true);
   });
@@ -25,7 +28,9 @@ describe('<UserProfile />', () => {
     const wrapper = shallow(<UserProfile user={user} showSettings={false} />);
     expect(
       wrapper.containsMatchingElement(
-        <Link to="/users/webkom/settings/profile">Innstillinger</Link>
+        <Link to="/users/webkom/settings/profile">
+          <Button>Innstillinger</Button>
+        </Link>
       )
     ).toBe(false);
   });


### PR DESCRIPTION
# Description

[Introduce a secondary button type](https://github.com/webkom/lego-webapp/commit/147a3232bebfba4b8a6bddced1e3aa6d92790f0a) 

And make the `ghost` type look more like this.

The secondary button shares the color of the default text color, and it looks much more sharp with the darker color. It replaces a lot of success buttons, as it doesn't really make sense for submit buttons to be of type success. In my eyes it should be used on submit buttons and other buttons with "significant value" that should pop out more on pages.

---

[Update buttons across the webapp](https://github.com/webkom/lego-webapp/commit/8eed84dc11b49d3b232d0ed36320306652635593) 

Employ both the `flat` and `secondary` types more.

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td><img width="561" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/a5853c54-e66c-486a-ae7f-0017f58bb929"></td>
		<td><img width="561" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/8a409304-208b-4d2c-bf6f-c3bccef73776"></td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested all button types on both dark and light theme.