### PR TITLE
Let users set event location before registration type

### DIFF
--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -228,6 +228,41 @@ function EventEditor({
               fieldClassName={styles.metaField}
               className={styles.formField}
             />
+            <Field
+              label="Bruk MazeMap"
+              name="useMazemap"
+              component={CheckBox.Field}
+              fieldClassName={styles.metaField}
+              className={styles.formField}
+              normalize={(v) => !!v}
+            />
+            {!event.useMazemap ? (
+              <Field
+                label="Sted"
+                name="location"
+                placeholder="Den Gode Nabo, Downtown, ..."
+                component={TextInput.Field}
+                fieldClassName={styles.metaField}
+                className={styles.formField}
+                warn={isTBA}
+              />
+            ) : (
+              <Flex alignItems="flex-end">
+                <Field
+                  label="MazeMap-rom"
+                  name="mazemapPoi"
+                  component={SelectInput.MazemapAutocomplete}
+                  fieldClassName={styles.metaField}
+                  placeholder="R1, Abakus, Kjel4 ..."
+                />
+                {event.mazemapPoi?.value && (
+                  <MazemapLink
+                    mazemapPoi={event.mazemapPoi?.value}
+                    linkText="↗️"
+                  />
+                )}
+              </Flex>
+            )}
             <Tooltip content="Kun la medlemmer i bestemt gruppe se arrangementet">
               <Field
                 label="Kun for spesifikk gruppe"
@@ -256,48 +291,6 @@ function EventEditor({
               fieldClassName={styles.metaField}
               options={eventStatusTypes}
             />
-            {['NORMAL', 'OPEN', 'INFINITE'].includes(
-              event.eventStatusType && event.eventStatusType.value
-            ) && (
-              <Field
-                label="Bruk mazemap"
-                name="useMazemap"
-                component={CheckBox.Field}
-                fieldClassName={styles.metaField}
-                className={styles.formField}
-                normalize={(v) => !!v}
-              />
-            )}
-            {['NORMAL', 'OPEN', 'INFINITE'].includes(
-              event.eventStatusType && event.eventStatusType.value
-            ) &&
-              (!event.useMazemap ? (
-                <Field
-                  label="Sted"
-                  name="location"
-                  placeholder="Den gode nabo, R5, ..."
-                  component={TextInput.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  warn={isTBA}
-                />
-              ) : (
-                <Flex alignItems="flex-end">
-                  <Field
-                    label="Mazemap-rom"
-                    name="mazemapPoi"
-                    component={SelectInput.MazemapAutocomplete}
-                    fieldClassName={styles.metaField}
-                    placeholder="R1, Abakus, Kjel4"
-                  />
-                  {event.mazemapPoi?.value && (
-                    <MazemapLink
-                      mazemapPoi={event.mazemapPoi?.value}
-                      linkText="↗️"
-                    />
-                  )}
-                </Flex>
-              ))}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -49,6 +49,7 @@ describe('Create event', () => {
     fieldError('cover').should('be.visible');
     fieldError('title').should('be.visible');
     fieldError('description').should('be.visible');
+    fieldError('mazemapPoi').should('be.visible');
     fieldError('eventType').should('be.visible');
     fieldError('isClarified').should('be.visible');
 
@@ -61,6 +62,11 @@ describe('Create event', () => {
 
     field('description').type('blir fett').blur();
     fieldError('description').should('not.exist');
+
+    field('useMazemap').uncheck();
+    cy.contains('Sted').click();
+    cy.focused().type('R4');
+    fieldError('mazemapPoi').should('not.exist');
 
     field('isClarified').check();
     fieldError('isClarified').should('not.exist');
@@ -165,6 +171,8 @@ describe('Create event', () => {
       .click();
     field('title').type('Pils på Webkomkontoret!').blur();
     field('description').type('blir fett').blur();
+    field('useMazemap').uncheck();
+    field('location').type('DT').blur();
     field('isClarified').check();
     selectField('eventType').click();
     cy.focused().type('sos{enter}', { force: true });
@@ -195,6 +203,9 @@ describe('Create event', () => {
     // Select type
     selectField('eventType').click();
     cy.focused().type('be{enter}', { force: true });
+
+    field('useMazemap').uncheck();
+    field('location').type('DT').blur();
 
     // Select company
     selectField('company').click();
@@ -236,6 +247,8 @@ describe('Create event', () => {
     field('title').type('Ubestemt event').blur();
     field('description').type('mer info kommer').blur();
     selectEditor().type('mer info kommer');
+    field('useMazemap').uncheck();
+    field('location').type('DT').blur();
 
     // Select type
     selectField('eventType').click();

--- a/cypress/e2e/event_editor_spec.js
+++ b/cypress/e2e/event_editor_spec.js
@@ -100,6 +100,8 @@ describe('Editor', () => {
     field('description').type('blir fett').blur();
     selectField('eventType').click();
     cy.focused().type('sos{enter}', { force: true });
+    field('useMazemap').uncheck();
+    field('location').type('DT').blur();
     field('isClarified').check();
 
     // Create event


### PR DESCRIPTION
# Description

I don't see how the location has anything to do with the registration type. I have personally created an event where I knew the location but not the registration type, so this restriction is just annoying.

# Testing

- [x] I have thoroughly tested my changes.

Tested that it works to create an event with a location but without any specified registration type.