### PR TITLE
Explicitly give navigation tabs a height

### DIFF
--- a/app/components/NavigationTab/NavigationLink.css
+++ b/app/components/NavigationTab/NavigationLink.css
@@ -1,8 +1,10 @@
 .link {
-  display: inline;
-  width: max-content;
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  height: 2em;
   margin-right: 0.5rem;
-  padding: 0 0.5rem;
+  padding: 0 0.75rem;
   background-color: var(--additive-background);
   border-radius: var(--border-radius-md);
   color: var(--lego-font-color);

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -169,6 +169,7 @@ export default class GalleryDetail extends Component<Props, State> {
             </div>
           )}
         </NavigationTab>
+
         <Gallery
           photos={pictures}
           hasMore={hasMore}


### PR DESCRIPTION
# Description

They would sometimes lose their height, making it look like they had no padding.

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td><img width="1144" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/d353897e-61d0-4af1-b7aa-42f1bbb55c83"></td>
		<td><img width="1144" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/9c1ea189-818d-40a3-9019-beaf839c179c"></td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Navigation tabs that were previously not affected still work as expected.