### PR TITLE
Listen for `isDragActive` on image drop

### DIFF
--- a/app/components/Form/ImageUploadField.css
+++ b/app/components/Form/ImageUploadField.css
@@ -6,5 +6,5 @@
 .coverImage {
   width: 100%;
   height: 300px;
-  background: var(--color-black);
+  background: var(--additive-background);
 }

--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -71,18 +71,23 @@ const FilePreview = ({ file, onRemove }: FilePreviewProps) => {
 };
 
 const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
-  const word = multiple ? 'bilder' : 'bilde';
   const onDropCallback = useCallback(
     (files: Array<DropFile>) => {
       files[0] && !multiple ? onDrop(files.slice(-1)) : onDrop(files);
     },
     [multiple, onDrop]
   );
-  const { getRootProps, getInputProps, isFocused, isDragAccept, isDragReject } =
-    useDropzone({
-      onDrop: onDropCallback,
-      accept: accept,
-    });
+  const {
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    isFocused,
+    isDragAccept,
+    isDragReject,
+  } = useDropzone({
+    onDrop: onDropCallback,
+    accept: accept,
+  });
 
   const style = useMemo(
     () =>
@@ -93,6 +98,9 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
       ),
     [isFocused, isDragAccept, isDragReject]
   );
+
+  const word = multiple ? 'bildene' : 'bildet';
+
   return (
     <div
       onClick={(e) => {
@@ -117,9 +125,15 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
             size={60}
             name={multiple ? 'images-outline' : 'image-outline'}
           />
-          <h4 className={styles.placeholderTitle}>
-            {`Dropp ${word} her eller trykk for å velge fra filsystem`}
-          </h4>
+          {isDragActive ? (
+            isDragAccept ? (
+              <span>Slipp {word} her ...</span>
+            ) : (
+              <span>Ugyldig filformat!</span>
+            )
+          ) : (
+            <span>Slipp {word} her eller trykk for å velge fra filsystem</span>
+          )}
         </Flex>
         {image && (
           <Image alt="presentation" className={styles.image} src={image} />

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -32,6 +32,10 @@
   height: inherit;
   width: inherit;
   position: absolute;
+  background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 50%);
+  font-weight: 500;
+  padding: 10px 40px;
+  text-align: center;
 }
 
 .inModalUpload .placeholderContainer {
@@ -51,21 +55,11 @@
   border: 3px dashed var(--danger-color);
 }
 
-.placeholderTitle {
-  background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 70%);
-  padding: 10px 40px;
-  text-align: center;
-}
-
-.inModalUpload .placeholderTitle {
-  background: none;
-}
-
 .image {
   width: 100%;
   height: inherit;
   object-fit: cover;
-  background: white;
+  background: var(--color-absolute-white);
   border-radius: inherit;
 }
 

--- a/app/routes/articles/components/ArticleEditor.css
+++ b/app/routes/articles/components/ArticleEditor.css
@@ -7,7 +7,7 @@
   width: 100%;
   height: 300px;
   overflow: hidden;
-  background: var(--color-black);
+  background: var(--additive-background);
   margin-bottom: 20px;
   position: relative;
 }

--- a/app/routes/pages/components/PageEditor.css
+++ b/app/routes/pages/components/PageEditor.css
@@ -11,7 +11,7 @@
   width: 100%;
   height: 300px;
   overflow: hidden;
-  background: var(--color-black);
+  background: var(--additive-background);
   margin-bottom: 20px;
   position: relative;
 }

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -6,6 +6,7 @@ import {
   selectFieldDropdown,
   selectEditor,
   setDatePickerDate,
+  uploadHeader,
 } from '../support/utils.js';
 
 describe('Create event', () => {
@@ -13,22 +14,6 @@ describe('Create event', () => {
     cy.resetDb();
     cy.cachedLogin();
   });
-
-  const uploadHeader = () => {
-    // Upload file
-    cy.upload_file(
-      c('ImageUploadField__coverImage') +
-        ' ' +
-        c('UploadImage__placeholderTitle'),
-      'images/screenshot.png'
-    );
-    cy.get('.cropper-move').click();
-    cy.get(c('Modal__content'))
-      .contains('Last opp')
-      .should('not.be.disabled')
-      .click();
-    cy.wait(1000);
-  };
 
   it('should fill required fields before being allowed to submit', () => {
     cy.visit('/events/create');
@@ -158,17 +143,7 @@ describe('Create event', () => {
     cy.focused().type('EOF');
 
     // Fill rest of form
-    cy.upload_file(
-      c('ImageUploadField__coverImage') +
-        ' ' +
-        c('UploadImage__placeholderTitle'),
-      'images/screenshot.png'
-    );
-    cy.get('.cropper-move').click();
-    cy.get(c('Modal__content'))
-      .contains('Last opp')
-      .should('not.be.disabled')
-      .click();
+    uploadHeader();
     field('title').type('Pils på Webkomkontoret!').blur();
     field('description').type('blir fett').blur();
     field('useMazemap').uncheck();

--- a/cypress/e2e/event_editor_spec.js
+++ b/cypress/e2e/event_editor_spec.js
@@ -1,4 +1,4 @@
-import { selectField, c, field } from '../support/utils.js';
+import { selectField, c, field, uploadHeader } from '../support/utils.js';
 
 const IS_MACOS = Cypress.platform.toLowerCase().search('darwin') !== -1;
 const ctrlKey = IS_MACOS ? '{cmd}' : '{ctrl}';
@@ -85,17 +85,7 @@ describe('Editor', () => {
     cy.focused().type('{enter}{enter}EOF{enter}');
 
     // Fill rest of form
-    cy.upload_file(
-      c('ImageUploadField__coverImage') +
-        ' ' +
-        c('UploadImage__placeholderTitle'),
-      'images/screenshot.png'
-    );
-    cy.get('.cropper-move').click();
-    cy.get(c('Modal__content'))
-      .contains('Last opp')
-      .should('not.be.disabled')
-      .click();
+    uploadHeader();
     field('title').type('Pils på Webkomkontoret!').blur();
     field('description').type('blir fett').blur();
     selectField('eventType').click();

--- a/cypress/e2e/event_payment_spec.js
+++ b/cypress/e2e/event_payment_spec.js
@@ -9,6 +9,7 @@ import {
   confirm3DSecure2Dialog,
   stripeError,
   clearCardDetails,
+  uploadHeader,
 } from '../support/utils.js';
 
 describe('Event registration & payment', () => {
@@ -21,21 +22,6 @@ describe('Event registration & payment', () => {
     Cypress.on('uncaught:exception', (err, runnable, promise) => {
       return false;
     });
-
-    const uploadHeader = () => {
-      // Upload file
-      cy.upload_file(
-        c('ImageUploadField__coverImage') +
-          ' ' +
-          c('UploadImage__placeholderTitle'),
-        'images/screenshot.png'
-      );
-      cy.get('.cropper-move').click();
-      cy.get(c('Modal__content'))
-        .contains('Last opp')
-        .should('not.be.disabled')
-        .click();
-    };
 
     it('Should be possible to create a priced event', () => {
       cy.visit('/events/create');

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -128,3 +128,25 @@ export const mockMazemapApi = () => {
     body: mockMazemapApiResponse,
   });
 };
+
+export const uploadHeader = () => {
+  // Intercept the upload request
+  cy.intercept('POST', '/api/v1/files/').as('fileUpload');
+
+  // Upload file
+  cy.upload_file(
+    c('ImageUploadField__coverImage') +
+      ' ' +
+      c('UploadImage__placeholderContainer') +
+      ' > span',
+    'images/screenshot.png'
+  );
+  cy.get('.cropper-move').click();
+  cy.get(c('Modal__content'))
+    .contains('Last opp')
+    .should('not.be.disabled')
+    .click();
+
+  // Wait for the upload request to finish and assert it was successful
+  cy.wait('@fileUpload').its('response.statusCode').should('eq', 201);
+};


### PR DESCRIPTION
# Description

Not an important feature, just a tiny cool one.

Make some minor styling changes as well, including removing the pitch black background on some cover image drop areas.

# Result

https://github.com/webkom/lego-webapp/assets/69514187/4bfd17c7-e00f-4044-b2d0-2d876c73dcfb

---

The old pitch black background:
<img width="1144" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/f89e6cb9-b801-486e-91b7-83943de98217">


# Testing

- [x] I have thoroughly tested my changes.

Uploading images still works.