### PR TITLE
Make icons behave like buttons and links

### DIFF
--- a/app/components/Button/Button.css
+++ b/app/components/Button/Button.css
@@ -48,7 +48,7 @@
     box-shadow, opacity;
 
   &:focus-visible {
-    box-shadow: 0 0 0 1.5px var(--color-black);
+    box-shadow: 0 0 0 1.5px var(--lego-font-color);
   }
 
   &:disabled {

--- a/app/components/CollapsibleDisplayContent/CollapsibleDisplayContent.css
+++ b/app/components/CollapsibleDisplayContent/CollapsibleDisplayContent.css
@@ -51,5 +51,4 @@
   margin: 0;
   border-radius: 50%;
   background-color: var(--lego-card-color);
-  box-shadow: 0 0 5px var(--lego-card-color);
 }

--- a/app/components/CollapsibleDisplayContent/index.tsx
+++ b/app/components/CollapsibleDisplayContent/index.tsx
@@ -62,20 +62,14 @@ function CollapsibleDisplayContent({
         />
       </div>
       {useCollapse && (
-        <div
-          className={styles.showMore}
-          onClick={() => {
-            setIsOpened(!isOpened);
-          }}
-        >
+        <div className={styles.showMore}>
           <Icon
-            name={
-              isOpened
-                ? 'chevron-up-circle-outline'
-                : 'chevron-down-circle-outline'
-            }
+            onClick={() => {
+              setIsOpened(!isOpened);
+            }}
+            name={isOpened ? 'chevron-up' : 'chevron-down'}
             className={styles.showMoreIcon}
-            size={40}
+            size={30}
           />
         </div>
       )}

--- a/app/components/Icon/Icon.css
+++ b/app/components/Icon/Icon.css
@@ -1,27 +1,34 @@
 .badge {
   position: absolute;
-  top: -12px;
-  right: -8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  top: -10px;
+  right: -7px;
   background-color: var(--lego-red-color);
   color: var(--color-white);
+  border: 1.5px solid var(--lego-background-color);
   border-radius: 50%;
-  min-width: 22px;
+  width: 22px;
+  height: 22px;
   font-size: var(--font-size-sm);
-  padding: 2px;
-  opacity: 0.9;
   z-index: 1;
 }
 
 .clickable {
+  display: flex;
   width: fit-content;
   height: fit-content;
   padding: 0.375rem;
   cursor: pointer;
   border-radius: 50%;
+  outline: none;
+  font-size: inherit;
   color: var(--lego-font-color);
   transition: background-color var(--easing-fast);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: var(--additive-background);
   }
 }
@@ -30,7 +37,8 @@
   composes: clickable;
   color: var(--danger-color);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: var(--color-red-1);
   }
 }
@@ -39,7 +47,8 @@
   composes: clickable;
   color: var(--color-green-6);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: var(--color-green-2);
   }
 }
@@ -48,7 +57,8 @@
   composes: clickable;
   color: var(--color-orange-6);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: var(--color-orange-2);
   }
 }

--- a/app/components/Icon/index.tsx
+++ b/app/components/Icon/index.tsx
@@ -1,15 +1,16 @@
 import cx from 'classnames';
+import { Link } from 'react-router-dom';
 import { Flex } from 'app/components/Layout';
 import styles from './Icon.css';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, MouseEventHandler } from 'react';
 
 type Props = {
-  /** Name of the icon can be found on the webpage*/
+  /** Name of the icon can be found on the webpage */
   name: string;
-  scaleOnHover?: boolean;
   className?: string;
   size?: number;
-  clickable?: boolean;
+  to?: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
   danger?: boolean; // name: trash
   success?: boolean; // name: checkmark
   edit?: boolean; // name: pencil
@@ -30,7 +31,8 @@ const Icon = ({
   className,
   style = {},
   size = 24,
-  clickable = false,
+  to,
+  onClick,
   danger = false,
   success = false,
   edit = false,
@@ -39,23 +41,42 @@ const Icon = ({
 }: Props) => {
   return (
     <Flex
-      className={cx(
-        className,
-        clickable && styles.clickable,
-        danger && styles.danger,
-        success && styles.success,
-        edit && styles.edit,
-        disabled && styles.disabled
-      )}
+      className={cx(className)}
       style={{
         fontSize: `${size.toString()}px`,
         ...style,
       }}
       {...props}
     >
-      {/* eslint-disable-next-line*/}
-      {/* @ts-ignore*/}
-      <ion-icon name={name}></ion-icon>
+      {to ? (
+        <Link to={to} className={styles.clickable}>
+          {/* eslint-disable-next-line*/}
+          {/* @ts-ignore*/}
+          <ion-icon name={name}></ion-icon>
+        </Link>
+      ) : onClick ? (
+        <button
+          type="button"
+          onClick={onClick}
+          className={cx(
+            styles.clickable,
+            danger && styles.danger,
+            success && styles.success,
+            edit && styles.edit,
+            disabled && styles.disabled
+          )}
+        >
+          {/* eslint-disable-next-line*/}
+          {/* @ts-ignore*/}
+          <ion-icon name={name}></ion-icon>
+        </button>
+      ) : (
+        <>
+          {/* eslint-disable-next-line*/}
+          {/* @ts-ignore*/}
+          <ion-icon name={name}></ion-icon>
+        </>
+      )}
     </Flex>
   );
 };

--- a/app/components/Modal/Modal.css
+++ b/app/components/Modal/Modal.css
@@ -60,5 +60,4 @@ html[data-theme='dark'] .backdrop {
   position: absolute;
   top: 1rem;
   right: 1rem;
-  padding: 0;
 }

--- a/app/components/Modal/index.tsx
+++ b/app/components/Modal/index.tsx
@@ -47,13 +47,10 @@ const Modal = ({
       />
     )}
   >
-    <div>
-      <button onClick={onHide} className={styles.closeButton}>
-        <Icon name="close" clickable size={24} />
-      </button>
-
+    <>
+      <Icon name="close" onClick={onHide} className={styles.closeButton} />
       {children}
-    </div>
+    </>
   </ReactModal>
 );
 

--- a/app/components/NavigationTab/NavigationLink.css
+++ b/app/components/NavigationTab/NavigationLink.css
@@ -5,9 +5,14 @@
   padding: 0 0.5rem;
   background-color: var(--additive-background);
   border-radius: var(--border-radius-md);
+  outline: none;
   color: var(--lego-font-color);
   transition: var(--easing-fast);
   transition-property: color, background-color;
+
+  &:focus-visible:not(.active) {
+    box-shadow: 0 0 0 1.5px var(--lego-font-color);
+  }
 
   &:hover:not(.active) {
     background-color: var(--color-gray-2);

--- a/app/components/RandomQuote/RandomQuote.css
+++ b/app/components/RandomQuote/RandomQuote.css
@@ -19,7 +19,7 @@
   margin-top: 5px;
 }
 
-.rotateIcon {
+.rotateIcon button {
   transform: rotate(360deg);
   transition: var(--easing-slow);
   transform-origin: center center;

--- a/app/components/RandomQuote/RandomQuote.tsx
+++ b/app/components/RandomQuote/RandomQuote.tsx
@@ -70,13 +70,10 @@ const RandomQuote = ({
         <Flex column justifyContent="space-between" gap={5}>
           <Icon
             name="refresh"
-            clickable
             onClick={onClick}
             className={cx(animation && styles.rotateIcon)}
           />
-          <Link to="/quotes/add">
-            <Icon name="add" clickable />
-          </Link>
+          <Icon to="/quotes/add" name="add" />
         </Flex>
       </Flex>
 

--- a/app/components/Search/Search.css
+++ b/app/components/Search/Search.css
@@ -52,13 +52,6 @@
   margin-left: 3px;
 }
 
-.closeButton {
-  width: 40px;
-  outline: none;
-  border: 0;
-  background: transparent;
-}
-
 .resultsContainer {
   background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 80%);
   overflow-y: auto;

--- a/app/components/Search/index.tsx
+++ b/app/components/Search/index.tsx
@@ -126,13 +126,12 @@ class Search extends Component<Props, State> {
             />
           ))}
 
-          <button
-            type="button"
-            className={styles.closeButton}
+          <Icon
+            name={searching ? 'refresh' : 'close'}
             onClick={onCloseSearch}
-          >
-            <Icon name={searching ? 'refresh' : 'close'} clickable size={30} />
-          </button>
+            size={30}
+            data-testid="closeButton"
+          />
         </div>
 
         <SearchResults

--- a/app/routes/overview/components/CompactEvents.css
+++ b/app/routes/overview/components/CompactEvents.css
@@ -43,8 +43,3 @@
 .compactEvents a:hover {
   color: var(--lego-link-color);
 }
-
-.showMoreLink {
-  margin: 0 auto;
-  font-size: var(--font-size-md);
-}

--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -48,7 +48,7 @@
 .showMore {
   display: flex;
   justify-content: center;
-  margin-top: 20px;
+  margin: 20px 0;
 }
 
 .desktopContainer {

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -130,12 +130,7 @@ const Overview = (props: Props) => {
 
       {frontpage.length > 8 && (
         <div className={styles.showMore}>
-          <Icon
-            clickable
-            onClick={showMore}
-            name="chevron-down-outline"
-            size={40}
-          />
+          <Icon onClick={showMore} name="chevron-down-outline" size={30} />
         </div>
       )}
     </Container>

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -37,7 +37,7 @@ type Props = {
 };
 
 const renderOptions = ({ fields }: any): ReactNode => (
-  <div>
+  <>
     <ul className={styles.options}>
       {fields.map((option: string, i: number) => (
         <li className={styles.optionField} key={i}>
@@ -55,8 +55,8 @@ const renderOptions = ({ fields }: any): ReactNode => (
           />
           <ConfirmModal
             title="Slett valg"
-            message="Er du sikker på at du vil slette dette valget?"
-            onConfirm={async () => fields.remove(i)}
+            message="Er du sikker på at du vil fjerne dette valget?"
+            onConfirm={async () => await fields.remove(i)}
             closeOnConfirm
           >
             {({ openConfirmModal }) => (
@@ -73,7 +73,7 @@ const renderOptions = ({ fields }: any): ReactNode => (
       <Icon name="add" size={25} />
       Legg til alternativ
     </Button>
-  </div>
+  </>
 );
 
 const validate = createValidator({
@@ -180,8 +180,9 @@ const EditPollForm = ({
             <FieldArray
               name="options"
               component={renderOptions}
-              rerenderOnEveryChange={true}
+              rerenderOnEveryChange
             />
+
             <Flex className={styles.actionButtons}>
               <Button disabled={pristine || submitting} submit>
                 {editing ? 'Lagre endringer' : 'Lag ny avstemning'}

--- a/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyEditor.tsx
@@ -141,15 +141,14 @@ const renderQuestions = ({ fields }) => (
       ))}
     </ul>
 
-    <Link
-      key="addNew"
-      to="#"
+    <Icon
+      name="add"
+      size={30}
       onClick={() => {
         fields.push(initialQuestion);
       }}
-    >
-      <Icon name="add" clickable size={30} className={styles.addQuestion} />
-    </Link>
+      className={styles.addQuestion}
+    />
   </>
 );
 
@@ -320,12 +319,6 @@ const SurveyEditor = ({
             />
 
             <Flex>
-              {spySubmittable((submittable) => (
-                <Button disabled={submitting || !submittable} submit>
-                  {editing ? 'Lagre' : 'Opprett'}
-                </Button>
-              ))}
-
               <Button
                 flat
                 onClick={() =>
@@ -334,6 +327,12 @@ const SurveyEditor = ({
               >
                 Avbryt
               </Button>
+
+              {spySubmittable((submittable) => (
+                <Button disabled={submitting || !submittable} submit>
+                  {editing ? 'Lagre' : 'Opprett'}
+                </Button>
+              ))}
             </Flex>
           </form>
         )}

--- a/app/routes/surveys/components/surveys.css
+++ b/app/routes/surveys/components/surveys.css
@@ -120,8 +120,7 @@
 }
 
 .addQuestion {
-  margin: 0 auto;
-  display: flex;
+  justify-content: center;
 }
 
 .addOption {

--- a/cypress/e2e/router_spec.js
+++ b/cypress/e2e/router_spec.js
@@ -166,7 +166,7 @@ describe('Navigate throughout app', () => {
     cy.contains('Artikler');
 
     // Go back
-    cy.get(c('closeButton')).click();
+    cy.get('[data-testid="closeButton"]').click();
     cy.url().should('contain', '/');
     cy.contains('Festet oppslag');
     cy.contains('Påmeldinger');


### PR DESCRIPTION
# Description

Not really a visual change, but rather an accessibility improvement and a reduction in technical debt. An icon can now behave like either buttons or links, which lets users focus on it and then trigger it by pressing enter.

# Result

Me tabbing around

https://github.com/webkom/lego-webapp/assets/69514187/48d79097-5743-4e4c-8e3d-b6142293ea85

# Testing

- [x] I have thoroughly tested my changes.

Went through icons with `onClick` events and things seems to work fine like before, just better heh.