### PR TITLE
Vertically align tag component on overview

### DIFF
--- a/app/components/Tags/Tag.css
+++ b/app/components/Tags/Tag.css
@@ -40,6 +40,7 @@
     min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100), 1)
   );
 
+  display: flex;
   color: hsl(0deg, 0%, calc(var(--lightness-switch) * 100%));
   background: rgb(var(--label-r), var(--label-g), var(--label-b));
   border-color: hsla(

--- a/app/routes/articles/components/Overview.tsx
+++ b/app/routes/articles/components/Overview.tsx
@@ -45,6 +45,7 @@ export const OverviewItem = ({
       ))}
 
       <Time time={article.createdAt} format="DD.MM.YYYY HH:mm" />
+
       <Tags className={styles.tagline}>
         {article.tags.map((tag) => (
           <Tag tag={tag} key={tag} />

--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -14,20 +14,17 @@
   padding: 28px 0 0;
 }
 
-.itemInfo {
-  color: var(--secondary-font-color);
+.dot {
+  margin: 0 6px;
 }
 
 .type {
-  margin-right: 4px;
+  margin-right: 6px;
 }
 
 .tagline {
-  display: inline-block;
-  white-space: nowrap;
-  transform: translateY(-7.5%);
-  vertical-align: middle;
-  overflow: hidden;
+  margin: 0;
+  display: inline-flex;
 }
 
 .otherItems {

--- a/app/routes/overview/components/Pinned.css
+++ b/app/routes/overview/components/Pinned.css
@@ -29,7 +29,9 @@
 
 .pinnedHeading {
   padding: 15px;
-  align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .itemTitle {

--- a/app/routes/overview/components/utils.tsx
+++ b/app/routes/overview/components/utils.tsx
@@ -1,4 +1,5 @@
 import moment from 'moment-timezone';
+import Flex from 'app/components/Layout/Flex';
 import Tags from 'app/components/Tags';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';
@@ -34,19 +35,24 @@ export const renderMeta = (
   }
 
   return (
-    <span className={styles.itemInfo}>
+    <Flex
+      wrap
+      alignItems="center"
+      justifyContent="center"
+      className="secondaryFontColor"
+    >
       <Time time={itemTime} format={format} />
+
       {isEvent(item) && item.location !== '-' && (
-        <span>
-          <span> • </span>
+        <>
+          <span className={styles.dot}> • </span>
           <span> {truncateString(item.location, 8)} </span>
-        </span>
+        </>
       )}
 
-      <span> • </span>
+      <span className={styles.dot}> • </span>
       <span className={styles.type}>
-        {' '}
-        {isEvent(item) ? eventTypeToString(item.eventType) : 'Artikkel'}{' '}
+        {isEvent(item) ? eventTypeToString(item.eventType) : 'Artikkel'}
       </span>
 
       {item.tags?.length > 0 && (
@@ -56,6 +62,6 @@ export const renderMeta = (
           ))}
         </Tags>
       )}
-    </span>
+    </Flex>
   );
 };


### PR DESCRIPTION
# Description

The display property was removed from the tag component since it could not be inline for it to work with the recent introduction of the author highlight on comments, but this broke the alignment of tags on the overview's pinned component.

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	</tr>
	<tr>
		<td>
			<img width="447" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/49f2ff72-9903-4d99-a9ca-212dff50259c">
		</td>
		<td>
			<img width="447" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/7a129808-f207-49e4-8f2b-e02d0e563861">
		</td>
	</tr>
</table>


# Testing

- [x] I have thoroughly tested my changes.

The author tag is still aligned properly:

<img width="447" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/3b1ff822-8ef8-4678-97d1-e9f8c786ebf5">

And other places where tags are used seem fine:

<img width="1145" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/c35c0d15-668a-4306-87af-080161aac103">

<img width="781" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/c9e8add0-9a42-46cc-8e07-28c46b00b9d2">
 
---

Resolves ABA-511