### PR TITLE
Replace verification form with FEIDE auth

### DIFF
--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -257,10 +257,8 @@ export const User = {
     'User.VALIDATE_REGISTRATION_TOKEN'
   ) as AAT,
   CREATE_USER: generateStatuses('User.CREATE_USER') as AAT,
-  SEND_STUDENT_CONFIRMATION_TOKEN: generateStatuses(
-    'User.SEND_STUDENT_CONFIRMATION_TOKEN'
-  ) as AAT,
-  CONFIRM_STUDENT_USER: generateStatuses('User.CONFIRM_STUDENT_USER') as AAT,
+  INIT_STUDENT_AUTH: generateStatuses('User.INIT_STUDENT_AUTH') as AAT,
+  COMPLETE_STUDENT_AUTH: generateStatuses('User.COMPLETE_STUDENT_AUTH') as AAT,
   SEND_FORGOT_PASSWORD_REQUEST: generateStatuses(
     'User.SEND_FORGOT_PASSWORD_REQUEST'
   ) as AAT,

--- a/app/actions/UserActions.ts
+++ b/app/actions/UserActions.ts
@@ -443,6 +443,35 @@ export function sendStudentConfirmationEmail(user: string): Thunk<void> {
     },
   });
 }
+
+export function startStudentAuth(): Thunk<void> {
+  return callAPI({
+    types: User.SEND_STUDENT_CONFIRMATION_TOKEN,
+    endpoint: `/oidc/authorize/`,
+    method: 'GET',
+    meta: {
+      errorMessage: 'Studentstatus feilet',
+    },
+  });
+}
+
+export function confirmStudentAuth({
+  code,
+  state,
+}: {
+  code: string;
+  state: string;
+}): Thunk<void> {
+  return callAPI({
+    types: User.SEND_STUDENT_CONFIRMATION_TOKEN,
+    endpoint: `/oidc/validate/?code=${code}&state=${state}`,
+    method: 'GET',
+    meta: {
+      errorMessage: 'Validering av studentstatus feilet',
+    },
+  });
+}
+
 export function confirmStudentUser(token: string): Thunk<void> {
   return callAPI({
     types: User.CONFIRM_STUDENT_USER,

--- a/app/actions/UserActions.ts
+++ b/app/actions/UserActions.ts
@@ -432,25 +432,14 @@ export function deleteUser(password: string): Thunk<Promise<void>> {
       })
     );
 }
-export function sendStudentConfirmationEmail(user: string): Thunk<void> {
-  return callAPI({
-    types: User.SEND_STUDENT_CONFIRMATION_TOKEN,
-    endpoint: `/users-student-confirmation-request/`,
-    method: 'POST',
-    body: user,
-    meta: {
-      errorMessage: 'Sending av student bekreftelsese-post feilet',
-    },
-  });
-}
 
 export function startStudentAuth(): Thunk<void> {
   return callAPI({
-    types: User.SEND_STUDENT_CONFIRMATION_TOKEN,
+    types: User.INIT_STUDENT_AUTH,
     endpoint: `/oidc/authorize/`,
     method: 'GET',
     meta: {
-      errorMessage: 'Studentstatus feilet',
+      errorMessage: 'Student verifisering feilet',
     },
   });
 }
@@ -463,7 +452,7 @@ export function confirmStudentAuth({
   state: string;
 }): Thunk<void> {
   return callAPI({
-    types: User.SEND_STUDENT_CONFIRMATION_TOKEN,
+    types: User.COMPLETE_STUDENT_AUTH,
     endpoint: `/oidc/validate/?code=${code}&state=${state}`,
     method: 'GET',
     meta: {
@@ -472,16 +461,6 @@ export function confirmStudentAuth({
   });
 }
 
-export function confirmStudentUser(token: string): Thunk<void> {
-  return callAPI({
-    types: User.CONFIRM_STUDENT_USER,
-    endpoint: `/users-student-confirmation-perform/?token=${token}`,
-    method: 'POST',
-    meta: {
-      errorMessage: 'Student bekreftelse feilet',
-    },
-  });
-}
 export function sendForgotPasswordEmail({
   email,
 }: {

--- a/app/reducers/auth.ts
+++ b/app/reducers/auth.ts
@@ -60,12 +60,6 @@ export default function auth(
     case User.VALIDATE_REGISTRATION_TOKEN.SUCCESS:
       return { ...state, registrationToken: action.meta.token };
 
-    case User.CONFIRM_STUDENT_USER.FAILURE:
-      return { ...state, studentConfirmed: false };
-
-    case User.CONFIRM_STUDENT_USER.SUCCESS:
-      return { ...state, studentConfirmed: true };
-
     default:
       return state;
   }

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -55,11 +55,6 @@ export default createEntityReducer({
         break;
       }
 
-      case User.CONFIRM_STUDENT_USER.SUCCESS: {
-        newState.byId = mergeObjects(newState.byId, action.payload);
-        break;
-      }
-
       default:
         break;
     }

--- a/app/routes/users/StudentConfirmationRoute.tsx
+++ b/app/routes/users/StudentConfirmationRoute.tsx
@@ -1,10 +1,12 @@
-import { push } from 'connected-react-router';
 import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import {
   sendStudentConfirmationEmail,
   confirmStudentUser,
+  startStudentAuth,
+  confirmStudentAuth,
+  updateUser,
 } from 'app/actions/UserActions';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import StudentConfirmation from './components/StudentConfirmation';
@@ -31,8 +33,10 @@ const mapStateToProps = (state, props) => {
 };
 
 const mapDispatchToProps = {
+  startStudentAuth,
+  confirmStudentAuth,
   sendStudentConfirmationEmail,
-  push,
+  updateUser,
 };
 export default compose(
   withPreparedDispatch('fetchStudentConfirmation', loadData),

--- a/app/routes/users/StudentConfirmationRoute.tsx
+++ b/app/routes/users/StudentConfirmationRoute.tsx
@@ -1,25 +1,11 @@
-import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import {
-  sendStudentConfirmationEmail,
-  confirmStudentUser,
   startStudentAuth,
   confirmStudentAuth,
   updateUser,
 } from 'app/actions/UserActions';
-import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import StudentConfirmation from './components/StudentConfirmation';
-
-const loadData = ({ location: { search } }, dispatch) => {
-  const { token } = qs.parse(search, {
-    ignoreQueryPrefix: true,
-  });
-
-  if (token) {
-    return dispatch(confirmStudentUser(token));
-  }
-};
 
 const StudentConfirmationRoute = (props) => {
   return <StudentConfirmation {...props} />;
@@ -27,18 +13,15 @@ const StudentConfirmationRoute = (props) => {
 
 const mapStateToProps = (state, props) => {
   return {
-    studentConfirmed: state.auth.studentConfirmed,
-    isStudent: props.currentUser && props.currentUser.isStudent,
+    isStudent: props.currentUser?.isStudent,
   };
 };
 
 const mapDispatchToProps = {
   startStudentAuth,
   confirmStudentAuth,
-  sendStudentConfirmationEmail,
   updateUser,
 };
-export default compose(
-  withPreparedDispatch('fetchStudentConfirmation', loadData),
-  connect(mapStateToProps, mapDispatchToProps)
-)(StudentConfirmationRoute);
+export default compose(connect(mapStateToProps, mapDispatchToProps))(
+  StudentConfirmationRoute
+);

--- a/app/routes/users/components/StudentConfirmation.tsx
+++ b/app/routes/users/components/StudentConfirmation.tsx
@@ -14,6 +14,31 @@ type Props = {
   isStudent: boolean;
 };
 
+const NotEligibleInfo = () => (
+  <div className={styles.notEligibleInfo}>
+    <p>
+      Dersom du mener dette er en feil, eller ønsker å søke om medlemskap kan du
+      enten:
+    </p>
+    <ol className={styles.infoList}>
+      <li>
+        Påse at du er har Datateknologi eller Kommunikasjonsteknologi og Digital
+        Sikkerhet som studie i StudentWeb og verifisere på nytt.
+      </li>
+      <li>
+        Sende en mail til <a href="mailto:webkom@abakus.no">webkom@abakus.no</a>{' '}
+        med dokumentasjon på at du går eller tar fag som tilhører et av studiene
+        over.
+      </li>
+      <li>
+        Sende en mail til <a href="mailto:abakus@abakus.no">abakus@abakus.no</a>{' '}
+        med søknad om hvorfor du ønsker å bli medlem av Abakus. (Det trenger
+        ikke være en stor søknad :))
+      </li>
+    </ol>
+  </div>
+);
+
 const StudentConfirmation = ({
   startStudentAuth,
   confirmStudentAuth,
@@ -63,58 +88,59 @@ const StudentConfirmation = ({
       <div>
         <h2>Verifiser studentstatus</h2>
 
-        {isStudent && (
-          <Card info>
-            <h4>Du er allerede verifisert som student</h4>
-            <p className={styles.infoText}>
-              Dersom du ønsker å endre trinn eller studie, vennligst send en
-              forespørsel til{' '}
-              <a href="mailto:webkom@abakus.no">webkom@abakus.no</a> med
-              dokumentasjon på ditt trinn og studie. Gyldig dokumentasjon kan
-              være:
-              <ul className={styles.programmeList}>
-                <li>
-                  Screenshot eller dokumentasjon fra studentWeb (at du tar fag
-                  tilhørende ditt ønsket trinn er nok)
-                </li>
-                <li>Dokumentasjon fra institutt/fakultet</li>
-              </ul>
-            </p>
-          </Card>
+        {isStudent == null && (
+          <p>
+            For å kunne bli medlem i Abakus og få mulighet til å delta på
+            arrangementer, få tilgang til bilder og interessegrupper og mer må
+            du verifisere at du går enten Kommunikasjonsteknologi & Digital
+            Sikkerhet eller Datateknologi. Ved å trykke på knappen under gir du
+            Abakus tilgang til dine studier og fag i StudentWeb gjennom FEIDE
+            slik at vi kan registrere deg som medlem.
+          </p>
         )}
 
+        {isStudent != null &&
+          (isStudent ? (
+            <Card info>
+              <h4>Du er verifisert som student</h4>
+              <p className={styles.infoText}>
+                Dersom du ønsker å endre trinn eller studie, vennligst send en
+                forespørsel til{' '}
+                <a href="mailto:webkom@abakus.no">webkom@abakus.no</a> med
+                dokumentasjon på ditt trinn og studie. Gyldig dokumentasjon kan
+                være:
+                <ul className={styles.programmeList}>
+                  <li>
+                    Screenshot eller dokumentasjon fra studentWeb (at du tar fag
+                    tilhørende ditt ønsket trinn er nok)
+                  </li>
+                  <li>Dokumentasjon fra institutt/fakultet</li>
+                </ul>
+              </p>
+            </Card>
+          ) : (
+            <Card danger>
+              <h4>
+                Informasjon vi har hentet om deg fra StudentWeb gir ikke
+                mulighet for automatisk medlemskap i Abakus
+              </h4>
+              <NotEligibleInfo />
+            </Card>
+          ))}
+
         {authRes && !isStudent && (
-          <Card
-            danger={authRes.status !== 'success'}
-            info={authRes.status === 'success'}
-          >
+          <Card danger={authRes.status !== 'success'}>
             {authRes.status === 'unauthorized' && (
               <>
                 <h4>
                   Ingen av dine nåværende studier tillater medlemskap i Abakus:
                 </h4>
-                <ul>
+                <ul className={styles.programmeList}>
                   {authRes.studyProgrammes.map((p) => (
                     <li key={p}>{p}</li>
                   ))}
                 </ul>
-                <p>
-                  Dersom du mener dette er en feil, eller ønsker å søke om
-                  medlemskap kan du enten:
-                </p>
-                <ol>
-                  <li>
-                    Sende en mail til{' '}
-                    <a href="mailto:webkom@abakus.no">webkom@abakus.no</a> med
-                    dokumentasjon på at du går studiet eller tar fag som
-                    tilsvarer studiet.
-                  </li>
-                  <li>
-                    Sende en mail til{' '}
-                    <a href="mailto:abakus@abakus.no">abakus@abakus.no</a> med
-                    søknad om hvorfor du ønsker å bli medlem av Abakus.
-                  </li>
-                </ol>
+                <NotEligibleInfo />
               </>
             )}
           </Card>
@@ -123,7 +149,7 @@ const StudentConfirmation = ({
         <Button success onClick={() => performStudentAuth()}>
           Verifiser med FEIDE
         </Button>
-        {isStudent && (
+        {isStudent != null && (
           <p className={styles.infoText}>
             Du har allerede verifisert din status. Dersom du har byttet studie
             og ønsker å bli medlem av Abakus, kan du verifisere deg på nytt og
@@ -132,8 +158,19 @@ const StudentConfirmation = ({
           </p>
         )}
 
-        <Modal show={showMemberModal} onHide={() => setShowMemberModal(false)}>
-          <Card info>Din studentstatus ble godkjent!</Card>
+        <Modal
+          show={showMemberModal}
+          contentClassName={styles.membershipModalContent}
+          onHide={() => setShowMemberModal(false)}
+        >
+          <Card info>
+            <Flex column>
+              <h4>Din studentstatus ble godkjent!</h4>
+              <p>
+                Du har blitt satt i gruppen: <b>{authRes?.grade}</b>
+              </p>
+            </Flex>
+          </Card>
           <h2>Vil du bli medlem av Abakus?</h2>
           <div>
             <p className={styles.infoText}>
@@ -165,7 +202,7 @@ const StudentConfirmation = ({
           </div>
 
           <Flex row>
-            <Button danger onClick={() => setAbakusMember(false)}>
+            <Button dark onClick={() => setAbakusMember(false)}>
               Jeg vil ikke bli medlem
             </Button>
             <Button success onClick={() => setAbakusMember(true)}>

--- a/app/routes/users/components/UserConfirmation.css
+++ b/app/routes/users/components/UserConfirmation.css
@@ -9,3 +9,9 @@
   font-size: var(--font-size-sm);
   line-height: 1.4em;
 }
+
+.programmeList {
+  list-style: disc;
+  list-style-position: inside;
+  font-style: italic;
+}

--- a/app/routes/users/components/UserConfirmation.css
+++ b/app/routes/users/components/UserConfirmation.css
@@ -15,3 +15,21 @@
   list-style-position: inside;
   font-style: italic;
 }
+
+.notEligibleInfo {
+  margin-top: 1em;
+}
+
+.infoList {
+  list-style-position: inside;
+  margin-left: 1em;
+}
+
+.membershipModalContent {
+  width: 600px;
+  max-width: 90%;
+
+  @media (--tall-viewport) {
+    max-height: calc(100vh - 300px);
+  }
+}

--- a/app/routes/users/components/UserProfile.css
+++ b/app/routes/users/components/UserProfile.css
@@ -82,3 +82,11 @@
   font-size: var(--font-size-sm);
   color: var(--secondary-font-color);
 }
+
+.settingsIcon {
+  transition: transform var(--easing-medium);
+
+  &:hover {
+    transform: rotate(90deg);
+  }
+}

--- a/app/routes/users/components/UserProfile.tsx
+++ b/app/routes/users/components/UserProfile.tsx
@@ -416,7 +416,15 @@ const UserProfile = (props: Props) => {
           )}
         </Flex>
         <Flex column className={styles.rightContent}>
-          <h2>{user.fullName}</h2>
+          <Flex justifyContent="space-between" alignItems="center">
+            <h2>{user.fullName}</h2>
+            <Icon
+              name="settings"
+              size={22}
+              className={styles.settingsIcon}
+              to={`/users/${user.username}/settings/profile`}
+            />
+          </Flex>
           <Flex wrap>
             {membershipsAsPills.map((membership) => (
               <GroupPill key={membership.id} group={membership.abakusGroup} />

--- a/app/routes/users/components/UserSettingsIndex.tsx
+++ b/app/routes/users/components/UserSettingsIndex.tsx
@@ -27,9 +27,15 @@ const UserSettingsIndex = (props: Props) => {
   return (
     <Content>
       <Helmet title="Innstillinger" />
-      <NavigationTab title="Innstillinger">
+      <NavigationTab
+        title="Innstillinger"
+        back={{
+          label: 'Profil',
+          path: `/users/${props.match?.params.username}`,
+        }}
+      >
         {isCurrentUser && (
-          <>
+          <div data-test-id="navigation-tab">
             <NavigationLink to={`${base}/profile`}>Profil</NavigationLink>
             <NavigationLink to={`${base}/notifications`}>
               Notifikasjoner
@@ -40,7 +46,7 @@ const UserSettingsIndex = (props: Props) => {
                 Verifiser studentstatus
               </NavigationLink>
             )}
-          </>
+          </div>
         )}
       </NavigationTab>
       {props.children &&

--- a/app/routes/users/components/UserSettingsIndex.tsx
+++ b/app/routes/users/components/UserSettingsIndex.tsx
@@ -41,11 +41,11 @@ const UserSettingsIndex = (props: Props) => {
               Notifikasjoner
             </NavigationLink>
             <NavigationLink to={`${base}/oauth2`}>OAuth2</NavigationLink>
-            {!props.currentUser.isStudent && (
-              <NavigationLink to={`${base}/student-confirmation`}>
-                Verifiser studentstatus
-              </NavigationLink>
-            )}
+            <NavigationLink to={`${base}/student-confirmation`}>
+              {props.currentUser.isStudent
+                ? 'Studentstatus'
+                : 'Verifiser studentstatus'}
+            </NavigationLink>
           </div>
         )}
       </NavigationTab>

--- a/cypress/e2e/router_spec.js
+++ b/cypress/e2e/router_spec.js
@@ -1,4 +1,4 @@
-import { c, a } from '../support/utils.js';
+import { c, a, t } from '../support/utils.js';
 
 describe('Navigate throughout app', () => {
   beforeEach(() => {
@@ -90,7 +90,7 @@ describe('Navigate throughout app', () => {
     cy.contains('Brukernavn');
 
     // Go to notifications
-    cy.get(c('NavigationTab'))
+    cy.get(t('navigation-tab'))
       .first()
       .within(() => {
         cy.contains('Notifikasjoner').click();
@@ -99,7 +99,7 @@ describe('Navigate throughout app', () => {
     cy.contains('E-poster som sendes direkte til deg');
 
     // Go to OAuth2
-    cy.get(c('NavigationTab'))
+    cy.get(t('navigation-tab'))
       .first()
       .within(() => {
         cy.contains('OAuth2').click();
@@ -108,13 +108,13 @@ describe('Navigate throughout app', () => {
     cy.contains('Denne nettsiden benytter seg av et API');
 
     // Go to student confirmation
-    cy.get(c('NavigationTab'))
+    cy.get(t('navigation-tab'))
       .first()
       .within(() => {
         cy.contains('Verifiser studentstatus').click();
       });
     cy.url().should('contain', '/users/me/settings/student-confirmation');
-    cy.contains('NTNU-brukernavn');
+    cy.contains('Verifiser studentstatus');
   });
 
   it('should be able to navigate to users meetings', () => {

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -9,6 +9,8 @@ export const c = (classname) => `[class*="${classname}"]`;
 // Find links by their path
 export const a = (path) => `a[href="${path}"]`;
 
+export const t = (testId) => `[data-test-id="${testId}"]`;
+
 export const field = (name) => cy.get(`[name="${name}"]`);
 
 // Used for react-select elements that cannot be found with the normal field method


### PR DESCRIPTION
# Description

Feide verification :grimacing: 

# Result

## Start page
![image](https://github.com/webkom/lego-webapp/assets/42850232/c8e507a8-8e3a-4108-8a5f-96e3f0924761)



## No valid study programmes:
[Screencast from 2023-07-30 18-12-10.webm](https://github.com/webkom/lego-webapp/assets/42850232/498b87c6-ce7a-4a6c-9d84-788d3ab67fc6)




## Valid study programme:

Notice that the result from the previous verification is still present. The user may re-verify with correct data to get the proper result.

[Screencast from 2023-07-30 18-14-34.webm](https://github.com/webkom/lego-webapp/assets/42850232/8f975db5-9e5a-47e4-ae4d-b435db9dfa37)



# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-521