### PR TITLE
Remove webp from accepted filetypes in ImageUpload

### DIFF
--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -245,7 +245,6 @@ export default class ImageUpload extends Component<Props, State> {
       'image/jpeg': ['*'],
       'image/png': ['*'],
       'image/gif': ['*'],
-      'image/webp': ['*'],
       'image/tif': ['*'],
       'image/bmp': ['*'],
       'image/avif': ['*'],


### PR DESCRIPTION
# Description

lego doesn't support webp images, causing an error when you attempt to upload one

# Result
Before: (after attempting to upload)
<img width="346" alt="Screenshot 2023-08-02 at 15 40 40" src="https://github.com/webkom/lego-webapp/assets/8343002/7454551f-2010-4cf8-a450-aa40128b4713">

Now: (when dropping the image into the upload field)
<img width="678" alt="Screenshot 2023-08-02 at 15 43 34" src="https://github.com/webkom/lego-webapp/assets/8343002/71b16ef8-5159-4826-a360-5b7777d716c9">

# Testing

- [x] I have thoroughly tested my changes.
