### PR TITLE
Fix overflowing text in tooltip on event creator page

### DIFF
--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -555,12 +555,18 @@ function EventEditor({
               <>
                 Jeg er kjent med at jeg kun kan bruke rettighetene mine til å
                 opprette et Abakusarrangement som er i tråd med{' '}
-                <Link to="/pages/arrangementer/86-arrangementskalender">
+                <Link
+                  style={{ display: 'contents' }}
+                  to="/pages/arrangementer/86-arrangementskalender"
+                >
                   arrangementskalenderen
                 </Link>{' '}
                 og Abakus sine blesteregler, og at jeg må ta kontakt med{' '}
-                <a href="mailto:hs@abakus.no">hs@abakus.no</a> dersom jeg er
-                usikker eller ønsker å opprette et annet/eksternt arrangement.
+                <a style={{ display: 'contents' }} href="mailto:hs@abakus.no">
+                  hs@abakus.no
+                </a>{' '}
+                dersom jeg er usikker eller ønsker å opprette et annet/eksternt
+                arrangement.
               </>
             }
           >


### PR DESCRIPTION
# Result
Now looks like this  
![Screenshot 2023-08-02 at 18 52 56](https://github.com/webkom/lego-webapp/assets/64247965/f9fc428f-8fe4-4715-b6ce-8e49aeaed17e)
instead of this  

<img width="799" alt="Screenshot 2023-07-22 at 18 20 45" src="https://github.com/webkom/lego-webapp/assets/64247965/bf036ff7-a56a-4df2-9ffe-9d0da7754785">

# Testing

Looks good on various screen sizes

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-517
