### PR TITLE
Fix production docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ ENV RELEASE ${RELEASE}
 
 COPY --from=builder /app/dist dist
 COPY --from=builder /app/dist-client dist-client
+COPY --from=builder /app/packages/lego-bricks/dist packages/lego-bricks/dist
+COPY --from=builder /app/packages/lego-bricks/package.json packages/lego-bricks/package.json
 COPY --from=builder /app/package.json .
 COPY --from=builder /app/node_modules node_modules
 


### PR DESCRIPTION
# Description

Soo, yarn workspaces creates a symlink from `lego-bricks` to `node-modules`. This doesn't work if we don't copy the actual files into the docker image.

I don't love this solution, but I couldn't find a way to make yarn actually copy the files. I think perhaps a good solution would be to just build `lego-bricks` into the bundle using webpack, but it wasn't suuper simple, so I might do that later.

# Result

It works now:)

# Testing

- [x] I have thoroughly tested my changes.

Built the image locally, and ran it successfully locally