### PR TITLE
Fix incorrect stripe input color

### DIFF
--- a/app/routes/events/components/StripeElement.tsx
+++ b/app/routes/events/components/StripeElement.tsx
@@ -57,7 +57,9 @@ type CompleteStatus =
 const StripeElementStyle = {
   style: {
     base: {
-      color: '#0d0d0d',
+      color: window.matchMedia('prefers-color-scheme: dark')
+        ? '#f2f2f2'
+        : '#0d0d0d',
       letterSpacing: '0.025em',
       fontFamily: 'Source Code Pro, monospace',
       '::placeholder': {

--- a/app/routes/events/components/StripeElement.tsx
+++ b/app/routes/events/components/StripeElement.tsx
@@ -71,8 +71,8 @@ function StripeElementStyle(fontColor) {
         color: '#c81917',
       },
     },
-  }
-};
+  };
+}
 
 const CardForm = (props: CardFormProps) => {
   const [paymentStarted, setPaymentStarted] = useState(false);

--- a/app/routes/events/components/StripeElement.tsx
+++ b/app/routes/events/components/StripeElement.tsx
@@ -14,6 +14,7 @@ import Card from 'app/components/Card';
 import config from 'app/config';
 import type { EventRegistrationPaymentStatus, Event } from 'app/models';
 import type { CurrentUser } from 'app/store/models/User';
+import { useTheme } from 'app/utils/themeUtils';
 import stripeStyles from './Stripe.css';
 
 type Props = {
@@ -54,22 +55,23 @@ type CompleteStatus =
   | 'invalid_payer_phone'
   | 'invalid_payer_email'
   | 'invalid_shipping_address';
-const StripeElementStyle = {
-  style: {
-    base: {
-      color: window.matchMedia('prefers-color-scheme: dark')
-        ? '#f2f2f2'
-        : '#0d0d0d',
-      letterSpacing: '0.025em',
-      fontFamily: 'Source Code Pro, monospace',
-      '::placeholder': {
-        color: '#8c8c8c',
+
+function StripeElementStyle(fontColor) {
+  return {
+    style: {
+      base: {
+        color: fontColor,
+        letterSpacing: '0.025em',
+        fontFamily: 'Source Code Pro, monospace',
+        '::placeholder': {
+          color: '#8c8c8c',
+        },
+      },
+      invalid: {
+        color: '#c81917',
       },
     },
-    invalid: {
-      color: '#c81917',
-    },
-  },
+  }
 };
 
 const CardForm = (props: CardFormProps) => {
@@ -84,6 +86,9 @@ const CardForm = (props: CardFormProps) => {
     setLoading,
     currentUser,
   } = props;
+
+  const theme = useTheme();
+  const fontColor = theme === 'dark' ? '#f2f2f2' : '#0d0d0d';
 
   const handleSubmit = (ev) => {
     ev.preventDefault();
@@ -139,21 +144,21 @@ const CardForm = (props: CardFormProps) => {
           Kortnummer
           <CardNumberElement
             className={stripeStyles.stripeElement}
-            options={StripeElementStyle}
+            options={StripeElementStyle(fontColor)}
           />
         </label>
         <label data-testid="expiry-input">
           Utløpsdato
           <CardExpiryElement
             className={stripeStyles.stripeElement}
-            options={StripeElementStyle}
+            options={StripeElementStyle(fontColor)}
           />
         </label>
         <label data-testid="cvc-input">
           CVC
           <CardCvcElement
             className={stripeStyles.stripeElement}
-            options={StripeElementStyle}
+            options={StripeElementStyle(fontColor)}
           />
         </label>
         <Button submit dark className={stripeStyles.stripeButton}>


### PR DESCRIPTION
# Description

Previously, the content of the card number, expiration date and cvc input fields were hard too see when using dark mode. This PR makes the content color white when using dark mode to improve contrast.

# Result

| Before: Dark text on dark background | After: Light text on dark background |
| -- | -- |
| ![image](https://github.com/webkom/lego-webapp/assets/33326578/37474f15-bfdb-43d8-bbdf-760aa526e679) | ![image](https://github.com/webkom/lego-webapp/assets/33326578/67370be4-3fb9-4019-80f7-647f45d1b947) |


# Testing

- [x] I have thoroughly tested my changes.

Checked that the contrast is correct in both dark and light mode.
