### PR TITLE
Fix unset theme on initialization

### DIFF
--- a/app/utils/themeUtils.tsx
+++ b/app/utils/themeUtils.tsx
@@ -24,7 +24,7 @@ export const ThemeContextListener = () => {
 
   useEffect(() => {
     const handleThemeChange = () => dispatch(setTheme(getTheme()));
-
+    handleThemeChange();
     window.addEventListener('themeChange', handleThemeChange);
     return () => window.removeEventListener('themeChange', handleThemeChange);
   }, [dispatch]);


### PR DESCRIPTION
# Description
The theme value accessed through `getTheme()` didn't get set on initialization, so the value was set to the default value (light). On dark mode, this would cause certain bugs, like the graph artwork in the background to disappear and the netcompany logo to use its light color variant.

# Result
**before**
![before](https://github.com/webkom/lego-webapp/assets/66320400/b1976436-c9cb-4cd5-98fb-a5658ab37025)

**after**
![after](https://github.com/webkom/lego-webapp/assets/66320400/4835716f-fb54-49dd-8b48-ed05703eb433)

# Testing

- [x] I have thoroughly tested my changes.
It just works

---

Resolves ABA-550
