### PR TITLE
Properly type actions

### DIFF
--- a/app/actions/AnnouncementsActions.ts
+++ b/app/actions/AnnouncementsActions.ts
@@ -1,10 +1,15 @@
 import callAPI from 'app/actions/callAPI';
 import { announcementsSchema } from 'app/reducers';
 import { Announcements } from './ActionTypes';
-import type { Thunk } from 'app/types';
+import type { AppDispatch } from 'app/store/createStore';
+import type { ID } from 'app/store/models';
+import type {
+  DetailedAnnouncement,
+  ListAnnouncement,
+} from 'app/store/models/Announcement';
 
-export function fetchAll(): Thunk<any> {
-  return callAPI({
+export function fetchAll() {
+  return callAPI<ListAnnouncement[]>({
     types: Announcements.FETCH_ALL,
     endpoint: '/announcements/',
     schema: [announcementsSchema],
@@ -14,6 +19,7 @@ export function fetchAll(): Thunk<any> {
     propagateError: true,
   });
 }
+
 export function createAnnouncement({
   message,
   users,
@@ -22,11 +28,10 @@ export function createAnnouncement({
   meetings,
   fromGroup,
   send,
-}: Record<string, any>): /*AnnouncementModel*/
-Thunk<any> {
-  return (dispatch) =>
+}: Record<string, any>) {
+  return (dispatch: AppDispatch) =>
     dispatch(
-      callAPI({
+      callAPI<DetailedAnnouncement>({
         types: Announcements.CREATE,
         endpoint: '/announcements/',
         method: 'POST',
@@ -45,13 +50,14 @@ Thunk<any> {
         },
       })
     ).then((action) => {
-      if (send && action && action.payload) {
+      if (send) {
         dispatch(sendAnnouncement(action.payload.result));
       }
     });
 }
-export function sendAnnouncement(announcementId: number): Thunk<any> {
-  return callAPI({
+
+export function sendAnnouncement(announcementId: ID) {
+  return callAPI<{ status: string }>({
     types: Announcements.SEND,
     endpoint: `/announcements/${announcementId}/send/`,
     method: 'POST',
@@ -62,7 +68,8 @@ export function sendAnnouncement(announcementId: number): Thunk<any> {
     },
   });
 }
-export function deleteAnnouncement(id: number): Thunk<any> {
+
+export function deleteAnnouncement(id: ID) {
   return callAPI({
     types: Announcements.DELETE,
     endpoint: `/announcements/${id}/`,

--- a/app/actions/CommentActions.ts
+++ b/app/actions/CommentActions.ts
@@ -3,14 +3,18 @@ import { commentSchema } from 'app/reducers';
 import { Comment } from './ActionTypes';
 import type { ID } from 'app/store/models';
 import type CommentType from 'app/store/models/Comment';
-import type { Thunk } from 'app/types';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export function addComment({
   text,
   contentTarget,
   parent,
-}: CommentType): Thunk<Promise<Record<string, any> | null | undefined>> {
-  return callAPI({
+}: {
+  text: string;
+  contentTarget: ContentTarget;
+  parent?: ID;
+}) {
+  return callAPI<CommentType>({
     types: Comment.ADD,
     endpoint: '/comments/',
     method: 'POST',
@@ -30,10 +34,8 @@ export function addComment({
     schema: commentSchema,
   });
 }
-export function deleteComment(
-  commentId: ID,
-  contentTarget: string
-): Thunk<any> {
+
+export function deleteComment(commentId: ID, contentTarget: ContentTarget) {
   return callAPI({
     types: Comment.DELETE,
     endpoint: `/comments/${commentId}/`,

--- a/app/actions/CompanyInterestActions.ts
+++ b/app/actions/CompanyInterestActions.ts
@@ -3,10 +3,15 @@ import callAPI from 'app/actions/callAPI';
 import { companyInterestSchema } from 'app/reducers';
 import { CompanyInterestForm } from './ActionTypes';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
-import type { Thunk } from 'app/types';
+import type { AppDispatch } from 'app/store/createStore';
+import type {
+  DetailedCompanyInterest,
+  ListCompanyInterest,
+} from 'app/store/models/CompanyInterest';
+import type { GetState } from 'app/types';
 
-export function fetchAll(): Thunk<any> {
-  return callAPI({
+export function fetchAll() {
+  return callAPI<ListCompanyInterest[]>({
     types: CompanyInterestForm.FETCH_ALL,
     endpoint: '/company-interests/',
     schema: [companyInterestSchema],
@@ -15,8 +20,8 @@ export function fetchAll(): Thunk<any> {
     },
   });
 }
-export function fetchCompanyInterest(companyInterestId: number): Thunk<any> {
-  return callAPI({
+export function fetchCompanyInterest(companyInterestId: number) {
+  return callAPI<DetailedCompanyInterest>({
     types: CompanyInterestForm.FETCH,
     endpoint: `/company-interests/${companyInterestId}/`,
     schema: companyInterestSchema,
@@ -28,10 +33,10 @@ export function fetchCompanyInterest(companyInterestId: number): Thunk<any> {
 export function createCompanyInterest(
   data: CompanyInterestEntity,
   isEnglish: boolean
-): Thunk<any> {
-  return (dispatch) => {
+) {
+  return (dispatch: AppDispatch) => {
     return dispatch(
-      callAPI({
+      callAPI<DetailedCompanyInterest>({
         types: CompanyInterestForm.CREATE,
         endpoint: '/company-interests/',
         method: 'POST',
@@ -52,8 +57,8 @@ export function createCompanyInterest(
     );
   };
 }
-export function deleteCompanyInterest(id: number): Thunk<any> {
-  return (dispatch) => {
+export function deleteCompanyInterest(id: number) {
+  return (dispatch: AppDispatch) => {
     return dispatch(
       callAPI({
         types: CompanyInterestForm.DELETE,
@@ -73,11 +78,8 @@ export function deleteCompanyInterest(id: number): Thunk<any> {
     );
   };
 }
-export function updateCompanyInterest(
-  id: number,
-  data: CompanyInterestEntity
-): Thunk<any> {
-  return (dispatch) => {
+export function updateCompanyInterest(id: number, data: CompanyInterestEntity) {
+  return (dispatch: AppDispatch) => {
     return dispatch(
       callAPI({
         types: CompanyInterestForm.UPDATE,
@@ -87,14 +89,9 @@ export function updateCompanyInterest(
         meta: {
           companyInterestId: id,
           errorMessage: 'Endring av bedriftsinteresse feilet!',
+          successMessage: 'Bedriftsinteresse endret!',
         },
       })
-    ).then(() =>
-      dispatch(
-        addToast({
-          message: 'Bedriftsinteresse endret!',
-        })
-      )
     );
   };
 }
@@ -104,11 +101,11 @@ export function fetch({
 }: {
   next?: boolean;
   filters?: Record<string, string | number>;
-} = {}): Thunk<any> {
-  return (dispatch, getState) => {
+} = {}) {
+  return (dispatch: AppDispatch, getState: GetState) => {
     const cursor = next ? getState().companyInterest.pagination.next : {};
     return dispatch(
-      callAPI({
+      callAPI<ListCompanyInterest[]>({
         types: CompanyInterestForm.FETCH_ALL,
         endpoint: '/company-interests/',
         query: { ...cursor, ...filters },

--- a/app/actions/ContactActions.ts
+++ b/app/actions/ContactActions.ts
@@ -1,10 +1,9 @@
 import { Contact } from './ActionTypes';
 import callAPI from './callAPI';
 import type { ContactForm } from 'app/reducers/contact';
-import type { Thunk } from 'app/types';
 
-export function sendContactMessage(contactForm: ContactForm): Thunk<any> {
-  return callAPI({
+export function sendContactMessage(contactForm: ContactForm) {
+  return callAPI<ContactForm>({
     types: Contact.SEND_MESSAGE,
     method: 'POST',
     endpoint: '/contact-form/',

--- a/app/actions/EventActions.ts
+++ b/app/actions/EventActions.ts
@@ -9,12 +9,14 @@ import {
 import createQueryString from 'app/utils/createQueryString';
 import { Event } from './ActionTypes';
 import type { EventRegistrationPresence } from 'app/models';
+import type { AppDispatch } from 'app/store/createStore';
 import type { ID } from 'app/store/models';
+import type { DetailedEvent, UnknownEvent } from 'app/store/models/Event';
 import type { Thunk, Action } from 'app/types';
 
 export const waitinglistPoolId = -1;
-export function fetchEvent(eventId: string): Thunk<any> {
-  return callAPI({
+export function fetchEvent(eventId: string) {
+  return callAPI<DetailedEvent>({
     types: Event.FETCH,
     endpoint: `/events/${eventId}/`,
     schema: eventSchema,
@@ -135,12 +137,10 @@ export function fetchAllergies(eventId: number): Thunk<any> {
   });
 }
 
-export function createEvent(
-  event: Record<string, any>
-): Thunk<Promise<Action | null | undefined>> {
-  return (dispatch) =>
+export function createEvent(event: Record<string, any>) {
+  return (dispatch: AppDispatch) =>
     dispatch(
-      callAPI({
+      callAPI<UnknownEvent>({
         types: Event.CREATE,
         endpoint: '/events/',
         method: 'POST',
@@ -152,8 +152,7 @@ export function createEvent(
       })
     ).then(
       (action) =>
-        action &&
-        action.payload &&
+        'success' in action &&
         dispatch(push(`/events/${action.payload.result}/`))
     );
 }

--- a/app/actions/FileActions.ts
+++ b/app/actions/FileActions.ts
@@ -2,7 +2,8 @@ import slug from 'slugify';
 import { imageGallerySchema } from 'app/reducers';
 import { File as FileType, ImageGallery } from './ActionTypes';
 import callAPI from './callAPI';
-import type { Thunk } from 'app/types';
+import type { AppDispatch } from 'app/store/createStore';
+import type { SignedPost } from 'app/store/models/File';
 
 const slugifyFilename: (filename: string) => string = (filename) => {
   // Slug options
@@ -24,8 +25,8 @@ const slugifyFilename: (filename: string) => string = (filename) => {
   return slug(filename, slugOpts);
 };
 
-export function fetchSignedPost(key: string, isPublic: boolean): Thunk<any> {
-  return callAPI({
+export function fetchSignedPost(key: string, isPublic: boolean) {
+  return callAPI<SignedPost>({
     types: FileType.FETCH_SIGNED_POST,
     method: 'POST',
     endpoint: '/files/',
@@ -51,13 +52,17 @@ export function uploadFile({
   fileName,
   isPublic = false,
   timeout,
-}: UploadArgs): Thunk<any> {
-  return (dispatch) =>
+}: UploadArgs) {
+  return (dispatch: AppDispatch) =>
     dispatch(fetchSignedPost(fileName || file.name, isPublic)).then(
       (action) => {
-        if (!action || !action.payload) return;
+        const meta = {
+          fileKey: action.payload.file_key,
+          fileToken: action.payload.file_token,
+          errorMessage: 'Filopplasting feilet',
+        };
         return dispatch(
-          callAPI({
+          callAPI<void, typeof meta>({
             types: FileType.UPLOAD,
             method: 'POST',
             endpoint: action.payload.url,
@@ -69,11 +74,7 @@ export function uploadFile({
               Accept: 'application/json',
             },
             requiresAuthentication: false,
-            meta: {
-              fileKey: action.payload.file_key,
-              fileToken: action.payload.file_token,
-              errorMessage: 'Filopplasting feilet',
-            },
+            meta,
           })
         );
       }
@@ -82,8 +83,8 @@ export function uploadFile({
 export function fetchImageGallery({
   query,
 }: {
-  query?: Record<string, any>;
-} = {}): Thunk<any> {
+  query?: Record<string, string>;
+} = {}) {
   return callAPI({
     types: ImageGallery.FETCH_ALL,
     endpoint: '/events/cover_image_gallery/',
@@ -97,22 +98,15 @@ export function fetchImageGallery({
   });
 }
 
-export function setSaveForUse(
-  key: string,
-  token: string,
-  saveForUse: boolean
-): Thunk<Promise<any>> {
-  return (dispatch) =>
-    dispatch(
-      callAPI({
-        types: FileType.PATCH,
-        endpoint: `/files/${key}/imagegallery/`,
-        method: 'PATCH',
-        body: { token: token, save_for_use: saveForUse },
-        meta: {
-          errorMessage: 'Endring av hendelse feilet',
-          id: key,
-        },
-      })
-    );
+export function setSaveForUse(key: string, token: string, saveForUse: boolean) {
+  return callAPI({
+    types: FileType.PATCH,
+    endpoint: `/files/${key}/imagegallery/`,
+    method: 'PATCH',
+    body: { token: token, save_for_use: saveForUse },
+    meta: {
+      errorMessage: 'Endring av hendelse feilet',
+      id: key,
+    },
+  });
 }

--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -11,9 +11,10 @@ import { createValidator, legoEditorRequired } from 'app/utils/validation';
 import styles from './CommentForm.css';
 import type { ID } from 'app/store/models';
 import type { CurrentUser } from 'app/store/models/User';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 type Props = {
-  contentTarget: string;
+  contentTarget: ContentTarget;
   user: CurrentUser;
   loggedIn: boolean;
   submitText?: string;

--- a/app/routes/announcements/components/AnnouncementItem.tsx
+++ b/app/routes/announcements/components/AnnouncementItem.tsx
@@ -97,17 +97,10 @@ const AnnouncementItem = ({
         actionGrant.includes('send') &&
         actionGrant.includes('delete') && (
           <Flex className={styles.wrapperSendButton}>
-            <Button
-              danger
-              className={styles.sendButton}
-              onClick={() => deleteAnnouncement(announcement.id)}
-            >
+            <Button danger onClick={() => deleteAnnouncement(announcement.id)}>
               Slett
             </Button>
-            <Button
-              className={styles.sendButton}
-              onClick={() => sendAnnouncement(announcement.id)}
-            >
+            <Button secondary onClick={() => sendAnnouncement(announcement.id)}>
               Send
             </Button>
           </Flex>

--- a/app/routes/announcements/components/AnnouncementsList.css
+++ b/app/routes/announcements/components/AnnouncementsList.css
@@ -43,10 +43,6 @@
   margin-top: 8px;
 }
 
-.sendButton {
-  height: 50px;
-}
-
 .wrapperSendButton {
   justify-content: space-around;
   align-items: center;

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -46,7 +46,8 @@ import type { DetailedMeeting } from 'app/store/models/Meeting';
 import type { AutocompleteUser, CurrentUser } from 'app/store/models/User';
 import type { History } from 'history';
 
-type Values = {
+export type MeetingFormValues = {
+  id?: ID;
   title?: string;
   report?: string;
   description?: string;
@@ -55,6 +56,7 @@ type Values = {
   useMazemap: boolean;
   mazemapPoi?: { value: number; label: string };
   location?: string;
+  reportAuthor?: { value: ID; label: string; id: ID };
   users?: AutocompleteUser[];
   groups?: AutocompleteGroup[];
 };
@@ -64,8 +66,10 @@ type Props = {
   meeting: DetailedMeeting;
   currentUser: CurrentUser;
   meetingInvitations: MeetingInvitationWithUser[];
-  initialValues: Values;
-  handleSubmitCallback: (data: Values) => Promise<{ payload: { result: ID } }>;
+  initialValues: MeetingFormValues;
+  handleSubmitCallback: (
+    data: MeetingFormValues
+  ) => Promise<{ payload: { result: ID } }>;
   push: History['push'];
   inviteUsersAndGroups: (args: {
     id: ID;
@@ -252,7 +256,7 @@ const MeetingEditor = ({
                 component={CheckBox.Field}
                 type="checkbox"
               />
-              {spyValues<Values>((values) => {
+              {spyValues<MeetingFormValues>((values) => {
                 return values?.useMazemap ? (
                   <Flex alignItems="center">
                     <Field
@@ -302,7 +306,7 @@ const MeetingEditor = ({
                 </div>
               </div>
 
-              {spyValues<Values>((values) => {
+              {spyValues<MeetingFormValues>((values) => {
                 const invitingUsers = values?.users ?? [];
                 const invitingGroups = values?.groups ?? [];
 

--- a/app/routes/userValidator/ValidatorRoute.tsx
+++ b/app/routes/userValidator/ValidatorRoute.tsx
@@ -10,8 +10,8 @@ import { Content } from 'app/components/Content';
 import Validator from 'app/components/UserValidator';
 import { selectAutocompleteRedux as selectAutocomplete } from 'app/reducers/search';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
-import type { User } from 'app/models';
 import type { UserSearchResult } from 'app/reducers/search';
+import type { AppDispatch } from 'app/store/createStore';
 import type { ComponentProps } from 'react';
 
 const searchTypes = ['users.user'];
@@ -39,7 +39,7 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-const mapDispatchToProps = (dispatch, { location }) => {
+const mapDispatchToProps = (dispatch: AppDispatch, { location }) => {
   const search = qs.parse(location.search, {
     ignoreQueryPrefix: true,
   });
@@ -49,13 +49,10 @@ const mapDispatchToProps = (dispatch, { location }) => {
     clearSearch: () =>
       dispatch(push(`/validator?${qs.stringify({ ...search, q: '' })}`)),
 
-    handleSelect: async (result: UserSearchResult): Promise<User> => {
-      const fetchRes = await dispatch(
-        fetchUser(result.username, { propagateError: false })
-      );
-
-      return Object.values(fetchRes.payload?.entities?.users)[0] as User;
+    handleSelect: async (result: UserSearchResult) => {
+      return dispatch(fetchUser(result.username, { propagateError: false }));
     },
+
     onQueryChanged: debounce((query) => {
       dispatch(push(`/validator?${qs.stringify({ ...search, q: query })}`));
 

--- a/app/store/createStore.ts
+++ b/app/store/createStore.ts
@@ -7,9 +7,9 @@ import loggerMiddleware from 'app/store/middleware/loggerMiddleware';
 import createMessageMiddleware from 'app/store/middleware/messageMiddleware';
 import promiseMiddleware from 'app/store/middleware/promiseMiddleware';
 import createSentryMiddleware from 'app/store/middleware/sentryMiddleware';
+import { isTruthy } from 'app/utils';
 import type { RootState } from 'app/store/createRootReducer';
 import type { GetCookie } from 'app/types';
-import type { History } from 'history';
 
 const createStore = (
   initialState: RootState | Record<string, never> = {},
@@ -18,9 +18,9 @@ const createStore = (
     getCookie,
   }: {
     Sentry?: any;
-    getCookie?: GetCookie;
-  } = {}
-): StoreWithHistory => {
+    getCookie: GetCookie;
+  }
+) => {
   const { createReduxHistory, routerMiddleware } = createReduxHistoryContext({
     history: __CLIENT__ ? createBrowserHistory() : createMemoryHistory(),
     reduxTravelling: __DEV__,
@@ -55,7 +55,7 @@ const createStore = (
             __CLIENT__ &&
               require('app/store/middleware/websocketMiddleware').default(),
             __CLIENT__ && __DEV__ && loggerMiddleware,
-          ].filter(Boolean)
+          ].filter(isTruthy)
         ),
   });
 
@@ -74,10 +74,6 @@ const createStore = (
 
 export default createStore;
 
-export type Store = ReturnType<typeof configureStore>;
+export type StoreWithHistory = ReturnType<typeof createStore>;
+export type Store = StoreWithHistory['store'];
 export type AppDispatch = Store['dispatch'];
-
-export type StoreWithHistory = {
-  store: Store;
-  connectedHistory: History & { listenObject: boolean };
-};

--- a/app/store/models/File.d.ts
+++ b/app/store/models/File.d.ts
@@ -1,0 +1,16 @@
+export type SignedPost = {
+  fields: {
+    'Content-Type': string;
+    acl: string;
+    key: string;
+    policy: string;
+    success_action_redirect: string;
+    'x-amz-algorithm': string;
+    'x-amz-credential': string;
+    'x-amz-date': string;
+    'x-amz-signature': string;
+  };
+  file_key: string;
+  file_token: string;
+  url: string;
+};

--- a/app/store/models/Reaction.d.ts
+++ b/app/store/models/Reaction.d.ts
@@ -7,6 +7,8 @@ export default interface Reaction {
   contentTarget: ContentTarget;
 }
 
+export type ReactionResponse = Omit<Reaction, 'contentTarget'>;
+
 export interface ReactionsGrouped {
   emoji: string;
   unicodeString: string;

--- a/app/store/models/entities.ts
+++ b/app/store/models/entities.ts
@@ -107,11 +107,16 @@ export default interface Entities {
   [EntityType.Surveys]: Record<ID, Survey>;
   [EntityType.Tags]: Record<ID, UnknownTag>;
   [EntityType.Users]: Record<ID, UnknownUser>;
-  [EntityType.FollowersCompany]: Record<ID, unknown>; // AFAIK unused
-  [EntityType.FollowersUser]: Record<ID, unknown>; // AFAIK unused
-  [EntityType.FollowersEvent]: Record<ID, unknown>; // AFAIK unused
+  // [EntityType.FollowersCompany]: Record<ID, unknown>; // AFAIK unused
+  // [EntityType.FollowersUser]: Record<ID, unknown>; // AFAIK unused
+  // [EntityType.FollowersEvent]: Record<ID, unknown>; // AFAIK unused
 }
 
-export interface NormalizedEntityPayload<EntityKeys extends keyof Entities> {
-  entities: Pick<Entities, EntityKeys>;
-}
+type InferEntityType<T> = {
+  [K in keyof Entities]: T extends Entities[K][ID] ? K : never;
+}[keyof Entities];
+
+export type NormalizedPayloadEntities<T> = Record<
+  InferEntityType<T>,
+  Record<ID, T | undefined>
+>;

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,5 +1,7 @@
-import type { ID } from './models';
-import type { ThunkAction } from '@reduxjs/toolkit';
+import type { ActionGrant } from './models';
+import type { ID } from './store/models';
+import type { NormalizedPayloadEntities } from './store/models/entities';
+import type { AnyAction, ThunkAction } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
 import type { JwtPayload } from 'jwt-decode';
 import type { Overwrite } from 'utility-types';
@@ -34,13 +36,6 @@ export type ArticleEntity = {
   description: string;
   pinned: boolean;
 };
-export type GalleryPictureEntity = {
-  description?: string;
-  active: boolean;
-  file: string;
-  galleryId: number;
-  taggees?: Array<Record<string, any>>;
-};
 export type GalleryEntity = {
   title: string;
   description?: string;
@@ -64,27 +59,27 @@ export type Token = DecodedToken & {
 
 export type Action = {
   type: string;
-  payload?: any;
-  meta?: any;
-  error?: boolean;
-  success?: boolean; // 65 WAT M8 https://github.com/acdlite/flux-standard-action
+  payload: any;
 };
-export type PromiseAction<T> = {
-  types: AsyncActionType;
-  promise: Promise<T>;
-  meta?: any;
-  payload?: any;
+
+export type NormalizedApiPayload<T = unknown> = {
+  actionGrant?: ActionGrant;
+  entities: NormalizedPayloadEntities<T extends Array<infer E> ? E : T>;
+  next?: string;
+  previous?: string;
+  result: T extends Array<unknown> ? ID[] : ID;
 };
+
 export type GetState = () => RootState;
 export type GetCookie = (arg0: string) => EncodedToken | null | undefined;
 
-export type Thunk<Returned> = ThunkAction<
-  Returned,
+export type Thunk<ReturnType> = ThunkAction<
+  ReturnType,
   RootState,
   {
     getCookie: GetCookie;
   },
-  Action
+  AnyAction
 >;
 
 export type ReduxFormProps = {

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -52,3 +52,6 @@ export function generateTreeStructure<
     return roots;
   }, []);
 }
+
+export const isTruthy = <T>(x: T | null | undefined | false | '' | 0): x is T =>
+  Boolean(x);

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@types/classnames": "^2.3.1",
     "@types/enzyme": "^3.10.16",
     "@types/express": "^4.17.21",
+    "@types/js-cookie": "^3.0.6",
     "@types/loadable__component": "^5.13.7",
     "@types/lodash": "^4.14.202",
     "@types/moment-timezone": "^0.5.30",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3954,6 +3954,11 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/js-cookie@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"


### PR DESCRIPTION
# Description

[Properly type the callAPI and promise middleware](https://github.com/webkom/lego-webapp/commit/7814e68d4752729ef70e559b169d571bea2e18b3) 

It is now possible to type API request!

---

[Type announcement, article, comment and company actions](https://github.com/webkom/lego-webapp/commit/6996a217d16b060daf41de4ea2a6e1fb95bd76ef)

# Result

No visual changes except this tiny fix:
<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	</tr>
	<tr>
		<td>
			<img width="400" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/0d96af9e-9b82-4d52-8e59-26dbc3945834">
		</td>
		<td>
			<img width="400" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/23751d60-b518-499e-a921-d443216e2970">
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested all actions that were typed, even though that should not have broken anything.