### PR TITLE
Update banner for admissions 2023

### DIFF
--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -96,9 +96,9 @@ const Overview = (props: Props) => {
     <Container>
       <Helmet title="Hjem" />
       <Banner
-        header="Velkommen til fadderperioden 2023!"
-        subHeader="Trykk her for mer informasjon til nye studenter"
-        link="https://ny.abakus.no"
+        header="Abakus has opptak!"
+        subHeader="Søk her"
+        link="https://opptak.abakus.no"
         color="red"
       />
       <Flex className={styles.desktopContainer}>

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -58,9 +58,9 @@ const PublicFrontpage = ({ frontpage, readmes }: Props) => {
   return (
     <Container>
       <Banner
-        header="Velkommen til fadderperioden 2023!"
-        subHeader="Trykk her for mer informasjon til nye studenter"
-        link="https://ny.abakus.no"
+        header="Abakus has opptak!"
+        subHeader="Søk her"
+        link="https://opptak.abakus.no"
         color="red"
       />
       <Container className={styles.container}>


### PR DESCRIPTION
# Description

Replace buddy-week banner with admissions banner.

A little late, so we should get this out asap:)

# Result

<img width="1135" alt="Screenshot 2023-08-28 at 13 09 39" src="https://github.com/webkom/lego-webapp/assets/8343002/e3f2042a-1fa2-42d2-aaf7-657bc7c06889">

# Testing

- [x] I have thoroughly tested my changes.

Opened the page and looked at the banner.

---

Resolves ... (either GitHub issue or Linear task)
