### PR TITLE
Give datepicker a retouch

### DIFF
--- a/app/components/Form/DatePicker.css
+++ b/app/components/Form/DatePicker.css
@@ -44,7 +44,7 @@
     border-top: var(--calendar-border);
   }
 
-  &:hover {
+  &:hover:not(.prevOrNextMonth, .selectedDate) {
     background: var(--additive-background);
   }
 }
@@ -59,4 +59,9 @@
 
 .arrowIcon {
   color: var(--lego-font-color);
+}
+
+.today {
+  color: var(--lego-font-color);
+  background-color: var(--additive-background);
 }

--- a/app/components/Form/DatePicker.css
+++ b/app/components/Form/DatePicker.css
@@ -1,19 +1,16 @@
-:root {
-  --calendar-border: 1px solid var(--border-gray);
-}
-
-.calendar {
-  display: flex;
-  width: 100%;
-  flex-wrap: wrap;
-  margin: 0 0 10px;
+.calendar th,
+.calendar td {
+  width: calc(100% / 7);
+  text-align: center;
+  font-size: var(--font-size-md);
+  padding: 5px;
+  transition: background var(--easing-blazingly-fast);
 }
 
 .dropdown {
   width: auto;
-  max-width: 320px;
-  padding: 0 20px 10px;
-  flex: 1;
+  max-width: 335px;
+  padding: 0 15px 8px;
 }
 
 .inputField {
@@ -22,43 +19,33 @@
 
 .header {
   font-size: var(--font-size-lg);
-  text-align: center;
   padding: 10px;
+  text-transform: capitalize;
 }
 
 .calendarItem {
-  flex: 0 14.2857%;
-  border-right: var(--calendar-border);
-  border-bottom: var(--calendar-border);
-  background: var(--color-white);
+  width: 100%;
+  height: 100%;
+  border-radius: var(--border-radius-sm);
   color: var(--lego-font-color);
   text-align: center;
   font-size: var(--font-size-md);
-  padding: 5px;
+  padding: 6px;
+  transition: background var(--easing-blazingly-fast);
 
-  &:nth-child(7n + 1) {
-    border-left: var(--calendar-border);
-  }
-
-  &:nth-child(-n + 7) {
-    border-top: var(--calendar-border);
-  }
-
-  &:hover:not(.prevOrNextMonth, .selectedDate) {
+  &:hover:not(.today, .selectedDate) {
     background: var(--additive-background);
   }
 }
 
-.prevOrNextMonth {
+.prevOrNextMonth:not(.selectedDate) {
   opacity: 0.3;
 }
 
 .selectedDate {
-  font-weight: 600;
-}
-
-.arrowIcon {
-  color: var(--lego-font-color);
+  font-weight: 500;
+  color: var(--color-white);
+  background-color: var(--lego-font-color);
 }
 
 .today {

--- a/app/components/Form/DatePicker.tsx
+++ b/app/components/Form/DatePicker.tsx
@@ -55,6 +55,8 @@ const DatePicker = ({
     setPickerOpen(false);
   };
 
+  const calendarDays = createMonthlyCalendar(date);
+
   return (
     <Dropdown
       show={pickerOpen}
@@ -76,32 +78,45 @@ const DatePicker = ({
           alignItems="center"
           className={styles.header}
         >
-          <button onClick={onPrev} className={styles.arrowIcon}>
-            <Icon name="arrow-back-outline" />
-          </button>
+          <Icon onClick={onPrev} name="arrow-back-outline" />
           <span>{date.format('MMMM YYYY')}</span>
-          <button onClick={onNext} className={styles.arrowIcon}>
-            <Icon name="arrow-forward-outline" />
-          </button>
+          <Icon onClick={onNext} name="arrow-forward-outline" />
         </Flex>
 
-        <div className={styles.calendar}>
-          {createMonthlyCalendar(date).map((dateProps, i) => (
-            <button
-              key={i}
-              className={cx(
-                styles.calendarItem,
-                dateProps.prevOrNextMonth && styles.prevOrNextMonth,
-                dateProps.day.isSame(parsedValue, 'day') && styles.selectedDate,
-                dateProps.day.isSame(moment(), 'day') && styles.today
-              )}
-              onClick={() => changeDay(dateProps.day)}
-              disabled={dateProps.prevOrNextMonth}
-            >
-              {dateProps.day.date()}
-            </button>
-          ))}
-        </div>
+        <table className={styles.calendar}>
+          <thead>
+            <tr>
+              {['Ma', 'Ti', 'On', 'To', 'Fr', 'Lø', 'Sø'].map((d, i) => (
+                <th key={i}>{d}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from(
+              { length: Math.ceil(calendarDays.length / 7) },
+              (_, i) => i
+            ).map((_, i) => (
+              <tr key={i}>
+                {calendarDays.slice(i * 7, i * 7 + 7).map((dateProps, j) => (
+                  <td key={j}>
+                    <button
+                      className={cx(
+                        styles.calendarItem,
+                        dateProps.prevOrNextMonth && styles.prevOrNextMonth,
+                        dateProps.day.isSame(parsedValue, 'day') &&
+                          styles.selectedDate,
+                        dateProps.day.isSame(moment(), 'day') && styles.today
+                      )}
+                      onClick={() => changeDay(dateProps.day)}
+                    >
+                      {dateProps.day.date()}
+                    </button>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
 
         {showTimePicker && <TimePicker value={value} onChange={onChange} />}
       </div>

--- a/app/components/Form/DatePicker.tsx
+++ b/app/components/Form/DatePicker.tsx
@@ -92,7 +92,8 @@ const DatePicker = ({
               className={cx(
                 styles.calendarItem,
                 dateProps.prevOrNextMonth && styles.prevOrNextMonth,
-                dateProps.day.isSame(parsedValue, 'day') && styles.selectedDate
+                dateProps.day.isSame(parsedValue, 'day') && styles.selectedDate,
+                dateProps.day.isSame(moment(), 'day') && styles.today
               )}
               onClick={() => changeDay(dateProps.day)}
               disabled={dateProps.prevOrNextMonth}

--- a/app/components/Form/TextInput.css
+++ b/app/components/Form/TextInput.css
@@ -11,12 +11,17 @@
   }
 }
 
-.spacing input,
+.centered input {
+  text-align: center;
+}
+
+.spacing:not(.centered) input,
 .prefix {
   color: var(--color-gray-5);
   padding-left: 10px;
 }
 
+/* stylelint-disable no-descending-specificity */
 .input input {
   width: 100%;
   height: 100%;

--- a/app/components/Form/TextInput.tsx
+++ b/app/components/Form/TextInput.tsx
@@ -16,6 +16,7 @@ type Props = {
   readOnly?: boolean;
   placeholder?: string;
   removeBorder?: boolean;
+  centered?: boolean;
 } & InputHTMLAttributes<HTMLInputElement>;
 
 const TextInput = ({
@@ -28,6 +29,7 @@ const TextInput = ({
   readOnly,
   placeholder,
   removeBorder = false,
+  centered = false,
   ...props
 }: Props) => {
   /* New ref is made because text inputs that are not Fields are not given a ref */
@@ -43,6 +45,7 @@ const TextInput = ({
         disabled && styles.disabled,
         !prefix && styles.spacing,
         removeBorder && styles.removeBorder,
+        centered && styles.centered,
         className
       )}
     >

--- a/app/components/Form/TimePicker.css
+++ b/app/components/Form/TimePicker.css
@@ -2,22 +2,24 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: 0.4rem;
 }
 
 .timePickerInput {
   display: flex;
   flex-direction: column;
-  width: 50px;
-
-  > input {
-    text-align: center;
-  }
-
-  > button {
-    font-size: var(--font-size-lg);
-  }
+  width: 40px;
 }
 
-html[data-theme='dark'] .arrowIcon {
-  color: var(--color-black);
+.arrowUp,
+.arrowDown {
+  transition: transform var(--easing-medium);
+}
+
+.arrowUp:hover {
+  transform: translateY(-3px);
+}
+
+.arrowDown:hover {
+  transform: translateY(3px);
 }

--- a/app/components/Form/TimePicker.tsx
+++ b/app/components/Form/TimePicker.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import Icon from 'app/components/Icon';
+import { Keyboard } from 'app/utils/constants';
 import parseDateValue from 'app/utils/parseDateValue';
 import { createField } from './Field';
 import TextInput from './TextInput';
 import styles from './TimePicker.css';
-import type { ComponentProps, SyntheticEvent } from 'react';
+import type { ComponentProps, KeyboardEvent, SyntheticEvent } from 'react';
 
 type TimePickerInputProps = ComponentProps<typeof TextInput> & {
   onNext: () => void;
@@ -15,17 +16,32 @@ const TimePickerInput = ({
   onNext,
   onPrev,
   ...props
-}: TimePickerInputProps) => (
-  <div className={styles.timePickerInput}>
-    <button type="button" onClick={onNext} className={styles.arrowIcon}>
-      <Icon justifyContent="center" name="chevron-up-outline" />
-    </button>
-    <TextInput {...props} />
-    <button type="button" onClick={onPrev} className={styles.arrowIcon}>
-      <Icon justifyContent="center" name="chevron-down-outline" />
-    </button>
-  </div>
-);
+}: TimePickerInputProps) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    switch (e.which) {
+      case Keyboard.UP:
+        onNext();
+        break;
+      case Keyboard.DOWN:
+        onPrev();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={styles.timePickerInput}>
+      <button type="button" onClick={onNext} className={styles.arrowUp}>
+        <Icon justifyContent="center" name="chevron-up-outline" />
+      </button>
+      <TextInput onKeyDown={handleKeyDown} centered {...props} />
+      <button type="button" onClick={onPrev} className={styles.arrowDown}>
+        <Icon justifyContent="center" name="chevron-down-outline" />
+      </button>
+    </div>
+  );
+};
 
 type Props = {
   value?: string;

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -308,7 +308,6 @@ describe('Create event', () => {
     cy.focused().type('{enter}', { force: true });
 
     field('mergeTime').click();
-    cy.get(c('DatePicker__header')).find('button:last-child').click();
     cy.contains(c('DatePicker__calendarItem'), '15').click();
 
     // Check clarification

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -32,7 +32,8 @@ describe('Create meeting', () => {
     cy.contains('button', 'Opprett møte').should('be.disabled');
     // change the meeting time to enable submit button
     field('startTime').click();
-    cy.get(c('TimePicker__arrowIcon')).first().click();
+    cy.get(c('TimePicker__arrowUp')).first().click();
+    cy.contains('Nytt møte').click(); // Click on something to close the datepicker
 
     cy.contains('button', 'Opprett møte').should('not.be.disabled').click();
 

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -61,7 +61,10 @@ export const setDatePickerDate = (name, date, isNextMonth = false) => {
   field(name).click();
 
   if (isNextMonth) {
-    cy.get(c('DatePicker__arrowIcon')).eq(1).should('not.be.disabled').click();
+    cy.get('ion-icon[arrow-forward-outline]')
+      .first()
+      .should('not.be.disabled')
+      .click();
   }
 
   cy.get('button:not(:disabled)')


### PR DESCRIPTION
# Description

[Highlight current day in date picker](https://github.com/webkom/lego-webapp/commit/ad00c24445eaa197046e006a4f2394a117b6bdbd)

---

[Give datepicker component a retouch](https://github.com/webkom/lego-webapp/commit/743c3ac9e36f238a570a5b78f2044368523f6728) 

- Center time input fields
- Let users change time with up and down keys!
- Remove the old school borders
- Label the weekdays
- Update arrow icons with transitions :)
- Un-disable dates from previous or next month

# Result
**Before**
<p align="center">
	<img width="49%" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/1a523f4a-bdb0-4099-88d4-18f68102e085">
	<img width="49%" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/a6e1cd4b-e772-4284-8f2e-3bb230590a00">
</p>

**After**

<p align="center">
	<img width="49%" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/ea8821a8-f479-4e28-a2ed-2e7b95e0fbc6">
	<img width="49%" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/d575c1c8-ef1e-4936-bcf1-50614a525321">
</p>

https://github.com/webkom/lego-webapp/assets/69514187/0acae3d2-43f8-4466-bb23-d7c1692f8cb6

# Testing

- [x] I have thoroughly tested my changes.

Setting and updating dates still work.