### PR TITLE
Type ion-icon web component

### DIFF
--- a/packages/lego-bricks/src/Global.d.ts
+++ b/packages/lego-bricks/src/Global.d.ts
@@ -1,0 +1,12 @@
+import type { IonIcon } from './components/Icon/IonIcons';
+import type { DOMAttributes, ReactNode } from 'react';
+
+type CustomElement<T> = Partial<T & DOMAttributes<T> & { children: ReactNode }>;
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      ['ion-icon']: CustomElement<IonIcon>;
+    }
+  }
+}

--- a/packages/lego-bricks/src/Globals.d.ts
+++ b/packages/lego-bricks/src/Globals.d.ts
@@ -1,1 +1,0 @@
-declare module '*.module.css';

--- a/packages/lego-bricks/src/Modules.d.ts
+++ b/packages/lego-bricks/src/Modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/packages/lego-bricks/src/components/Icon/IonIcons.ts
+++ b/packages/lego-bricks/src/components/Icon/IonIcons.ts
@@ -1,0 +1,51 @@
+/**
+ * Definitions for the <ion-icon> web component. Props are copied from the ionicons codebase: https://github.com/ionic-team/ionicons/blob/main/src/components.d.ts
+ */
+
+export interface IonIcon {
+  /**
+   * The color to use for the background of the item.
+   */
+  color?: string;
+  /**
+   * Specifies whether the icon should horizontally flip when `dir` is `"rtl"`.
+   */
+  flipRtl?: boolean;
+  /**
+   * A combination of both `name` and `src`. If a `src` url is detected it will set the `src` property. Otherwise it assumes it's a built-in named SVG and set the `name` property.
+   */
+  icon?: any;
+  /**
+   * Specifies which icon to use on `ios` mode.
+   */
+  ios?: string;
+  /**
+   * If enabled, ion-icon will be loaded lazily when it's visible in the viewport. Default, `false`.
+   */
+  lazy?: boolean;
+  /**
+   * Specifies which icon to use on `md` mode.
+   */
+  md?: string;
+  /**
+   * The mode determines which platform styles to use.
+   */
+  mode?: string;
+  /**
+   * Specifies which icon to use from the built-in set of icons.
+   */
+  name?: string;
+  /**
+   * When set to `false`, SVG content that is HTTP fetched will not be checked if the response SVG content has any `<script>` elements, or any attributes that start with `on`, such as `onclick`.
+   * @default true
+   */
+  sanitize?: boolean;
+  /**
+   * The size of the icon. Available options are: `"small"` and `"large"`.
+   */
+  size?: string;
+  /**
+   * Specifies the exact `src` of an SVG file to use.
+   */
+  src?: string;
+}

--- a/packages/lego-bricks/src/components/Icon/index.tsx
+++ b/packages/lego-bricks/src/components/Icon/index.tsx
@@ -50,8 +50,6 @@ export const Icon = ({
     >
       {to ? (
         <Link to={to} className={styles.clickable}>
-          {/* eslint-disable-next-line*/}
-          {/* @ts-ignore*/}
           <ion-icon name={name}></ion-icon>
         </Link>
       ) : onClick ? (
@@ -66,14 +64,10 @@ export const Icon = ({
             disabled && styles.disabled
           )}
         >
-          {/* eslint-disable-next-line*/}
-          {/* @ts-ignore*/}
           <ion-icon name={name}></ion-icon>
         </button>
       ) : (
         <>
-          {/* eslint-disable-next-line*/}
-          {/* @ts-ignore*/}
           <ion-icon name={name}></ion-icon>
         </>
       )}

--- a/packages/lego-bricks/src/index.ts
+++ b/packages/lego-bricks/src/index.ts
@@ -1,4 +1,5 @@
-import './Globals.d.ts';
+import './Global.d.ts';
+import './Modules.d.ts';
 import './global.css';
 
 export { Button } from './components/Button';


### PR DESCRIPTION
# Description

The ion-icon can be used as a normal HTML-element as it is a web component. Typescript doesn't know this though, unless we add type definitions for it.

# Result

There are now type definitions, meaning we don't need to use ts-ignore in the Icon-component anymore:)

# Testing

- [x] I have thoroughly tested my changes.

Only typscript changes. 
---

Resolves ... (either GitHub issue or Linear task)
