### PR TITLE
Use date-relative merge time in event cypress test

### DIFF
--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -307,8 +307,7 @@ describe('Create event', () => {
       .and('contain', 'Abakus');
     cy.focused().type('{enter}', { force: true });
 
-    field('mergeTime').click();
-    cy.contains(c('DatePicker__calendarItem'), '15').click();
+    setDatePickerDate('mergeTime', tomorrowDay, tomorrowDay < todayDay);
 
     // Check clarification
     field('isClarified').check();


### PR DESCRIPTION
# Description

Is there some new validation here? How does this code from 2019 just suddenly cause all cypress runs to fail?? Well anyways I fixed it by always using the date tomorrow as merge-time, this avoid merge time being before the registration time.

# Result

Cypress doesn't fail.

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ... (either GitHub issue or Linear task)
