### PR TITLE
Fix statistics positions

### DIFF
--- a/app/routes/events/components/EventAttendeeStatistics.css
+++ b/app/routes/events/components/EventAttendeeStatistics.css
@@ -38,4 +38,12 @@
 
 .chartContainer {
   overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1em;
+  padding: 6px;
+}
+
+.graphCard {
+  margin-top: 1em;
 }

--- a/app/routes/events/components/EventAttendeeStatistics.css
+++ b/app/routes/events/components/EventAttendeeStatistics.css
@@ -43,7 +43,6 @@
   gap: 1em;
   padding: 6px;
 }
-
 .graphCard {
   margin-top: 1em;
 }

--- a/app/routes/events/components/EventAttendeeStatistics.css
+++ b/app/routes/events/components/EventAttendeeStatistics.css
@@ -43,6 +43,7 @@
   gap: 1em;
   padding: 6px;
 }
+
 .graphCard {
   margin-top: 1em;
 }

--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -48,16 +48,16 @@ const PieChartWithLabel = ({
   distributionData: DistributionDataPoint[];
 }) => {
   return (
-    <>
-      <h4>{label}</h4>
-      <Flex alignItems="center" style={{ marginBottom: '3rem' }} wrap={true}>
+    <Card>
+      <Card.Header>{label}</Card.Header>
+      <Flex alignItems="center" wrap column>
         <DistributionPieChart
           dataKey="count"
           distributionData={distributionData}
         />
         <ChartLabel distributionData={distributionData} />
       </Flex>
-    </>
+    </Card>
   );
 };
 
@@ -416,11 +416,12 @@ const EventAttendeeStatistics = ({
             label={'Gruppetilhørighet'}
             distributionData={groupDistribution}
           />
-
-          <h4>Påmeldinger og avmeldinger per dag</h4>
+        </div>
+      )}
+      <Card className={styles.graphCard}>
+        <Card.Header>Påmeldinger og avmeldinger per dag</Card.Header>
+        <ResponsiveContainer width="100%" height={300}>
           <LineChart
-            width={375}
-            height={300}
             data={registrationTimeDistribution}
             margin={{
               top: 10,
@@ -448,8 +449,8 @@ const EventAttendeeStatistics = ({
               activeDot={{ r: 8 }}
             />
           </LineChart>
-        </div>
-      )}
+        </ResponsiveContainer>
+      </Card>
     </>
   );
 };


### PR DESCRIPTION
# Description

- Displays the statistics charts as two grid columns instead of one.
- Adds card background to all charts.

# Result

| Before | After |
| -- | -- |
| ![Screenshot from 2023-09-27 12-22-54](https://github.com/webkom/lego-webapp/assets/33326578/825f56a8-1269-4134-a96e-2cf0eacbc4c4) | ![Screenshot from 2023-09-27 12-22-16](https://github.com/webkom/lego-webapp/assets/33326578/f59ff2a0-0b7f-4de3-9ff9-d091f99f9a61) |


# Testing

- [x] I have thoroughly tested my changes.

1. Navigate to an event and click on "Se påmeldinger".
2. Click on "Statistikk".
3. Verify that the new design uses a two column grid and that all charts have a card background.

Resolves [ABA-497](https://linear.app/abakus-webkom/issue/ABA-497/improve-the-statistics-page)
