### PR TITLE
Refactor forms using MultipleSelectGroup to react-final-forms

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
         exclude: [build]
 
   - name: minio
-    image: minio/minio
+    image: minio/minio:RELEASE.2023-09-23T03-47-50Z
     detach: true
     environment:
       MINIO_ACCESS_KEY: lego-dev
@@ -362,6 +362,6 @@ image_pull_secrets:
 
 ---
 kind: signature
-hmac: 51b0a49b62c375f26f0ab24b0559fdf8f1747586051b25ffac639395f55b10d6
+hmac: 4c241249a689b9571f62e2b58eb7a868909024245ef074fe413fb275c1ed982f
 
 ...

--- a/app/routes/bdb/components/AddSemester.tsx
+++ b/app/routes/bdb/components/AddSemester.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@webkom/lego-bricks';
 import { Component } from 'react';
+import { Field, FormSpy } from 'react-final-form';
 import { Content } from 'app/components/Content';
 import { TextInput, RadioButton, MultiSelectGroup } from 'app/components/Form';
-import type { CompanySemesterContactedStatus } from 'app/models';
+import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import type { SemesterStatusEntity } from 'app/reducers/companies';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
+import { createValidator, required } from 'app/utils/validation';
 import {
   getContactedStatuses,
   selectMostProminentStatus,
@@ -13,9 +15,6 @@ import {
 } from '../utils';
 import SemesterStatusContent from './SemesterStatusContent';
 import styles from './bdb.css';
-import LegoFinalForm from 'app/components/Form/LegoFinalForm';
-import { createValidator, required } from 'app/utils/validation';
-import { Field, FormSpy } from 'react-final-form';
 
 type Props = {
   addSemesterStatus: (

--- a/app/routes/bdb/components/AddSemester.tsx
+++ b/app/routes/bdb/components/AddSemester.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@webkom/lego-bricks';
 import { Component } from 'react';
-import { Field } from 'redux-form';
 import { Content } from 'app/components/Content';
 import { TextInput, RadioButton, MultiSelectGroup } from 'app/components/Form';
 import type { CompanySemesterContactedStatus } from 'app/models';
@@ -14,6 +13,9 @@ import {
 } from '../utils';
 import SemesterStatusContent from './SemesterStatusContent';
 import styles from './bdb.css';
+import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import { createValidator, required } from 'app/utils/validation';
+import { Field, FormSpy } from 'react-final-form';
 
 type Props = {
   addSemesterStatus: (
@@ -30,20 +32,32 @@ type Props = {
   addSemester: (arg0: CompanySemesterEntity) => Promise<any>;
   deleteCompany: (arg0: number) => Promise<any>;
 };
+
 type State = {
   contactedStatus: Array</*TODO: ContactedStatus */ any>;
   submit: boolean;
 };
+
+const validate = createValidator({
+  year: [required()],
+  semester: [required()],
+});
+
 export default class AddSemester extends Component<Props, State> {
   state = {
-    contactedStatus: [],
     submit: false,
   };
-  onSubmit = ({ year, semester, contract }: SemesterStatusEntity) => {
+
+  onSubmit = ({
+    year,
+    semester,
+    contract,
+    semesterStatus,
+  }: SemesterStatusEntity) => {
+    const contactedStatus = semesterStatus.contactedStatus;
     if (!this.state.submit) return;
     const { companyId, addSemesterStatus, companySemesters, addSemester } =
       this.props;
-    const { contactedStatus } = this.state;
     const globalSemester = companySemesters.find((companySemester) => {
       return (
         companySemester.year === Number(year) &&
@@ -82,26 +96,16 @@ export default class AddSemester extends Component<Props, State> {
       });
     }
   };
+
   setContactedStatus = (event: Record<string, any>) => {
     this.setState({
       contactedStatus: event.target.value,
     });
   };
-  editFunction = (statusString: CompanySemesterContactedStatus) => {
-    this.setState({
-      contactedStatus: getContactedStatuses(
-        this.state.contactedStatus,
-        statusString
-      ),
-    });
-  };
 
   render() {
-    const { companyId, submitting, autoFocus, handleSubmit, deleteCompany } =
-      this.props;
-    const semesterStatus = {
-      contactedStatus: this.state.contactedStatus,
-    };
+    const { companyId, submitting, autoFocus, deleteCompany } = this.props;
+
     return (
       <Content>
         <DetailNavigation
@@ -121,77 +125,118 @@ export default class AddSemester extends Component<Props, State> {
             Bdb-forsiden!
           </i>
 
-          <form onSubmit={handleSubmit(this.onSubmit)}>
-            <Field
-              autoFocus={autoFocus}
-              placeholder="2020"
-              label="År"
-              name="year"
-              type="number"
-              component={TextInput.Field}
-              className={styles.yearForm}
-            />
-
-            <div className={styles.choices}>
-              <MultiSelectGroup name="semester" label="Semester">
+          <LegoFinalForm
+            onSubmit={this.onSubmit}
+            validate={validate}
+            initialValues={{
+              semesterStatus: {
+                contactedStatus: [],
+              },
+            }}
+            subscription={{}}
+          >
+            {({ handleSubmit }) => (
+              <form onSubmit={handleSubmit}>
                 <Field
-                  name="Spring"
-                  label="Vår"
-                  component={RadioButton.Field}
-                  inputValue="spring"
+                  autoFocus={autoFocus}
+                  placeholder="2020"
+                  label="År"
+                  name="year"
+                  type="number"
+                  component={TextInput.Field}
+                  className={styles.yearForm}
                 />
-                <Field
-                  name="Autumn"
-                  label="Høst"
-                  component={RadioButton.Field}
-                  inputValue="autumn"
-                />
-              </MultiSelectGroup>
-            </div>
 
-            <label>Status</label>
-            <div
-              style={{
-                width: '200px',
-                minHeight: '30px',
-                margin: '15px 0 25px',
-                borderRadius: '5px',
-                border: '1px solid var(--border-gray)',
-              }}
-              type="button"
-              className={
-                styles[
-                  selectColorCode(
-                    selectMostProminentStatus(semesterStatus.contactedStatus)
-                  )
-                ]
-              }
-            >
-              <SemesterStatusContent
-                semesterStatus={semesterStatus}
-                submit={false}
-                editFunction={(statusCode) => this.editFunction(statusCode)}
-                style={{
-                  minHeight: '30px',
-                  padding: '10px',
-                }}
-              />
-            </div>
+                <div className={styles.choices}>
+                  <MultiSelectGroup name="semester" label="Semester">
+                    <Field
+                      name="Spring"
+                      label="Vår"
+                      component={RadioButton.Field}
+                      inputValue="spring"
+                      showErrors={false}
+                    />
+                    <Field
+                      name="Autumn"
+                      label="Høst"
+                      component={RadioButton.Field}
+                      inputValue="autumn"
+                      showErrors={false}
+                    />
+                  </MultiSelectGroup>
+                </div>
 
-            <div className={styles.clear} />
+                <label>Status</label>
 
-            <Button
-              disabled={submitting}
-              onClick={() =>
-                this.setState({
-                  submit: true,
-                })
-              }
-              submit
-            >
-              Lagre
-            </Button>
-          </form>
+                <Field name="semesterStatus">
+                  {({ input }) => (
+                    <div
+                      style={{
+                        width: '200px',
+                        minHeight: '30px',
+                        margin: '15px 0 25px',
+                        borderRadius: '5px',
+                        border: '1px solid var(--border-gray)',
+                      }}
+                      className={
+                        styles[
+                          selectColorCode(
+                            selectMostProminentStatus(
+                              input.value.contactedStatus
+                            )
+                          )
+                        ]
+                      }
+                    >
+                      <SemesterStatusContent
+                        semesterStatus={input.value}
+                        submit={false}
+                        editFunction={(statusString) => {
+                          input.onChange({
+                            contactedStatus: getContactedStatuses(
+                              input.value.contactedStatus,
+                              statusString
+                            ),
+                          });
+                        }}
+                        style={{
+                          minHeight: '30px',
+                          padding: '10px',
+                        }}
+                      />
+                    </div>
+                  )}
+                </Field>
+
+                <div className={styles.clear} />
+
+                <Button
+                  disabled={submitting}
+                  onClick={() =>
+                    this.setState({
+                      submit: true,
+                    })
+                  }
+                  submit
+                >
+                  Lagre
+                </Button>
+
+                <FormSpy
+                  subscription={{
+                    values: true,
+                  }}
+                >
+                  {(props) => {
+                    console.log(props.values);
+                    return (
+                      <pre>{JSON.stringify(props.values, undefined, 2)}</pre>
+                    );
+                  }}
+                </FormSpy>
+              </form>
+            )}
+          </LegoFinalForm>
         </div>
       </Content>
     );

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -23,7 +23,6 @@ type Props = {
   uploadFile: (arg0: Record<string, any>) => Promise<any>;
   company: CompanyEntity;
   submitting: boolean;
-  handleSubmit: (arg0: (arg0: CompanyEntity) => Promise<any>) => void;
   autoFocus: any;
   fetching: boolean;
   submitFunction: (arg0: SubmitCompanyEntity) => Promise<any>;

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -1,5 +1,5 @@
 import { LoadingIndicator, Button } from '@webkom/lego-bricks';
-import { Field } from 'redux-form';
+import { Field } from 'react-final-form';
 import { Content } from 'app/components/Content';
 import {
   TextEditor,
@@ -8,8 +8,8 @@ import {
   SelectInput,
   ImageUploadField,
   MultiSelectGroup,
-  legoForm,
 } from 'app/components/Form';
+import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import InfoBubble from 'app/components/InfoBubble';
 import type {
   CompanyEntity,
@@ -26,21 +26,23 @@ type Props = {
   handleSubmit: (arg0: (arg0: CompanyEntity) => Promise<any>) => void;
   autoFocus: any;
   fetching: boolean;
-  submitFunction: (
-    arg0: SubmitCompanyEntity,
-    arg1: number | null | undefined
-  ) => Promise<any>;
+  submitFunction: (arg0: SubmitCompanyEntity) => Promise<any>;
   deleteCompany: (arg0: number) => Promise<any>;
 };
+
+const validate = createValidator({
+  name: [required()],
+  paymentMail: [isEmail()],
+});
 
 const CompanyEditor = ({
   company,
   submitting,
   autoFocus,
-  handleSubmit,
   uploadFile,
   fetching,
   deleteCompany,
+  submitFunction,
 }: Props) => {
   if (fetching) {
     return <LoadingIndicator loading />;
@@ -56,208 +58,209 @@ const CompanyEditor = ({
       className={styles.editTitle}
     />
   );
+
+  const onSubmit = (formContent) =>
+    submitFunction({
+      ...formContent,
+      logo: formContent.logo || undefined,
+      studentContact:
+        formContent.studentContact && Number(formContent.studentContact.id),
+      website: httpCheck(formContent.website),
+      companyId: company && company.id,
+    });
+
   return (
     <Content>
       <div className={styles.detail}>
-        <form onSubmit={handleSubmit}>
-          <Field
-            name="logo"
-            component={ImageUploadField}
-            uploadFile={uploadFile}
-            aspectRatio={20 / 6}
-            img={company && company.logo}
-          />
+        <LegoFinalForm
+          onSubmit={onSubmit}
+          validate={validate}
+          subscription={{}}
+        >
+          {({ handleSubmit }) => (
+            <form onSubmit={handleSubmit}>
+              <Field
+                name="logo"
+                component={ImageUploadField}
+                uploadFile={uploadFile}
+                aspectRatio={20 / 6}
+                img={company && company.logo}
+              />
 
-          {company ? (
-            <DetailNavigation
-              title={nameField}
-              companyId={company.id}
-              deleteFunction={deleteCompany}
-            />
-          ) : (
-            <ListNavigation title={nameField} />
+              {company ? (
+                <DetailNavigation
+                  title={nameField}
+                  companyId={company.id}
+                  deleteFunction={deleteCompany}
+                />
+              ) : (
+                <ListNavigation title={nameField} />
+              )}
+
+              <div className={styles.description}>
+                <Field
+                  placeholder="Beskrivelse av bedriften"
+                  label=" "
+                  autoFocus={autoFocus}
+                  name="description"
+                  component={TextEditor.Field}
+                />
+              </div>
+
+              <div className={styles.infoBubbles}>
+                <InfoBubble
+                  icon="briefcase"
+                  data={
+                    <Field
+                      placeholder="Type bedrift"
+                      label=" "
+                      autoFocus={autoFocus}
+                      name="companyType"
+                      component={TextInput.Field}
+                      className={styles.editBubble}
+                    />
+                  }
+                  meta="Type bedrift"
+                  style={{
+                    order: 0,
+                  }}
+                />
+                <InfoBubble
+                  icon="mail"
+                  data={
+                    <Field
+                      placeholder="Fakturamail"
+                      label=" "
+                      autoFocus={autoFocus}
+                      name="paymentMail"
+                      component={TextInput.Field}
+                      className={styles.editBubble}
+                      required
+                    />
+                  }
+                  meta="Fakturamail"
+                  style={{
+                    order: 1,
+                  }}
+                />
+                <InfoBubble
+                  icon="call"
+                  data={
+                    <Field
+                      placeholder="Telefonnummer"
+                      label=" "
+                      autoFocus={autoFocus}
+                      name="phone"
+                      component={TextInput.Field}
+                      className={styles.editBubble}
+                    />
+                  }
+                  meta="Telefon"
+                  style={{
+                    order: 2,
+                  }}
+                />
+              </div>
+
+              <div className={styles.infoBubbles}>
+                <InfoBubble
+                  icon="at"
+                  data={
+                    <Field
+                      placeholder="Nettside"
+                      label=" "
+                      autoFocus={autoFocus}
+                      name="website"
+                      component={TextInput.Field}
+                      className={styles.editBubble}
+                    />
+                  }
+                  meta="Nettside"
+                  style={{
+                    order: 0,
+                  }}
+                />
+
+                <InfoBubble
+                  icon="home"
+                  data={
+                    <Field
+                      placeholder="Adresse"
+                      label=" "
+                      autoFocus={autoFocus}
+                      name="address"
+                      component={TextInput.Field}
+                      className={styles.editBubble}
+                    />
+                  }
+                  meta="Adresse"
+                  style={{
+                    order: 1,
+                  }}
+                />
+                <InfoBubble
+                  icon="person"
+                  data={
+                    <Field
+                      placeholder="Studentkontakt"
+                      label=" "
+                      autoFocus={autoFocus}
+                      name="studentContact"
+                      component={SelectInput.AutocompleteField}
+                      className={styles.editBubble}
+                      filter={['users.user']}
+                    />
+                  }
+                  meta="Studentkontakt"
+                  style={{
+                    order: 2,
+                  }}
+                />
+              </div>
+
+              <div className={styles.info}>
+                <div
+                  style={{
+                    order: 0,
+                  }}
+                >
+                  <MultiSelectGroup name="active" label="Aktiv bedrift?">
+                    <Field
+                      name="Yes"
+                      label="Ja"
+                      component={RadioButton.Field}
+                      inputValue="true"
+                    />
+                    <Field
+                      name="No"
+                      label="Nei"
+                      component={RadioButton.Field}
+                      inputValue="false"
+                    />
+                  </MultiSelectGroup>
+                </div>
+              </div>
+
+              <div className={styles.adminNote}>
+                <Field
+                  placeholder="Bedriften ønsker kun kurs"
+                  label="Notat fra Bedkom"
+                  autoFocus={autoFocus}
+                  name="adminComment"
+                  component={TextEditor.Field}
+                />
+              </div>
+
+              <div className={styles.clear} />
+              <Button disabled={submitting} submit>
+                Lagre
+              </Button>
+            </form>
           )}
-
-          <div className={styles.description}>
-            <Field
-              placeholder="Beskrivelse av bedriften"
-              label=" "
-              autoFocus={autoFocus}
-              name="description"
-              component={TextEditor.Field}
-            />
-          </div>
-
-          <div className={styles.infoBubbles}>
-            <InfoBubble
-              icon="briefcase"
-              data={
-                <Field
-                  placeholder="Type bedrift"
-                  label=" "
-                  autoFocus={autoFocus}
-                  name="companyType"
-                  component={TextInput.Field}
-                  className={styles.editBubble}
-                />
-              }
-              meta="Type bedrift"
-              style={{
-                order: 0,
-              }}
-            />
-            <InfoBubble
-              icon="mail"
-              data={
-                <Field
-                  placeholder="Fakturamail"
-                  label=" "
-                  autoFocus={autoFocus}
-                  name="paymentMail"
-                  component={TextInput.Field}
-                  className={styles.editBubble}
-                />
-              }
-              meta="Fakturamail"
-              style={{
-                order: 1,
-              }}
-            />
-            <InfoBubble
-              icon="call"
-              data={
-                <Field
-                  placeholder="Telefonnummer"
-                  label=" "
-                  autoFocus={autoFocus}
-                  name="phone"
-                  component={TextInput.Field}
-                  className={styles.editBubble}
-                />
-              }
-              meta="Telefon"
-              style={{
-                order: 2,
-              }}
-            />
-          </div>
-
-          <div className={styles.infoBubbles}>
-            <InfoBubble
-              icon="at"
-              data={
-                <Field
-                  placeholder="Nettside"
-                  label=" "
-                  autoFocus={autoFocus}
-                  name="website"
-                  component={TextInput.Field}
-                  className={styles.editBubble}
-                />
-              }
-              meta="Nettside"
-              style={{
-                order: 0,
-              }}
-            />
-
-            <InfoBubble
-              icon="home"
-              data={
-                <Field
-                  placeholder="Adresse"
-                  label=" "
-                  autoFocus={autoFocus}
-                  name="address"
-                  component={TextInput.Field}
-                  className={styles.editBubble}
-                />
-              }
-              meta="Adresse"
-              style={{
-                order: 1,
-              }}
-            />
-            <InfoBubble
-              icon="person"
-              data={
-                <Field
-                  placeholder="Studentkontakt"
-                  label=" "
-                  autoFocus={autoFocus}
-                  name="studentContact"
-                  component={SelectInput.AutocompleteField}
-                  className={styles.editBubble}
-                  filter={['users.user']}
-                />
-              }
-              meta="Studentkontakt"
-              style={{
-                order: 2,
-              }}
-            />
-          </div>
-
-          <div className={styles.info}>
-            <div
-              style={{
-                order: 0,
-              }}
-            >
-              <MultiSelectGroup name="active" label="Aktiv bedrift?">
-                <Field
-                  name="Yes"
-                  label="Ja"
-                  component={RadioButton.Field}
-                  inputValue="true"
-                />
-                <Field
-                  name="No"
-                  label="Nei"
-                  component={RadioButton.Field}
-                  inputValue="false"
-                />
-              </MultiSelectGroup>
-            </div>
-          </div>
-
-          <div className={styles.adminNote}>
-            <Field
-              placeholder="Bedriften ønsker kun kurs"
-              label="Notat fra Bedkom"
-              autoFocus={autoFocus}
-              name="adminComment"
-              component={TextEditor.Field}
-            />
-          </div>
-
-          <div className={styles.clear} />
-          <Button disabled={submitting} submit>
-            Lagre
-          </Button>
-        </form>
+        </LegoFinalForm>
       </div>
     </Content>
   );
 };
 
-const onSubmit = (formContent, dispatch, { company, submitFunction }: Props) =>
-  submitFunction({
-    ...formContent,
-    logo: formContent.logo || undefined,
-    studentContact:
-      formContent.studentContact && Number(formContent.studentContact.id),
-    website: httpCheck(formContent.website),
-    companyId: company && company.id,
-  });
-
-const validate = createValidator({
-  name: [required()],
-  paymentMail: [isEmail()],
-});
-export default legoForm({
-  form: 'companyEditor',
-  validate,
-  onSubmit,
-  enableReinitialize: true,
-})(CompanyEditor);
+export default CompanyEditor;

--- a/app/routes/bdb/components/SemesterStatusContent.tsx
+++ b/app/routes/bdb/components/SemesterStatusContent.tsx
@@ -17,8 +17,9 @@ type Props = {
   semesterStatus: Record<string, any>;
   editFunction: (
     arg0: CompanySemesterContactedStatus
-  ) => Promise<any> | null | undefined;
+  ) => Promise<any> | null | undefined | void;
   style?: Record<string, any>;
+  submit: boolean;
 };
 type State = {
   displayDropdown: boolean;
@@ -30,6 +31,7 @@ export default class SemesterStatusContent extends Component<Props, State> {
 
   render() {
     const { semesterStatus, editFunction, style } = this.props;
+
     const statusesToRender = (
       <div
         style={{
@@ -45,14 +47,20 @@ export default class SemesterStatusContent extends Component<Props, State> {
           : getStatusString('not_contacted')}
       </div>
     );
+
     const statusCodes = sortStatusesByProminence(
       Object.keys(statusStrings)
     ).filter((code) => code !== 'not_contacted');
+
     const dropDownItems = (
       <Dropdown.List>
         {statusCodes.map((statusString, j) => (
           <Dropdown.ListItem key={j} className={styles.dropDownItem}>
-            <Button flat onClick={() => editFunction(statusString)}>
+            <Button
+              flat
+              onClick={() => editFunction(statusString)}
+              submit={this.props.submit}
+            >
               <Flex>
                 {getStatusString(statusString)}
                 {semesterStatus.contactedStatus.indexOf(statusString) !==
@@ -70,6 +78,7 @@ export default class SemesterStatusContent extends Component<Props, State> {
         ))}
       </Dropdown.List>
     );
+
     return (
       <Dropdown
         show={this.state.displayDropdown}

--- a/app/routes/bdb/components/SemesterStatusContent.tsx
+++ b/app/routes/bdb/components/SemesterStatusContent.tsx
@@ -19,8 +19,8 @@ type Props = {
     arg0: CompanySemesterContactedStatus
   ) => Promise<any> | null | undefined | void;
   style?: Record<string, any>;
-  submit: boolean;
 };
+
 type State = {
   displayDropdown: boolean;
 };
@@ -56,11 +56,7 @@ export default class SemesterStatusContent extends Component<Props, State> {
       <Dropdown.List>
         {statusCodes.map((statusString, j) => (
           <Dropdown.ListItem key={j} className={styles.dropDownItem}>
-            <Button
-              flat
-              onClick={() => editFunction(statusString)}
-              submit={this.props.submit}
-            >
+            <Button flat onClick={() => editFunction(statusString)}>
               <Flex>
                 {getStatusString(statusString)}
                 {semesterStatus.contactedStatus.indexOf(statusString) !==

--- a/app/routes/companyInterest/components/CompanySemesterGUI.tsx
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@webkom/lego-bricks';
+import { Field } from 'react-final-form';
 import { Content } from 'app/components/Content';
 import {
   Form,
@@ -6,6 +7,7 @@ import {
   RadioButton,
   MultiSelectGroup,
 } from 'app/components/Form';
+import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
@@ -13,8 +15,6 @@ import { createValidator, required } from 'app/utils/validation';
 import { semesterToText, SemesterNavigation } from '../utils';
 import styles from './CompanyInterest.css';
 import type { FormProps } from 'redux-form';
-import LegoFinalForm from 'app/components/Form/LegoFinalForm';
-import { Field } from 'react-final-form';
 
 type Props = {
   onSubmit: (arg0: CompanySemesterEntity) => Promise<any>;

--- a/app/routes/companyInterest/components/CompanySemesterGUI.tsx
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.tsx
@@ -1,12 +1,10 @@
 import { Button } from '@webkom/lego-bricks';
-import { reset, Field } from 'redux-form';
 import { Content } from 'app/components/Content';
 import {
   Form,
   TextInput,
   RadioButton,
   MultiSelectGroup,
-  legoForm,
 } from 'app/components/Form';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
@@ -15,6 +13,8 @@ import { createValidator, required } from 'app/utils/validation';
 import { semesterToText, SemesterNavigation } from '../utils';
 import styles from './CompanyInterest.css';
 import type { FormProps } from 'redux-form';
+import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import { Field } from 'react-final-form';
 
 type Props = {
   onSubmit: (arg0: CompanySemesterEntity) => Promise<any>;
@@ -27,6 +27,11 @@ type Props = {
   addSemester: (arg0: CompanySemesterEntity) => void;
   activeSemesters: Array<CompanySemesterEntity>;
 } & FormProps;
+
+const validate = createValidator({
+  year: [required()],
+  semester: [required()],
+});
 
 const CompanySemesterGUI = (props: Props) => {
   const activeSemesters = (semesters) => (
@@ -48,83 +53,84 @@ const CompanySemesterGUI = (props: Props) => {
     </Flex>
   );
 
-  const { handleSubmit, autoFocus } = props;
+  const onSubmit = ({ year, semester }) => {
+    const { semesters, addSemester, editSemester } = props;
+    const existingCompanySemester = semesters.find((companySemester) => {
+      return (
+        Number(companySemester.year) === Number(year) &&
+        companySemester.semester === semester
+      );
+    });
+    if (existingCompanySemester)
+      return editSemester({
+        ...existingCompanySemester,
+        activeInterestForm: true,
+      });
+    else
+      return addSemester({
+        year,
+        semester,
+      }); // Default is activeInterestForm: true
+  };
+
+  const { autoFocus, initialValues } = props;
   return (
     <Content>
       <SemesterNavigation title="Endre aktive semestre" />
-      <Form onSubmit={handleSubmit}>
-        <Flex className={styles.guiWrapper}>
-          <Flex
-            column
-            style={{
-              marginRight: '50px',
-            }}
-          >
-            <label className={styles.heading}>Legg til aktivt semester</label>
-            <Field
-              autoFocus={autoFocus}
-              placeholder="2020"
-              label="År"
-              name="year"
-              type="number"
-              component={TextInput.Field}
-              className={styles.yearForm}
-              required
-            />
-            <MultiSelectGroup name="semester" label="Semester">
-              <Field
-                name="Spring"
-                label="Vår"
-                component={RadioButton.Field}
-                inputValue="spring"
-              />
-              <Field
-                name="Autumn"
-                label="Høst"
-                component={RadioButton.Field}
-                inputValue="autumn"
-              />
-            </MultiSelectGroup>
-            <Button submit>Legg til semester</Button>
-          </Flex>
-          <Flex column>
-            <label className={styles.heading}>Deaktiver semestre</label>
-            {activeSemesters(props.activeSemesters)}
-          </Flex>
-        </Flex>
-      </Form>
+      <LegoFinalForm
+        onSubmit={onSubmit}
+        validate={validate}
+        initialValues={initialValues}
+        subscription={{}}
+      >
+        {({ handleSubmit }) => (
+          <Form onSubmit={handleSubmit}>
+            <Flex className={styles.guiWrapper}>
+              <Flex
+                column
+                style={{
+                  marginRight: '50px',
+                }}
+              >
+                <label className={styles.heading}>
+                  Legg til aktivt semester
+                </label>
+                <Field
+                  autoFocus={autoFocus}
+                  placeholder="2020"
+                  label="År"
+                  name="year"
+                  type="number"
+                  component={TextInput.Field}
+                  className={styles.yearForm}
+                  required
+                />
+                <MultiSelectGroup name="semester" label="Semester">
+                  <Field
+                    name="Spring"
+                    label="Vår"
+                    component={RadioButton.Field}
+                    inputValue="spring"
+                  />
+                  <Field
+                    name="Autumn"
+                    label="Høst"
+                    component={RadioButton.Field}
+                    inputValue="autumn"
+                  />
+                </MultiSelectGroup>
+                <Button submit>Legg til semester</Button>
+              </Flex>
+              <Flex column>
+                <label className={styles.heading}>Deaktiver semestre</label>
+                {activeSemesters(props.activeSemesters)}
+              </Flex>
+            </Flex>
+          </Form>
+        )}
+      </LegoFinalForm>
     </Content>
   );
 };
 
-const onSubmit = ({ year, semester }, dispatch, props: Props) => {
-  const { semesters, addSemester, editSemester } = props;
-  const existingCompanySemester = semesters.find((companySemester) => {
-    return (
-      Number(companySemester.year) === Number(year) &&
-      companySemester.semester === semester
-    );
-  });
-  if (existingCompanySemester)
-    return editSemester({
-      ...existingCompanySemester,
-      activeInterestForm: true,
-    });
-  else
-    return addSemester({
-      year,
-      semester,
-    }); // Default is activeInterestForm: true
-};
-
-const validate = createValidator({
-  year: [required()],
-  semester: [required()],
-});
-export default legoForm({
-  form: 'addCompanySemester',
-  onSubmitSuccess: (result, dispatch) => dispatch(reset('addCompanySemester')),
-  onSubmit,
-  enableReinitialize: true,
-  validate,
-})(CompanySemesterGUI);
+export default CompanySemesterGUI;

--- a/app/routes/companyInterest/components/CompanySemesterGUI.tsx
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.tsx
@@ -17,7 +17,6 @@ import styles from './CompanyInterest.css';
 import type { FormProps } from 'redux-form';
 
 type Props = {
-  onSubmit: (arg0: CompanySemesterEntity) => Promise<any>;
   push: (arg0: string) => void;
   events: Array<Record<string, any>>;
   semesters: Array<CompanySemesterEntity>;

--- a/app/routes/companyInterest/components/Translations.ts
+++ b/app/routes/companyInterest/components/Translations.ts
@@ -19,10 +19,10 @@ export const EVENTS = {
   //   norwegian: 'Digital presentasjon',
   //   english: 'Digital presentation',
   // },
-  bedex: {
-    norwegian: 'Bedriftsekskursjon (BedEx)',
-    english: 'Company excursion (BedEx)',
-  },
+  // bedex: {
+  //   norwegian: 'Bedriftsekskursjon (BedEx)',
+  //   english: 'Company excursion (BedEx)',
+  // },
   other: {
     norwegian: 'Alternativt arrangement',
     english: 'Other event',

--- a/app/routes/companyInterest/components/Translations.ts
+++ b/app/routes/companyInterest/components/Translations.ts
@@ -77,12 +77,6 @@ export const README = {
     norwegian: 'Annonse i readme',
     english: 'Advertisement in readme',
   },
-  /*
-    collaboration: {
-      norwegian: 'Samarbeid med andre linjeforeninger',
-      english: 'Collaboration with other student organizations',
-    },
-    */
 };
 
 export const COMPANY_TYPES: Record<
@@ -125,22 +119,20 @@ export const COLLABORATION_TYPES = {
     norwegian: 'Samarbeid med TIHLDE linjeforening',
     english: 'Event in collaboration with TIHLDE',
   },
-
-  /*
-      collaboration_anniversary: {
-        english: "Collaboration with Abakus' anniversary committee*",
-        norwegian: 'Samarbeid med Abakus sitt Jubileum*',
-      },
-      collaboration_revue_anniversary: {
-        english: "Collaboration with the revue's anniversary committee*",
-        norwegian: 'Samarbeid med Revyen sitt Jubileum*',
-      },
-      */
-  /*   collaboration_revue: {
-        norwegian: 'Samarbeid med Revyen**',
-        english: 'Collaboration with the revue**',
-      }, */
+  collaboration_revue: {
+    norwegian: 'Samarbeid med Revyen',
+    english: 'Collaboration with the revue',
+  },
+  // collaboration_anniversary: {
+  //   english: "Collaboration with Abakus' anniversary committee*",
+  //   norwegian: 'Samarbeid med Abakus sitt Jubileum*',
+  // },
+  // collaboration_revue_anniversary: {
+  //   english: "Collaboration with the revue's anniversary committee*",
+  //   norwegian: 'Samarbeid med Revyen sitt Jubileum*',
+  // },
 };
+
 export const TARGET_GRADES = {
   '1': {
     norwegian: '1. klasse',


### PR DESCRIPTION
# Description

After last nights updates to the company interest page, a few other pages that used `MultipleSelectGroup` broke. This was because a `FormSpy` was added to `MultipleSelectGroup`, and as that is a `react-final-form` feature, all non-`react-finial-form`-forms that used `MultipleSelectGroup` broke. So, this PR rewites all these forms to `react-final-form` (as well as rewiting one of them to a functional component). 

This PR also adds and removes some events from the company interest page as requested by Bedkom:)

# Result

No visual results, except that the forms are now working again.

# Testing

- [x] I have thoroughly tested my changes.
