### PR TITLE
Fix invisible export to CSV button

### DIFF
--- a/app/components/Tooltip/index.tsx
+++ b/app/components/Tooltip/index.tsx
@@ -10,6 +10,7 @@ type Props = {
   onClick?: () => void;
   placement?: 'top' | 'bottom' | 'left' | 'right';
   style?: CSSProperties;
+  disabled?: boolean;
 };
 
 const Tooltip = ({
@@ -19,6 +20,7 @@ const Tooltip = ({
   onClick,
   placement,
   style,
+  disabled,
 }: Props) => {
   const [hovered, setHovered] = useState(false);
   const tooltipRef = useRef<HTMLDivElement>(null);
@@ -54,10 +56,10 @@ const Tooltip = ({
   });
 
   useEffect(() => {
-    if (hovered && update !== null) {
+    if (hovered && !disabled && update !== null) {
       update();
     }
-  }, [hovered, update]);
+  }, [hovered, disabled, update]);
 
   const tooltipClass = hovered ? styles.baseTooltipHover : styles.tooltip;
 

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -233,11 +233,7 @@ class CompanyInterestList extends Component<Props, State> {
             </a>
           ) : (
             <Tooltip
-              style={
-                this.props.selectedSemesterOption.year
-                  ? { display: 'none' }
-                  : undefined
-              }
+              disabled={!!this.props.selectedSemesterOption.id}
               content={'Vennligst velg semester'}
             >
               <Button
@@ -248,7 +244,7 @@ class CompanyInterestList extends Component<Props, State> {
                     ),
                   })
                 }
-                disabled={!this.props.selectedSemesterOption.year}
+                disabled={!this.props.selectedSemesterOption.id}
               >
                 Eksporter til CSV
               </Button>


### PR DESCRIPTION
# Description

Fixes a bug where the "Eksporter til CSV"-button on the company interest list disappears when choosing a semester. Previously you would set the Tootltip to `display: none` when not wanting to show the helper text, but this would also hide all child components. The bug is fixed by introducing a new `disabled` prop to the Tooltip component.

# Result

### Before
When not having a semester selected the button is disabled and a tooltip is shown:
<img width="1126" alt="Screenshot 2023-09-29 at 22 19 27" src="https://github.com/webkom/lego-webapp/assets/99358375/574200e3-aaac-4fe5-a920-3b5daf090de8"><br>

When choosing a semester the button disappears:
<img width="1124" alt="Screenshot 2023-09-29 at 22 19 33" src="https://github.com/webkom/lego-webapp/assets/99358375/da47719c-dfb1-4943-aaff-06bfe01b7ed2">

### After
<img width="1121" alt="Screenshot 2023-09-29 at 22 33 43" src="https://github.com/webkom/lego-webapp/assets/99358375/daa74450-7620-457a-ad73-f60e308d8c53">


# Testing

- [x] I have thoroughly tested my changes.
