### PR TITLE
Update navlinks to use gap instead of margin

### DIFF
--- a/app/components/NavigationTab/NavigationLink.css
+++ b/app/components/NavigationTab/NavigationLink.css
@@ -3,7 +3,6 @@
   align-items: center;
   width: fit-content;
   height: 2em;
-  margin-right: 0.5rem;
   padding: 0 0.75rem;
   background-color: var(--additive-background);
   border-radius: var(--border-radius-md);

--- a/app/components/NavigationTab/NavigationTab.css
+++ b/app/components/NavigationTab/NavigationTab.css
@@ -24,6 +24,7 @@
   display: flex;
   flex-flow: row wrap;
   align-items: center;
+  gap: 0.5rem;
 }
 
 .back {


### PR DESCRIPTION
Give navlinks vertical distance when they wrap.

# Description

Smol visible change

# Result

### Before
<img width="319" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/b6d91108-2d6b-41b9-a251-17ba77dda142">

### After:
<img width="338" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/004c3097-60e8-4436-bef1-ae0c207dd215">

# Testing

- [x] I have thoroughly tested my changes.

Visited a few places they were used on mobile and desktop sizes - seems okidoks to me

---


