### PR TITLE
Replace abascan popups with a list of recent scans

### DIFF
--- a/app/actions/EventActions.ts
+++ b/app/actions/EventActions.ts
@@ -308,9 +308,6 @@ export function markUsernamePresent(
     body: {
       username,
     },
-    meta: {
-      errorMessage: 'Oppdatering av tilstedeværelse feilet',
-    },
   });
 }
 export function updatePresence(

--- a/app/components/UserValidator/Validator.css
+++ b/app/components/UserValidator/Validator.css
@@ -1,28 +1,5 @@
 @import url('~app/styles/variables.css');
 
-.overlay {
-  z-index: 100;
-  position: absolute;
-  left: 0;
-  right: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  padding: 45px;
-  background: var(--color-white);
-  margin: 0 35%;
-  border: 10px solid #fbfbfb;
-  border-radius: var(--border-radius-lg);
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity var(--linear-slow), visibility var(--linear-slow);
-
-  @media (--mobile-device) {
-    margin: 0 5%;
-  }
-}
-
 .scannerModal {
   text-align: center;
 }
@@ -35,9 +12,4 @@
   display: flex;
   align-items: center;
   margin-right: 0.2rem;
-}
-
-.shown {
-  visibility: visible;
-  opacity: 1;
 }

--- a/app/components/UserValidator/index.tsx
+++ b/app/components/UserValidator/index.tsx
@@ -1,14 +1,15 @@
 import { Button } from '@webkom/lego-bricks';
-import cx from 'classnames';
 import { get } from 'lodash';
 import { useCallback, useRef, useState } from 'react';
 import { QrReader } from 'react-qr-reader';
+import type { addToast } from 'app/actions/ToastActions';
 import goodSound from 'app/assets/good-sound.mp3';
 import Icon from 'app/components/Icon';
 import Modal from 'app/components/Modal';
 import SearchPage from 'app/components/Search/SearchPage';
 import type { User } from 'app/models';
 import type { UserSearchResult } from 'app/reducers/search';
+import { Flex } from '../Layout';
 import styles from './Validator.css';
 import type { ComponentProps } from 'react';
 import type { Required } from 'utility-types';
@@ -19,10 +20,16 @@ type Res = {
   payload: unknown;
 };
 
+type ScanResult = {
+  message: string;
+  count: number;
+};
+
 type Props = Omit<
   ComponentProps<typeof SearchPage<UserSearchResult>>,
   'handleSelect'
 > & {
+  addToast: typeof addToast;
   clearSearch: () => void;
   handleSelect: (arg0: UserWithUsername) => Promise<User | Res>;
   onQueryChanged: (arg0: string) => void;
@@ -36,40 +43,94 @@ const isUser = (user: User | Res): user is User => {
 };
 
 const Validator = (props: Props) => {
-  const { clearSearch, handleSelect, validateAbakusGroup } = props;
+  const { addToast, clearSearch, handleSelect, validateAbakusGroup } = props;
   const input = useRef<HTMLInputElement | null | undefined>(null);
-  const [completed, setCompleted] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [scanResults, setScanResults] = useState<ScanResult[]>([]);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [showScanner, setShowScanner] = useState(false);
 
-  const showCompleted = () => {
-    setCompleted(true);
-    setTimeout(() => setCompleted(false), 2000);
+  const showSuccessModal = (message: string) => {
+    setSuccessMessage(message);
+    setTimeout(() => setSuccessMessage(null), 2000);
   };
 
+  /**
+   * Add new scan result to the start of the array if not duplicate of most recent result,
+   * if not increase the count
+   *
+   * @param {string} result The newest scan
+   * @returns void
+   */
+  const addScanResult = (result: string) => {
+    setScanResults((prevScanResults) => {
+      if (
+        prevScanResults.length !== 0 &&
+        prevScanResults[0].message === result
+      ) {
+        prevScanResults[0].count++;
+        return prevScanResults;
+      }
+      return [{ message: result, count: 1 }, ...prevScanResults].slice(0, 5);
+    });
+  };
+
+  /**
+   * Display search results depending on the current view
+   *
+   * @param {string}  result          The result from the API call
+   * @param {boolean} [success=false] Whether the API call was fetched successfully or not
+   * @returns void
+   */
+  const displayResult = useCallback(
+    (result: string, success = false) => {
+      if (showScanner) {
+        addScanResult(result);
+        return;
+      }
+      if (success) {
+        showSuccessModal(result);
+      } else {
+        addToast({ message: result });
+      }
+    },
+    [addToast, showScanner]
+  );
+
+  /**
+   * Handle selection/scan of user and process the result
+   */
   const onSelect = useCallback(
-    (result: UserWithUsername) => {
+    ({ username }: UserWithUsername) => {
       clearSearch();
-      return handleSelect(result)
+      setIsLoading(true);
+      return handleSelect({ username })
         .then(
           (user) => {
+            setIsLoading(false);
             if (!validateAbakusGroup || (isUser(user) && user.isAbakusMember)) {
               const sound = new window.Audio(goodSound);
               sound.play();
-              showCompleted();
+              if (validateAbakusGroup) {
+                displayResult(`${username} er Abakus-medlem`, true);
+              } else {
+                displayResult(`${username} ble registrert`, true);
+              }
             } else {
-              alert('Brukeren er ikke medlem av Abakus!');
+              displayResult(`${username} er ikke medlem av Abakus!`);
             }
           },
           (err) => {
+            setIsLoading(false);
             const payload = get(err, 'payload.response.jsonData');
             if (payload && payload.errorCode === 'not_registered') {
-              alert('Bruker er ikke påmeldt på eventet!');
+              displayResult(`${username} er ikke påmeldt arrangementet`);
             } else if (payload && payload.errorCode === 'already_present') {
-              alert(payload.error);
+              displayResult(`${username} er allerede registrert`);
             } else if (payload && payload.detail === 'Not found.') {
-              alert(`Brukeren finnes ikke!\nBrukernavn: ${result.username}`);
+              displayResult(`Brukeren finnes ikke!\nBrukernavn: ${username}`);
             } else {
-              alert(
+              displayResult(
                 `Det oppsto en uventet feil: ${JSON.stringify(payload || err)}`
               );
             }
@@ -81,36 +142,38 @@ const Validator = (props: Props) => {
           }
         });
     },
-    [clearSearch, handleSelect, validateAbakusGroup]
+    [clearSearch, displayResult, handleSelect, validateAbakusGroup]
   );
 
   const handleScannerResult = (scannerResult: string) => {
-    if (scannerResult.length > 0 && !completed) {
-      onSelect({
-        username: scannerResult,
-      });
+    if (scannerResult.length > 0 && !isLoading && !successMessage) {
+      onSelect({ username: scannerResult });
     }
   };
 
   return (
     <>
-      <div
-        className={cx(styles.overlay, {
-          [styles.shown]: completed,
-        })}
+      <Modal
+        show={successMessage !== null}
+        onHide={() => setSuccessMessage(null)}
       >
-        <h3>
-          Tusen takk! Kos deg{' '}
-          <span role="img" aria-label="smile">
-            😀
-          </span>
-        </h3>
-        <Icon name="checkmark" success size={160} />
-      </div>
+        <Flex
+          alignItems="center"
+          column
+          justifyContent="center"
+          padding={'2rem 0'}
+        >
+          <h3>{successMessage}</h3>
+          <Icon name="checkmark" success size={160} />
+        </Flex>
+      </Modal>
       <Modal
         contentClassName={styles.scannerModal}
         show={showScanner}
-        onHide={() => setShowScanner(false)}
+        onHide={() => {
+          setShowScanner(false);
+          setScanResults([]);
+        }}
       >
         <h1>Scan ABA-ID</h1>
         <QrReader
@@ -127,6 +190,19 @@ const Validator = (props: Props) => {
             facingMode: 'environment',
           }}
         />
+        <h3>Nylig scannede ABA-IDer</h3>
+        <Flex column justifyContent="center" gap={5}>
+          {scanResults.map(({ message, count }) => (
+            <span key={message + count}>
+              {message} (x{count})
+            </span>
+          ))}
+          {scanResults.length === 0 && (
+            <span className="secondaryFontColor">
+              De 5 siste ABA-IDene du scanner vises her
+            </span>
+          )}
+        </Flex>
       </Modal>
       <Button
         className={styles.scannerButton}

--- a/app/routes/events/EventAbacardRoute.ts
+++ b/app/routes/events/EventAbacardRoute.ts
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { markUsernamePresent } from 'app/actions/EventActions';
 import { autocomplete } from 'app/actions/SearchActions';
+import { addToast } from 'app/actions/ToastActions';
 import { getRegistrationGroups } from 'app/reducers/events';
 import { selectAutocompleteRedux as selectAutocomplete } from 'app/reducers/search';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
@@ -40,6 +41,7 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = (dispatch, { eventId }) => {
   const url = `/events/${eventId}/administrate/abacard?q=`;
   return {
+    addToast: (args: Parameters<typeof addToast>) => dispatch(addToast(args)),
     clearSearch: () => dispatch(replace(url)),
     markUsernamePresent: (eventId: number, username: string) =>
       dispatch(markUsernamePresent(eventId, username)),

--- a/app/routes/events/components/EventAdministrate/Abacard.tsx
+++ b/app/routes/events/components/EventAdministrate/Abacard.tsx
@@ -1,4 +1,5 @@
 import { get } from 'lodash';
+import type { addToast } from 'app/actions/ToastActions';
 import Validator from 'app/components/UserValidator';
 import type { EventRegistration, Event } from 'app/models';
 import type { UserSearchResult } from 'app/reducers/search';
@@ -14,6 +15,7 @@ type Props = {
   onQueryChanged: (arg0: string) => void;
   results: Array<UserSearchResult>;
   searching: boolean;
+  addToast: typeof addToast;
 };
 
 const Abacard = (props: Props) => {

--- a/app/routes/userValidator/ValidatorRoute.tsx
+++ b/app/routes/userValidator/ValidatorRoute.tsx
@@ -4,6 +4,7 @@ import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { autocomplete } from 'app/actions/SearchActions';
+import { addToast } from 'app/actions/ToastActions';
 import { fetchUser } from 'app/actions/UserActions';
 import { Content } from 'app/components/Content';
 import Validator from 'app/components/UserValidator';
@@ -44,6 +45,7 @@ const mapDispatchToProps = (dispatch, { location }) => {
   });
 
   return {
+    addToast: (args: Parameters<typeof addToast>) => dispatch(addToast(args)),
     clearSearch: () =>
       dispatch(push(`/validator?${qs.stringify({ ...search, q: '' })}`)),
 


### PR DESCRIPTION
# Description

Changes in how abacard handles responses
* Avoids using `alert()` or other elements that require the user to interact with them (`Modal` is used, but it is set to close by itself)
* Remove custom overlay code and replace it with `Modal` component
* Search by username: Displays responses using Modal and Toast
* Scan by ABAID: Displays responses in a list displaying the 5 most recent responses
* Displays a different feedback when it is used through `/validator` route than through `Abacard` route to emphasize what the result actually means.

This does nothing to solve the double-scanning, but it handles it quite a bit more gracefully - which was the main problem to be solved. If someone wants to ratelimit the amount of times requests for the same user is sent - feel free, it's a pretty minimal change.

# Result

<table>
<tr>
 <th>
 <th> Before
 <th> After
<tr>
 <td>Before scanning
 <td><img width="371" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/dc7b254c-f738-4060-bacb-94960751ee6b">
 <td><img width="374" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/c89a43a6-9fcd-4294-9f44-b31ff2418c49">
<tr>
 <td>After registering (with abaid)
 <td><img width="371" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/0263ec09-8852-443f-ba02-78c712d878b4">
<img width="456" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/a2664862-2b43-49d3-8d9f-df749fa76a5b">
Both happen pretty much at the same time
 <td><img width="371" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/e4b68597-fa4e-44fe-b384-964a50c4f051">
If the last message received matches the new message, the counter for that message updates. If not it displays as a new row.
<tr>
 <td>After registering (with search)
 <td><img width="372" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/2aa8848f-7f2e-41b4-8658-f8c9ff7691ca">
 <td><img width="372" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/e5a01366-7f95-4a19-a4af-946cd1b3bce6">
<tr>
 <td>After faulty register (with search)
 <td><img width="456" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/a2664862-2b43-49d3-8d9f-df749fa76a5b">
 <td><img width="373" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/61a09057-d4f7-484e-80ba-84e603343b70">
Using toasts
</table>



# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-449
