### PR TITLE
Make tags inline-flex instead of flex

### DIFF
--- a/app/components/Tags/Tag.css
+++ b/app/components/Tags/Tag.css
@@ -40,7 +40,7 @@
     min(calc((var(--perceived-lightness) - var(--border-threshold)) * 100), 1)
   );
 
-  display: flex;
+  display: inline-flex;
   color: hsl(0deg, 0%, calc(var(--lightness-switch) * 100%));
   background: rgb(var(--label-r), var(--label-g), var(--label-b));
   border-color: hsla(


### PR DESCRIPTION
# Description

Makes tags take up only the space they need, and as such avoid the "bugs" that have been occurring on the website as of late when tags take up too much space or do not adhere to margins/gaps.

# Result

<table>
<tr>
 <td>
 <td>Before
 <td>After
<tr>
 <td>Admin email-lists
 <td> <img width="271" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/a6718381-5373-4b66-934f-48568a7ae2c0">
 <td>  <img width="269" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/3681749e-87d9-4336-bd85-ecbca4e1852c">
<tr>
 <td>Admin email-users
 <td> <img width="196" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/8681c938-57a4-4d4e-bd40-ec99a8d59f03">
 <td>  <img width="175" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/b092f6a7-19e0-40a7-b984-173086754279">
<tr>
 <td>Admin restricted-mail
 <td><img width="183" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/b6277c71-b605-4417-bd48-7f26e513010c">
 <td><img width="179" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/9770881e-ab3a-4a49-ab3a-b60f061d54bb">
<tr>
 <td>Articles-overview
 <td><img width="310" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/bfa1724b-9b18-496f-8239-ac4b582c9586">
 <td><img width="306" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/f21f6e7b-cfcd-4fa0-9850-99d32962aa90">
<tr>
 <td>New joblistings
 <td><img width="150" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/aec04a58-7553-4526-a33e-d1ff1ede6b8e">
 <td><img width="199" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/67677bce-5c22-4e6a-8655-47a76930db4e">
</table>

# Testing

- [ ] I have thoroughly tested my changes.

Visited all the places I could find that tags are used locally, and it seemed to work quite nice.

---

Resolves ABA-582
