### PR TITLE
Fix adding new company through interest form

### DIFF
--- a/app/components/Form/SelectInput.tsx
+++ b/app/components/Form/SelectInput.tsx
@@ -32,6 +32,8 @@ type Props = {
   value: any;
   disabled?: boolean;
   options?: Record<string, any>[];
+  creatable?: boolean;
+  isMulti?: boolean;
 };
 
 export const selectStyles = {
@@ -100,9 +102,15 @@ function SelectInput({
   options = [],
   disabled = false,
   placeholder,
+  creatable,
   ...props
 }: Props) {
   if (props.tags) {
+    creatable = true;
+    props.isMulti = true;
+  }
+
+  if (creatable) {
     return (
       <div className={style.field}>
         <Creatable
@@ -110,7 +118,7 @@ function SelectInput({
           isDisabled={disabled}
           placeholder={!disabled && placeholder}
           instanceId={name}
-          isMulti
+          isMulti={props.isMulti}
           onBlur={() => onBlur(value)}
           value={value}
           isValidNewOption={isValidNewOption}

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -322,8 +322,18 @@ const requiredIfEventType = (eventType: string) =>
     return event && event.checked;
   });
 
+const validateCompany = (value) => {
+  if (!value) {
+    return [false, 'Du må velge en bedrift'] as const;
+  } else if (value['__isNew__'] || !value.value) {
+    return [!!value.label, 'Ny bedrift må ha et navn'] as const;
+  } else {
+    return [typeof value?.value !== 'number', 'Ugyldig bedrift'] as const;
+  }
+};
+
 const validate = createValidator({
-  company: [required()],
+  company: [validateCompany],
   contactPerson: [required()],
   mail: [required(), isEmail()],
   phone: [required()],
@@ -348,8 +358,10 @@ const CompanyInterestPage = (props: Props) => {
 
   const onSubmit = (data) => {
     const { company } = data;
-    const companyId = company['value'] ? Number(company['value']) : null;
-    const companyName = companyId === null ? company['label'] : '';
+    const nameOnly = company['__isNew__'] || !company.value;
+    const companyId = nameOnly ? null : company['value'];
+    const companyName = nameOnly ? company['label'] : '';
+
     const [range_start, range_end] = data.participantRange
       ? PARTICIPANT_RANGE_MAP[data.participantRange]
       : [null, null];
@@ -447,6 +459,7 @@ const CompanyInterestPage = (props: Props) => {
               filter={['companies.company']}
               fieldClassName={styles.metaField}
               component={SelectInput.AutocompleteField}
+              creatable
               required
             />
             <Field


### PR DESCRIPTION
# Description

I think the refactor to react-final-form must have broken the feature where one could add a new company in the company interest form, if it wasn't already in our database.

# Result

I made some small front-end only changes to make it send the new company name in the correct format.

# Testing

- [x] I have thoroughly tested my changes.

I have sent in a few company interest forms to test. It works well when creating new company interests. It's a teensy bit buggy when editing the name, but do we ever do that?
I think it's fine for a quick fix.

---
