### PR TITLE
Remove extra divs wrapping NavLinks

### DIFF
--- a/app/routes/admin/groups/components/GroupPage.tsx
+++ b/app/routes/admin/groups/components/GroupPage.tsx
@@ -11,7 +11,7 @@ import type { Location } from 'history';
 const NavigationLinks = ({ groupId }: { groupId: string }) => {
   const baseUrl = `/admin/groups/${groupId}`;
   return (
-    <div>
+    <>
       <NavigationLink to={`${baseUrl}/settings`}>Rediger</NavigationLink>
       <NavigationLink to={`${baseUrl}/members?descendants=false`}>
         Medlemmer
@@ -20,7 +20,7 @@ const NavigationLinks = ({ groupId }: { groupId: string }) => {
         Implisitte medlemmer
       </NavigationLink>
       <NavigationLink to={`${baseUrl}/permissions`}>Rettigheter</NavigationLink>
-    </div>
+    </>
   );
 };
 

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -158,14 +158,14 @@ export default class GalleryDetail extends Component<Props, State> {
           }
         >
           {actionGrant?.includes('edit') && (
-            <div>
+            <>
               <NavigationLink to="#" onClick={() => this.toggleUpload()}>
                 Last opp bilder
               </NavigationLink>
               <NavigationLink to={`/photos/${gallery.id}/edit`}>
                 Rediger
               </NavigationLink>
-            </div>
+            </>
           )}
         </NavigationTab>
 


### PR DESCRIPTION
# Description

Realized that I missed two places when I checked the effect of replacing margins with gap in #4157. Namely group admin site and gallery details. Searched through all occurrences of NavLink now, and these were the only ones wrapped in extra divs I could find - so all else should be good.

# Result

<table>
<tr>
 <td>
 <td>Before
 <td>After
<tr>
 <td>Admin group-details
 <td><img width="508" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/ca55752e-4e2e-4de6-9930-38ee2fb1678a">
 <td><img width="529" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/a9dd08d8-de0a-4631-9732-0b26800c916b">
<tr>
 <td>Gallery detail
 <td><img width="251" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/c4dfe2f2-604f-4abf-9834-e1e44beaaabe">
 <td><img width="262" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/535c35d3-2549-472a-b516-676085d810e3">
</table>

# Testing

- [ ] I have thoroughly tested my changes.


