### PR TITLE
Make react-cropper take up the full width of picture

### DIFF
--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -280,6 +280,7 @@ export default class ImageUpload extends Component<Props, State> {
                 className={styles.cropper}
                 aspectRatio={aspectRatio}
                 guides={false}
+                autoCropArea={1}
               />
             )}
             {multiple && !crop && (


### PR DESCRIPTION
# Description

Small thing to make cropper take as much as possible of the image (width-wise).  
Seemingly all aspect ratios were already correct

# Result
Good boy

### After (Shiba happy)
![Skjermbilde 2023-10-04 kl  21 24 11](https://github.com/webkom/lego-webapp/assets/64247965/28fa43db-a563-447f-867a-e922f7194dcd)


### Before (Shiba scared)
![Skjermbilde 2023-10-04 kl  21 22 00](https://github.com/webkom/lego-webapp/assets/64247965/d29039ae-b2d3-4a85-b1b0-8504260b5622)

# Testing

- [x] I have thoroughly tested my changes.
Looked through all usages of ImageUpload

---

Resolves ABA-450
