### PR TITLE
Bump mazemap from 2.0.63 to 2.0.96

### DIFF
--- a/app/components/MazemapEmbed/MazemapEmbed.css
+++ b/app/components/MazemapEmbed/MazemapEmbed.css
@@ -9,3 +9,7 @@
   width: 100%;
   transform: translate(-50%, -50%);
 }
+
+.mazemapEmbed {
+  --lego-font-color: var(--color-absolute-black);
+}

--- a/app/components/MazemapEmbed/index.tsx
+++ b/app/components/MazemapEmbed/index.tsx
@@ -3,6 +3,14 @@ import 'node_modules/mazemap/mazemap.min.css';
 import styles from './MazemapEmbed.css';
 import MazemapLink from './MazemapLink';
 
+type MazeMap = {
+  Map: any;
+  Data: any;
+  MazeMarker: any;
+  Util: any;
+  Highlighter: any;
+};
+
 type Props = {
   mazemapPoi: number;
   height?: number;
@@ -18,7 +26,7 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
   const [hasMounted, setHasMounted] = useState<boolean>(false);
   useEffect(() => setHasMounted(true), []);
   //import Mazemap dynamically to prevent ssr issues
-  const [Mazemap, setMazemap] = useState(null);
+  const [Mazemap, setMazemap] = useState<MazeMap>(null);
   const [blockScrollZoom, setBlockScrollZoom] = useState<boolean>(false);
   const [blockTouchMovement, setBlockTouchZoom] = useState<boolean>(false);
   //initialize map only once, mazemapPoi will probably not change

--- a/app/components/MazemapEmbed/index.tsx
+++ b/app/components/MazemapEmbed/index.tsx
@@ -184,6 +184,7 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
           touchAction: 'pan-x pan-y',
         }}
         id="mazemap-embed"
+        className={styles.mazemapEmbed}
       >
         {(blockScrollZoom || blockTouchMovement) && (
           <span className={styles.blockingText}>

--- a/app/components/Search/mazemapAutocomplete.tsx
+++ b/app/components/Search/mazemapAutocomplete.tsx
@@ -87,6 +87,7 @@ function mazemapAutocomplete<Props>({
                 ),
               });
             })
+            .catch((error) => {})
             .finally(() =>
               this.setState({
                 searching: false,

--- a/app/components/Search/mazemapAutocomplete.tsx
+++ b/app/components/Search/mazemapAutocomplete.tsx
@@ -87,7 +87,7 @@ function mazemapAutocomplete<Props>({
                 ),
               });
             })
-            .catch((error) => {})
+            .catch(() => {})
             .finally(() =>
               this.setState({
                 searching: false,

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -28,6 +28,7 @@
 
   --color-absolute-white: #fff; /* White on dark mode as well */
   --color-white: var(--color-absolute-white);
+  --color-absolute-black: #000; /* Black on dark mode as well */
   --color-black: #000;
 
   --border-gray: var(--color-gray-2);

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -201,7 +201,7 @@ describe('Create meeting', () => {
     setDatePickerTime('startTime', '17', '15');
     setDatePickerTime('endTime', '20', '00');
     field('useMazemap').click();
-    selectFromSelectField('mazemapPoi', 'Abakus, Realfagbygget', 'a');
+    selectFromSelectField('mazemapPoi', 'Abakus, Realfagbygget', 'abakus');
     selectFromSelectField('users', 'bedkom bedkom (bedkom)', 'bedkom');
 
     selectEditor().type('{enter}{enter}Meeting report');

--- a/mazemap/package.json
+++ b/mazemap/package.json
@@ -1,12 +1,12 @@
 {
   "name": "mazemap",
-  "version": "2.0.63",
+  "version": "2.0.96",
   "main": "mazemap.min.js",
   "license": "",
   "author": "Dag Jomar Mersland <dagjomar@mazemap.com>",
   "dependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "sh install.sh 2.0.63"
+    "install": "sh install.sh 2.0.96"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11113,7 +11113,7 @@ mathml-tag-names@^2.1.3:
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
 
 "mazemap@file:mazemap":
-  version "2.0.63"
+  version "2.0.96"
 
 md5-hex@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
# Description

Bumps mazemap from 2.0.63 to 2.0.96
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://api.mazemap.com/js/v2.0.106/docs/#release">mazemaps api docs</a>.</em></p>
<blockquote>
version 2.0.96

May 5, 2023

    Update a console error to include missing error information

version 2.0.95

March 21, 2023

    Minor change in the [JSAPI as NPM Module + React](https://api.mazemap.com/js/v2.0.106/docs/#ex-jsapi-module-import-react-project) example.

version 2.0.94

February 28, 2023

    Fixed bug where icon images could sometimes have wrong offset.

version 2.0.93

January 25, 2023

    Make the Mazemap.Config.getSearchApiBaseUrl() include /search by default. Should not affect any existing integrations unless you are manually setting the search api base url using Mazemap.Config.setSearchApiBaseUrl()
    Switch from devtiles.mazemap.com to staging-tiles.mazemap.com as tile server for the staging environment.
    Added a basic venue/conference app integration solution example
    Enable Ambient Occlusion shadow rendering by default in 3d mode.

version 2.0.92

January 20, 2023

    Upgrade Mapbox GL version from 2.8.2 to 2.12.0. https://github.com/mapbox/mapbox-gl-js/releases

version 2.0.91

December 21, 2022

    Fixed a bug where the floorId returned by the Mazemap.Util.getMapClickData function would point to the outline id instead of floor id.

version 2.0.90

December 15, 2022

    Turned on options.antialias by default on the map object for increasing visual quality of lines and 3d objects.

version 2.0.89

December 14, 2022

    Fixed a bug in the map zLevelUpdater when using buildingClosestToCenter option. It would sometimes set an empty object of zLevels instead of refreshing properly.

version 2.0.88

December 13, 2022

    Added imgOffsetLeft and imgOffsetTop options to MazeMarker.

version 2.0.87

December 12, 2022

    Fixed CORS issue with routing arrow png image.
    Updated [BlueDot](https://api.mazemap.com/js/v2.0.106/docs/#api-bluedot) documentation, describing how the zLevel can be set to null for outdoor/unknown floor, and adding examples of how this is visualized in the map.
    Added documentation in API Reference: [BlueDot](https://api.mazemap.com/js/v2.0.106/docs/#api-bluedot)
    See [Basic BlueDot](https://api.mazemap.com/js/v2.0.106/docs/#ex-bluedot-basic) example and [BlueDot Location Controller](https://api.mazemap.com/js/v2.0.106/docs/#ex-bluedot-location-controller) example.

version 2.0.86

December 6, 2022

    Added support for [Basic 3D Maps](https://api.mazemap.com/js/v2.0.106/docs/#ex-basic-3d). See example page.

version 2.0.85

December 5, 2022

    Fixed bug: There was a minor visual bug in the [BlueDot](https://api.mazemap.com/js/v2.0.106/docs/#ex-bluedot-basic) direction/bearing indication, where it could sometimes overshoot the animation and look weird.

version 2.0.84

November 30, 2022

    Added experimental zLevelUpdaterType: 'userFocused' floor level handler, available as new [Map options](https://api.mazemap.com/js/v2.0.106/docs/#api-map).

version 2.0.83

November 18, 2022

    Minor adjustments to api reference documentation

version 2.0.82

November 17, 2022

    Added support for directional arrows on routes. See option showDirectionArrows on the [RouteController](https://api.mazemap.com/js/v2.0.106/docs/#api-routecontroller) class. This is off by default and can be turned on by setting the option to true. See the [Basic Route](https://api.mazemap.com/js/v2.0.106/docs/#ex-route-basic) for a visual example of how this looks.
    Added support for different route colors for DRIVE and BICYCLE segments. These colors are customizable in the [RouteController](https://api.mazemap.com/js/v2.0.106/docs/#api-routecontroller) class.

version 2.0.80

October 31, 2022

    Added an optional visual component to the [BlueDot](https://api.mazemap.com/js/v2.0.106/docs/#ex-bluedot-basic) class to indicate direction/bearing.

version 2.0.75

August 26, 2022

    Minor changes to the position of map attribution control and size of MazeMap logo.

version 2.0.74

June 22, 2022

    Added externalId to campus data model.

version 2.0.72

May 23, 2022

    Changed the default outdoor base map style to "v2022", with more visible car parks and green areas.

version 2.0.70

March 31, 2022

    Added [Show POI Information](https://api.mazemap.com/js/v2.0.106/docs/#ex-rich-poi) example to demonstrate how to show Rich Poi info, such as images.

version 2.0.66

Februrary 25, 2022

    Breaking change:
    Removed legacy Mazemap.Data.getPoiCategoryStyleById method.
    Breaking change:
    Renamed Mazemap.Data.getPoiCategoryIdsByCampusId to getSelectablePoiTypesForCampusId.
    Breaking change:
    Renamed Mazemap.Data.getPoisByCategoryAndCampusId to getPoisByTypeIdAndCampusIdAsGeoJSON.
    Updated [Fetching POI Types](https://api.mazemap.com/js/v2.0.106/docs/#ex-data-poi-types) example to use newly named methods and using new poi type icon url.

version 2.0.65

Februrary 24, 2022

    Added[ guidelines page](https://api.mazemap.com/js/v2.0.106/docs/#guidelines)
    Added getIconSvgUrl and getIconPngUrl. See [Data: Icons](https://api.mazemap.com/js/v2.0.106/docs/#api-data:-icons), and [Fetching Poi Type Example](https://api.mazemap.com/js/v2.0.106/docs/#ex-data-poi-types).

version 2.0.64

Februrary 9, 2022

    Improve theming of the floor selector control, adding a new activeColor option + setActiveColor(color) method.
    This makes it easier to programmatically set the color of the floor selector, without needing to specify CSS overrides in a stylesheet.
</blockquote>
</details>

# Result

Seemingly everything works like before but it should now use a newer mapbox version.   
(Newest version doesnt work with our webpack config)

# Testing

- [x] I have thoroughly tested my changes.
Map and search still works

