### PR TITLE
Define padding for header icons

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -42,6 +42,11 @@
   width: 160px;
 }
 
+.buttonGroup button {
+  flex-shrink: 0;
+  padding: 0 7px;
+}
+
 .buttonGroup button,
 .buttonGroup img {
   border: 0;


### PR DESCRIPTION
# Description

Changes:

* Add `flex-shrink: 0;` to prevent profile picture to shrink to an oval when it doesn't have enough space. This rather forces the Abakus-logo to scale down if the screen is too small (however with screens that small we have bigger problems than the logo..).
* Add padding to the button element wrapping header icons, as it was not defined (aka left up to the browser to decide). Thus caused Safari to have twice the paddings that Chrome has, and as such the header looked very off on iPhones.

Chrome's default padding for buttons is `1px 6px`, so the added `0 7px` looks quite similar to what it looks like in my browser - except that it's now the same across browsers.

# Result

Note that the before-version doesn't look *that* off in this preview, but that is only because I couldn't login - and when you're not logged in it doesn't show as many icons in the header.

<table>
<tr>
 <th>
 <th>Before
 <th>After


<tr>
 <td>iPhone 13
 <td>

![IMG_2201](https://github.com/webkom/lego-webapp/assets/13599770/cb603afc-427f-4ed9-a515-437669e9164a)

 <td>

![IMG_2200](https://github.com/webkom/lego-webapp/assets/13599770/cf2345bb-5abd-4a23-8afb-53c799e986a2)

<tr>
 <td>Chrome devtools with the same viewport
 <td><img width="390" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/9c920df8-9b28-49aa-963b-473e96bfda60">
 <td><img width="392" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/378402b1-7036-4fbc-8af2-9b8de2778acc">

</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-592
