### PR TITLE
Add wait to fix cypress comment test

### DIFF
--- a/cypress/e2e/event_visit_spec.js
+++ b/cypress/e2e/event_visit_spec.js
@@ -51,6 +51,8 @@ describe('View event', () => {
   it('Should be possible to comment', () => {
     cy.visit('/events/20');
 
+    cy.wait(500);
+
     cy.contains('button', 'Kommenter').should('not.be.visible');
     cy.get(c('CommentForm')).find('input').first().click();
     cy.focused().type('This event will be awesome');


### PR DESCRIPTION
# Description

I don't know why it didn't work, but waiting a bit fixes it.

# Result

# Testing

- [x] I have thoroughly tested my changes.

Cypress no logner fails. It consistently failed without the wait.

---

Resolves ... (either GitHub issue or Linear task)
