### PR TITLE
Remove random key from comment field

### DIFF
--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -48,21 +48,21 @@ const CommentForm = ({
     <Card>
       <LegoFinalForm
         validateOnSubmitOnly
-        initialValues={{
-          commentKey: Math.random(),
-        }}
         validate={validate}
-        onSubmit={({ text }) =>
+        onSubmit={({ text }, form) => {
+          // Clear the form value
+          form.change('text', undefined);
+
           dispatch(
             addComment({
               contentTarget,
               text,
               parent,
             })
-          )
-        }
+          );
+        }}
       >
-        {({ handleSubmit, values }) => {
+        {({ handleSubmit }) => {
           return (
             <form onSubmit={handleSubmit}>
               <Flex alignItems="center" gap="1rem">
@@ -70,7 +70,6 @@ const CommentForm = ({
 
                 <div className={styles.field}>
                   <Field
-                    key={values.commentKey}
                     autoFocus={autoFocus}
                     name="text"
                     placeholder={placeholder}

--- a/app/components/Form/TextInput.tsx
+++ b/app/components/Form/TextInput.tsx
@@ -1,17 +1,17 @@
 import cx from 'classnames';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
 import { createField } from './Field';
 import styles from './TextInput.css';
-import type { ReactNode, InputHTMLAttributes } from 'react';
+import type { ReactNode, InputHTMLAttributes, RefObject } from 'react';
 
 type Props = {
   type?: string;
   prefix?: ReactNode;
   suffix?: string;
   className?: string;
-  inputRef?: HTMLInputElement;
+  inputRef?: RefObject<HTMLInputElement>;
   disabled?: boolean;
   readOnly?: boolean;
   placeholder?: string;
@@ -32,8 +32,10 @@ const TextInput = ({
   centered = false,
   ...props
 }: Props) => {
-  /* New ref is made because text inputs that are not Fields are not given a ref */
-  const newInputRef = useRef<HTMLInputElement>(inputRef);
+  // New ref is made because text inputs that are not Fields are not given a ref
+  const newInputRef = useRef<HTMLInputElement>(null);
+  // Force use of inputRef from props if set, as newInputRef does not update the inputRef and parent components thus loose access
+  const ref = useMemo(() => inputRef ?? newInputRef, [inputRef, newInputRef]);
 
   return (
     <Flex
@@ -53,12 +55,12 @@ const TextInput = ({
         <Icon
           name={prefix}
           size={16}
-          onClick={() => newInputRef.current.focus()}
+          onClick={() => ref.current && ref.current.focus()}
           className={styles.prefix}
         />
       )}
       <input
-        ref={newInputRef}
+        ref={ref}
         type={type}
         placeholder={placeholder}
         disabled={disabled}

--- a/cypress/e2e/event_visit_spec.js
+++ b/cypress/e2e/event_visit_spec.js
@@ -51,8 +51,6 @@ describe('View event', () => {
   it('Should be possible to comment', () => {
     cy.visit('/events/20');
 
-    cy.wait(500);
-
     cy.contains('button', 'Kommenter').should('not.be.visible');
     cy.get(c('CommentForm')).find('input').first().click();
     cy.focused().type('This event will be awesome');


### PR DESCRIPTION
# Description

Removes the wait introduced in #4176 

`CommentField`s were set to have a random key (why I do not know), that would make it re-render excessively (and thus clear the focus and content of the new comment). This removes the key, and rather handles form resetting by using the `form.change()` method.

Changes done to `TextInput.ts` were done to avoid bugs that were discovered while trying another approach.
* When `inputRef` was used as a parameter in `useRef()`, it did not update `inputRef` when `newInputRef` was used. Thus it was not possible to pass a ref through to the component.
* Small typescript errors

# Result

When run on my machine this works quite well, and I can start writing comments before all the content of the page has been loaded - which was not the case previously.

To see if this resolves the cypress-bug, we'll probably have to wait and see. This passed cypress on the first attempt, but lately it has worked some times and some times not, so it's no guarantee.

# Testing

- [ ] I have thoroughly tested my changes.

Have been testing that the comment form works as expected in the event view.
