### PR TITLE
Add white-space attribute to tooltip

### DIFF
--- a/app/components/Tooltip/Tooltip.css
+++ b/app/components/Tooltip/Tooltip.css
@@ -31,6 +31,7 @@
   align-items: center;
   padding: 7px 11px;
   line-height: 1.3;
+  white-space: wrap;
 }
 
 .arrow {


### PR DESCRIPTION
# Description

Fixes the bug where the tooltip on the frontepage for "Festet event" would not wrap to multiple lines. Occurred due to inheriting styling from the compactEvent element.

# Result

## Before
<img width="356" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/b9699480-b5c7-432d-91b5-1e5e424cb0da">

## After
<img width="320" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/52512ba9-85b0-4909-8dee-dda66b9b9a58">


# Testing

- [ ] I have thoroughly tested my changes.



---

Resolves ABA-585
