### PR TITLE
Add registration activationTime to default EventItem card in eventlist

### DIFF
--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -75,13 +75,45 @@ const TimeStamp = ({ event }: TimeStampProps) => {
   return (
     <div className={styles.eventTime}>
       <Flex alignItems="center" gap={10}>
-        <Icon name="calendar-number-outline" size={20} />
+        <Tooltip content={"Arrangementsdato"}>
+          <Icon name="calendar-number-outline" size={20} />
+        </Tooltip>
         <Time time={event.startTime} format="ll" />
       </Flex>
       <Flex alignItems="center" gap={10}>
-        <Icon name="time-outline" size={20} />
+        <Tooltip content={"Starttidspunkt"}>
+          <Icon name="time-outline" size={20} />
+        </Tooltip>
         <Time time={event.startTime} format="HH:mm" />
       </Flex>
+    </div>
+  );
+};
+
+
+const TimeStartAndRegistration = ({ event }: TimeStampProps) => {
+  return (
+    <div className={styles.eventTime}>
+      <Flex alignItems="center" gap={10}>
+        <Tooltip content={"Arrangementstart"}>
+          <Icon name="calendar-number-outline" size={20} />
+        </Tooltip>
+        <Time time={event.startTime} format="ll" />
+        <Time time={event.startTime} format="HH:mm" />
+      </Flex>
+
+      {!!event.activationTime && (
+
+        <Flex alignItems="center" gap={10}>
+          <Tooltip content={"Påmelding åpner"}>
+            <Icon name="alarm-outline" size={20} />
+          </Tooltip>
+          <Time time={event.activationTime} format="ll" />
+          <Time time={event.activationTime} format="HH:mm" />
+        </Flex>
+      )
+
+      }
     </div>
   );
 };
@@ -199,7 +231,7 @@ const EventItem = ({
               <h3 className={styles.eventItemTitle}>{event.title}</h3>
               {event.totalCapacity > 0 && <Attendance event={event} />}
             </Link>
-            <TimeStamp event={event} />
+            <TimeStartAndRegistration event={event} />
             {showTags && (
               <Flex wrap>
                 {event.tags.map((tag, index) => (

--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -4,6 +4,7 @@ import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import Pill from 'app/components/Pill';
 import Tag from 'app/components/Tags/Tag';
+import TextWithIcon from 'app/components/TextWithIcon';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
 import type { Event } from 'app/models';
@@ -95,19 +96,23 @@ const TimeStartAndRegistration = ({ event }: TimeStampProps) => {
     <div className={styles.eventTime}>
       <Flex alignItems="center" gap={10}>
         <Tooltip content={'Arrangementstart'}>
-          <Icon name="calendar-number-outline" size={20} />
+          <TextWithIcon
+            iconName="calendar-number-outline"
+            content={<Time time={event.startTime} format="ll HH:mm" />}
+            className={styles.textWithIcon}
+          />
         </Tooltip>
-        <Time time={event.startTime} format="ll" />
-        <Time time={event.startTime} format="HH:mm" />
       </Flex>
 
       {!!event.activationTime && (
         <Flex alignItems="center" gap={10}>
           <Tooltip content={'Påmelding åpner'}>
-            <Icon name="alarm-outline" size={20} />
+            <TextWithIcon
+              iconName="alarm-outline"
+              content={<Time time={event.activationTime} format="ll HH:mm" />}
+              className={styles.textWithIcon}
+            />
           </Tooltip>
-          <Time time={event.activationTime} format="ll" />
-          <Time time={event.activationTime} format="HH:mm" />
         </Flex>
       )}
     </div>

--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -4,7 +4,6 @@ import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import Pill from 'app/components/Pill';
 import Tag from 'app/components/Tags/Tag';
-import TextWithIcon from 'app/components/TextWithIcon';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
 import type { Event } from 'app/models';
@@ -96,23 +95,17 @@ const TimeStartAndRegistration = ({ event }: TimeStampProps) => {
     <div className={styles.eventTime}>
       <Flex alignItems="center" gap={10}>
         <Tooltip content={'Arrangementstart'}>
-          <TextWithIcon
-            iconName="calendar-number-outline"
-            content={<Time time={event.startTime} format="ll HH:mm" />}
-            className={styles.textWithIcon}
-          />
+          <Icon name="calendar-number-outline" size={20} />
         </Tooltip>
+        <Time time={event.startTime} format="ll HH:mm" />
       </Flex>
 
       {!!event.activationTime && (
         <Flex alignItems="center" gap={10}>
           <Tooltip content={'Påmelding åpner'}>
-            <TextWithIcon
-              iconName="alarm-outline"
-              content={<Time time={event.activationTime} format="ll HH:mm" />}
-              className={styles.textWithIcon}
-            />
+            <Icon name="alarm-outline" size={20} />
           </Tooltip>
+          <Time time={event.activationTime} format="ll HH:mm" />
         </Flex>
       )}
     </div>

--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -75,13 +75,13 @@ const TimeStamp = ({ event }: TimeStampProps) => {
   return (
     <div className={styles.eventTime}>
       <Flex alignItems="center" gap={10}>
-        <Tooltip content={"Arrangementsdato"}>
+        <Tooltip content={'Arrangementsdato'}>
           <Icon name="calendar-number-outline" size={20} />
         </Tooltip>
         <Time time={event.startTime} format="ll" />
       </Flex>
       <Flex alignItems="center" gap={10}>
-        <Tooltip content={"Starttidspunkt"}>
+        <Tooltip content={'Starttidspunkt'}>
           <Icon name="time-outline" size={20} />
         </Tooltip>
         <Time time={event.startTime} format="HH:mm" />
@@ -90,12 +90,11 @@ const TimeStamp = ({ event }: TimeStampProps) => {
   );
 };
 
-
 const TimeStartAndRegistration = ({ event }: TimeStampProps) => {
   return (
     <div className={styles.eventTime}>
       <Flex alignItems="center" gap={10}>
-        <Tooltip content={"Arrangementstart"}>
+        <Tooltip content={'Arrangementstart'}>
           <Icon name="calendar-number-outline" size={20} />
         </Tooltip>
         <Time time={event.startTime} format="ll" />
@@ -103,17 +102,14 @@ const TimeStartAndRegistration = ({ event }: TimeStampProps) => {
       </Flex>
 
       {!!event.activationTime && (
-
         <Flex alignItems="center" gap={10}>
-          <Tooltip content={"Påmelding åpner"}>
+          <Tooltip content={'Påmelding åpner'}>
             <Icon name="alarm-outline" size={20} />
           </Tooltip>
           <Time time={event.activationTime} format="ll" />
           <Time time={event.activationTime} format="HH:mm" />
         </Flex>
-      )
-
-      }
+      )}
     </div>
   );
 };

--- a/app/components/EventItem/styles.css
+++ b/app/components/EventItem/styles.css
@@ -59,7 +59,3 @@
   object-fit: contain;
   background: white;
 }
-
-.textWithIcon {
-  font-size: var(--font-size-sm);
-}

--- a/app/components/EventItem/styles.css
+++ b/app/components/EventItem/styles.css
@@ -59,3 +59,7 @@
   object-fit: contain;
   background: white;
 }
+
+.textWithIcon {
+  font-size: var(--font-size-sm);
+}

--- a/app/routes/events/components/CalendarCell.tsx
+++ b/app/routes/events/components/CalendarCell.tsx
@@ -6,7 +6,7 @@ import { createSelector } from 'reselect';
 import Pill from 'app/components/Pill';
 import Popover from 'app/components/Popover';
 import TextWithIcon from 'app/components/TextWithIcon';
-import { FromToTime } from 'app/components/Time';
+import Time, { FromToTime } from 'app/components/Time';
 import type { Event } from 'app/models';
 import { colorForEvent, textColorForEvent } from '../utils';
 import styles from './Calendar.css';
@@ -78,6 +78,17 @@ const renderEvent = (event: Event) => {
         content={<strong>{event.location}</strong>}
         className={styles.textWithIcon}
       />
+      {event.activationTime && (
+        <TextWithIcon
+          iconName="alarm-outline"
+          content={
+            <strong>
+              Påmelding <Time time={event.activationTime} format="ll HH:mm" />
+            </strong>
+          }
+          className={styles.textWithIcon}
+        />
+      )}
     </Popover>
   );
 };


### PR DESCRIPTION
# Description

Update `EventItem` component to also include the time the event registration opens.

Also includes a tooltip

## Note:
Due to some styling differences, it was better to not combine the `TimeStamp` and `TimeStartAndRegistration` components

# Result
## Before

### Event List
<img src="https://github.com/webkom/lego-webapp/assets/55885035/73349abc-0f44-4d74-83b4-eaaa415b2197">

### Calendar Tooltip
![image](https://github.com/webkom/lego-webapp/assets/55885035/e5ab90bc-ca6d-4a04-a767-e88945b8815a)

<hr/>
<hr/>
<hr/>

 ## After
![Screenshot from 2023-10-12 19-17-54](https://github.com/webkom/lego-webapp/assets/55885035/0144da50-be0d-4dff-99c9-150f41c3a830)

### Tooltip:
![Screenshot from 2023-10-12 19-22-47](https://github.com/webkom/lego-webapp/assets/55885035/c121d580-351c-43e0-807a-453c027ca597)

### Calendar Tooltip:
![image](https://github.com/webkom/lego-webapp/assets/55885035/022ac6b3-ed18-4e73-a7fd-ce8cb85cffbe)


# Testing

- [X] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-588