### PR TITLE
Fix wrong color in text inputs

### DIFF
--- a/app/components/Form/TextInput.css
+++ b/app/components/Form/TextInput.css
@@ -15,9 +15,12 @@
   text-align: center;
 }
 
-.spacing:not(.centered) input,
 .prefix {
   color: var(--color-gray-5);
+}
+
+.prefix,
+.spacing:not(.centered) input {
   padding-left: 10px;
 }
 

--- a/app/components/Form/TextInput.tsx
+++ b/app/components/Form/TextInput.tsx
@@ -52,12 +52,12 @@ const TextInput = ({
       )}
     >
       {prefix && (
-        <Icon
-          name={prefix}
-          size={16}
+        <div
           onClick={() => ref.current && ref.current.focus()}
           className={styles.prefix}
-        />
+        >
+          <Icon name={prefix} size={16} />
+        </div>
       )}
       <input
         ref={ref}


### PR DESCRIPTION
# Description

Also fix wrong styling on prefix icon given by the recent changes to the Icon component.

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td>
			<img width="368" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/8d8124f4-2da8-481e-a8f5-91211eb60c1f">
		</td>
		<td>
			<img width="368" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/6847bdfe-78ae-45a8-bcb2-0e296e638056">
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

- Text inputs now have a correct text color. 
- Tested with and without a `prefix`, and `centered` inputs.
- `prefix` still works as expected, by focusing on the input when clicked.

---

Resolves ABA-602