### PR TITLE
Highlight current day appropriately when selected in datepicker

### DIFF
--- a/app/components/Form/DatePicker.css
+++ b/app/components/Form/DatePicker.css
@@ -48,7 +48,7 @@
   background-color: var(--lego-font-color);
 }
 
-.today {
+.today:not(.selectedDate) {
   color: var(--lego-font-color);
   background-color: var(--additive-background);
 }


### PR DESCRIPTION
# Description

It is bad feedback to not highlight the current day like you would for other dates.

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td>
			<img src="https://github.com/webkom/lego-webapp/assets/69514187/56936b12-6fcb-43ad-ae30-ae8670075347" width="300" />
		</td>
		<td>
			<img src="https://github.com/webkom/lego-webapp/assets/69514187/d55b404e-b608-4e92-9989-4a04b1755737" width="300" />
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above of working changes.

Highlighting the current day still works like before.
<img src="https://github.com/webkom/lego-webapp/assets/69514187/15419bb6-2015-4b7d-b482-51c8d45fa2c8" width="300" />
