### PR TITLE
Add dropdown menu to navbar

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -121,43 +121,6 @@
   }
 }
 
-.navigation {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-  align-items: center;
-  flex: 2;
-  white-space: nowrap;
-  margin-right: 5px;
-
-  @media (--mobile-device) {
-    display: none;
-  }
-}
-
-.navigation a {
-  font-size: var(--font-size-lg);
-  padding: 10px 1rem;
-  height: 100%;
-  color: var(--lego-font-color);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  transition: color var(--linear-medium);
-  white-space: nowrap;
-
-  &:hover,
-  &.activeItem {
-    color: var(--color-gray-7);
-  }
-
-  &:hover::after,
-  &.activeItem::after {
-    transform: scaleX(1);
-  }
-}
-
 .logoLightMode,
 .logoDarkMode {
   display: none;

--- a/app/components/Header/Navbar/AboutDropdown.tsx
+++ b/app/components/Header/Navbar/AboutDropdown.tsx
@@ -1,0 +1,41 @@
+import { ItemProps } from './Item';
+import ItemGrid from './ItemGrid';
+
+const AboutDropdown = () => {
+  const items: ItemProps[] = [
+    {
+      title: 'Generelt',
+      description: 'Alt du trenger å vite om landets beste linjeforening',
+      to: '/pages/info-om-abakus',
+    },
+    {
+      title: 'For bedrifter',
+      description: 'Les om alt Abakus kan tilby din bedrift',
+      to: '/pages/bedrifter/for-bedrifter',
+    },
+    {
+      title: 'Interessegrupper',
+      description: 'Utforsk og engasjer deg i en interessegruppe',
+      to: '/interestgroups',
+    },
+    {
+      title: 'Revyen',
+      description: 'Kontakt eller les om revyen til Abakus',
+      to: '/pages/grupper/104-revyen',
+    },
+    {
+      title: 'Komiteer',
+      description: 'Les om ansvarsområdene til komiteene i Abakus',
+      to: '/pages/komiteer/4',
+    },
+    {
+      title: 'Kontakt Abakus',
+      description: 'Nå ut til Hovedstyret eller komiteene',
+      to: '/contact',
+    },
+  ];
+
+  return <ItemGrid items={items} />;
+};
+
+export default AboutDropdown;

--- a/app/components/Header/Navbar/AboutDropdown.tsx
+++ b/app/components/Header/Navbar/AboutDropdown.tsx
@@ -20,7 +20,7 @@ const AboutDropdown = () => {
     },
     {
       title: 'Revyen',
-      description: 'Kontakt eller les om revyen til Abakus',
+      description: 'Les om revyen og revygruppene i Abakus',
       to: '/pages/grupper/104-revyen',
     },
     {
@@ -30,7 +30,7 @@ const AboutDropdown = () => {
     },
     {
       title: 'Kontakt Abakus',
-      description: 'Nå ut til Hovedstyret eller komiteene',
+      description: 'Nå ut til Hovedstyret, revyen eller komiteene',
       to: '/contact',
     },
   ];

--- a/app/components/Header/Navbar/AboutDropdown.tsx
+++ b/app/components/Header/Navbar/AboutDropdown.tsx
@@ -1,5 +1,5 @@
-import { ItemProps } from './Item';
 import ItemGrid from './ItemGrid';
+import type { ItemProps } from './Item';
 
 const AboutDropdown = () => {
   const items: ItemProps[] = [

--- a/app/components/Header/Navbar/CareerDropdown.tsx
+++ b/app/components/Header/Navbar/CareerDropdown.tsx
@@ -1,0 +1,17 @@
+import { ItemProps } from './Item';
+import ItemList from './ItemList';
+
+const CareerDropdown = () => {
+  const items: ItemProps[] = [
+    {
+      title: 'Jobbannonser',
+      iconName: 'newspaper-outline',
+      to: '/joblistings',
+    },
+    { title: 'Bedrifter', iconName: 'briefcase-outline', to: '/companies' },
+  ];
+
+  return <ItemList items={items} />;
+};
+
+export default CareerDropdown;

--- a/app/components/Header/Navbar/CareerDropdown.tsx
+++ b/app/components/Header/Navbar/CareerDropdown.tsx
@@ -1,5 +1,5 @@
-import { ItemProps } from './Item';
 import ItemList from './ItemList';
+import type { ItemProps } from './Item';
 
 const CareerDropdown = () => {
   const items: ItemProps[] = [

--- a/app/components/Header/Navbar/EventsDropwdown.css
+++ b/app/components/Header/Navbar/EventsDropwdown.css
@@ -1,0 +1,4 @@
+.items {
+  display: flex;
+  flex-direction: column;
+}

--- a/app/components/Header/Navbar/EventsDropwdown.tsx
+++ b/app/components/Header/Navbar/EventsDropwdown.tsx
@@ -1,5 +1,5 @@
-import { ItemProps } from './Item';
 import ItemList from './ItemList';
+import type { ItemProps } from './Item';
 
 const EventsDropdown = () => {
   const items: ItemProps[] = [

--- a/app/components/Header/Navbar/EventsDropwdown.tsx
+++ b/app/components/Header/Navbar/EventsDropwdown.tsx
@@ -1,0 +1,13 @@
+import { ItemProps } from './Item';
+import ItemList from './ItemList';
+
+const EventsDropdown = () => {
+  const items: ItemProps[] = [
+    { title: 'Liste', iconName: 'list-outline', to: '/events' },
+    { title: 'Kalender', iconName: 'calendar-outline', to: '/events/calendar' },
+  ];
+
+  return <ItemList items={items} />;
+};
+
+export default EventsDropdown;

--- a/app/components/Header/Navbar/Item.css
+++ b/app/components/Header/Navbar/Item.css
@@ -1,0 +1,28 @@
+.item {
+  color: var(--lego-font-color);
+  cursor: pointer;
+  padding: 0.4rem;
+  width: 250px;
+  border-radius: var(--border-radius-md);
+
+  &:hover {
+    background-color: var(--additive-background);
+  }
+}
+
+.description {
+  color: var(--secondary-font-color);
+  font-size: var(--font-size-sm);
+  line-height: 1.2rem;
+}
+
+.item .titleIcon {
+  opacity: 0;
+  transition: var(--easing-medium);
+  font-size: var(--font-size-sm);
+}
+
+.item:hover .titleIcon {
+  opacity: 1;
+  translate: 0.3rem;
+}

--- a/app/components/Header/Navbar/Item.tsx
+++ b/app/components/Header/Navbar/Item.tsx
@@ -1,0 +1,34 @@
+import TextWithIcon from 'app/components/TextWithIcon';
+import { Link } from 'react-router-dom';
+import styles from './Item.css';
+import Icon from 'app/components/Icon';
+import Flex from 'app/components/Layout/Flex';
+
+export type ItemProps = {
+  title: string;
+  iconName?: string;
+  to: string;
+  description?: string;
+};
+
+const Item = ({ iconName, title, to, description }: ItemProps) => {
+  return (
+    <Link to={to} className={styles.item}>
+      {iconName ? (
+        <TextWithIcon iconName={iconName} content={title} />
+      ) : (
+        <Flex alignItems="center">
+          {title}{' '}
+          <Icon
+            size={18}
+            className={styles.titleIcon}
+            name="chevron-forward-outline"
+          />
+        </Flex>
+      )}
+      {description && <p className={styles.description}>{description}</p>}
+    </Link>
+  );
+};
+
+export default Item;

--- a/app/components/Header/Navbar/Item.tsx
+++ b/app/components/Header/Navbar/Item.tsx
@@ -1,8 +1,8 @@
-import TextWithIcon from 'app/components/TextWithIcon';
 import { Link } from 'react-router-dom';
-import styles from './Item.css';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
+import TextWithIcon from 'app/components/TextWithIcon';
+import styles from './Item.css';
 
 export type ItemProps = {
   title: string;

--- a/app/components/Header/Navbar/ItemGrid.css
+++ b/app/components/Header/Navbar/ItemGrid.css
@@ -1,0 +1,4 @@
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}

--- a/app/components/Header/Navbar/ItemGrid.tsx
+++ b/app/components/Header/Navbar/ItemGrid.tsx
@@ -1,5 +1,6 @@
-import Item, { ItemProps } from './Item';
+import Item from './Item';
 import styles from './ItemGrid.css';
+import type { ItemProps } from './Item';
 
 type Props = {
   items: ItemProps[];
@@ -9,7 +10,12 @@ const ItemGrid = ({ items }: Props) => {
   return (
     <div className={styles.grid}>
       {items.map((item) => (
-        <Item title={item.title} description={item.description} to={item.to} />
+        <Item
+          key={item.title}
+          title={item.title}
+          description={item.description}
+          to={item.to}
+        />
       ))}
     </div>
   );

--- a/app/components/Header/Navbar/ItemGrid.tsx
+++ b/app/components/Header/Navbar/ItemGrid.tsx
@@ -1,0 +1,18 @@
+import Item, { ItemProps } from './Item';
+import styles from './ItemGrid.css';
+
+type Props = {
+  items: ItemProps[];
+};
+
+const ItemGrid = ({ items }: Props) => {
+  return (
+    <div className={styles.grid}>
+      {items.map((item) => (
+        <Item title={item.title} description={item.description} to={item.to} />
+      ))}
+    </div>
+  );
+};
+
+export default ItemGrid;

--- a/app/components/Header/Navbar/ItemList.tsx
+++ b/app/components/Header/Navbar/ItemList.tsx
@@ -1,0 +1,18 @@
+import Flex from 'app/components/Layout/Flex';
+import Item, { ItemProps } from './Item';
+
+type Props = {
+  items: ItemProps[];
+};
+
+const ItemList = ({ items }: Props) => {
+  return (
+    <Flex column={true}>
+      {items.map((item) => (
+        <Item iconName={item.iconName} title={item.title} to={item.to} />
+      ))}
+    </Flex>
+  );
+};
+
+export default ItemList;

--- a/app/components/Header/Navbar/ItemList.tsx
+++ b/app/components/Header/Navbar/ItemList.tsx
@@ -1,5 +1,6 @@
 import Flex from 'app/components/Layout/Flex';
-import Item, { ItemProps } from './Item';
+import Item from './Item';
+import type { ItemProps } from './Item';
 
 type Props = {
   items: ItemProps[];
@@ -9,7 +10,12 @@ const ItemList = ({ items }: Props) => {
   return (
     <Flex column={true}>
       {items.map((item) => (
-        <Item iconName={item.iconName} title={item.title} to={item.to} />
+        <Item
+          key={item.title}
+          iconName={item.iconName}
+          title={item.title}
+          to={item.to}
+        />
       ))}
     </Flex>
   );

--- a/app/components/Header/Navbar/Navbar.css
+++ b/app/components/Header/Navbar/Navbar.css
@@ -1,0 +1,43 @@
+.navigation {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+  flex: 2;
+  white-space: nowrap;
+  margin-right: 5px;
+
+  @media (--mobile-device) {
+    display: none;
+  }
+}
+
+.navigation a {
+  font-size: var(--font-size-lg);
+  padding: 10px 1rem;
+  height: 100%;
+  color: var(--lego-font-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: color var(--linear-medium);
+  white-space: nowrap;
+
+  &:hover,
+  &.activeItem {
+    color: var(--color-gray-7);
+  }
+
+  &:hover::after,
+  &.activeItem::after {
+    transform: scaleX(1);
+  }
+}
+
+.navbarDropdown {
+  width: auto;
+  padding: 15px;
+  margin: 0;
+  padding-top: 10px;
+}

--- a/app/components/Header/Navbar/Navbar.tsx
+++ b/app/components/Header/Navbar/Navbar.tsx
@@ -1,10 +1,11 @@
-import Dropdown from 'app/components/Dropdown';
+import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import styles from './Navbar.css';
-import { ReactElement, useState } from 'react';
-import EventsDropdown from './EventsDropwdown';
-import CareerDropdown from './CareerDropdown';
+import Dropdown from 'app/components/Dropdown';
 import AboutDropdown from './AboutDropdown';
+import CareerDropdown from './CareerDropdown';
+import EventsDropdown from './EventsDropwdown';
+import styles from './Navbar.css';
+import type { ReactElement } from 'react';
 
 type Props = {
   loggedIn: boolean;
@@ -62,6 +63,7 @@ const Navbar = ({ loggedIn }: Props) => {
 
         const navLinkItem = (
           <NavLink
+            key={link.to}
             to={link.to}
             activeClassName={styles.activeItem}
             onMouseEnter={() => setHoverIndex(i)}
@@ -74,6 +76,7 @@ const Navbar = ({ loggedIn }: Props) => {
 
         return (
           <Dropdown
+            key={link.to}
             show={visibleDropdown && hoverIndex == i}
             toggle={() => setVisibleDropdown(false)}
             triggerComponent={navLinkItem}

--- a/app/components/Header/Navbar/Navbar.tsx
+++ b/app/components/Header/Navbar/Navbar.tsx
@@ -1,0 +1,91 @@
+import Dropdown from 'app/components/Dropdown';
+import { NavLink } from 'react-router-dom';
+import styles from './Navbar.css';
+import { ReactElement, useState } from 'react';
+import EventsDropdown from './EventsDropwdown';
+import CareerDropdown from './CareerDropdown';
+import AboutDropdown from './AboutDropdown';
+
+type Props = {
+  loggedIn: boolean;
+};
+
+type NavbarLink = {
+  title: string;
+  to: string;
+  visibility: 'logged-in-only' | 'logged-out-only' | 'always';
+  dropdown?: ReactElement;
+};
+
+const Navbar = ({ loggedIn }: Props) => {
+  const [visibleDropdown, setVisibleDropdown] = useState(false);
+  const [hoverIndex, setHoverIndex] = useState(0);
+
+  const links: NavbarLink[] = [
+    {
+      title: 'For bedrifter',
+      to: '/pages/bedrifter/for-bedrifter',
+      visibility: 'logged-out-only',
+    },
+    {
+      title: 'Arrangementer',
+      to: '/events',
+      dropdown: <EventsDropdown />,
+      visibility: 'always',
+    },
+    {
+      title: 'Karriere',
+      to: '/joblistings',
+      dropdown: <CareerDropdown />,
+      visibility: 'logged-in-only',
+    },
+    {
+      title: 'Om Abakus',
+      to: '/pages/info-om-abakus',
+      dropdown: <AboutDropdown />,
+      visibility: 'always',
+    },
+  ];
+
+  return (
+    <div
+      className={styles.navigation}
+      onMouseEnter={() => setVisibleDropdown(true)}
+      onMouseLeave={() => setVisibleDropdown(false)}
+    >
+      {links.map((link, i) => {
+        if (
+          (link.visibility == 'logged-in-only' && !loggedIn) ||
+          (link.visibility == 'logged-out-only' && loggedIn)
+        )
+          return;
+
+        const navLinkItem = (
+          <NavLink
+            to={link.to}
+            activeClassName={styles.activeItem}
+            onMouseEnter={() => setHoverIndex(i)}
+          >
+            {link.title}
+          </NavLink>
+        );
+
+        if (link.dropdown == null) return navLinkItem;
+
+        return (
+          <Dropdown
+            show={visibleDropdown && hoverIndex == i}
+            toggle={() => setVisibleDropdown(false)}
+            triggerComponent={navLinkItem}
+            contentClassName={styles.navbarDropdown}
+            closeOnContentClick={true}
+          >
+            {link.dropdown}
+          </Dropdown>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Navbar;

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -22,6 +22,7 @@ import Search from '../Search';
 import FancyNodesCanvas from './FancyNodesCanvas';
 import styles from './Header.css';
 import ToggleTheme from './ToggleTheme';
+import Navbar from './Navbar/Navbar';
 
 type Props = {
   searchOpen: boolean;
@@ -156,30 +157,7 @@ const Header = ({ loggedIn, currentUser, loading, ...props }: Props) => {
         </Link>
 
         <div className={styles.menu}>
-          <div className={styles.navigation}>
-            <NavLink to="/events" activeClassName={styles.activeItem}>
-              Arrangementer
-            </NavLink>
-            {!loggedIn ? (
-              <NavLink
-                to="/pages/bedrifter/for-bedrifter"
-                activeClassName={styles.activeItem}
-              >
-                For bedrifter
-              </NavLink>
-            ) : (
-              <NavLink to="/joblistings" activeClassName={styles.activeItem}>
-                Karriere
-              </NavLink>
-            )}
-            <NavLink
-              to="/pages/info-om-abakus"
-              activeClassName={styles.activeItem}
-            >
-              Om Abakus
-            </NavLink>
-          </div>
-
+          <Navbar loggedIn={loggedIn} />
           <div className={styles.buttonGroup}>
             <ToggleTheme
               loggedIn={loggedIn}

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -21,8 +21,8 @@ import { ProfilePicture, Image } from '../Image';
 import Search from '../Search';
 import FancyNodesCanvas from './FancyNodesCanvas';
 import styles from './Header.css';
-import ToggleTheme from './ToggleTheme';
 import Navbar from './Navbar/Navbar';
+import ToggleTheme from './ToggleTheme';
 
 type Props = {
   searchOpen: boolean;


### PR DESCRIPTION
# Description
Adds a simple dropdown menu that appears when you hover over the navbar. 

It lacks animations, like in Ivar's original PR, but I was told to be agile so I'm just throwing this PR out there. I tried to add an identical animation, but it was literally mission impossible ;(

# Result

**Before**

[Screencast from 2023-10-13 22-53-19.webm](https://github.com/webkom/lego-webapp/assets/66320400/ede42d98-12dc-40ac-b256-ef42e99bd3a8)

**After**

Light mode:

[Screencast from 2023-10-14 11-13-56.webm](https://github.com/webkom/lego-webapp/assets/66320400/d1de229d-bc89-4f33-baa0-99293737b7ba)

Dark mode:

[Screencast from 2023-10-14 11-14-16.webm](https://github.com/webkom/lego-webapp/assets/66320400/162b7dc9-f334-4210-bdbb-4736a4a3d641)

# Testing

- [x] I have thoroughly tested my changes.

Everything works... EXCEPT this tiny [bug](https://linear.app/abakus-webkom/issue/ABA-606/following-a-link-to-om-abakus-does-not-open-the-appropriate-tab-if) that I encountered. It is not caused by the changes in this PR tho, so it will need to be fixed in a separate PR.

---

Resolves ABA-143
