### PR TITLE
Fix and use the `description` on fields

### DIFF
--- a/app/components/Form/Field.css
+++ b/app/components/Form/Field.css
@@ -41,6 +41,10 @@
   font-size: var(--font-size-lg);
 }
 
+.description {
+  margin-left: 7px;
+}
+
 .required {
   color: var(--danger-color);
   font-weight: 600;

--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -110,7 +110,7 @@ export function createField(Component: ComponentType<any>, options?: Options) {
     const inlineLabel = options?.inlineLabel;
 
     const labelComponent = (
-      <Flex>
+      <Flex alignItems="center">
         {label && (
           <div
             style={{
@@ -123,20 +123,11 @@ export function createField(Component: ComponentType<any>, options?: Options) {
           </div>
         )}
         {description && (
-          <Tooltip
-            style={{
-              display: 'inline-block',
-            }}
-            content={description}
-          >
-            <div
-              style={{
-                marginLeft: '10px',
-              }}
-            >
-              <Icon size={32} name="help" />
-            </div>
-          </Tooltip>
+          <Flex className={styles.description}>
+            <Tooltip content={description}>
+              <Icon size={18} name="help-circle-outline" />
+            </Tooltip>
+          </Flex>
         )}
         {required && <span className={styles.required}>*</span>}
       </Flex>

--- a/app/components/Form/ObjectPermissions.tsx
+++ b/app/components/Form/ObjectPermissions.tsx
@@ -1,5 +1,4 @@
 import { SelectInput, CheckBox } from 'app/components/Form';
-import Tooltip from 'app/components/Tooltip';
 import type { PublicGroup } from 'app/store/models/Group';
 
 /*
@@ -33,13 +32,12 @@ const ObjectPermissions = ({
 }) => {
   return [
     requireAuth && (
-      <Tooltip content="Gi alle brukere lesetilgang. Dette inkluderer også brukere som ikke har logget inn.">
-        <CheckBox.Field
-          inverted
-          {...requireAuth}
-          label="Åpen for alle - offentlig på nettet."
-        />
-      </Tooltip>
+      <CheckBox.Field
+        description="Gi alle brukere lesetilgang. Dette inkluderer også brukere som ikke har logget inn."
+        inverted
+        {...requireAuth}
+        label="Åpen for alle - offentlig på nettet"
+      />
     ),
     canEditGroups && (
       <SelectInput.AutocompleteField

--- a/app/components/GroupForm/index.tsx
+++ b/app/components/GroupForm/index.tsx
@@ -8,7 +8,6 @@ import {
   CheckBox,
   legoForm,
 } from 'app/components/Form';
-import Tooltip from 'app/components/Tooltip';
 import type { DetailedGroup } from 'app/store/models/Group';
 import { createValidator, required } from 'app/utils/validation';
 import styles from './index.css';
@@ -53,22 +52,20 @@ function GroupForm({
         name="contactEmail"
         component={TextInput.Field}
       />
-      <Tooltip content="Skal gruppen vises på brukerprofilen til folk?">
-        <Field
-          label="Vis badge på brukerprofiler"
-          name="showBadge"
-          component={CheckBox.Field}
-          normalize={(v) => !!v}
-        />
-      </Tooltip>
-      <Tooltip content="Er dette en aktiv gruppe?">
-        <Field
-          label="Aktiv gruppe"
-          name="active"
-          component={CheckBox.Field}
-          normalize={(v) => !!v}
-        />
-      </Tooltip>
+      <Field
+        label="Vis badge på brukerprofiler"
+        description="Skal gruppen vises på brukerprofilen til folk?"
+        name="showBadge"
+        component={CheckBox.Field}
+        normalize={(v) => !!v}
+      />
+      <Field
+        label="Aktiv gruppe"
+        description="Er dette en aktiv gruppe?"
+        name="active"
+        component={CheckBox.Field}
+        normalize={(v) => !!v}
+      />
       <Field
         label="Beskrivelse"
         placeholder="Vil du strikke din egen lue? Eller har du allerede […]"

--- a/app/routes/admin/email/components/EmailListEditor.tsx
+++ b/app/routes/admin/email/components/EmailListEditor.tsx
@@ -7,7 +7,6 @@ import {
   handleSubmissionError,
   legoForm,
 } from 'app/components/Form';
-import Tooltip from 'app/components/Tooltip';
 import { roleOptions } from 'app/utils/constants';
 import { createValidator, required, EMAIL_REGEX } from 'app/utils/validation';
 
@@ -62,25 +61,23 @@ const EmailListEditor = ({ submitting, handleSubmit, emailListId }: Props) => (
       component={SelectInput.Field}
     />
 
-    <Tooltip content="Når denne er aktivert vil kun brukere med aktiv @abakus.no-adresse få e-post fra denne listen">
-      <Field
-        label="Kun for for brukere med internmail (@abakus.no)"
-        name="requireInternalAddress"
-        component={CheckBox.Field}
-        normalize={(v) => !!v}
-      />
-    </Tooltip>
+    <Field
+      label="Kun for for brukere med internmail (@abakus.no)"
+      description="Når denne er aktivert vil kun brukere med aktiv @abakus.no-adresse få e-post fra denne listen"
+      name="requireInternalAddress"
+      component={CheckBox.Field}
+      normalize={(v) => !!v}
+    />
 
-    <Tooltip content="Her kan du legge til e-postene til de som skal ha mailer fra gruppemailen, men ikke er medlem av abakus">
-      <Field
-        label="E-poster for medlemmer utenfor abakus"
-        name="additionalEmails"
-        placeholder="Skriv inn e-post her"
-        component={SelectInput.Field}
-        isMulti
-        tags
-      />
-    </Tooltip>
+    <Field
+      label="E-poster for medlemmer utenfor abakus"
+      description="Her kan du legge til e-postene til de som skal ha mailer fra gruppemailen, men ikke er medlem av abakus"
+      name="additionalEmails"
+      placeholder="Skriv inn e-post her"
+      component={SelectInput.Field}
+      isMulti
+      tags
+    />
     <Button submit disabled={submitting}>
       {emailListId ? 'Oppdater e-postliste' : 'Lag e-postliste'}
     </Button>

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -17,7 +17,6 @@ import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
 import { ConfirmModal } from 'app/components/Modal/ConfirmModal';
 import NavigationTab from 'app/components/NavigationTab';
-import Tooltip from 'app/components/Tooltip';
 import type { EditingEvent } from 'app/routes/events/utils';
 import type { DetailedArticle } from 'app/store/models/Article';
 import type { CurrentUser } from 'app/store/models/User';
@@ -75,20 +74,8 @@ const ArticleEditor = ({
         <Flex>
           <Field
             name="youtubeUrl"
-            label={
-              <Flex>
-                <div>Erstatt cover-bildet med video fra YouTube</div>
-                <div
-                  style={{
-                    marginLeft: '5px',
-                  }}
-                >
-                  <Tooltip content="Valgfritt felt. Videoen erstatter ikke coveret i listen over artikler.">
-                    <Icon name="information-circle-outline" size={20} />
-                  </Tooltip>
-                </div>
-              </Flex>
-            }
+            label="Erstatt cover-bildet med video fra YouTube"
+            description="Videoen erstatter ikke coveret i listen over artikler"
             placeholder="https://www.youtube.com/watch?v=bLHL75H_VEM&t=5"
             component={TextInput.Field}
           />

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -31,7 +31,6 @@ import { ConfirmModal } from 'app/components/Modal/ConfirmModal';
 import NavigationTab from 'app/components/NavigationTab';
 import Tag from 'app/components/Tags/Tag';
 import { FormatTime } from 'app/components/Time';
-import Tooltip from 'app/components/Tooltip';
 import { AttendanceStatus } from 'app/components/UserAttendance';
 import AttendanceModal from 'app/components/UserAttendance/AttendanceModal';
 import type {
@@ -193,49 +192,31 @@ function EventEditor({
           </>
         </Modal>
 
-        <Flex wrap alignItems="center" justifyContent="space-between">
-          <Flex alignItems="center" justifyContent="space-between">
-            <Button onClick={() => setShowImageGallery(true)}>
-              Velg bilde fra bildegalleriet
-            </Button>
-            <Tooltip content="Velg et bilde som er lastet opp og markert for bruk fra tidligere arrangementer.">
-              <Icon
-                name="information-circle-outline"
-                size={20}
-                style={{
-                  cursor: 'help',
-                  marginLeft: '0.5em',
-                }}
-              />
-            </Tooltip>
-          </Flex>
+        <Flex alignItems="center" justifyContent="space-between">
+          <Button onClick={() => setShowImageGallery(true)}>
+            Velg bilde fra bildegalleriet
+          </Button>
 
-          <Tooltip content="Lagre bildet til bildegalleriet. Det kan da brukes i andre arrangementer.">
+          <div>
             <Field
               label="Lagre til bildegalleriet"
+              description="Lagre bildet til bildegalleriet slik at det kan bli brukt til andre arrangementer"
               name="saveToImageGallery"
               component={CheckBox.Field}
               fieldClassName={styles.metaField}
               className={styles.formField}
               normalize={(v) => !!v}
             />
-          </Tooltip>
+          </div>
         </Flex>
-        <Flex>
-          <Field
-            name="youtubeUrl"
-            label={
-              <Flex alignItems="center" gap={6}>
-                <div>Erstatt cover-bildet med video fra YouTube</div>
-                <Tooltip content="Valgfritt felt. Videoen erstatter ikke coveret i listen over arrangementer.">
-                  <Icon name="information-circle-outline" size={20} />
-                </Tooltip>
-              </Flex>
-            }
-            placeholder="https://www.youtube.com/watch?v=bLHL75H_VEM&t=5"
-            component={TextInput.Field}
-          />
-        </Flex>
+
+        <Field
+          name="youtubeUrl"
+          label="Erstatt cover-bildet med video fra YouTube"
+          description="Videoen erstatter ikke coveret i listen over arrangementer"
+          placeholder="https://www.youtube.com/watch?v=bLHL75H_VEM&t=5"
+          component={TextInput.Field}
+        />
         <Field
           label="Festet på forsiden"
           name="pinned"
@@ -244,17 +225,15 @@ function EventEditor({
           className={styles.formField}
           normalize={(v) => !!v}
         />
-        <Flex wrap alignItems="center" justifyContent="space-between">
-          <Field
-            label="Tittel"
-            name="title"
-            placeholder="Tittel"
-            style={{
-              borderBottom: `3px solid ${color}`,
-            }}
-            component={TextInput.Field}
-          />
-        </Flex>
+        <Field
+          label="Tittel"
+          name="title"
+          placeholder="Tittel"
+          style={{
+            borderBottom: `3px solid ${color}`,
+          }}
+          component={TextInput.Field}
+        />
         <Field
           name="description"
           label="Kalenderbeskrivelse"
@@ -355,16 +334,15 @@ function EventEditor({
                 )}
               </Flex>
             )}
-            <Tooltip content="Kun la medlemmer i bestemt gruppe se arrangementet">
-              <Field
-                label="Kun for spesifikk gruppe"
-                name="isGroupOnly"
-                component={CheckBox.Field}
-                fieldClassName={styles.metaField}
-                className={styles.formField}
-                normalize={(v) => !!v}
-              />
-            </Tooltip>
+            <Field
+              label="Kun for spesifikk gruppe"
+              description="Gjør arrangementet synlig for kun medlemmer i spesifikke grupper"
+              name="isGroupOnly"
+              component={CheckBox.Field}
+              fieldClassName={styles.metaField}
+              className={styles.formField}
+              normalize={(v) => !!v}
+            />
             {event.isGroupOnly && (
               <div className={styles.subSection}>
                 <Field
@@ -397,28 +375,26 @@ function EventEditor({
             )}
             {event.isPriced && (
               <div className={styles.subSection}>
-                <Tooltip content="Manuell betaling kan også godkjennes av oss i etterkant">
-                  <Field
-                    label="Betaling via Abakus.no"
-                    name="useStripe"
-                    component={CheckBox.Field}
-                    fieldClassName={styles.metaField}
-                    className={styles.formField}
-                    normalize={(v) => !!v}
-                  />
-                </Tooltip>
+                <Field
+                  label="Betaling via Abakus.no"
+                  description="Manuell betaling kan også godkjennes av oss i etterkant"
+                  name="useStripe"
+                  component={CheckBox.Field}
+                  fieldClassName={styles.metaField}
+                  className={styles.formField}
+                  normalize={(v) => !!v}
+                />
                 {event.useStripe && (
                   <div className={styles.subSection}>
-                    <Tooltip content="Legger automatisk transaksjonskostnaden til prisen">
-                      <Field
-                        label="Legg til systemgebyr"
-                        name="addFee"
-                        component={CheckBox.Field}
-                        fieldClassName={styles.metaField}
-                        className={styles.formField}
-                        normalize={(v) => !!v}
-                      />
-                    </Tooltip>
+                    <Field
+                      label="Legg til systemgebyr"
+                      description="Legger automatisk transaksjonskostnaden til prisen"
+                      name="addFee"
+                      component={CheckBox.Field}
+                      fieldClassName={styles.metaField}
+                      className={styles.formField}
+                      normalize={(v) => !!v}
+                    />
                   </div>
                 )}
                 <Field
@@ -468,57 +444,55 @@ function EventEditor({
             ) &&
               event.heedPenalties && (
                 <div className={styles.subSection}>
-                  <Tooltip content="Frist for avmelding – fører til prikk etterpå">
-                    <Field
-                      key="unregistrationDeadline"
-                      label="Avregistreringsfrist"
-                      name="unregistrationDeadline"
-                      component={DatePicker.Field}
-                      fieldClassName={styles.metaField}
-                      className={styles.formField}
-                    />
-                  </Tooltip>
+                  <Field
+                    key="unregistrationDeadline"
+                    label="Avregistreringsfrist"
+                    description="Frist for avmelding - fører til prikk etterpå"
+                    name="unregistrationDeadline"
+                    component={DatePicker.Field}
+                    fieldClassName={styles.metaField}
+                    className={styles.formField}
+                  />
                 </div>
               )}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (
-              <Tooltip content="Separate frister for påmelding og avmelding - antall timer før arrangementet. Det vil ikke være mulig å melde seg av eller på etter de satte fristene (negativ verdi betyr antall timer etter starten på arrangementet)">
-                <Field
-                  label="Separat avregistregistreringsfrist"
-                  name="separateDeadlines"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={(v) => !!v}
-                />
-              </Tooltip>
+              <Field
+                label="Separat avregistregistreringsfrist"
+                description="Separate frister for påmelding og avmelding - antall timer før arrangementet. Det vil ikke være mulig å melde seg av eller på etter de satte fristene (negativ verdi betyr antall timer etter starten på arrangementet)"
+                name="separateDeadlines"
+                component={CheckBox.Field}
+                fieldClassName={styles.metaField}
+                className={styles.formField}
+                normalize={(v) => !!v}
+              />
             )}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) &&
               event.separateDeadlines && (
                 <div className={styles.subSection}>
-                  <Tooltip content="Frist for avmelding antall timer før arrangementet (negativ verdi betyr antall timer etter starten på arrangementet)">
-                    <Field
-                      key="unregistrationDeadlineHours"
-                      label="Avregistrering antall timer før"
-                      name="unregistrationDeadlineHours"
-                      type="number"
-                      component={TextInput.Field}
-                      fieldClassName={styles.metaField}
-                      className={styles.formField}
-                    />
-                  </Tooltip>
+                  <Field
+                    key="unregistrationDeadlineHours"
+                    label="Avregistrering antall timer før"
+                    description="Frist for avmelding antall timer før arrangementet (negativ verdi betyr antall timer etter starten på arrangementet)"
+                    name="unregistrationDeadlineHours"
+                    type="number"
+                    component={TextInput.Field}
+                    fieldClassName={styles.metaField}
+                    className={styles.formField}
+                  />
                 </div>
               )}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (
-              <Tooltip content="Frist for påmelding/avmelding - antall timer før arrangementet. Det er ikke mulig å melde seg hverken på eller av etter denne fristen (negativ verdi betyr antall timer etter starten på arrangementet)">
+              <>
                 <Field
                   key="registrationDeadlineHours"
                   label="Registrering antall timer før"
+                  description="Frist for påmelding/avmelding - antall timer før arrangementet. Det er ikke mulig å melde seg hverken på eller av etter denne fristen (negativ verdi betyr antall timer etter starten på arrangementet)"
                   name="registrationDeadlineHours"
                   type="number"
                   component={TextInput.Field}
@@ -529,50 +503,47 @@ function EventEditor({
                   Stenger{' '}
                   <FormatTime time={moment(event.registrationDeadline)} />
                 </p>
-              </Tooltip>
+              </>
             )}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (
-              <Tooltip content="Bruk samtykke til bilder">
-                <Field
-                  label="Samtykke til bilder"
-                  name="useConsent"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={(v) => !!v}
-                />
-              </Tooltip>
+              <Field
+                label="Samtykke til bilder"
+                description="Bruk samtykke til bilder"
+                name="useConsent"
+                component={CheckBox.Field}
+                fieldClassName={styles.metaField}
+                className={styles.formField}
+                normalize={(v) => !!v}
+              />
             )}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (
-              <Tooltip content="Navn, telefonnummer og e-post kan deles med folk utenfor Abakus til smittesporing. Dersom informasjonen skal kunne deles med andre enn FHI og NTNU, må dette spesifiseres i beskrivelsen.">
-                <Field
-                  label="Informasjon kan deles til smittesporing"
-                  name="useContactTracing"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={(v) => !!v}
-                  disabled={moment().isAfter(event.activationTime)}
-                />
-              </Tooltip>
+              <Field
+                label="Informasjon kan deles til smittesporing"
+                description="Navn, telefonnummer og e-post kan deles med folk utenfor Abakus til smittesporing. Dersom informasjonen skal kunne deles med andre enn FHI og NTNU, må dette spesifiseres i beskrivelsen."
+                name="useContactTracing"
+                component={CheckBox.Field}
+                fieldClassName={styles.metaField}
+                className={styles.formField}
+                normalize={(v) => !!v}
+                disabled={moment().isAfter(event.activationTime)}
+              />
             )}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (
-              <Tooltip content="Still et spørsmål ved påmelding">
-                <Field
-                  label="Påmeldingsspørsmål"
-                  name="hasFeedbackQuestion"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={(v) => !!v}
-                />
-              </Tooltip>
+              <Field
+                label="Påmeldingsspørsmål"
+                description="Still et spørsmål ved påmelding"
+                name="hasFeedbackQuestion"
+                component={CheckBox.Field}
+                fieldClassName={styles.metaField}
+                className={styles.formField}
+                normalize={(v) => !!v}
+              />
             )}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
@@ -620,15 +591,14 @@ function EventEditor({
                   />
                 </div>
                 {pools && pools.length > 1 && (
-                  <Tooltip content="Tidspunkt for å slå sammen poolene">
-                    <Field
-                      label="Sammenslåingstidspunkt"
-                      name="mergeTime"
-                      component={DatePicker.Field}
-                      fieldClassName={styles.metaField}
-                      className={styles.formField}
-                    />
-                  </Tooltip>
+                  <Field
+                    label="Sammenslåingstidspunkt"
+                    description="Tidspunkt for å slå sammen poolene"
+                    name="mergeTime"
+                    component={DatePicker.Field}
+                    fieldClassName={styles.metaField}
+                    className={styles.formField}
+                  />
                 )}
                 {isEditPage && (
                   <Admin
@@ -642,8 +612,16 @@ function EventEditor({
           </ContentSidebar>
         </ContentSection>
         {!isEditPage && (
-          <Tooltip
-            content={
+          <Field
+            label={
+              <>
+                Arrangementet er avklart i{' '}
+                <Link to="/pages/arrangementer/86-arrangementskalender">
+                  arrangementskalenderen
+                </Link>
+              </>
+            }
+            description={
               <>
                 Jeg er kjent med at jeg kun kan bruke rettighetene mine til å
                 opprette et Abakusarrangement som er i tråd med{' '}
@@ -661,23 +639,12 @@ function EventEditor({
                 arrangement.
               </>
             }
-          >
-            <Field
-              label={
-                <>
-                  Arrangementet er avklart i{' '}
-                  <Link to="/pages/arrangementer/86-arrangementskalender">
-                    arrangementskalenderen
-                  </Link>
-                </>
-              }
-              name="isClarified"
-              component={CheckBox.Field}
-              fieldClassName={styles.metaFieldInformation}
-              className={styles.formField}
-              normalize={(v) => !!v}
-            />
-          </Tooltip>
+            name="isClarified"
+            component={CheckBox.Field}
+            fieldClassName={styles.metaFieldInformation}
+            className={styles.formField}
+            normalize={(v) => !!v}
+          />
         )}
 
         <Flex wrap>

--- a/app/routes/photos/components/GalleryPictureEditModal.tsx
+++ b/app/routes/photos/components/GalleryPictureEditModal.tsx
@@ -3,12 +3,10 @@ import { Link } from 'react-router-dom';
 import { Field, reduxForm } from 'redux-form';
 import { Content } from 'app/components/Content';
 import { Form, TextArea, SelectInput, CheckBox } from 'app/components/Form';
-import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import { Flex } from 'app/components/Layout';
 import Modal from 'app/components/Modal';
 import ProgressiveImage from 'app/components/ProgressiveImage';
-import Tooltip from 'app/components/Tooltip';
 import GalleryDetailsRow from './GalleryDetailsRow';
 import styles from './GalleryPictureModal.css';
 
@@ -80,21 +78,7 @@ const GalleryPictureEditModal = ({
             id="gallery-picture-description"
           />
           <Field
-            label={
-              <Flex>
-                <div>Synlig for offenligheten</div>
-                <div
-                  style={{
-                    marginLeft: '5px',
-                  }}
-                >
-                  <Tooltip content="Om bildet skal være synlig for brukere som ikke har tilgang til å redigere albumet.">
-                    <Icon name="information-circle-outline" size={20} />
-                  </Tooltip>
-                </div>
-              </Flex>
-            }
-            placeholder="Synlig for alle brukere"
+            label="Synlig for alle brukere"
             name="active"
             component={CheckBox.Field}
             id="gallery-picture-active"


### PR DESCRIPTION
# Description

[Fix the description styling on fields](https://github.com/webkom/lego-webapp/commit/777abf74d476d55758593db65a7cf19fee568a1e)

[Refactor fields to use description prop](https://github.com/webkom/lego-webapp/commit/a2abc2a0770b1880f33bdda2eaa7f580dee2d4ae)

# Result

The icons makes the page more "cluttered", but easier/better to use. It's a trade-off. Note that the event editor is the only page with a ton of field descriptions, so given that it's an anomaly I wouldn't say it's a big deal.

<img width="368" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/33fe3004-153e-4239-8607-eff5b3c13ce3">

# Testing

- [x] I have thoroughly tested my changes.

All fields still look as expected.