### PR TITLE
Fix TextWithIcon icon alignment

### DIFF
--- a/app/components/TextWithIcon/TextWithIcon.css
+++ b/app/components/TextWithIcon/TextWithIcon.css
@@ -1,5 +1,8 @@
 .infoIcon {
-  min-width: 26px;
   justify-content: center;
   padding-right: 0.2em;
+}
+
+.textContainer {
+  width: max-content;
 }

--- a/app/components/TextWithIcon/index.tsx
+++ b/app/components/TextWithIcon/index.tsx
@@ -15,13 +15,14 @@ type Props = {
 
 const TextWithIcon = ({
   iconName,
+  className,
   content,
   tooltipContentIcon,
   iconRight = false,
   size,
 }: Props) => {
   return (
-    <Flex alignItems="center" gap={5}>
+    <Flex alignItems="center" gap={5} className={className}>
       <div className={styles.textContainer}>
         {iconRight ? <span>{content}</span> : <></>}
       </div>

--- a/app/components/TextWithIcon/index.tsx
+++ b/app/components/TextWithIcon/index.tsx
@@ -15,15 +15,16 @@ type Props = {
 
 const TextWithIcon = ({
   iconName,
-  className,
   content,
   tooltipContentIcon,
   iconRight = false,
   size,
 }: Props) => {
   return (
-    <Flex alignItems="center" className={className}>
-      {iconRight ? <>{content}</> : <></>}
+    <Flex alignItems="center" gap={5}>
+      <div className={styles.textContainer}>
+        {iconRight ? <span>{content}</span> : <></>}
+      </div>
       {tooltipContentIcon ? (
         <Tooltip content={tooltipContentIcon}>
           <Icon
@@ -39,8 +40,7 @@ const TextWithIcon = ({
           size={size ? size : undefined}
         />
       )}
-
-      {iconRight ? <></> : <>{content}</>}
+      <div>{iconRight ? <></> : <>{content}</>}</div>
     </Flex>
   );
 };


### PR DESCRIPTION
# Description

Fixed wrapping of TextWithIcon component, thus also fixing the alignment of icons. Did this by wrapping the content (the text) in a span, and adding a div wrapping the span with "width: max-content".

# Result

**before**
![image](https://github.com/webkom/lego-webapp/assets/99915933/70f9a754-fa26-460a-a86c-8a3a79fe5c64)

**after**
![image](https://github.com/webkom/lego-webapp/assets/99915933/102f367e-65d6-4061-98a9-be598248f465)

# Testing

- I have thoroughly tested my changes.

Tested locally on both laptop, desktop and mobile views.

---
