### PR TITLE
Add section-dividers and titles to event statistics

### DIFF
--- a/app/routes/events/components/EventAttendeeStatistics.css
+++ b/app/routes/events/components/EventAttendeeStatistics.css
@@ -1,3 +1,13 @@
+.sectionDividerTitle {
+  margin-top: 1em;
+  margin-bottom: 0;
+}
+
+.sectionDividerDescription {
+  color: var(--secondary-font-color);
+  margin-bottom: 1em;
+}
+
 .metrics {
   height: 80px;
   line-height: 1.3;

--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -380,7 +380,17 @@ const EventAttendeeStatistics = ({
         </Card>
       )}
 
+      <h2 className={styles.sectionDividerTitle}>Statistikk</h2>
+      <p className={styles.sectionDividerDescription}>
+        Statistikk av besøkende på arrangementssiden.
+      </p>
+
       <Analytics eventId={eventId} />
+
+      <h2 className={styles.sectionDividerTitle}>Analyse</h2>
+      <p className={styles.sectionDividerDescription}>
+        Analyse av brukerne som er påmeldt arrangementet.
+      </p>
 
       {registrations.length === 0 ? (
         <p className={styles.noRegistrationsText}>Ingen er påmeldt enda.</p>


### PR DESCRIPTION
# Description

Add title and description to the two main sections of the event statistics to make it clearer what the different sections are based on.

# Result

<table>
<tr>
 <th>
 <th>Before
 <th>After
<tr>
 <td>No signups
 <td><img width="1024" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/a4d79b70-2277-4101-91e3-36725ede9d7f">
 <td>
<img width="1017" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/2a1beed2-e8d6-45cd-8359-537f2625083a">

<tr>
 <td>After signups
 <td><img width="1012" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/8f6c1a12-9ef1-44aa-ac65-3ffd94da3798">
 <td><img width="1014" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/854492c2-3bd5-4c69-a464-0a628c82769e">

</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

