### PR TITLE
Change default survey activation time to 14:30

### DIFF
--- a/app/routes/surveys/AddSurveyRoute.ts
+++ b/app/routes/surveys/AddSurveyRoute.ts
@@ -14,7 +14,7 @@ import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import SurveyEditor, {
   initialQuestion,
 } from './components/SurveyEditor/SurveyEditor';
-import { defaultActiveFrom } from './utils';
+import { getActiveFrom } from './utils';
 import type { DeepPartial } from 'utility-types';
 
 const loadData = (props, dispatch) => {
@@ -54,7 +54,7 @@ const mapStateToProps = (state, props) => {
         label: fullEvent.title,
       }
     : undefined;
-  const activeFrom = fullEvent ? fullEvent.endTime : defaultActiveFrom(12, 0);
+  const activeFrom = getActiveFrom(fullEvent?.endTime, 14, 30);
   const title = fullEvent ? `Spørreundersøkelse for ${fullEvent.title}` : '';
   let initialValues: DeepPartial<FormSurvey> | null = null;
 

--- a/app/routes/surveys/utils.tsx
+++ b/app/routes/surveys/utils.tsx
@@ -3,7 +3,7 @@ import Icon from 'app/components/Icon';
 import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import config from 'app/config';
-import type { ActionGrant } from 'app/models';
+import type { ActionGrant, Dateish } from 'app/models';
 import type { ID } from 'app/store/models';
 import styles from './components/surveys.css';
 import type { ReactNode } from 'react';
@@ -76,8 +76,15 @@ export const TokenNavigation = ({
     )}
   </NavigationTab>
 );
-export const defaultActiveFrom = (hours: number, minutes: number) =>
-  moment().startOf('day').add({ day: 1, hours, minutes }).toISOString();
+export const getActiveFrom = (
+  eventEndTime: Dateish,
+  hours: number,
+  minutes: number
+) =>
+  moment(eventEndTime)
+    .startOf('day')
+    .add({ days: 1, hours, minutes })
+    .toISOString();
 
 export const getCsvUrl = (surveyId: ID) =>
   `${config.serverUrl}/surveys/${surveyId}/csv/`;


### PR DESCRIPTION
# Description

This was requested by the arranging komitees a few weeks ago to avoid conflicts with event registrations, which are usually on the hour. It sets default activation time to 14:30 the day after the event end time, or tomorrow at 14:30 if no event is selected.

# Result

See how it says 14:30(the event is 23. Oct):
<img width="544" alt="Screenshot 2023-10-18 at 15 03 49" src="https://github.com/webkom/lego-webapp/assets/8343002/f7f32afb-af59-4aa0-8ada-8fe6956a6259">

# Testing

- [x] I have thoroughly tested my changes.

Have tested both with and without a connected event, and with templates.
---

Resolves ABA-612
