### PR TITLE
Add external links to nav menu

### DIFF
--- a/app/components/Search/index.tsx
+++ b/app/components/Search/index.tsx
@@ -12,7 +12,7 @@ import QuickLinks from './QuickLinks';
 import styles from './Search.css';
 import SearchBar from './SearchBar';
 import SearchResults from './SearchResults';
-import { getAdminLinks, getRegularLinks } from './utils';
+import { getAdminLinks, getExternalLinks, getRegularLinks } from './utils';
 
 type StateProps = {
   allowed: Allowed;
@@ -78,6 +78,11 @@ const Search = (props: Props) => {
     loggedIn,
   });
 
+  const externalLinks = getExternalLinks({
+    allowed,
+    loggedIn,
+  });
+
   const adminLinks = getAdminLinks({
     allowed,
     loggedIn,
@@ -106,6 +111,13 @@ const Search = (props: Props) => {
             links={regularLinks}
             onCloseSearch={onCloseSearch}
           />
+          {externalLinks.length > 0 && (
+            <QuickLinks
+              title="Andre tjenester"
+              links={externalLinks}
+              onCloseSearch={onCloseSearch}
+            />
+          )}
           {adminLinks.length > 0 && (
             <QuickLinks
               title="Admin"

--- a/app/components/Search/utils.tsx
+++ b/app/components/Search/utils.tsx
@@ -136,6 +136,37 @@ const LINKS: Array<Link> = [
   },
 ];
 
+const EXTERNAL_LINKS: Link[] = [
+  {
+    key: 'warning-portal',
+    requireLogin: true,
+    title: 'Varslingsportal',
+    icon: 'warning-outline',
+    url: 'https://portal.mittvarsel.no/skjema/abakus/t3fMsqnZcCaeFX2u.9824?lang=no',
+  },
+  {
+    key: 'bill',
+    requireLogin: true,
+    title: 'Kvitteringsskildring',
+    icon: 'receipt-outline',
+    url: 'https://kvittering.abakus.no',
+  },
+  {
+    key: 'wiki',
+    requireLogin: true,
+    title: 'Wiki',
+    icon: 'document-text-outline',
+    url: 'https://wiki.abakus.no',
+  },
+  {
+    key: 'ababart',
+    requireLogin: true,
+    title: 'Se flere',
+    icon: 'link-outline',
+    url: 'https://aba.wtf',
+  },
+];
+
 const sortFn = (a, b) => {
   // Sort non-strings last:
   if (typeof a.title !== 'string') {
@@ -188,6 +219,9 @@ export type NavigationLink = [string, ReactNode]; // [url, label(as a react-node
 
 export function getRegularLinks(options: Options): Array<NavigationLink> {
   return retrieveAllowed(SORTED_REGULAR, options);
+}
+export function getExternalLinks(options: Options): Array<NavigationLink> {
+  return retrieveAllowed(EXTERNAL_LINKS, options);
 }
 export function getAdminLinks(options: Options): Array<NavigationLink> {
   return retrieveAllowed(SORTED_ADMIN, options);


### PR DESCRIPTION
# Description

Add a few highlighted external links to the nav menu, and a link to AbaBart where users can find the rest of them.

# Result

## Before
<img width="960" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/a0365eed-b78c-48c6-b925-153f0b908386">

## After
<img width="962" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/970241a5-10fc-4d45-a05b-d61a74a43226">

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-614
