### PR TITLE
Add revue board to contact form

### DIFF
--- a/app/routes/contact/ContactRoute.ts
+++ b/app/routes/contact/ContactRoute.ts
@@ -2,10 +2,10 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { reduxForm, reset, change } from 'redux-form';
 import { sendContactMessage } from 'app/actions/ContactActions';
-import { fetchAllWithType } from 'app/actions/GroupActions';
+import { fetchAllWithType, fetchGroup } from 'app/actions/GroupActions';
 import { addToast } from 'app/actions/ToastActions';
 import { GroupType } from 'app/models';
-import { selectGroupsWithType } from 'app/reducers/groups';
+import { selectGroup, selectGroupsWithType } from 'app/reducers/groups';
 import { createValidator, required, maxLength } from 'app/utils/validation';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import Contact from './components/Contact';
@@ -16,14 +16,21 @@ const validate = createValidator({
   message: [required()],
   captchaResponse: [required('Captcha er ikke validert')],
 });
-const groupType = GroupType.Committee;
+
+const commiteeGroupType = GroupType.Committee;
+const revueBoardGroupId = 59;
 
 const mapStateToProps = (state) => {
-  const groups = selectGroupsWithType(state, {
-    groupType,
+  const commitees = selectGroupsWithType(state, {
+    groupType: commiteeGroupType,
   });
+
+  const revueBoard = selectGroup(state, {
+    groupId: revueBoardGroupId,
+  });
+
   return {
-    groups,
+    groups: [...commitees, revueBoard],
   };
 };
 
@@ -35,7 +42,10 @@ const mapDispatchToProps = {
 };
 export default compose(
   withPreparedDispatch('fetchContact', (_, dispatch) =>
-    dispatch(fetchAllWithType(groupType))
+    Promise.all([
+      dispatch(fetchAllWithType(commiteeGroupType)),
+      dispatch(fetchGroup(revueBoardGroupId)),
+    ])
   ),
   connect(mapStateToProps, mapDispatchToProps),
   reduxForm({

--- a/app/routes/contact/components/ContactForm.tsx
+++ b/app/routes/contact/components/ContactForm.tsx
@@ -51,16 +51,19 @@ const ContactForm = (props: Props) => {
     value: null,
     label: 'Hovedstyret',
   };
-  const recipientOptions = groups.map((g) => ({
-    value: g.id,
-    label: g.name,
-  }));
+  const recipientOptions = groups.map(
+    (g) =>
+      g && {
+        value: g.id,
+        label: g.name,
+      }
+  );
   return (
     <Form onSubmit={props.handleSubmit(submit)}>
       <p>
-        Dette skjemaet er et verktøy for å nå ut til Abakus sine komiteer eller
-        Hovedstyret, enten du har spørsmål, tilbakemeldinger, eller bare ønsker
-        å dele informasjon med oss.
+        Dette skjemaet er et verktøy for å nå ut til Abakus sine komiteer,
+        revyen eller Hovedstyret, enten du har spørsmål, tilbakemeldinger, eller
+        bare ønsker å dele informasjon med oss.
       </p>
       <Card severity="info">
         <p>
@@ -84,11 +87,11 @@ const ContactForm = (props: Props) => {
         </p>
       </Card>
       <p>
-        Sender du meldingen til en spesifikk komité er det kun lederen av
-        komiteen som vil motta meldingen. Dersom du sender til Hovedstyret vil
-        hele styret motta meldingen. Både komitéledere og Hovedstyret som mottar
-        henvendelser har signert taushetserklæring, og de vil kontakte deg og
-        følge opp saken dersom det ønskes.
+        Sender du meldingen til revyen eller en spesifikk komité er det kun
+        lederen av gruppa som vil motta meldingen. Dersom du sender til
+        Hovedstyret vil hele styret motta meldingen. Hovedstyret, revyleder og
+        komitéledere som mottar henvendelser har signert taushetserklæring, og
+        de vil kontakte deg og følge opp saken dersom det ønskes.
       </p>
 
       <Field


### PR DESCRIPTION
# Description
Adds "RevyStyret" to the dropdown in the contact form. Only the leader will get contacted, like for committees.

# Result
![image](https://github.com/webkom/lego-webapp/assets/66320400/81059710-a748-4143-b742-a72d65210043)

# Testing
- [X] I have thoroughly tested my changes.
It works with the new backend changes [see this](https://github.com/webkom/lego/pull/3511)

---

Resolves ABA-617
