### PR TITLE
Improve final-form submit-button and submission-error consistency

### DIFF
--- a/app/actions/CompanyActions.ts
+++ b/app/actions/CompanyActions.ts
@@ -404,7 +404,7 @@ export function addSemester({
         },
         meta: {
           errorMessage: 'Legge til semester feilet',
-          successMessage: 'Semest lagt til!',
+          successMessage: 'Semester lagt til!',
         },
       })
     );

--- a/app/components/CommentForm/CommentForm.css
+++ b/app/components/CommentForm/CommentForm.css
@@ -6,7 +6,7 @@
   margin: 0;
 }
 
-.submittable {
+.submitButton:disabled {
   opacity: 0;
   transition: opacity var(--easing-medium);
 }

--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -1,17 +1,15 @@
-import { Button } from '@webkom/lego-bricks';
-import cx from 'classnames';
 import { Field } from 'react-final-form';
 import { addComment } from 'app/actions/CommentActions';
 import Card from 'app/components/Card';
 import { TextInput } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { ProfilePicture } from 'app/components/Image';
 import Flex from 'app/components/Layout/Flex';
 import { useAppDispatch } from 'app/store/hooks';
 import type { ID } from 'app/store/models';
 import type { CurrentUser } from 'app/store/models/User';
-import { spySubmittable } from 'app/utils/formSpyUtils';
 import { createValidator, legoEditorRequired } from 'app/utils/validation';
 import styles from './CommentForm.css';
 
@@ -49,17 +47,16 @@ const CommentForm = ({
       <LegoFinalForm
         validateOnSubmitOnly
         validate={validate}
-        onSubmit={({ text }, form) => {
-          // Clear the form value
-          form.change('text', undefined);
-
-          dispatch(
+        onSubmit={async ({ text }, form) => {
+          await dispatch(
             addComment({
               contentTarget,
               text,
               parent,
             })
           );
+
+          form.restart();
         }}
       >
         {({ handleSubmit }) => {
@@ -79,14 +76,7 @@ const CommentForm = ({
                   />
                 </div>
 
-                {spySubmittable((submittable) => (
-                  <Button
-                    type="submit"
-                    className={cx(!submittable && styles.submittable)}
-                  >
-                    {submitText}
-                  </Button>
-                ))}
+                <SubmitButton>{submitText}</SubmitButton>
               </Flex>
 
               <SubmissionError />

--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -76,7 +76,9 @@ const CommentForm = ({
                   />
                 </div>
 
-                <SubmitButton>{submitText}</SubmitButton>
+                <SubmitButton className={styles.submitButton}>
+                  {submitText}
+                </SubmitButton>
               </Flex>
 
               <SubmissionError />

--- a/app/components/Form/SubmissionError.css
+++ b/app/components/Form/SubmissionError.css
@@ -1,0 +1,3 @@
+.submissionErrorContainer {
+  margin-bottom: 15px;
+}

--- a/app/components/Form/SubmissionError.tsx
+++ b/app/components/Form/SubmissionError.tsx
@@ -1,7 +1,16 @@
 import { RenderErrorMessage } from 'app/components/Form/Field';
 import { spyFormError } from 'app/utils/formSpyUtils';
+import styles from './SubmissionError.css';
 
 const SubmissionError = () =>
-  spyFormError((error) => <>{error && <RenderErrorMessage error={error} />}</>);
+  spyFormError((error) => (
+    <>
+      {error && (
+        <div className={styles.submissionErrorContainer}>
+          <RenderErrorMessage error={error} />
+        </div>
+      )}
+    </>
+  ));
 
 export default SubmissionError;

--- a/app/components/Form/SubmitButton.tsx
+++ b/app/components/Form/SubmitButton.tsx
@@ -1,14 +1,15 @@
 import { Button } from '@webkom/lego-bricks';
 import { spySubmittable } from 'app/utils/formSpyUtils';
-import type { ReactNode } from 'react';
+import type { MouseEventHandler, ReactNode } from 'react';
 
 type Props = {
   children: ReactNode;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export const SubmitButton = ({ children }: Props) =>
+export const SubmitButton = ({ children, onClick }: Props) =>
   spySubmittable((submittable) => (
-    <Button submit disabled={!submittable}>
+    <Button submit disabled={!submittable} onClick={onClick}>
       {children}
     </Button>
   ));

--- a/app/components/Form/SubmitButton.tsx
+++ b/app/components/Form/SubmitButton.tsx
@@ -5,11 +5,17 @@ import type { MouseEventHandler, ReactNode } from 'react';
 type Props = {
   children: ReactNode;
   onClick?: MouseEventHandler<HTMLButtonElement>;
+  className?: string;
 };
 
-export const SubmitButton = ({ children, onClick }: Props) =>
+export const SubmitButton = ({ children, onClick, className }: Props) =>
   spySubmittable((submittable) => (
-    <Button submit disabled={!submittable} onClick={onClick}>
+    <Button
+      submit
+      disabled={!submittable}
+      onClick={onClick}
+      className={className}
+    >
       {children}
     </Button>
   ));

--- a/app/components/LoginForm/LoginForm.tsx
+++ b/app/components/LoginForm/LoginForm.tsx
@@ -1,30 +1,14 @@
-import { Button } from '@webkom/lego-bricks';
 import { FORM_ERROR } from 'final-form';
 import { Field } from 'react-final-form';
 import { login } from 'app/actions/UserActions';
 import { Form } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import TextInput from 'app/components/Form/TextInput';
 import { useAppDispatch } from 'app/store/hooks';
 import type { Action } from 'app/types';
-import { spyFormError, spySubmittable } from 'app/utils/formSpyUtils';
 import { createValidator, required } from 'app/utils/validation';
-
-type ErrorProps = {
-  error: string;
-};
-
-const Error = ({ error }: ErrorProps) => {
-  return (
-    <p
-      style={{
-        color: 'var(--danger-color)',
-      }}
-    >
-      {error}
-    </p>
-  );
-};
 
 type FormValues = {
   username: string;
@@ -84,15 +68,8 @@ const LoginForm = (props: Props) => {
               component={TextInput.Field}
             />
 
-            {spyFormError((error) => (
-              <>{error && <Error error={error} />}</>
-            ))}
-
-            {spySubmittable((submittable) => (
-              <Button dark submit disabled={!submittable}>
-                Logg inn
-              </Button>
-            ))}
+            <SubmissionError />
+            <SubmitButton>Logg inn</SubmitButton>
           </Form>
         )}
       </LegoFinalForm>

--- a/app/routes/bdb/components/AddSemester.tsx
+++ b/app/routes/bdb/components/AddSemester.tsx
@@ -1,9 +1,10 @@
-import { Button } from '@webkom/lego-bricks';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
 import { Content } from 'app/components/Content';
 import { TextInput, RadioButton, MultiSelectGroup } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import type { SemesterStatusEntity } from 'app/reducers/companies';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import { createValidator, required } from 'app/utils/validation';
@@ -22,7 +23,6 @@ type Props = {
     arg1: Record<string, any> | null | undefined
   ) => Promise<any>;
   companyId: number;
-  submitting: boolean;
   autoFocus: any;
   companySemesters: Array<Record<string, any>>;
   addSemester: (arg0: CompanySemesterEntity) => Promise<any>;
@@ -86,7 +86,7 @@ const AddSemester = (props: Props) => {
     }
   };
 
-  const { companyId, submitting, autoFocus, deleteCompany } = props;
+  const { companyId, autoFocus, deleteCompany } = props;
 
   return (
     <Content>
@@ -189,13 +189,8 @@ const AddSemester = (props: Props) => {
 
               <div className={styles.clear} />
 
-              <Button
-                disabled={submitting}
-                onClick={() => setSubmit(true)}
-                submit
-              >
-                Lagre
-              </Button>
+              <SubmissionError />
+              <SubmitButton onClick={() => setSubmit(true)}>Lagre</SubmitButton>
             </form>
           )}
         </LegoFinalForm>

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -1,4 +1,4 @@
-import { LoadingIndicator, Button } from '@webkom/lego-bricks';
+import { LoadingIndicator } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
 import { Content } from 'app/components/Content';
 import {
@@ -10,6 +10,8 @@ import {
   MultiSelectGroup,
 } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import InfoBubble from 'app/components/InfoBubble';
 import type {
   CompanyEntity,
@@ -22,7 +24,6 @@ import styles from './bdb.css';
 type Props = {
   uploadFile: (arg0: Record<string, any>) => Promise<any>;
   company: CompanyEntity;
-  submitting: boolean;
   autoFocus: any;
   fetching: boolean;
   submitFunction: (arg0: SubmitCompanyEntity) => Promise<any>;
@@ -36,7 +37,6 @@ const validate = createValidator({
 
 const CompanyEditor = ({
   company,
-  submitting,
   autoFocus,
   uploadFile,
   fetching,
@@ -250,10 +250,8 @@ const CompanyEditor = ({
                 />
               </div>
 
-              <div className={styles.clear} />
-              <Button disabled={submitting} submit>
-                Lagre
-              </Button>
+              <SubmissionError />
+              <SubmitButton>Lagre</SubmitButton>
             </form>
           )}
         </LegoFinalForm>

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -5,7 +5,6 @@ import { Field, FormSpy } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
-import { SubmissionError } from 'redux-form';
 import english from 'app/assets/great_britain.svg';
 import norwegian from 'app/assets/norway.svg';
 import Card from 'app/components/Card';
@@ -14,13 +13,14 @@ import { FlexRow } from 'app/components/FlexBox';
 import {
   TextEditor,
   TextInput,
-  Button,
   CheckBox,
   SelectInput,
   RadioButton,
   MultiSelectGroup,
 } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import Icon from 'app/components/Icon';
 import { Image } from 'app/components/Image';
 import Flex from 'app/components/Layout/Flex';
@@ -28,7 +28,7 @@ import { readmeIfy } from 'app/components/ReadmeLogo';
 import Tooltip from 'app/components/Tooltip';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
-import { spySubmittable, spyValues } from 'app/utils/formSpyUtils';
+import { spyValues } from 'app/utils/formSpyUtils';
 import {
   createValidator,
   required,
@@ -411,12 +411,7 @@ const CompanyInterestPage = (props: Props) => {
             ? '/companyInterest/'
             : '/pages/bedrifter/for-bedrifter'
         )
-      )
-      .catch((err) => {
-        if (err.payload && err.payload.response) {
-          throw new SubmissionError(err.payload.response.jsonData);
-        }
-      });
+      );
   };
 
   const { language } = props;
@@ -855,13 +850,12 @@ const CompanyInterestPage = (props: Props) => {
               {interestText.priorityReasoning[language]}
             </div>
 
-            {spySubmittable((submittable) => (
-              <Button secondary disabled={!submittable} submit>
-                {props.edit
-                  ? 'Oppdater bedriftsinteresse'
-                  : FORM_LABELS.create[language]}
-              </Button>
-            ))}
+            <SubmissionError />
+            <SubmitButton>
+              {props.edit
+                ? 'Oppdater bedriftsinteresse'
+                : FORM_LABELS.create[language]}
+            </SubmitButton>
           </form>
         )}
       </LegoFinalForm>

--- a/app/routes/companyInterest/components/CompanySemesterGUI.tsx
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.tsx
@@ -11,6 +11,7 @@ import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
+import { Semester } from 'app/store/models';
 import type CompanySemester from 'app/store/models/CompanySemester';
 import { createValidator, required } from 'app/utils/validation';
 import { semesterToText, SemesterNavigation } from '../utils';
@@ -22,8 +23,15 @@ type Props = {
   editSemester: (semester: CompanySemester) => Promise<void>;
   addSemester: (semester: Omit<CompanySemester, 'id'>) => Promise<void>;
   activeSemesters: Array<CompanySemester>;
-  initialValues: Record<string, any>;
+  initialValues: Partial<FormValues>;
 };
+
+type FormValues = {
+  year: string;
+  semester: Semester;
+};
+
+const TypedLegoForm = LegoFinalForm<FormValues>;
 
 const validate = createValidator({
   year: [required()],
@@ -68,7 +76,10 @@ const AddSemesterForm = ({
   editSemester,
   initialValues,
 }: AddSemesterProps) => {
-  const onSubmit = async ({ year, semester }, form: FormApi) => {
+  const onSubmit = async (
+    { year, semester }: FormValues,
+    form: FormApi<FormValues>
+  ) => {
     const existingCompanySemester = semesters.find((companySemester) => {
       return (
         Number(companySemester.year) === Number(year) &&
@@ -82,7 +93,7 @@ const AddSemesterForm = ({
       });
     else
       await addSemester({
-        year,
+        year: Number(year),
         semester,
       }); // Default is activeInterestForm: true
 
@@ -90,7 +101,7 @@ const AddSemesterForm = ({
   };
 
   return (
-    <LegoFinalForm
+    <TypedLegoForm
       onSubmit={onSubmit}
       validate={validate}
       initialValues={initialValues}
@@ -113,13 +124,13 @@ const AddSemesterForm = ({
               name="Spring"
               label="Vår"
               component={RadioButton.Field}
-              inputValue="spring"
+              inputValue={Semester.Spring}
             />
             <Field
               name="Autumn"
               label="Høst"
               component={RadioButton.Field}
-              inputValue="autumn"
+              inputValue={Semester.Autumn}
             />
           </MultiSelectGroup>
 
@@ -127,7 +138,7 @@ const AddSemesterForm = ({
           <SubmitButton>Legg til semester</SubmitButton>
         </Form>
       )}
-    </LegoFinalForm>
+    </TypedLegoForm>
   );
 };
 

--- a/app/routes/companyInterest/components/CompanySemesterGUI.tsx
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
 import { Content } from 'app/components/Content';
 import {
@@ -8,52 +7,68 @@ import {
   MultiSelectGroup,
 } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
-import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
+import type CompanySemester from 'app/store/models/CompanySemester';
 import { createValidator, required } from 'app/utils/validation';
 import { semesterToText, SemesterNavigation } from '../utils';
 import styles from './CompanyInterest.css';
-import type { FormProps } from 'redux-form';
+import type { FormApi } from 'final-form';
 
 type Props = {
-  push: (arg0: string) => void;
-  events: Array<Record<string, any>>;
-  semesters: Array<CompanySemesterEntity>;
-  autoFocus: any;
-  edit: boolean;
-  editSemester: (arg0: CompanySemesterEntity) => void;
-  addSemester: (arg0: CompanySemesterEntity) => void;
-  activeSemesters: Array<CompanySemesterEntity>;
-} & FormProps;
+  semesters: Array<CompanySemester>;
+  editSemester: (semester: CompanySemester) => Promise<void>;
+  addSemester: (semester: Omit<CompanySemester, 'id'>) => Promise<void>;
+  activeSemesters: Array<CompanySemester>;
+  initialValues: Record<string, any>;
+};
 
 const validate = createValidator({
   year: [required()],
   semester: [required()],
 });
 
-const CompanySemesterGUI = (props: Props) => {
-  const activeSemesters = (semesters) => (
-    <Flex column>
-      {semesters.map((semester, index) => (
-        <Flex key={index} className={styles.guiBoxes}>
-          <div className={styles.checkboxSpan}>
-            {semesterToText({ ...semester, language: 'norwegian' })}
-          </div>
-          <Icon
-            name="close-circle"
-            onClick={() =>
-              props.editSemester({ ...semester, activeInterestForm: false })
-            }
-            className={styles.remove}
-          />
-        </Flex>
-      ))}
+const CompanySemesterGUI = (props: Props) => (
+  <Content>
+    <SemesterNavigation title="Endre aktive semestre" />
+    <Flex className={styles.guiWrapper}>
+      <Flex
+        column
+        style={{
+          marginRight: '50px',
+        }}
+      >
+        <AddSemesterForm
+          semesters={props.semesters}
+          addSemester={props.addSemester}
+          editSemester={props.editSemester}
+          initialValues={props.initialValues}
+        />
+      </Flex>
+      <Flex column>
+        <label className={styles.heading}>Deaktiver semestre</label>
+        <ActiveSemesters
+          semesters={props.activeSemesters}
+          editSemester={props.editSemester}
+        />
+      </Flex>
     </Flex>
-  );
+  </Content>
+);
 
-  const onSubmit = ({ year, semester }) => {
-    const { semesters, addSemester, editSemester } = props;
+type AddSemesterProps = Pick<
+  Props,
+  'semesters' | 'addSemester' | 'editSemester' | 'initialValues'
+>;
+const AddSemesterForm = ({
+  semesters,
+  addSemester,
+  editSemester,
+  initialValues,
+}: AddSemesterProps) => {
+  const onSubmit = async ({ year, semester }, form: FormApi) => {
     const existingCompanySemester = semesters.find((companySemester) => {
       return (
         Number(companySemester.year) === Number(year) &&
@@ -61,75 +76,80 @@ const CompanySemesterGUI = (props: Props) => {
       );
     });
     if (existingCompanySemester)
-      return editSemester({
+      await editSemester({
         ...existingCompanySemester,
         activeInterestForm: true,
       });
     else
-      return addSemester({
+      await addSemester({
         year,
         semester,
       }); // Default is activeInterestForm: true
+
+    form.restart();
   };
 
-  const { autoFocus, initialValues } = props;
   return (
-    <Content>
-      <SemesterNavigation title="Endre aktive semestre" />
-      <LegoFinalForm
-        onSubmit={onSubmit}
-        validate={validate}
-        initialValues={initialValues}
-        subscription={{}}
-      >
-        {({ handleSubmit }) => (
-          <Form onSubmit={handleSubmit}>
-            <Flex className={styles.guiWrapper}>
-              <Flex
-                column
-                style={{
-                  marginRight: '50px',
-                }}
-              >
-                <label className={styles.heading}>
-                  Legg til aktivt semester
-                </label>
-                <Field
-                  autoFocus={autoFocus}
-                  placeholder="2020"
-                  label="År"
-                  name="year"
-                  type="number"
-                  component={TextInput.Field}
-                  className={styles.yearForm}
-                  required
-                />
-                <MultiSelectGroup name="semester" label="Semester">
-                  <Field
-                    name="Spring"
-                    label="Vår"
-                    component={RadioButton.Field}
-                    inputValue="spring"
-                  />
-                  <Field
-                    name="Autumn"
-                    label="Høst"
-                    component={RadioButton.Field}
-                    inputValue="autumn"
-                  />
-                </MultiSelectGroup>
-                <Button submit>Legg til semester</Button>
-              </Flex>
-              <Flex column>
-                <label className={styles.heading}>Deaktiver semestre</label>
-                {activeSemesters(props.activeSemesters)}
-              </Flex>
-            </Flex>
-          </Form>
-        )}
-      </LegoFinalForm>
-    </Content>
+    <LegoFinalForm
+      onSubmit={onSubmit}
+      validate={validate}
+      initialValues={initialValues}
+      subscription={{}}
+    >
+      {({ handleSubmit }) => (
+        <Form onSubmit={handleSubmit}>
+          <label className={styles.heading}>Legg til aktivt semester</label>
+          <Field
+            placeholder="2020"
+            label="År"
+            name="year"
+            type="number"
+            component={TextInput.Field}
+            className={styles.yearForm}
+            required
+          />
+          <MultiSelectGroup name="semester" label="Semester">
+            <Field
+              name="Spring"
+              label="Vår"
+              component={RadioButton.Field}
+              inputValue="spring"
+            />
+            <Field
+              name="Autumn"
+              label="Høst"
+              component={RadioButton.Field}
+              inputValue="autumn"
+            />
+          </MultiSelectGroup>
+
+          <SubmissionError />
+          <SubmitButton>Legg til semester</SubmitButton>
+        </Form>
+      )}
+    </LegoFinalForm>
   );
 };
+
+type ActiveSemestersProps = {
+  semesters: Array<CompanySemester>;
+  editSemester: (semester: CompanySemester) => void;
+};
+const ActiveSemesters = ({ semesters, editSemester }: ActiveSemestersProps) => (
+  <Flex column>
+    {semesters.map((semester, index) => (
+      <Flex key={index} className={styles.guiBoxes}>
+        <div>{semesterToText({ ...semester, language: 'norwegian' })}</div>
+        <Icon
+          name="close-circle"
+          onClick={() =>
+            editSemester({ ...semester, activeInterestForm: false })
+          }
+          className={styles.remove}
+        />
+      </Flex>
+    ))}
+  </Flex>
+);
 
 export default CompanySemesterGUI;

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -17,6 +17,7 @@ import {
 } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import Icon from 'app/components/Icon';
 import { Flex } from 'app/components/Layout';
 import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
@@ -28,7 +29,7 @@ import styles from 'app/routes/meetings/components/MeetingEditor.css';
 import type { ID } from 'app/store/models';
 import type { DetailedMeeting } from 'app/store/models/Meeting';
 import type { AutocompleteUser, CurrentUser } from 'app/store/models/User';
-import { spySubmittable, spyValues } from 'app/utils/formSpyUtils';
+import { spyValues } from 'app/utils/formSpyUtils';
 import {
   createValidator,
   ifField,
@@ -311,11 +312,9 @@ const MeetingEditor = ({
                 >
                   Avbryt
                 </Button>
-                {spySubmittable((submittable) => (
-                  <Button disabled={!submittable} submit>
-                    {isEditPage ? 'Lagre endringer' : 'Opprett møte'}
-                  </Button>
-                ))}
+                <SubmitButton>
+                  {isEditPage ? 'Lagre endringer' : 'Opprett møte'}
+                </SubmitButton>
                 {isEditPage && canDelete && (
                   <ConfirmModal
                     title="Slett møtet"

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -11,6 +11,8 @@ import {
   CheckBox,
 } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import Icon from 'app/components/Icon';
 import Flex from 'app/components/Layout/Flex';
 import { ConfirmModal } from 'app/components/Modal/ConfirmModal';
@@ -137,8 +139,9 @@ const EditPollForm = ({
         mutators={{
           ...arrayMutators,
         }}
+        subscription={{}}
       >
-        {({ handleSubmit, pristine, submitting }) => (
+        {({ handleSubmit }) => (
           <form onSubmit={handleSubmit}>
             <Field
               name="title"
@@ -183,10 +186,11 @@ const EditPollForm = ({
               rerenderOnEveryChange
             />
 
+            <SubmissionError />
             <Flex className={styles.actionButtons}>
-              <Button disabled={pristine || submitting} submit>
+              <SubmitButton>
                 {editing ? 'Lagre endringer' : 'Lag ny avstemning'}
-              </Button>
+              </SubmitButton>
               {editing && (
                 <ConfirmModal
                   title="Slett avstemning"

--- a/app/routes/quotes/components/AddQuote.tsx
+++ b/app/routes/quotes/components/AddQuote.tsx
@@ -1,13 +1,15 @@
 import moment from 'moment-timezone';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
-import { Button, TextInput } from 'app/components/Form';
+import { TextInput } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { withSubmissionErrorFinalForm } from 'app/components/Form/utils';
 import RandomQuote from 'app/components/RandomQuote/RandomQuote';
 import type { ActionGrant } from 'app/models';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
-import { spySubmittable, spyValues } from 'app/utils/formSpyUtils';
+import { spyValues } from 'app/utils/formSpyUtils';
 import { createValidator, required } from 'app/utils/validation';
 import { navigation } from '../utils';
 import styles from './Quotes.css';
@@ -82,11 +84,8 @@ const AddQuote = ({ addQuotes, actionGrant }: Props) => {
 
                 <div className={styles.clear} />
 
-                {spySubmittable((submittable) => (
-                  <Button type="submit" disabled={!submittable}>
-                    Send inn sitat
-                  </Button>
-                ))}
+                <SubmissionError />
+                <SubmitButton>Send inn sitat</SubmitButton>
               </form>
             </div>
 

--- a/app/routes/users/components/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
 import {
   Form,
@@ -8,11 +7,12 @@ import {
   PhoneNumberInput,
 } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
+import SubmissionError from 'app/components/Form/SubmissionError';
+import { SubmitButton } from 'app/components/Form/SubmitButton';
 import type { UserEntity } from 'app/reducers/users';
 import DeleteUser from 'app/routes/users/components/DeleteUser';
 import RemovePicture from 'app/routes/users/components/RemovePicture';
 import { useIsCurrentUser } from 'app/routes/users/utils';
-import { spySubmittable } from 'app/utils/formSpyUtils';
 import {
   createValidator,
   required,
@@ -214,11 +214,9 @@ const UserSettings = (props: Props) => {
                 />
               </MultiSelectGroup>
             )}
-            {spySubmittable((submittable) => (
-              <Button success disabled={!submittable} submit>
-                Lagre
-              </Button>
-            ))}
+
+            <SubmissionError />
+            <SubmitButton>Lagre</SubmitButton>
           </Form>
         )}
       </LegoFinalForm>


### PR DESCRIPTION
Note: this PR builds on #4220 because I created the `<SubmitButton>`-component there, only 59a86e130a788453b4123a4979d6f9bff7752729 is relevant.


The `<SubmitButton>`-component just reduces some boilerplate, with the bonus that it enforces consistency in submit-buttons. 

`<SubmissionError>` shows any errors that arise when submitting the form, meaning that the forms that were missing this would simply not show the error message.

I also did a bit of refactoring in `CompanySemesterGUI` because the previous structure made no sense.

# Result

Some forms had green or grey submit-buttons, now they are all black. 

The login-form had a custom error-component which was simply red text, it now uses `<SubmissionError>`:

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="362" alt="Screenshot 2023-10-21 at 14 20 38" src="https://github.com/webkom/lego-webapp/assets/8343002/04f0ff80-e1ae-4015-8710-f0dc16c45d39">
 <td><img width="362" alt="Screenshot 2023-10-21 at 14 19 42" src="https://github.com/webkom/lego-webapp/assets/8343002/ce875aa5-9a8a-496e-a7b9-07d295949c4f">
</table>


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
