### PR TITLE
Reimplement createEntityReducer in the style of redux-toolkits createEntityAdapter

### DIFF
--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -1,6 +1,6 @@
 import type { AsyncActionType } from 'app/types';
 
-const generateStatuses = (name: string): AsyncActionType => ({
+export const generateStatuses = (name: string): AsyncActionType => ({
   BEGIN: `${name}.BEGIN`,
   SUCCESS: `${name}.SUCCESS`,
   FAILURE: `${name}.FAILURE`,

--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -177,7 +177,6 @@ export const Favorite = {
  *
  */
 export const Comment = {
-  FETCH: generateStatuses('Comment.FETCH') as AAT,
   ADD: generateStatuses('Comment.ADD') as AAT,
   DELETE: generateStatuses('Comment.DELETE') as AAT,
 };

--- a/app/models.ts
+++ b/app/models.ts
@@ -7,7 +7,14 @@ import type { Moment } from 'moment';
 // TODO: Id handling could be opaque
 export type ID = number;
 export type Dateish = Moment | Date | string;
-export type ActionGrant = Array<string>;
+export type ActionGrant = (
+  | 'create'
+  | 'edit'
+  | 'delete'
+  | 'list'
+  | 'view'
+  | string
+)[];
 export type IcalToken = string;
 export enum EventTime {
   activate = 'activationTime',

--- a/app/reducers/__tests__/allowed.spec.ts
+++ b/app/reducers/__tests__/allowed.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Meta } from '../../actions/ActionTypes';
+import { Meta } from 'app/actions/ActionTypes';
 import allowed from '../allowed';
 
 describe('reducers', () => {

--- a/app/reducers/__tests__/comments.spec.ts
+++ b/app/reducers/__tests__/comments.spec.ts
@@ -1,15 +1,23 @@
+import { combineReducers, createSlice } from '@reduxjs/toolkit';
 import { describe, it, expect } from 'vitest';
 import { Comment } from 'app/actions/ActionTypes';
-import comments, { mutateComments } from '../comments';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import comments, { addCommentCases, mutateComments } from '../comments';
+import type { EntityId } from '@reduxjs/toolkit';
+import type { DetailedArticle } from 'app/store/models/Article';
+import type CommentType from 'app/store/models/Comment';
+import type { PublicUser } from 'app/store/models/User';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 describe('reducers', () => {
   describe('comments', () => {
     it('Deleting comments should set text and author to null', () => {
       const prevState = {
         actionGrant: [],
-        pagination: {},
-        items: [91],
-        byId: {
+        paginationNext: {},
+        ids: [91],
+        entities: {
           91: {
             id: 91,
             text: 'hello world',
@@ -18,8 +26,9 @@ describe('reducers', () => {
               username: 'webkom',
             },
             parent: null,
-          },
+          } as CommentType,
         },
+        fetching: false,
       };
       const action = {
         type: Comment.DELETE.SUCCESS,
@@ -27,26 +36,35 @@ describe('reducers', () => {
           id: 91,
         },
       };
-      expect(comments(prevState, action).byId[91].text).toBeNull();
-      expect(comments(prevState, action).byId[91].author).toBeNull();
+      expect(comments(prevState, action).entities[91]?.text).toBeNull();
+      expect(comments(prevState, action).entities[91]?.author).toBeNull();
     });
   });
 });
+
 describe('mutateComments', () => {
   const prevState = {
     actionGrant: [],
     pagination: {},
+    paginationNext: {},
+    fetching: false,
     items: [3, 4],
     byId: {
       3: {
         id: 3,
         text: 'hello world',
-        name: 'welcome',
+        author: {
+          id: 1,
+        } as PublicUser,
+        comments: [],
       },
       4: {
         id: 4,
         text: 'test',
-        name: 'test',
+        author: {
+          id: 2,
+        } as PublicUser,
+        comments: [],
       },
     },
   };
@@ -56,45 +74,32 @@ describe('mutateComments', () => {
       contentTarget: 'articles.article-3',
     },
     payload: {
-      result: {
-        id: 33,
-        text: 'comment',
-        author: {
-          id: 1,
-          username: 'webkom',
+      result: 33,
+      entities: {
+        comments: {
+          33: {
+            id: 33,
+            text: 'comment',
+            author: {
+              id: 1,
+              username: 'webkom',
+            },
+            parent: null,
+          },
         },
-        parent: null,
       },
     },
   };
   it('should add comment to correct entity', () => {
     const reducer = mutateComments('articles');
     expect(reducer(prevState, action)).toEqual({
-      actionGrant: [],
-      pagination: {},
-      items: [3, 4],
+      ...prevState,
       byId: {
         3: {
-          id: 3,
-          text: 'hello world',
-          name: 'welcome',
-          comments: [
-            {
-              id: 33,
-              text: 'comment',
-              author: {
-                id: 1,
-                username: 'webkom',
-              },
-              parent: null,
-            },
-          ],
+          ...prevState.byId[3],
+          comments: [33],
         },
-        4: {
-          id: 4,
-          text: 'test',
-          name: 'test',
-        },
+        4: prevState.byId[4],
       },
     });
   });
@@ -102,5 +107,96 @@ describe('mutateComments', () => {
     const reducer = mutateComments('events');
     const newState = reducer(prevState, action);
     expect(newState).toEqual(prevState);
+  });
+});
+
+describe('addCommentCases', () => {
+  const articlesAdapter = createLegoAdapter(EntityType.Articles);
+  const initialArticlesState = {
+    ...articlesAdapter.getInitialState(),
+    ids: [2, 3],
+    entities: {
+      2: {
+        id: 2,
+        title: 'Article 1',
+        comments: [] as EntityId[],
+      } as DetailedArticle,
+      3: {
+        id: 3,
+        title: 'Article 2',
+        comments: [] as EntityId[],
+      } as DetailedArticle,
+    },
+  };
+  const articlesSlice = createSlice({
+    name: EntityType.Articles,
+    initialState: initialArticlesState,
+    reducers: {},
+    extraReducers: articlesAdapter.buildReducers({
+      extraCases: (addCase) => {
+        addCommentCases(EntityType.Articles, addCase);
+      },
+    }),
+  });
+  const eventsAdapter = createLegoAdapter(EntityType.Events);
+  const eventsSlice = createSlice({
+    name: EntityType.Events,
+    initialState: eventsAdapter.getInitialState(),
+    reducers: {},
+  });
+  const reducer = combineReducers({
+    events: eventsSlice.reducer,
+    articles: articlesSlice.reducer,
+  });
+
+  const action = (contentTarget: ContentTarget) => ({
+    type: Comment.ADD.SUCCESS,
+    meta: {
+      contentTarget,
+    },
+    payload: {
+      entities: {
+        comments: {
+          33: {
+            id: 33,
+            text: 'comment',
+            author: {
+              id: 1,
+              username: 'webkom',
+            },
+            parent: null,
+          },
+        },
+      },
+      result: 33,
+    },
+  });
+
+  it('should add comment ID to the correct entity', () => {
+    expect(reducer(undefined, action('articles.article-3'))).toEqual({
+      articles: {
+        ...articlesAdapter.getInitialState(),
+        ids: [2, 3],
+        entities: {
+          2: {
+            id: 2,
+            title: 'Article 1',
+            comments: [],
+          },
+          3: {
+            id: 3,
+            title: 'Article 2',
+            comments: [33],
+          },
+        },
+      },
+      events: eventsAdapter.getInitialState(),
+    });
+  });
+  it('should not add comment ID with different contentTarget', () => {
+    expect(reducer(undefined, action('events.event-3'))).toEqual({
+      articles: initialArticlesState,
+      events: eventsAdapter.getInitialState(),
+    });
   });
 });

--- a/app/reducers/__tests__/reactions.spec.ts
+++ b/app/reducers/__tests__/reactions.spec.ts
@@ -246,6 +246,7 @@ describe('reducers', () => {
 
     const remove = (contentTarget: ContentTarget) => ({
       type: Reaction.DELETE.SUCCESS,
+      payload: [],
       meta: {
         contentTarget,
         id: 33,

--- a/app/reducers/__tests__/reactions.spec.ts
+++ b/app/reducers/__tests__/reactions.spec.ts
@@ -1,6 +1,12 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { describe, it, expect } from 'vitest';
-import { Reaction } from '../../actions/ActionTypes';
-import { mutateReactions } from '../reactions';
+import { Reaction } from 'app/actions/ActionTypes';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import { addReactionCases, mutateReactions } from '../reactions';
+import type { DetailedArticle } from 'app/store/models/Article';
+import type { ReactionsGrouped } from 'app/store/models/Reaction';
+import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 describe('reducers', () => {
   describe('mutateReactions', () => {
@@ -181,6 +187,178 @@ describe('reducers', () => {
       };
       const newState = reducer(prevState, action);
       expect(newState).toEqual(prevState);
+    });
+  });
+
+  describe('addReactionCases', () => {
+    const articlesAdapter = createLegoAdapter(EntityType.Articles);
+    const createInitialState = (
+      article1HasReacted: boolean,
+      article1ReactionCount: number
+    ) => ({
+      ...articlesAdapter.getInitialState(),
+      ids: [2, 3],
+      entities: {
+        2: {
+          id: 2,
+          title: 'Article 1',
+          reactionsGrouped: [
+            {
+              emoji: ':joy:',
+              unicodeString: '123',
+              count: article1ReactionCount,
+              hasReacted: article1HasReacted,
+              reactionId: article1HasReacted ? 33 : undefined,
+            },
+          ],
+        } as DetailedArticle,
+        3: {
+          id: 3,
+          title: 'Article 2',
+          reactionsGrouped: [] as ReactionsGrouped[],
+        } as DetailedArticle,
+      },
+    });
+    const articlesSlice = createSlice({
+      name: EntityType.Articles,
+      initialState: createInitialState(false, 1),
+      reducers: {},
+      extraReducers: articlesAdapter.buildReducers({
+        extraCases: (addCase) => {
+          addReactionCases(EntityType.Articles, addCase);
+        },
+      }),
+    });
+    const reducer = articlesSlice.reducer;
+
+    const add = (contentTarget: ContentTarget) => ({
+      type: Reaction.ADD.SUCCESS,
+      meta: {
+        contentTarget,
+        emoji: ':joy:',
+        unicodeString: '123',
+      },
+      payload: {
+        id: 33,
+        emoji: ':pizza:',
+      },
+    });
+
+    const remove = (contentTarget: ContentTarget) => ({
+      type: Reaction.DELETE.SUCCESS,
+      meta: {
+        contentTarget,
+        id: 33,
+      },
+    });
+
+    it('should add reaction to entity', () => {
+      const initialState = createInitialState(false, 1);
+      expect(reducer(initialState, add('articles.article-3'))).toEqual({
+        ...initialState,
+        entities: {
+          2: {
+            id: 2,
+            title: 'Article 1',
+            reactionsGrouped: [
+              {
+                emoji: ':joy:',
+                unicodeString: '123',
+                count: 1,
+                hasReacted: false,
+              },
+            ],
+          },
+          3: {
+            id: 3,
+            title: 'Article 2',
+            reactionsGrouped: [
+              {
+                emoji: ':joy:',
+                unicodeString: '123',
+                count: 1,
+                hasReacted: true,
+                reactionId: 33,
+              },
+            ],
+          },
+        },
+      });
+    });
+    it('should group reactions', () => {
+      const initialState = createInitialState(false, 1);
+      expect(reducer(initialState, add('articles.article-2'))).toEqual({
+        ...initialState,
+        entities: {
+          2: {
+            id: 2,
+            title: 'Article 1',
+            reactionsGrouped: [
+              {
+                emoji: ':joy:',
+                unicodeString: '123',
+                count: 2,
+                hasReacted: true,
+                reactionId: 33,
+              },
+            ],
+          },
+          3: {
+            id: 3,
+            title: 'Article 2',
+            reactionsGrouped: [],
+          },
+        },
+      });
+    });
+    it('should delete reaction from entity', () => {
+      const initialState = createInitialState(true, 1);
+      expect(reducer(initialState, remove('articles.article-2'))).toEqual({
+        ...initialState,
+        entities: {
+          2: {
+            id: 2,
+            title: 'Article 1',
+            reactionsGrouped: [],
+          },
+          3: {
+            id: 3,
+            title: 'Article 2',
+            reactionsGrouped: [],
+          },
+        },
+      });
+    });
+    it('should remove grouped reaction', () => {
+      const initialState = createInitialState(true, 4);
+      expect(reducer(initialState, remove('articles.article-2'))).toEqual({
+        ...initialState,
+        entities: {
+          2: {
+            id: 2,
+            title: 'Article 1',
+            reactionsGrouped: [
+              {
+                emoji: ':joy:',
+                count: 3,
+                hasReacted: false,
+                unicodeString: '123',
+              },
+            ],
+          },
+          3: {
+            id: 3,
+            title: 'Article 2',
+            reactionsGrouped: [],
+          },
+        },
+      });
+    });
+    it('should not add reaction to wrong contentTarget', () => {
+      const initialState = createInitialState(false, 1);
+      expect(reducer(initialState, add('events.event-2'))).toEqual(
+        initialState
+      );
     });
   });
 });

--- a/app/reducers/allowed.ts
+++ b/app/reducers/allowed.ts
@@ -1,5 +1,6 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { Meta } from '../actions/ActionTypes';
-import type { AnyAction, Reducer } from '@reduxjs/toolkit';
+import type { AnyAction } from '@reduxjs/toolkit';
 
 const initialState = {
   events: false,
@@ -22,17 +23,15 @@ const initialState = {
 
 export type Allowed = typeof initialState;
 
-const allowed: Reducer<typeof initialState> = (
-  state = initialState,
-  action: AnyAction
-) => {
-  switch (action.type) {
-    case Meta.FETCH.SUCCESS:
+const allowed = createSlice({
+  name: 'allowed',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(Meta.FETCH.SUCCESS, (state, action: AnyAction) => {
       return action.payload.isAllowed;
+    });
+  },
+});
 
-    default:
-      return state;
-  }
-};
-
-export default allowed;
+export default allowed.reducer;

--- a/app/reducers/articles.ts
+++ b/app/reducers/articles.ts
@@ -1,6 +1,6 @@
 import { orderBy } from 'lodash';
 import { createSelector } from 'reselect';
-import { mutateComments } from 'app/reducers/comments';
+import { mutateComments, selectCommentEntities } from 'app/reducers/comments';
 import { mutateReactions } from 'app/reducers/reactions';
 import { selectUserById } from 'app/reducers/users';
 import { typeable } from 'app/reducers/utils';
@@ -89,9 +89,11 @@ export const selectArticleBySlug = createSelector(
 
 export const selectCommentsForArticle = createSelector(
   selectArticleById,
-  (state) => state.comments.byId,
-  (article, commentsById) => {
+  selectCommentEntities,
+  (article, commentEntities) => {
     if (!article) return [];
-    return (article.comments || []).map((commentId) => commentsById[commentId]);
+    return (article.comments || []).map(
+      (commentId) => commentEntities[commentId]
+    );
   }
 );

--- a/app/reducers/articles.ts
+++ b/app/reducers/articles.ts
@@ -1,47 +1,57 @@
-import { orderBy } from 'lodash';
+import { createSlice } from '@reduxjs/toolkit';
+import moment from 'moment-timezone';
 import { createSelector } from 'reselect';
-import { mutateComments, selectCommentEntities } from 'app/reducers/comments';
-import { mutateReactions } from 'app/reducers/reactions';
+import { Article } from 'app/actions/ActionTypes';
+import { addCommentCases, selectCommentEntities } from 'app/reducers/comments';
+import { addReactionCases } from 'app/reducers/reactions';
 import { selectUserById } from 'app/reducers/users';
 import { typeable } from 'app/reducers/utils';
-import createEntityReducer from 'app/utils/createEntityReducer';
-import joinReducers from 'app/utils/joinReducers';
-import { Article } from '../actions/ActionTypes';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import type { ArticleWithAuthorDetails } from 'app/routes/articles/ArticleListRoute';
 import type { RootState } from 'app/store/createRootReducer';
 import type { PublicArticle, UnknownArticle } from 'app/store/models/Article';
+import type { Pagination } from 'app/utils/legoAdapter/buildPaginationReducer';
 import type { Selector } from 'reselect';
 
-export default createEntityReducer<UnknownArticle>({
-  key: 'articles',
-  types: {
-    fetch: Article.FETCH,
-    mutate: Article.CREATE,
-    delete: Article.DELETE,
-  },
-  mutate: joinReducers(
-    mutateReactions<UnknownArticle>('articles'),
-    mutateComments<UnknownArticle>('articles')
-  ),
+const legoAdapter = createLegoAdapter(EntityType.Articles, {
+  sortComparer: (a, b) => moment(a.createdAt).diff(moment(b.createdAt)),
 });
 
-function transformArticle(article) {
-  return { ...article };
-}
+const articlesSlice = createSlice({
+  name: EntityType.Articles,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [Article.FETCH],
+    deleteActions: [Article.DELETE],
+    extraCases: (addCase) => {
+      addCommentCases(EntityType.Articles, addCase);
+      addReactionCases(EntityType.Articles, addCase);
+    },
+  }),
+});
 
+export default articlesSlice.reducer;
+export const {
+  selectAll: selectAllArticles,
+  selectIds: selectArticleIds,
+  selectEntities: selectArticleEntities,
+  selectById: selectArticleById,
+} = legoAdapter.getSelectors((state: RootState) => state.articles);
+
+type SelectArticlesOpts = {
+  pagination?: Pagination;
+};
 export const selectArticles = typeable(
   createSelector(
-    (state) => state.articles.byId,
-    (state) => state.articles.items,
-    (_, props) => props && props.pagination,
+    selectArticleEntities,
+    selectArticleIds,
+    (_: RootState, props: SelectArticlesOpts) => props && props.pagination,
     (articlesById, articleIds, pagination) =>
-      orderBy<UnknownArticle>(
-        (pagination ? pagination.items : articleIds).map((id) =>
-          transformArticle(articlesById[id])
-        ) as ReadonlyArray<UnknownArticle>,
-        ['createdAt', 'id'],
-        ['desc', 'desc']
-      )
+      (pagination ? pagination.ids : articleIds).map(
+        (id) => articlesById[id]
+      ) as ReadonlyArray<UnknownArticle>
   )
 );
 
@@ -65,26 +75,18 @@ export const selectArticlesWithAuthorDetails: Selector<
 
 export const selectArticlesByTag = createSelector(
   selectArticles,
-  (state, props) => props.tag,
+  (_: RootState, props: { tag: string }) => props.tag,
   (articles, tag) =>
     articles.filter((article) =>
       tag ? article.tags.indexOf(tag) !== -1 : true
     )
 );
-export const selectArticleById = createSelector(
-  (state) => state.articles.byId,
-  (state, props) => props.articleId,
-  (articlesById, articleId) => transformArticle(articlesById[articleId])
-);
+
 export const selectArticleBySlug = createSelector(
-  (state) => state.articles.byId,
-  (state, props) => props.articleSlug,
+  (state: RootState) => state.articles.entities,
+  (_: RootState, slug: string) => slug,
   (articlesById, articleSlug) =>
-    transformArticle(
-      Object.values(articlesById).find(
-        (article) => article.slug === articleSlug
-      )
-    )
+    Object.values(articlesById).find((article) => article?.slug === articleSlug)
 );
 
 export const selectCommentsForArticle = createSelector(
@@ -92,7 +94,7 @@ export const selectCommentsForArticle = createSelector(
   selectCommentEntities,
   (article, commentEntities) => {
     if (!article) return [];
-    return (article.comments || []).map(
+    return (('comments' in article && article.comments) || []).map(
       (commentId) => commentEntities[commentId]
     );
   }

--- a/app/reducers/comments.ts
+++ b/app/reducers/comments.ts
@@ -1,10 +1,16 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { produce } from 'immer';
 import { Comment } from 'app/actions/ActionTypes';
-import createEntityReducer, {
-  type EntityReducerState,
-} from 'app/utils/createEntityReducer';
+import { EntityType } from 'app/store/models/entities';
+import { parseContentTarget } from 'app/store/utils/contentTarget';
+import { type EntityReducerState } from 'app/utils/createEntityReducer';
 import getEntityType from 'app/utils/getEntityType';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import type { EntityId } from '@reduxjs/toolkit';
+import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
+import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
 import type { ID } from 'app/models';
+import type { RootState } from 'app/store/createRootReducer';
 import type { Comment as CommentType } from 'app/store/models/Comment';
 import type { AnyAction } from 'redux';
 
@@ -28,9 +34,11 @@ export function mutateComments<T, S = EntityReducerState<T>>(
         const targetType = getEntityType(serverTargetType);
 
         if (targetType === forTargetType) {
-          newState.byId[targetId].comments =
-            newState.byId[targetId].comments || [];
-          newState.byId[targetId].comments.push(action.payload.result);
+          const target = newState.byId[targetId];
+          if (target) {
+            target.comments ||= [];
+            target.comments.push(action.payload.result);
+          }
         }
 
         break;
@@ -42,24 +50,46 @@ export function mutateComments<T, S = EntityReducerState<T>>(
   });
 }
 
-const mutate = produce(
-  (newState: EntityReducerState<CommentType>, action: AnyAction): void => {
-    switch (action.type) {
-      case Comment.DELETE.SUCCESS:
-        newState.byId[action.meta.id].text = null;
-        newState.byId[action.meta.id].author = null;
-        break;
+export const addCommentCases = (
+  forTargetType: EntityType,
+  addCase: ActionReducerMapBuilder<
+    EntityState<{ comments?: EntityId[] }>
+  >['addCase']
+) => {
+  addCase(Comment.ADD.SUCCESS, (state, action: AnyAction) => {
+    const { targetType, targetId } = parseContentTarget(
+      action.meta.contentTarget
+    );
 
-      default:
-        break;
+    if (targetType === forTargetType) {
+      const target = state.entities[targetId];
+      if (target) {
+        target.comments ??= [];
+        target.comments.push(action.payload.result);
+      }
     }
-  }
-);
+  });
+};
 
-export default createEntityReducer<CommentType>({
-  key: 'comments',
-  types: {
-    fetch: Comment.FETCH,
-  },
-  mutate,
+const legoAdapter = createLegoAdapter(EntityType.Comments);
+
+const commentSlice = createSlice({
+  name: EntityType.Comments,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    extraCases: (addCase) => {
+      addCase(Comment.DELETE.SUCCESS, (state, action: AnyAction) => {
+        const comment = state.entities[action.meta.id];
+        if (comment) {
+          comment.text = null;
+          comment.author = null;
+        }
+      });
+    },
+  }),
 });
+
+export default commentSlice.reducer;
+export const { selectEntities: selectCommentEntities } =
+  legoAdapter.getSelectors((state: RootState) => state.comments);

--- a/app/reducers/companies.ts
+++ b/app/reducers/companies.ts
@@ -1,6 +1,6 @@
 import { produce } from 'immer';
 import { createSelector } from 'reselect';
-import { mutateComments } from 'app/reducers/comments';
+import { mutateComments, selectCommentEntities } from 'app/reducers/comments';
 import { selectJoblistings } from 'app/reducers/joblistings';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
@@ -228,9 +228,11 @@ export const selectCompanyContactById = createSelector(
 );
 export const selectCommentsForCompany = createSelector(
   selectCompanyById,
-  (state) => state.comments.byId,
-  (company, commentsById) => {
-    if (!company || !commentsById) return [];
-    return (company.comments || []).map((commentId) => commentsById[commentId]);
+  selectCommentEntities,
+  (company, commentEntities) => {
+    if (!company || !commentEntities) return [];
+    return (company.comments || []).map(
+      (commentId) => commentEntities[commentId]
+    );
   }
 );

--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -5,7 +5,7 @@ import { normalize } from 'normalizr';
 import { createSelector } from 'reselect';
 import config from 'app/config';
 import { eventSchema } from 'app/reducers';
-import { mutateComments } from 'app/reducers/comments';
+import { mutateComments, selectCommentEntities } from 'app/reducers/comments';
 import { isCurrentUser as checkIfCurrentUser } from 'app/routes/users/utils';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
@@ -386,10 +386,12 @@ export const selectRegistrationForEventByUserId = createSelector(
 );
 export const selectCommentsForEvent = createSelector(
   selectEventById,
-  (state) => state.comments.byId,
-  (event, commentsById) => {
+  selectCommentEntities,
+  (event, commentEntities) => {
     if (!event) return [];
-    return (event.comments || []).map((commentId) => commentsById[commentId]);
+    return (event.comments || []).map(
+      (commentId) => commentEntities[commentId]
+    );
   }
 );
 export const selectRegistrationsFromPools = createSelector(

--- a/app/reducers/galleryPictures.ts
+++ b/app/reducers/galleryPictures.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { Gallery, GalleryPicture } from 'app/actions/ActionTypes';
-import { mutateComments } from 'app/reducers/comments';
+import { mutateComments, selectCommentEntities } from 'app/reducers/comments';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
 import type { ID } from 'app/models';
@@ -135,9 +135,11 @@ export const selectGalleryPictureById = createSelector(
 );
 export const selectCommentsForGalleryPicture = createSelector(
   selectGalleryPictureById,
-  (state) => state.comments.byId,
-  (picture, commentsById) => {
+  selectCommentEntities,
+  (picture, commentEntities) => {
     if (!picture) return [];
-    return (picture.comments || []).map((commentId) => commentsById[commentId]);
+    return (picture.comments || []).map(
+      (commentId) => commentEntities[commentId]
+    );
   }
 );

--- a/app/reducers/meetings.ts
+++ b/app/reducers/meetings.ts
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 import { createSelector } from 'reselect';
-import { mutateComments } from 'app/reducers/comments';
+import { mutateComments, selectCommentEntities } from 'app/reducers/comments';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
 import { Meeting } from '../actions/ActionTypes';
@@ -39,10 +39,10 @@ export const selectMeetingById = createSelector(
 );
 export const selectCommentsForMeeting = createSelector(
   selectMeetingById,
-  (state) => state.comments.byId,
-  (meeting, commentsById) => {
+  selectCommentEntities,
+  (meeting, commentEntities) => {
     if (!meeting || !meeting.comments) return [];
-    return meeting.comments.map((commentId) => commentsById[commentId]);
+    return meeting.comments.map((commentId) => commentEntities[commentId]);
   }
 );
 

--- a/app/reducers/reactions.ts
+++ b/app/reducers/reactions.ts
@@ -1,8 +1,12 @@
 import { Reaction } from 'app/actions/ActionTypes';
+import { parseContentTarget } from 'app/store/utils/contentTarget';
 import getEntityType from 'app/utils/getEntityType';
 import type { AnyAction } from '@reduxjs/toolkit';
+import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
+import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
 import type { ID } from 'app/store/models';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
+import type { EntityType } from 'app/store/models/entities';
 import type { EntityReducerState } from 'app/utils/createEntityReducer';
 
 type WithReactions<T> = T & { reactionsGrouped: ReactionsGrouped[] };
@@ -106,3 +110,76 @@ export function mutateReactions<T, S = EntityReducerState<T>>(
     }
   };
 }
+
+export const addReactionCases = (
+  forTargetType: EntityType,
+  addCase: ActionReducerMapBuilder<
+    EntityState<{ reactionsGrouped?: ReactionsGrouped[] }>
+  >['addCase']
+) => {
+  addCase(Reaction.ADD.SUCCESS, (state, action: AnyAction) => {
+    const { targetType, targetId } = parseContentTarget(
+      action.meta.contentTarget
+    );
+    if (targetType !== forTargetType) {
+      return;
+    }
+
+    const entity = state.entities[targetId];
+    if (!entity) {
+      return;
+    }
+
+    const reactionEmoji = action.meta.emoji;
+    const reactionId = action.payload.id;
+
+    entity.reactionsGrouped ??= [];
+
+    let found = false;
+    for (const reaction of entity.reactionsGrouped) {
+      if (reaction.emoji === reactionEmoji) {
+        found = true;
+        reaction.count++;
+        reaction.hasReacted = true;
+        reaction.reactionId = reactionId;
+      }
+    }
+
+    if (!found) {
+      const unicodeString = action.meta.unicodeString;
+
+      entity.reactionsGrouped.push({
+        emoji: reactionEmoji,
+        unicodeString,
+        count: 1,
+        hasReacted: true,
+        reactionId,
+      });
+    }
+  });
+  addCase(Reaction.DELETE.SUCCESS, (state, action: AnyAction) => {
+    const { targetType, targetId } = parseContentTarget(
+      action.meta.contentTarget
+    );
+    if (targetType !== forTargetType) {
+      return;
+    }
+
+    const entity = state.entities[targetId];
+    if (!entity) {
+      return;
+    }
+
+    entity.reactionsGrouped ??= [];
+    for (const reaction of entity.reactionsGrouped) {
+      if (reaction.reactionId === action.meta.id) {
+        reaction.count--;
+        reaction.hasReacted = false;
+        delete reaction.reactionId;
+      }
+    }
+    entity.reactionsGrouped = entity.reactionsGrouped.filter(
+      (reaction) => reaction.count !== 0
+    );
+  });
+};

--- a/app/reducers/selectors.ts
+++ b/app/reducers/selectors.ts
@@ -45,6 +45,7 @@ export const selectPaginationNext =
         next: { ...query, cursor: '' },
         previous: false,
         items: [],
+        ids: [],
       },
       paginationKey,
     };

--- a/app/routes/articles/ArticleDetailRoute.ts
+++ b/app/routes/articles/ArticleDetailRoute.ts
@@ -26,22 +26,16 @@ type Params = {
 const mapStateToProps = (state, props) => {
   const { articleIdOrSlug } = props.match.params;
   const article = !isNaN(articleIdOrSlug)
-    ? selectArticleById(state, {
-        articleId: articleIdOrSlug,
-      })
-    : selectArticleBySlug(state, {
-        articleSlug: articleIdOrSlug,
-      });
+    ? selectArticleById(state, articleIdOrSlug)
+    : selectArticleBySlug(state, articleIdOrSlug);
   const articleId = article && article.id;
 
-  const comments = selectCommentsForArticle(state, {
-    articleId,
-  });
-  const authors = article.authors?.map((e) => {
-    return selectUserById(state, {
+  const comments = articleId && selectCommentsForArticle(state, articleId);
+  const authors = article?.authors?.map((e) =>
+    selectUserById(state, {
       userId: e,
-    });
-  });
+    })
+  );
   const emojis = selectEmojis(state);
 
   return {

--- a/app/routes/articles/ArticleEditRoute.ts
+++ b/app/routes/articles/ArticleEditRoute.ts
@@ -15,13 +15,15 @@ import loadingIndicator from 'app/utils/loadingIndicator';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import ArticleEditor from './components/ArticleEditor';
+import type { RootState } from 'app/store/createRootReducer';
+import type { DetailedArticle } from 'app/store/models/Article';
 import type { DetailedUser } from 'app/store/models/User';
 
-const mapStateToProps = (state, props) => {
+const mapStateToProps = (state: RootState, props) => {
   const { articleId } = props.match.params;
-  const article = selectArticleById(state, {
-    articleId,
-  });
+  const article = selectArticleById(state, articleId) as
+    | DetailedArticle
+    | undefined;
 
   const currentUser = selectCurrentUser(state);
   const authors: DetailedUser[] = article?.authors?.length
@@ -35,14 +37,14 @@ const mapStateToProps = (state, props) => {
     initialValues: {
       ...article,
       ...objectPermissionsToInitialValues({
-        canViewGroups: article.canViewGroups,
-        canEditGroups: article.canEditGroups,
-        canEditUsers: article.canEditUsers,
+        canViewGroups: article?.canViewGroups,
+        canEditGroups: article?.canEditGroups,
+        canEditUsers: article?.canEditUsers,
       }),
       authors: authors
         .filter(Boolean)
         .map((user) => ({ user, label: user.fullName, value: user.id })),
-      tags: (article.tags || []).map((tag) => ({
+      tags: (article?.tags || []).map((tag) => ({
         label: tag,
         value: tag,
       })),

--- a/app/store/models/Article.d.ts
+++ b/app/store/models/Article.d.ts
@@ -74,8 +74,11 @@ export type PublicArticle = Pick<
 > &
   AllowedPermissionsMixin;
 
-export type UnknownArticle =
+export type UnknownArticle = (
   | DetailedArticle
   | AdminDetailedArticle
-  | SearchArticle
-  | PublicArticle;
+  | PublicArticle
+) & {
+  comments?: ID[];
+  reactionsGrouped?: ReactionsGrouped[];
+};

--- a/app/store/models/Article.d.ts
+++ b/app/store/models/Article.d.ts
@@ -1,8 +1,10 @@
 import type { Dateish } from 'app/models';
 import type AllowedPermissionsMixin from 'app/store/models/AllowedPermissionsMixin';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
+import type { PublicGroup } from 'app/store/models/Group';
 import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
+import type { PublicUser } from 'app/store/models/User';
 import type { ID } from 'app/store/models/index';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
@@ -22,6 +24,9 @@ interface CompleteArticle {
   pinned: boolean;
   reactionsGrouped?: ReactionsGrouped[];
   youtubeUrl: string;
+  canEditUsers: PublicUser[];
+  canViewGroups: PublicGroup[];
+  canEditGroups: PublicGroup[];
 }
 
 export type DetailedArticle = Pick<
@@ -41,15 +46,13 @@ export type DetailedArticle = Pick<
   | 'pinned'
   | 'reactionsGrouped'
   | 'youtubeUrl'
+  | 'canEditUsers'
+  | 'canViewGroups'
+  | 'canEditGroups'
 > &
   AllowedPermissionsMixin;
 
 export type AdminDetailedArticle = DetailedArticle & ObjectPermissionsMixin;
-
-export type SearchArticle = Pick<
-  CompleteArticle,
-  'id' | 'title' | 'cover' | 'description' | 'content' | 'pinned' | 'createdAt'
->;
 
 export type AutocompleteArticle = Pick<
   CompleteArticle,
@@ -82,3 +85,8 @@ export type UnknownArticle = (
   comments?: ID[];
   reactionsGrouped?: ReactionsGrouped[];
 };
+
+export type SearchArticle = Pick<
+  CompleteArticle,
+  'id' | 'title' | 'cover' | 'description' | 'content' | 'pinned' | 'createdAt'
+>;

--- a/app/store/models/Comment.d.ts
+++ b/app/store/models/Comment.d.ts
@@ -1,12 +1,12 @@
 import type { Dateish } from 'app/models';
-import type User from 'app/store/models/User';
+import type { PublicUser } from 'app/store/models/User';
 import type { ID } from 'app/store/models/index';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export interface Comment {
   id: ID;
   text: string | null;
-  author: User | null;
+  author: PublicUser | null;
   contentTarget: ContentTarget;
   createdAt: Dateish;
   updatedAt: Dateish;

--- a/app/store/utils/contentTarget.ts
+++ b/app/store/utils/contentTarget.ts
@@ -4,7 +4,7 @@ import type { EntityServerName } from 'app/utils/getEntityType';
 
 export type ContentTarget = `${EntityServerName}-${ID}`;
 
-export const parseContentTarget = (contentTarget: string) => {
+export const parseContentTarget = (contentTarget: ContentTarget) => {
   const [serverTargetType, targetId] = contentTarget.split('-') as [
     EntityServerName,
     ID

--- a/app/types.ts
+++ b/app/types.ts
@@ -18,9 +18,9 @@ export type ValueLabel<T extends object, K extends keyof T> = Overwrite<
 >;
 
 export type AsyncActionType = {
-  BEGIN: string;
-  SUCCESS: string;
-  FAILURE: string;
+  BEGIN: `${string}.BEGIN`;
+  SUCCESS: `${string}.SUCCESS`;
+  FAILURE: `${string}.FAILURE`;
 };
 export type AsyncActionTypeArray = [string, string, string];
 export type EntityID = number;

--- a/app/utils/getEntityType.ts
+++ b/app/utils/getEntityType.ts
@@ -1,14 +1,16 @@
-import type { $Keys } from 'utility-types';
+import { EntityType } from 'app/store/models/entities';
 
 const entityTypeMappings = {
-  'events.event': 'events',
-  'articles.article': 'articles',
-  'quotes.quote': 'quotes',
-  'companies.company': 'companies',
-  'meetings.meeting': 'meetings',
-  'gallery.gallerypicture': 'galleryPictures',
+  'events.event': EntityType.Events,
+  'articles.article': EntityType.Articles,
+  'quotes.quote': EntityType.Quotes,
+  'companies.company': EntityType.Companies,
+  'meetings.meeting': EntityType.Meetings,
+  'gallery.gallerypicture': EntityType.GalleryPictures,
 };
-export type EntityServerName = $Keys<typeof entityTypeMappings>;
-export default function getEntityType(serverName: EntityServerName): string {
-  return entityTypeMappings[serverName] || serverName;
+export type EntityServerName = keyof typeof entityTypeMappings;
+export default function getEntityType(
+  serverName: EntityServerName
+): EntityType {
+  return entityTypeMappings[serverName];
 }

--- a/app/utils/legoAdapter/__tests__/asyncApiActions.spec.ts
+++ b/app/utils/legoAdapter/__tests__/asyncApiActions.spec.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { generateStatuses } from 'app/actions/ActionTypes';
+import { EntityType } from 'app/store/models/entities';
+import {
+  isAsyncApiActionBegin,
+  isAsyncApiActionFailure,
+  isAsyncApiActionSuccess,
+} from 'app/utils/legoAdapter/asyncApiActions';
+
+describe('async action type guards', () => {
+  const FETCH = generateStatuses('FETCH');
+  const UPDATE = generateStatuses('UPDATE');
+
+  const baseAction = {
+    meta: {
+      endpoint: '/something',
+      schemaKey: 'something',
+    },
+  };
+
+  describe('isAsyncApiActionSuccess', () => {
+    it('should return true on SUCCESS actions', () => {
+      expect(
+        isAsyncApiActionSuccess({ ...baseAction, type: FETCH.SUCCESS })
+      ).toBe(true);
+      expect(
+        isAsyncApiActionSuccess({ ...baseAction, type: UPDATE.SUCCESS })
+      ).toBe(true);
+    });
+    it('should return false on other actions', () => {
+      expect(
+        isAsyncApiActionSuccess({ ...baseAction, type: FETCH.BEGIN })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionSuccess({ ...baseAction, type: FETCH.FAILURE })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionSuccess({ ...baseAction, type: UPDATE.BEGIN })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionSuccess({ ...baseAction, type: UPDATE.FAILURE })
+      ).toBe(false);
+    });
+
+    describe('.matching', () => {
+      it('should return true only if matching actionTypes', () => {
+        expect(
+          isAsyncApiActionSuccess.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.SUCCESS,
+          })
+        ).toBe(true);
+        expect(
+          isAsyncApiActionSuccess.matching([FETCH])({
+            ...baseAction,
+            type: UPDATE.SUCCESS,
+          })
+        ).toBe(false);
+      });
+      it('should return false if not SUCCESS even if matching actionTypes', () => {
+        expect(
+          isAsyncApiActionSuccess.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.BEGIN,
+          })
+        ).toBe(false);
+        expect(
+          isAsyncApiActionSuccess.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.FAILURE,
+          })
+        ).toBe(false);
+      });
+    });
+    describe('.containsEntity', () => {
+      it('should return true when entity is in payload', () => {
+        expect(
+          isAsyncApiActionSuccess.containingEntity(EntityType.Articles)({
+            ...baseAction,
+            type: FETCH.SUCCESS,
+            payload: {
+              entities: {
+                [EntityType.Articles]: {},
+              },
+            },
+          })
+        ).toBe(true);
+        expect(
+          isAsyncApiActionSuccess.containingEntity(EntityType.Events)({
+            ...baseAction,
+            type: FETCH.SUCCESS,
+            payload: {
+              entities: {
+                [EntityType.Events]: {},
+              },
+            },
+          })
+        ).toBe(true);
+      });
+      it('should return false when entity is not in payload', () => {
+        expect(
+          isAsyncApiActionSuccess.containingEntity(EntityType.Articles)({
+            ...baseAction,
+            type: FETCH.SUCCESS,
+            payload: {
+              entities: {
+                [EntityType.Emojis]: {},
+              },
+            },
+          })
+        ).toBe(false);
+        expect(
+          isAsyncApiActionSuccess.containingEntity(EntityType.Events)({
+            ...baseAction,
+            type: FETCH.SUCCESS,
+            payload: {
+              entities: {
+                [EntityType.Announcements]: {},
+              },
+            },
+          })
+        ).toBe(false);
+      });
+    });
+  });
+  describe('isAsyncApiActionFailure', () => {
+    it('should return true on FAILURE actions', () => {
+      expect(
+        isAsyncApiActionFailure({ ...baseAction, type: FETCH.FAILURE })
+      ).toBe(true);
+      expect(
+        isAsyncApiActionFailure({ ...baseAction, type: UPDATE.FAILURE })
+      ).toBe(true);
+    });
+    it('should return false on other actions', () => {
+      expect(
+        isAsyncApiActionFailure({ ...baseAction, type: FETCH.BEGIN })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionFailure({ ...baseAction, type: FETCH.SUCCESS })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionFailure({ ...baseAction, type: UPDATE.BEGIN })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionFailure({ ...baseAction, type: UPDATE.SUCCESS })
+      ).toBe(false);
+    });
+
+    describe('.matching', () => {
+      it('should return true only if matching actionTypes', () => {
+        expect(
+          isAsyncApiActionFailure.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.FAILURE,
+          })
+        ).toBe(true);
+        expect(
+          isAsyncApiActionFailure.matching([FETCH])({
+            ...baseAction,
+            type: UPDATE.FAILURE,
+          })
+        ).toBe(false);
+      });
+      it('should return false if not SUCCESS even if matching actionTypes', () => {
+        expect(
+          isAsyncApiActionFailure.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.BEGIN,
+          })
+        ).toBe(false);
+        expect(
+          isAsyncApiActionFailure.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.SUCCESS,
+          })
+        ).toBe(false);
+      });
+    });
+  });
+  describe('isAsyncApiActionBegin', () => {
+    it('should return true on FAILURE actions', () => {
+      expect(isAsyncApiActionBegin({ ...baseAction, type: FETCH.BEGIN })).toBe(
+        true
+      );
+      expect(isAsyncApiActionBegin({ ...baseAction, type: UPDATE.BEGIN })).toBe(
+        true
+      );
+    });
+    it('should return false on other actions', () => {
+      expect(
+        isAsyncApiActionBegin({ ...baseAction, type: FETCH.FAILURE })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionBegin({ ...baseAction, type: FETCH.SUCCESS })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionBegin({ ...baseAction, type: UPDATE.FAILURE })
+      ).toBe(false);
+      expect(
+        isAsyncApiActionBegin({ ...baseAction, type: UPDATE.SUCCESS })
+      ).toBe(false);
+    });
+
+    describe('.matching', () => {
+      it('should return true only if matching actionTypes', () => {
+        expect(
+          isAsyncApiActionBegin.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.BEGIN,
+          })
+        ).toBe(true);
+        expect(
+          isAsyncApiActionBegin.matching([FETCH])({
+            ...baseAction,
+            type: UPDATE.BEGIN,
+          })
+        ).toBe(false);
+      });
+      it('should return false if not SUCCESS even if matching actionTypes', () => {
+        expect(
+          isAsyncApiActionBegin.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.FAILURE,
+          })
+        ).toBe(false);
+        expect(
+          isAsyncApiActionBegin.matching([FETCH])({
+            ...baseAction,
+            type: FETCH.SUCCESS,
+          })
+        ).toBe(false);
+      });
+    });
+  });
+});

--- a/app/utils/legoAdapter/__tests__/buildActionGrantReducer.spec.ts
+++ b/app/utils/legoAdapter/__tests__/buildActionGrantReducer.spec.ts
@@ -1,0 +1,46 @@
+import { createReducer } from '@reduxjs/toolkit';
+import { describe, it, expect } from 'vitest';
+import { EntityType } from 'app/store/models/entities';
+import buildActionGrantReducer from 'app/utils/legoAdapter/buildActionGrantReducer';
+
+describe('buildActionGrantReducer', () => {
+  const initialState = {
+    actionGrant: [],
+  };
+
+  const reducer = createReducer(initialState, (builder) => {
+    buildActionGrantReducer(builder, EntityType.Articles);
+  });
+
+  it('should replace actionGrant if schemaKey of the action matches entity type', () => {
+    expect(
+      reducer(initialState, {
+        type: 'FETCH.SUCCESS',
+        payload: {
+          actionGrant: ['expected'],
+        },
+        meta: {
+          endpoint: '/endpoint',
+          schemaKey: EntityType.Articles,
+        },
+      })
+    ).toEqual({
+      ...initialState,
+      actionGrant: ['expected'],
+    });
+  });
+  it('should not change actionGrant if shemaKey does not match', () => {
+    expect(
+      reducer(initialState, {
+        type: 'FETCH.SUCCESS',
+        payload: {
+          actionGrant: ['expected'],
+        },
+        meta: {
+          endpoint: '/endpoint',
+          schemaKey: EntityType.Comments,
+        },
+      })
+    ).toEqual(initialState);
+  });
+});

--- a/app/utils/legoAdapter/__tests__/buildDeleteEntityReducer.spec.ts
+++ b/app/utils/legoAdapter/__tests__/buildDeleteEntityReducer.spec.ts
@@ -1,0 +1,91 @@
+import { createEntityAdapter, createReducer } from '@reduxjs/toolkit';
+import { describe, it, expect } from 'vitest';
+import { generateStatuses } from 'app/actions/ActionTypes';
+import buildDeleteEntityReducer from 'app/utils/legoAdapter/buildDeleteEntityReducer';
+
+type Entity = {
+  id: number;
+};
+
+describe('addFetchingReducer', () => {
+  const DELETE = generateStatuses('DELETE');
+  const UNRELATED = generateStatuses('UNRELATED');
+
+  const baseAction = {
+    meta: {
+      endpoint: '/something',
+      schemaKey: 'something',
+      id: 1,
+    },
+  };
+
+  const adapter = createEntityAdapter<Entity>();
+
+  const reducer = createReducer(adapter.getInitialState(), (builder) => {
+    buildDeleteEntityReducer(builder, [DELETE]);
+  });
+
+  const initialState = {
+    ...adapter.getInitialState(),
+    ids: [1, 2],
+    entities: {
+      1: {
+        id: 1,
+      },
+      2: {
+        id: 2,
+      },
+    },
+  };
+
+  it('should delete on delete success', () => {
+    const deleteBegan = reducer(initialState, {
+      ...baseAction,
+      type: DELETE.BEGIN,
+    });
+    const actuallyDeleted = reducer(deleteBegan, {
+      ...baseAction,
+      type: DELETE.SUCCESS,
+    });
+    expect(actuallyDeleted).toEqual({
+      ...initialState,
+      ids: [2],
+      entities: {
+        2: initialState.entities[2],
+      },
+    });
+  });
+
+  it('should not delete on delete failure', () => {
+    const deleteBegan = reducer(initialState, {
+      ...baseAction,
+      type: DELETE.BEGIN,
+    });
+    const deleteFailed = reducer(deleteBegan, {
+      ...baseAction,
+      type: DELETE.FAILURE,
+    });
+    expect(deleteFailed).toEqual(initialState);
+  });
+
+  it('should ignore unspecified actionTypes', () => {
+    expect(
+      reducer(initialState, {
+        ...baseAction,
+        type: UNRELATED.BEGIN,
+      })
+    ).toEqual(initialState);
+    expect(
+      reducer(initialState, {
+        ...baseAction,
+        type: UNRELATED.FAILURE,
+      })
+    ).toEqual(initialState);
+    expect(
+      reducer(initialState, {
+        ...baseAction,
+        type: UNRELATED.SUCCESS,
+      })
+    ).toEqual(initialState);
+  });
+});

--- a/app/utils/legoAdapter/__tests__/buildEntitiesReducer.spec.ts
+++ b/app/utils/legoAdapter/__tests__/buildEntitiesReducer.spec.ts
@@ -1,0 +1,100 @@
+import { createEntityAdapter, createReducer } from '@reduxjs/toolkit';
+import { describe, it, expect } from 'vitest';
+import { EntityType } from 'app/store/models/entities';
+import buildEntitiesReducer from 'app/utils/legoAdapter/buildEntitiesReducer';
+import type { UnknownArticle } from 'app/store/models/Article';
+
+describe('buildEntitiesReducer', () => {
+  const adapter = createEntityAdapter<UnknownArticle>();
+  const initialState = adapter.getInitialState();
+
+  const reducer = createReducer(initialState, (builder) => {
+    buildEntitiesReducer(builder, adapter, EntityType.Articles);
+  });
+
+  it('adds new entities of the specified type', () => {
+    expect(
+      reducer(initialState, {
+        type: 'WHATEVER.FETCH.SUCCESS',
+        meta: {
+          endpoint: '/whatever',
+          schemaKey: 'whatever',
+        },
+        payload: {
+          entities: {
+            [EntityType.Articles]: {
+              1: {
+                id: 1,
+                expected: true,
+              },
+            },
+          },
+        },
+      })
+    ).toEqual({
+      ids: [1],
+      entities: {
+        1: {
+          id: 1,
+          expected: true,
+        },
+      },
+    });
+  });
+  it('updates entities of the specified type', () => {
+    const state = {
+      ...initialState,
+      ids: [1],
+      entities: {
+        1: {
+          id: 1,
+          property: 'initial',
+          otherProperty: 'unchanged',
+        } as unknown as UnknownArticle,
+      },
+    };
+    expect(
+      reducer(state, {
+        type: 'WHATEVER.FETCH.SUCCESS',
+        meta: {
+          endpoint: '/whatever',
+          schemaKey: 'whatever',
+        },
+        payload: {
+          entities: {
+            [EntityType.Articles]: {
+              1: {
+                id: 1,
+                property: 'changed',
+              },
+            },
+          },
+        },
+      })
+    ).toEqual({
+      ids: [1],
+      entities: {
+        1: {
+          id: 1,
+          property: 'changed',
+          otherProperty: 'unchanged',
+        },
+      },
+    });
+  });
+  it('ignores entities of other types', () => {
+    expect(
+      reducer(initialState, {
+        type: 'WHATEVER.FETCH.SUCCESS',
+        payload: {
+          entities: {
+            [EntityType.Announcements]: {
+              id: 1,
+              expected: false,
+            },
+          },
+        },
+      })
+    ).toEqual(initialState);
+  });
+});

--- a/app/utils/legoAdapter/__tests__/buildFetchingReducer.spec.ts
+++ b/app/utils/legoAdapter/__tests__/buildFetchingReducer.spec.ts
@@ -1,0 +1,59 @@
+import { createReducer } from '@reduxjs/toolkit';
+import { describe, it, expect } from 'vitest';
+import { generateStatuses } from 'app/actions/ActionTypes';
+import buildFetchingReducer from 'app/utils/legoAdapter/buildFetchingReducer';
+
+describe('addFetchingReducer', () => {
+  const FETCH = generateStatuses('FETCH');
+  const NOT_FETCH = generateStatuses('NOT_FETCH');
+
+  const baseAction = {
+    meta: {
+      endpoint: '/something',
+      schemaKey: 'something',
+    },
+  };
+
+  const reducer = createReducer({ fetching: false }, (builder) => {
+    buildFetchingReducer(builder, [FETCH]);
+  });
+
+  it('should set fetching=true on BEGIN action', () => {
+    expect(
+      reducer({ fetching: false }, { ...baseAction, type: FETCH.BEGIN })
+    ).toEqual({
+      fetching: true,
+    });
+  });
+  it('should set fetching=false on FAILURE action', () => {
+    expect(
+      reducer({ fetching: true }, { ...baseAction, type: FETCH.FAILURE })
+    ).toEqual({
+      fetching: false,
+    });
+  });
+  it('should set fetching=false on SUCCESS action', () => {
+    expect(
+      reducer({ fetching: true }, { ...baseAction, type: FETCH.SUCCESS })
+    ).toEqual({
+      fetching: false,
+    });
+  });
+  it("should ignore actions that don't match", () => {
+    expect(
+      reducer({ fetching: false }, { ...baseAction, type: NOT_FETCH.BEGIN })
+    ).toEqual({
+      fetching: false,
+    });
+    expect(
+      reducer({ fetching: true }, { ...baseAction, type: NOT_FETCH.FAILURE })
+    ).toEqual({
+      fetching: true,
+    });
+    expect(
+      reducer({ fetching: true }, { ...baseAction, type: NOT_FETCH.SUCCESS })
+    ).toEqual({
+      fetching: true,
+    });
+  });
+});

--- a/app/utils/legoAdapter/__tests__/buildPaginationReducer.spec.ts
+++ b/app/utils/legoAdapter/__tests__/buildPaginationReducer.spec.ts
@@ -1,0 +1,129 @@
+import { createReducer } from '@reduxjs/toolkit';
+import { describe, it, expect } from 'vitest';
+import { generateStatuses } from 'app/actions/ActionTypes';
+import buildPaginationReducer from 'app/utils/legoAdapter/buildPaginationReducer';
+import type { Pagination } from 'app/utils/legoAdapter/buildPaginationReducer';
+
+describe('buildPaginationReducer', () => {
+  const FETCH = generateStatuses('FETCH');
+
+  const initialState = { paginationNext: {} };
+  const initialPaginationState: Pagination = {
+    query: {},
+    ids: [],
+    hasMore: false,
+    hasMoreBackwards: false,
+    next: undefined,
+    previous: undefined,
+  };
+  const stateWithInitialPagination = {
+    ...initialState,
+    paginationNext: {
+      '/fetch/': initialPaginationState,
+    },
+  };
+
+  const reducer = createReducer(initialState, (builder) => {
+    buildPaginationReducer(builder, [FETCH]);
+  });
+
+  const fetchSuccess = {
+    type: FETCH.SUCCESS,
+    meta: {
+      endpoint: '/fetch',
+      paginationKey: '/fetch/',
+      query: { title: 'ab' },
+    },
+    payload: {
+      result: [1, 2, 3],
+      next: 'https://lego.abakus.no/fetch?cursor=abc123&title=ab',
+    },
+  };
+
+  it('should add initial pagination state on fetch begin', () => {
+    expect(
+      reducer(initialState, {
+        type: FETCH.BEGIN,
+        meta: { endpoint: '/fetch', paginationKey: '/fetch/', query: {} },
+      })
+    ).toEqual(stateWithInitialPagination);
+    expect(
+      reducer(initialState, {
+        type: FETCH.BEGIN,
+        meta: {
+          endpoint: '/fetch',
+          paginationKey: '/fetch/',
+          query: { title: 'ab' },
+        },
+      })
+    ).toEqual({
+      ...initialState,
+      paginationNext: {
+        '/fetch/': { ...initialPaginationState, query: { title: 'ab' } },
+      },
+    });
+  });
+  it('should update ids on fetch success', () => {
+    const newState = reducer(stateWithInitialPagination, fetchSuccess);
+    expect(newState.paginationNext['/fetch/'].ids).toEqual([1, 2, 3]);
+  });
+  it('should update state if "next" set in the fetch success action', () => {
+    const newState = reducer(stateWithInitialPagination, fetchSuccess);
+    expect(newState.paginationNext['/fetch/'].next).toEqual({
+      title: 'ab',
+      cursor: 'abc123',
+    });
+    expect(newState.paginationNext['/fetch/'].hasMore).toEqual(true);
+  });
+  it('should update state if "previous" set in the fetch success action', () => {
+    const newState = reducer(stateWithInitialPagination, {
+      ...fetchSuccess,
+      payload: {
+        result: [1],
+        previous: 'http://lego.abakus.no/fetch?cursor=test&title=ab',
+      },
+    });
+    expect(newState.paginationNext['/fetch/'].previous).toEqual({
+      title: 'ab',
+      cursor: 'test',
+    });
+    expect(newState.paginationNext['/fetch/'].hasMoreBackwards).toEqual(true);
+  });
+  it('should remove next/previous if a fetch success action does not have them', () => {
+    const newState = reducer(
+      {
+        ...stateWithInitialPagination,
+        paginationNext: {
+          '/fetch/': {
+            ...initialPaginationState,
+            next: {
+              cursor: 123,
+            },
+            previous: {
+              cursor: 321,
+            },
+          },
+        },
+      },
+      { ...fetchSuccess, payload: { result: [] } }
+    );
+    expect(newState.paginationNext['/fetch/'].next).toEqual(undefined);
+    expect(newState.paginationNext['/fetch/'].hasMore).toEqual(false);
+    expect(newState.paginationNext['/fetch/'].previous).toEqual(undefined);
+    expect(newState.paginationNext['/fetch/'].hasMoreBackwards).toEqual(false);
+  });
+  it('should keep initial state if no next or previous urls are provided', () => {
+    const newState = reducer(stateWithInitialPagination, {
+      type: FETCH.SUCCESS,
+      meta: {
+        endpoint: '/fetch',
+        paginationKey: '/fetch/',
+        query: { title: 'ab' },
+      },
+      payload: {
+        result: [],
+      },
+    });
+    expect(newState).toEqual(stateWithInitialPagination);
+  });
+});

--- a/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
+++ b/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
@@ -31,6 +31,47 @@ describe('createLegoAdapter', () => {
   });
 
   describe('buildReducers', () => {
+    describe('default reducer functionality', () => {
+      const FETCH = generateStatuses('FETCH');
+      const actionBase = {
+        meta: {
+          endpoint: '/something',
+          schemaKey: 'something',
+        },
+      };
+      const fetchBegin = { ...actionBase, type: FETCH.BEGIN };
+      const fetchSuccess = { ...actionBase, type: FETCH.SUCCESS };
+      const fetchFailure = { ...actionBase, type: FETCH.FAILURE };
+
+      const adapter = createLegoAdapter(EntityType.Articles);
+      const initialState = adapter.getInitialState();
+      const reducer = createReducer(
+        initialState,
+        adapter.buildReducers({
+          fetchActions: [FETCH],
+        })
+      );
+
+      it('should set fetching=true on FETCH.BEGIN', () => {
+        const newState = reducer(initialState, fetchBegin);
+        expect(newState.fetching).toEqual(true);
+      });
+      it('should set fetching=false on FETCH.SUCCESS', () => {
+        const newState = reducer(
+          { ...initialState, fetching: true },
+          fetchSuccess
+        );
+        expect(newState.fetching).toBeFalsy();
+      });
+      it('should set fetching=false on FETCH.FAILURE', () => {
+        const newState = reducer(
+          { ...initialState, fetching: true },
+          fetchFailure
+        );
+        expect(newState.fetching).toBeFalsy();
+      });
+    });
+
     describe('extra reducers cases/matchers/default case', () => {
       const FETCH = generateStatuses('FETCH');
 

--- a/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
+++ b/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
@@ -16,6 +16,18 @@ describe('createLegoAdapter', () => {
         fetching: false,
       });
     });
+
+    it('should allow additional initial state to be added', () => {
+      const adapter = createLegoAdapter(EntityType.Articles);
+
+      expect(adapter.getInitialState({ smashed: false })).toEqual({
+        actionGrant: [],
+        ids: [],
+        entities: {},
+        fetching: false,
+        smashed: false,
+      });
+    });
   });
 
   describe('buildReducers', () => {

--- a/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
+++ b/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
@@ -104,6 +104,11 @@ describe('createLegoAdapter', () => {
         expect(newState.ids).toEqual([42]);
         expect(newState.entities).toEqual({ 42: article });
       });
+
+      it('should update actionGrant on FETCH.SUCCESS', () => {
+        const newState = reducer(initialState, fetchSuccess);
+        expect(newState.actionGrant).toEqual(['list', 'create']);
+      });
     });
 
     describe('extra reducers cases/matchers/default case', () => {

--- a/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
+++ b/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
@@ -1,0 +1,88 @@
+import { createReducer } from '@reduxjs/toolkit';
+import { describe, it, expect } from 'vitest';
+import { generateStatuses } from 'app/actions/ActionTypes';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+
+describe('createLegoAdapter', () => {
+  describe('getInitialState', () => {
+    it('should create initial state', () => {
+      const adapter = createLegoAdapter(EntityType.Articles);
+
+      expect(adapter.getInitialState()).toEqual({
+        actionGrant: [],
+        ids: [],
+        entities: {},
+        fetching: false,
+      });
+    });
+  });
+
+  describe('buildReducers', () => {
+    describe('extra reducers cases/matchers/default case', () => {
+      const FETCH = generateStatuses('FETCH');
+
+      it('should reduce cases specified in buildReducers', () => {
+        const adapter = createLegoAdapter(EntityType.Articles);
+        const initialState = adapter.getInitialState();
+        const reducer = createReducer(
+          initialState,
+          adapter.buildReducers({
+            fetchActions: [FETCH],
+            extraCases: (addCase) => {
+              addCase('testAction', (state) => {
+                state.actionGrant = ['expected'];
+              });
+            },
+          })
+        );
+
+        expect(reducer(initialState, { type: 'testAction' })).toEqual({
+          ...initialState,
+          actionGrant: ['expected'],
+        });
+      });
+      it('should reduce matchers specified in buildReducers', () => {
+        const adapter = createLegoAdapter(EntityType.Articles);
+        const initialState = adapter.getInitialState();
+        const reducer = createReducer(
+          initialState,
+          adapter.buildReducers({
+            fetchActions: [FETCH],
+            extraMatchers: (addMatcher) => {
+              addMatcher(
+                ({ type }) => type.includes('test'),
+                (state) => {
+                  state.actionGrant = ['expected'];
+                }
+              );
+            },
+          })
+        );
+
+        expect(reducer(initialState, { type: 'testAction' })).toEqual({
+          ...initialState,
+          actionGrant: ['expected'],
+        });
+      });
+      it('should reduce using the defaultCaseReducer', () => {
+        const adapter = createLegoAdapter(EntityType.Articles);
+
+        const initialState = adapter.getInitialState();
+        const reducer = createReducer(
+          initialState,
+          adapter.buildReducers({
+            defaultCaseReducer: (state) => {
+              state.actionGrant = ['expected'];
+            },
+          })
+        );
+
+        expect(reducer(initialState, { type: 'thisActionIsATest' })).toEqual({
+          ...initialState,
+          actionGrant: ['expected'],
+        });
+      });
+    });
+  });
+});

--- a/app/utils/legoAdapter/asyncApiActions.ts
+++ b/app/utils/legoAdapter/asyncApiActions.ts
@@ -1,0 +1,103 @@
+// is often expanded with additional properties
+import type { AnyAction } from '@reduxjs/toolkit';
+import type { ID } from 'app/store/models';
+import type Entities from 'app/store/models/entities';
+import type {
+  EntityType,
+  NormalizedEntityPayload,
+} from 'app/store/models/entities';
+import type { AsyncActionType } from 'app/types';
+
+interface BaseMeta {
+  queryString: string;
+  cursor: string;
+  errorMessage: string;
+  enableOptimistic: boolean;
+  endpoint: string;
+  schemaKey: string;
+}
+export interface FetchMeta extends BaseMeta {
+  paginationKey?: string;
+  query?: {
+    [key: string]: string;
+  };
+}
+export interface DeleteMeta extends BaseMeta {
+  id: ID;
+}
+
+export interface FetchPayload {
+  actionGrant?: string[];
+  entities: Partial<Entities>;
+  result?: ID[];
+  next?: string;
+  previous?: string;
+}
+
+interface AsyncApiAction<Meta extends BaseMeta = BaseMeta, Payload = null> {
+  type: string;
+  meta: Meta;
+  payload: Payload;
+}
+
+export interface AsyncApiActionBegin<Meta extends BaseMeta = BaseMeta>
+  extends AsyncApiAction<Meta> {
+  type: `${string}.BEGIN`;
+}
+
+export interface AsyncApiActionFailure<Meta extends BaseMeta = BaseMeta>
+  extends AsyncApiAction<Meta> {
+  type: `${string}.FAILURE`;
+}
+
+export interface AsyncApiActionSuccess<
+  Meta extends BaseMeta = BaseMeta,
+  Payload extends FetchPayload | [] | null = FetchPayload | [] | null
+> extends AsyncApiAction<Meta, Payload> {
+  type: `${string}.SUCCESS`;
+}
+
+export interface AsyncApiActionSuccessWithEntityType<T extends EntityType>
+  extends AsyncApiActionSuccess<FetchMeta, FetchPayload> {
+  payload: AsyncApiActionSuccess['payload'] & NormalizedEntityPayload<T>;
+}
+
+const isAsyncApiAction = (action: AnyAction): action is AsyncApiAction =>
+  action.meta && action.meta.endpoint;
+
+export const isAsyncApiActionBegin = (
+  action: AnyAction
+): action is AsyncApiActionBegin =>
+  isAsyncApiAction(action) && action.type.endsWith('.BEGIN');
+isAsyncApiActionBegin.matching =
+  <Meta extends BaseMeta = BaseMeta>(actionTypes: AsyncActionType[]) =>
+  (action: AnyAction): action is AsyncApiActionBegin<Meta> =>
+    isAsyncApiActionBegin(action) &&
+    actionTypes.map((t) => t.BEGIN).includes(action.type);
+
+export const isAsyncApiActionFailure = (
+  action: AnyAction
+): action is AsyncApiActionFailure =>
+  isAsyncApiAction(action) && action.type.endsWith('.FAILURE');
+isAsyncApiActionFailure.matching =
+  <Meta extends BaseMeta = BaseMeta>(actionTypes: AsyncActionType[]) =>
+  (action: AnyAction): action is AsyncApiActionFailure<Meta> =>
+    isAsyncApiActionFailure(action) &&
+    actionTypes.map((t) => t.FAILURE).includes(action.type);
+
+export const isAsyncApiActionSuccess = (
+  action: AnyAction
+): action is AsyncApiActionSuccess =>
+  isAsyncApiAction(action) && action.type.endsWith('.SUCCESS');
+isAsyncApiActionSuccess.matching =
+  <Meta extends BaseMeta = BaseMeta>(actionTypes: AsyncActionType[]) =>
+  (action: AnyAction): action is AsyncApiActionSuccess<Meta> =>
+    isAsyncApiActionSuccess(action) &&
+    actionTypes.map((t) => t.SUCCESS).includes(action.type);
+isAsyncApiActionSuccess.containingEntity =
+  <T extends EntityType>(entityType: T) =>
+  (action: AnyAction): action is AsyncApiActionSuccessWithEntityType<T> =>
+    isAsyncApiActionSuccess(action) &&
+    !!action.payload &&
+    'entities' in action.payload &&
+    entityType in action.payload.entities;

--- a/app/utils/legoAdapter/asyncApiActions.ts
+++ b/app/utils/legoAdapter/asyncApiActions.ts
@@ -94,6 +94,10 @@ isAsyncApiActionSuccess.matching =
   (action: AnyAction): action is AsyncApiActionSuccess<Meta> =>
     isAsyncApiActionSuccess(action) &&
     actionTypes.map((t) => t.SUCCESS).includes(action.type);
+isAsyncApiActionSuccess.withSchemaKey =
+  <Meta extends BaseMeta = BaseMeta>(entityType: EntityType) =>
+  (action: AnyAction): action is AsyncApiActionSuccess<Meta> =>
+    isAsyncApiActionSuccess(action) && action.meta.schemaKey === entityType;
 isAsyncApiActionSuccess.containingEntity =
   <T extends EntityType>(entityType: T) =>
   (action: AnyAction): action is AsyncApiActionSuccessWithEntityType<T> =>

--- a/app/utils/legoAdapter/asyncApiActions.ts
+++ b/app/utils/legoAdapter/asyncApiActions.ts
@@ -26,6 +26,7 @@ export interface DeleteMeta extends BaseMeta {
   id: ID;
 }
 
+type AnyPayload = FetchPayload | [] | null;
 export interface FetchPayload {
   actionGrant?: string[];
   entities: Partial<Entities>;
@@ -52,7 +53,7 @@ export interface AsyncApiActionFailure<Meta extends BaseMeta = BaseMeta>
 
 export interface AsyncApiActionSuccess<
   Meta extends BaseMeta = BaseMeta,
-  Payload extends FetchPayload | [] | null = FetchPayload | [] | null
+  Payload extends AnyPayload = AnyPayload
 > extends AsyncApiAction<Meta, Payload> {
   type: `${string}.SUCCESS`;
 }
@@ -90,8 +91,10 @@ export const isAsyncApiActionSuccess = (
 ): action is AsyncApiActionSuccess =>
   isAsyncApiAction(action) && action.type.endsWith('.SUCCESS');
 isAsyncApiActionSuccess.matching =
-  <Meta extends BaseMeta = BaseMeta>(actionTypes: AsyncActionType[]) =>
-  (action: AnyAction): action is AsyncApiActionSuccess<Meta> =>
+  <Meta extends BaseMeta = BaseMeta, Payload extends AnyPayload = null>(
+    actionTypes: AsyncActionType[]
+  ) =>
+  (action: AnyAction): action is AsyncApiActionSuccess<Meta, Payload> =>
     isAsyncApiActionSuccess(action) &&
     actionTypes.map((t) => t.SUCCESS).includes(action.type);
 isAsyncApiActionSuccess.withSchemaKey =

--- a/app/utils/legoAdapter/buildActionGrantReducer.ts
+++ b/app/utils/legoAdapter/buildActionGrantReducer.ts
@@ -1,0 +1,27 @@
+import { isAsyncApiActionSuccess } from 'app/utils/legoAdapter/asyncApiActions';
+import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
+import type { EntityType } from 'app/store/models/entities';
+
+interface StateWithActionGrant {
+  actionGrant: string[];
+}
+
+const buildActionGrantReducer = (
+  builder: ActionReducerMapBuilder<StateWithActionGrant>,
+  entityType: EntityType
+) => {
+  builder.addMatcher(
+    isAsyncApiActionSuccess.withSchemaKey(entityType),
+    (state, action) => {
+      if (
+        action.payload &&
+        'actionGrant' in action.payload &&
+        action.payload.actionGrant
+      ) {
+        state.actionGrant = action.payload.actionGrant;
+      }
+    }
+  );
+};
+
+export default buildActionGrantReducer;

--- a/app/utils/legoAdapter/buildDeleteEntityReducer.ts
+++ b/app/utils/legoAdapter/buildDeleteEntityReducer.ts
@@ -1,0 +1,23 @@
+import { isAsyncApiActionSuccess } from 'app/utils/legoAdapter/asyncApiActions';
+import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
+import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
+import type { AsyncActionType } from 'app/types';
+import type { DeleteMeta } from 'app/utils/legoAdapter/asyncApiActions';
+
+/**
+ * Handles optimistic and actual deletion of entities
+ */
+const buildDeleteEntityReducer = (
+  builder: ActionReducerMapBuilder<EntityState<unknown>>,
+  deleteActions: AsyncActionType[]
+) => {
+  builder.addMatcher(
+    isAsyncApiActionSuccess.matching<DeleteMeta>(deleteActions),
+    (state, action) => {
+      state.ids = state.ids.filter((id) => id !== action.meta.id);
+      delete state.entities[action.meta.id];
+    }
+  );
+};
+
+export default buildDeleteEntityReducer;

--- a/app/utils/legoAdapter/buildEntitiesReducer.ts
+++ b/app/utils/legoAdapter/buildEntitiesReducer.ts
@@ -1,0 +1,30 @@
+import { isAsyncApiActionSuccess } from 'app/utils/legoAdapter/asyncApiActions';
+import type { EntityAdapter } from '@reduxjs/toolkit';
+import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
+import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
+import type { ID } from 'app/store/models';
+import type Entities from 'app/store/models/entities';
+import type { EntityType } from 'app/store/models/entities';
+
+const buildEntitiesReducer = <
+  T extends EntityType,
+  Entity extends Entities[T][ID] = Entities[T][ID]
+>(
+  builder: ActionReducerMapBuilder<EntityState<Entity>>,
+  adapter: EntityAdapter<Entity>,
+  entityType: T
+) => {
+  builder.addMatcher(
+    isAsyncApiActionSuccess.containingEntity(entityType),
+    (state, action) => {
+      // typescript is not quite able to infer this type on its own
+      const payloadEntities = action.payload.entities[entityType] as Record<
+        ID,
+        Entity
+      >;
+      adapter.upsertMany(state, payloadEntities);
+    }
+  );
+};
+
+export default buildEntitiesReducer;

--- a/app/utils/legoAdapter/buildFetchingReducer.ts
+++ b/app/utils/legoAdapter/buildFetchingReducer.ts
@@ -1,0 +1,28 @@
+import {
+  isAsyncApiActionBegin,
+  isAsyncApiActionFailure,
+  isAsyncApiActionSuccess,
+} from 'app/utils/legoAdapter/asyncApiActions';
+import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
+import type { AsyncActionType } from 'app/types';
+
+type StateWithFetching = {
+  fetching: boolean;
+};
+
+const buildFetchingReducer = (
+  builder: ActionReducerMapBuilder<StateWithFetching>,
+  actionTypes: AsyncActionType[]
+) => {
+  builder.addMatcher(isAsyncApiActionBegin.matching(actionTypes), (state) => {
+    state.fetching = true;
+  });
+  builder.addMatcher(isAsyncApiActionFailure.matching(actionTypes), (state) => {
+    state.fetching = false;
+  });
+  builder.addMatcher(isAsyncApiActionSuccess.matching(actionTypes), (state) => {
+    state.fetching = false;
+  });
+};
+
+export default buildFetchingReducer;

--- a/app/utils/legoAdapter/buildPaginationReducer.ts
+++ b/app/utils/legoAdapter/buildPaginationReducer.ts
@@ -1,0 +1,82 @@
+import { parse } from 'qs';
+import {
+  isAsyncApiActionBegin,
+  isAsyncApiActionSuccess,
+} from 'app/utils/legoAdapter/asyncApiActions';
+import type { EntityId } from '@reduxjs/toolkit';
+import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
+import type { AsyncActionType } from 'app/types';
+import type {
+  FetchMeta,
+  FetchPayload,
+} from 'app/utils/legoAdapter/asyncApiActions';
+import type { ParsedQs } from 'qs';
+
+interface Query {
+  [key: string]: string;
+}
+
+export type Pagination = {
+  query: ParsedQs;
+  ids: EntityId[];
+  hasMore: boolean;
+  hasMoreBackwards: boolean;
+  next?: ParsedQs;
+  previous?: ParsedQs;
+};
+
+type StateWithPagination = {
+  paginationNext: {
+    [key: string]: Pagination;
+  };
+};
+
+const createInitialPagination = (query: Query) => ({
+  query,
+  ids: [],
+  hasMore: false,
+  hasMoreBackwards: false,
+});
+
+const buildPaginationReducer = (
+  builder: ActionReducerMapBuilder<StateWithPagination>,
+  actionTypes: AsyncActionType[]
+) => {
+  builder.addMatcher(
+    isAsyncApiActionBegin.matching<FetchMeta>(actionTypes),
+    (state, action) => {
+      state.paginationNext[action.meta.paginationKey ?? ''] ??=
+        createInitialPagination(action.meta.query ?? {});
+    }
+  );
+  builder.addMatcher(
+    isAsyncApiActionSuccess.matching<FetchMeta, FetchPayload>(actionTypes),
+    (state, action) => {
+      state.paginationNext[action.meta.paginationKey ?? ''] ??=
+        createInitialPagination(action.meta.query ?? {});
+      const paginationNext =
+        state.paginationNext[action.meta.paginationKey ?? ''];
+
+      paginationNext.ids = [
+        ...new Set(paginationNext.ids.concat(action.payload.result ?? [])),
+      ];
+
+      if (action.payload.next) {
+        paginationNext.hasMore = true;
+        paginationNext.next = parse(action.payload.next.split('?')[1]);
+      } else {
+        paginationNext.hasMore = false;
+        paginationNext.next = undefined;
+      }
+      if (action.payload.previous) {
+        paginationNext.hasMoreBackwards = true;
+        paginationNext.previous = parse(action.payload.previous.split('?')[1]);
+      } else {
+        paginationNext.hasMoreBackwards = false;
+        paginationNext.previous = undefined;
+      }
+    }
+  );
+};
+
+export default buildPaginationReducer;

--- a/app/utils/legoAdapter/createLegoAdapter.ts
+++ b/app/utils/legoAdapter/createLegoAdapter.ts
@@ -1,4 +1,5 @@
 import { createEntityAdapter } from '@reduxjs/toolkit';
+import buildActionGrantReducer from 'app/utils/legoAdapter/buildActionGrantReducer';
 import buildEntitiesReducer from 'app/utils/legoAdapter/buildEntitiesReducer';
 import buildFetchingReducer from 'app/utils/legoAdapter/buildFetchingReducer';
 import type { EntityAdapter } from '@reduxjs/toolkit';
@@ -67,6 +68,7 @@ const createLegoAdapter = <
 
         buildFetchingReducer(builder, fetchActions);
         buildEntitiesReducer(builder, entityAdapter, entityType);
+        buildActionGrantReducer(builder, entityType);
 
         extraMatchers?.(builder.addMatcher);
 

--- a/app/utils/legoAdapter/createLegoAdapter.ts
+++ b/app/utils/legoAdapter/createLegoAdapter.ts
@@ -1,4 +1,5 @@
 import { createEntityAdapter } from '@reduxjs/toolkit';
+import buildEntitiesReducer from 'app/utils/legoAdapter/buildEntitiesReducer';
 import buildFetchingReducer from 'app/utils/legoAdapter/buildFetchingReducer';
 import type { EntityAdapter } from '@reduxjs/toolkit';
 import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
@@ -6,8 +7,8 @@ import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
 import type { NoInfer } from '@reduxjs/toolkit/src/tsHelpers';
 import type { ActionGrant } from 'app/models';
 import type { ID } from 'app/store/models';
-import type Entities from 'app/store/models/entities';
 import type { EntityType } from 'app/store/models/entities';
+import type Entities from 'app/store/models/entities';
 import type { AsyncActionType } from 'app/types';
 
 // The base redux-state of the entity-slice
@@ -65,6 +66,7 @@ const createLegoAdapter = <
         extraCases?.(builder.addCase);
 
         buildFetchingReducer(builder, fetchActions);
+        buildEntitiesReducer(builder, entityAdapter, entityType);
 
         extraMatchers?.(builder.addMatcher);
 

--- a/app/utils/legoAdapter/createLegoAdapter.ts
+++ b/app/utils/legoAdapter/createLegoAdapter.ts
@@ -18,6 +18,7 @@ interface LegoEntityState<Entity> extends EntityState<Entity> {
 // Type of the generated adapter-object
 interface LegoAdapter<Entity> extends EntityAdapter<Entity> {
   getInitialState(): LegoEntityState<Entity>;
+  getInitialState<S extends object>(state: S): LegoEntityState<Entity> & S;
   buildReducers(options?: {
     extraCases?: (addCase: ReducerBuilder<Entity>['addCase']) => void;
     extraMatchers?: (addMatcher: ReducerBuilder<Entity>['addMatcher']) => void;
@@ -45,11 +46,12 @@ const createLegoAdapter = <
 
   return {
     ...entityAdapter,
-    getInitialState() {
+    getInitialState(extraState = {}) {
       return {
         ...entityAdapter.getInitialState(),
         actionGrant: [],
         fetching: false,
+        ...extraState,
       };
     },
     buildReducers({ extraCases, extraMatchers, defaultCaseReducer } = {}) {

--- a/app/utils/legoAdapter/createLegoAdapter.ts
+++ b/app/utils/legoAdapter/createLegoAdapter.ts
@@ -1,0 +1,69 @@
+import { createEntityAdapter } from '@reduxjs/toolkit';
+import type { EntityAdapter } from '@reduxjs/toolkit';
+import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
+import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
+import type { NoInfer } from '@reduxjs/toolkit/src/tsHelpers';
+import type { ActionGrant } from 'app/models';
+import type { ID } from 'app/store/models';
+import type Entities from 'app/store/models/entities';
+import type { EntityType } from 'app/store/models/entities';
+import type { AsyncActionType } from 'app/types';
+
+// The base redux-state of the entity-slice
+interface LegoEntityState<Entity> extends EntityState<Entity> {
+  actionGrant: ActionGrant;
+  fetching: boolean;
+}
+
+// Type of the generated adapter-object
+interface LegoAdapter<Entity> extends EntityAdapter<Entity> {
+  getInitialState(): LegoEntityState<Entity>;
+  buildReducers(options?: {
+    extraCases?: (addCase: ReducerBuilder<Entity>['addCase']) => void;
+    extraMatchers?: (addMatcher: ReducerBuilder<Entity>['addMatcher']) => void;
+    defaultCaseReducer?: Parameters<
+      ReducerBuilder<Entity>['addDefaultCase']
+    >[0];
+    fetchActions?: AsyncActionType[];
+  }): (builder: ReducerBuilder<Entity>) => void;
+}
+
+// Helpers
+type ReducerBuilder<Entity> = ActionReducerMapBuilder<
+  NoInfer<LegoEntityState<Entity>>
+>;
+type LegoAdapterOptions<T> = Parameters<typeof createEntityAdapter<T>>[0];
+
+const createLegoAdapter = <
+  Type extends EntityType,
+  Entity extends Entities[Type][ID] = Entities[Type][ID]
+>(
+  entityType: Type,
+  opts: LegoAdapterOptions<Entity> = {}
+): LegoAdapter<Entity> => {
+  const entityAdapter = createEntityAdapter<Entity>(opts);
+
+  return {
+    ...entityAdapter,
+    getInitialState() {
+      return {
+        ...entityAdapter.getInitialState(),
+        actionGrant: [],
+        fetching: false,
+      };
+    },
+    buildReducers({ extraCases, extraMatchers, defaultCaseReducer } = {}) {
+      return (builder) => {
+        extraCases?.(builder.addCase);
+
+        extraMatchers?.(builder.addMatcher);
+
+        if (defaultCaseReducer) {
+          builder.addDefaultCase(defaultCaseReducer);
+        }
+      };
+    },
+  };
+};
+
+export default createLegoAdapter;

--- a/app/utils/legoAdapter/createLegoAdapter.ts
+++ b/app/utils/legoAdapter/createLegoAdapter.ts
@@ -1,7 +1,9 @@
 import { createEntityAdapter } from '@reduxjs/toolkit';
 import buildActionGrantReducer from 'app/utils/legoAdapter/buildActionGrantReducer';
+import buildDeleteEntityReducer from 'app/utils/legoAdapter/buildDeleteEntityReducer';
 import buildEntitiesReducer from 'app/utils/legoAdapter/buildEntitiesReducer';
 import buildFetchingReducer from 'app/utils/legoAdapter/buildFetchingReducer';
+import buildPaginationReducer from 'app/utils/legoAdapter/buildPaginationReducer';
 import type { EntityAdapter } from '@reduxjs/toolkit';
 import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
@@ -11,11 +13,13 @@ import type { ID } from 'app/store/models';
 import type { EntityType } from 'app/store/models/entities';
 import type Entities from 'app/store/models/entities';
 import type { AsyncActionType } from 'app/types';
+import type { Pagination } from 'app/utils/legoAdapter/buildPaginationReducer';
 
 // The base redux-state of the entity-slice
 interface LegoEntityState<Entity> extends EntityState<Entity> {
   actionGrant: ActionGrant;
   fetching: boolean;
+  paginationNext: { [key: string]: Pagination };
 }
 
 // Type of the generated adapter-object
@@ -29,6 +33,7 @@ interface LegoAdapter<Entity> extends EntityAdapter<Entity> {
       ReducerBuilder<Entity>['addDefaultCase']
     >[0];
     fetchActions?: AsyncActionType[];
+    deleteActions?: AsyncActionType[];
   }): (builder: ReducerBuilder<Entity>) => void;
 }
 
@@ -54,6 +59,7 @@ const createLegoAdapter = <
         ...entityAdapter.getInitialState(),
         actionGrant: [],
         fetching: false,
+        paginationNext: {},
         ...extraState,
       };
     },
@@ -62,6 +68,7 @@ const createLegoAdapter = <
       extraMatchers,
       defaultCaseReducer,
       fetchActions = [],
+      deleteActions = [],
     } = {}) {
       return (builder) => {
         extraCases?.(builder.addCase);
@@ -69,6 +76,8 @@ const createLegoAdapter = <
         buildFetchingReducer(builder, fetchActions);
         buildEntitiesReducer(builder, entityAdapter, entityType);
         buildActionGrantReducer(builder, entityType);
+        buildDeleteEntityReducer(builder, deleteActions);
+        buildPaginationReducer(builder, fetchActions);
 
         extraMatchers?.(builder.addMatcher);
 

--- a/app/utils/legoAdapter/createLegoAdapter.ts
+++ b/app/utils/legoAdapter/createLegoAdapter.ts
@@ -1,4 +1,5 @@
 import { createEntityAdapter } from '@reduxjs/toolkit';
+import buildFetchingReducer from 'app/utils/legoAdapter/buildFetchingReducer';
 import type { EntityAdapter } from '@reduxjs/toolkit';
 import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
@@ -54,9 +55,16 @@ const createLegoAdapter = <
         ...extraState,
       };
     },
-    buildReducers({ extraCases, extraMatchers, defaultCaseReducer } = {}) {
+    buildReducers({
+      extraCases,
+      extraMatchers,
+      defaultCaseReducer,
+      fetchActions = [],
+    } = {}) {
       return (builder) => {
         extraCases?.(builder.addCase);
+
+        buildFetchingReducer(builder, fetchActions);
 
         extraMatchers?.(builder.addMatcher);
 


### PR DESCRIPTION
# Description

This was a project I was playing with a bit this summer. It's basically a full rewrite of `createEntityReducer` with the goal of making it more modular and easier to integrate with [Redux Toolkit](https://redux-toolkit.js.org/).

The [`createEntityAdapter`](https://redux-toolkit.js.org/api/createEntityAdapter) function in Redux Toolkit is basically a way to add some of the most basic `createEntityReducer` into a redux slice created using the Redux Toolkit syntax. It minimizes boilerplate, while still being typed perfectly. I therefore built the new `createEntityReducer` as an extended version of `createEntityAdapter`, calling it `createLegoAdapter`. Each separate function of the adapter is defined separately (f.ex. updating `fetching`-state), well typed and unit-tested.

I also decided on keeping our weird `generateStatuses` `ActionTypes`, as it would be a breaking change to remove them. It doesn't match Redux Toolkit's standard way of doing actions, so we are missing out on a lot of typing stuff there, but I think it will be easier to make the transition once all entity reducers are updated to `createLegoAdapter`, and we no longer need backwards compatibility with `createEntityReducer`.

There are a couple of things missing compared to the old `createEntityReducer`. This only supports `paginationNext`, not the other system just called `pagination`, meaning some routes will need some refactoring. This also doesn't support optimistic updates on creation, but this is barely ever used so it can be implemented at a later date.

# Result

It will be suuper easy to rewrite existing `createEntityReducer`-reducers to Redux Toolkit slices using `createLegoAdapter` to keep the same functionality.

It will in general reduce a lot of the boilerplate code in reducers. F.ex. we have a lot of selectors that simply select an entity by id, which looks something like this:
```ts
export const selectCompanyInterestById = createSelector(
  (state) => state.companyInterest.byId,
  (state, props) => props.companyInterestId,
  (companyInterestById, companyInterestId) =>
    companyInterestById[companyInterestId]
);
```
This selector is provided for free with `createLegoAdapter`, you can simply get it using:
```ts
export const { 
	selectById: selectCompanyInterestById 
} = legoAdapter.getSelectors((state: RootState) => state.companyInterest);
```


# Testing

- [x] I have thoroughly tested my changes.

Everything is quite thoroughly unit tested, but all functionality should still be tested thourougly when migrating slices. 

---

Resolves ABA-659
