### PR TITLE
Remove flex from tooltip content

### DIFF
--- a/app/components/Tooltip/Tooltip.css
+++ b/app/components/Tooltip/Tooltip.css
@@ -27,8 +27,7 @@
 }
 
 .content {
-  display: flex;
-  align-items: center;
+  display: block;
   padding: 7px 11px;
   line-height: 1.3;
   white-space: wrap;


### PR DESCRIPTION
# Description

Change Tooltip content styling from flex to block, so that content will behave as they are inline elements and not be adjusted by the flex styling.

Haven't searched that much - but within the places I found it made no difference that the align-items wasn't set (and it wont work without flex), so removed that as well.

# Result

## Before
<img width="314" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/8ec7c0e2-8be4-4ac8-94ae-434b85e149fe">


## After
<img width="318" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/3a963587-b7ff-454c-a3d0-a15a9bcc6a28">

The other tooltips I've visited (mainly the welcome page and the rest on the event detail page) behave the same before and after.

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-609
