### PR TITLE
Hide Contact Tracing Field in EventEditor

### DIFF
--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -524,6 +524,7 @@ function EventEditor({
                 normalize={(v) => !!v}
               />
             )}
+            {/* TODO: enable this if the world encounters a new pandemic
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (
@@ -538,6 +539,7 @@ function EventEditor({
                 disabled={moment().isAfter(event.activationTime)}
               />
             )}
+*/}
             {['NORMAL', 'INFINITE'].includes(
               event.eventStatusType && event.eventStatusType.value
             ) && (


### PR DESCRIPTION
# Description

This PR hides the field for contact tracing, so that no one can enable it by mistake. I think the rest of the functionality should remain in the codebase though, so it is really easy to just make this visible if we ever encounter another pandemic. 

# Result

The field in the EventEditor is hidden. 

# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-183
