### PR TITLE
Hide navbar in mobile view

### DIFF
--- a/app/components/Header/Navbar/Navbar.css
+++ b/app/components/Header/Navbar/Navbar.css
@@ -1,3 +1,5 @@
+@import url('~app/styles/variables.css');
+
 .navigation {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
# Description

Because of poor testing on my part, I didn't notice that the navbar was still visible on mobile view with the new changes in #4188. This is fixed now.

# Result

**before**
![image](https://github.com/webkom/lego-webapp/assets/66320400/7348b359-f258-41cb-ab14-c403a2a721bd)


**after**
![image](https://github.com/webkom/lego-webapp/assets/66320400/577668ce-974c-48b5-bf5b-a616e076a4d7)


# Testing

- [X] I have thoroughly tested my changes.

I've tested it for both desktop and mobile view this time :)))))

