### PR TITLE
Fix Italic issue

### DIFF
--- a/app/routes/pages/components/LandingPage.tsx
+++ b/app/routes/pages/components/LandingPage.tsx
@@ -216,8 +216,8 @@ const info = {
   whoWeAre: (
     <span>
       Abakus er linjeforeningen for studentene ved Datateknologi &{' '}
-      Cybersikkerhet og datakommunikasjon på NTNU, og drives av studenter
-      ved disse studiene.
+      Cybersikkerhet og datakommunikasjon på NTNU, og drives av studenter ved
+      disse studiene.
     </span>
   ),
   whatWeDo:

--- a/app/routes/pages/components/LandingPage.tsx
+++ b/app/routes/pages/components/LandingPage.tsx
@@ -216,7 +216,7 @@ const info = {
   whoWeAre: (
     <span>
       Abakus er linjeforeningen for studentene ved Datateknologi &{' '}
-      <i>Cybersikkerhet og datakommunikasjon</i> på NTNU, og drives av studenter
+      Cybersikkerhet og datakommunikasjon på NTNU, og drives av studenter
       ved disse studiene.
     </span>
   ),


### PR DESCRIPTION
# Description

Fixed the italic issue on landingpage. fixed issue were "Datateknologi was written normally, but "Cybersikkerhet og datakommunikasjon" were written in italics.
**bug-fix**

# Result

 **before** 
<img width="248" alt="image" src="https://github.com/webkom/lego-webapp/assets/102583541/ed04ad96-9a89-4a4a-84ee-1c977c1847c2">

 **after**
<img width="287" alt="image" src="https://github.com/webkom/lego-webapp/assets/102583541/d133eccf-9acf-47ad-b005-83ea29188655">


# Testing

- [ ] I have thoroughly tested my changes.
I've tested for different sizes: Issue
<img width="846" alt="image" src="https://github.com/webkom/lego-webapp/assets/102583541/2f98a173-af97-4a45-b903-f9b486d7fe38">

It may be difficult to differentiate which to words do correspond to one thing. It may also look like it's one study programme or three
---

Resolves ... (either GitHub issue or Linear task)
ABA-631