### PR TITLE
Listen to changes in current page to expand category

### DIFF
--- a/app/routes/pages/components/PageHierarchy.tsx
+++ b/app/routes/pages/components/PageHierarchy.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import Icon from 'app/components/Icon';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import styles from './PageHierarchy.css';
@@ -58,8 +58,8 @@ const HierarchySection = ({
     <nav className={styles.pageList}>
       {items.length > 0 && (
         <AccordionContainer title={title} currentCategory={currentCategory}>
-          {items.map((item, key) => (
-            <Link to={item.url} key={key}>
+          {items.map((item) => (
+            <Link to={item.url} key={item.url + item.title}>
               <div className={styles.links} onClick={handleCloseSidebar}>
                 <div
                   className={
@@ -85,15 +85,22 @@ type AccordionProps = {
   currentCategory: string;
 };
 
-const AccordionContainer = ({ title, children }: AccordionProps) => {
-  const location = useLocation();
-  const currentCategory = location.pathname.split('/')[2];
+const AccordionContainer = ({
+  title,
+  children,
+  currentCategory,
+}: AccordionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
 
-  const [isOpen, setIsOpen] = useState(
-    currentCategory === title.toLowerCase() ||
+  useEffect(() => {
+    if (
+      currentCategory === title.toLowerCase() ||
       (currentCategory === 'info-om-abakus' &&
         title.toLowerCase() === 'generelt')
-  );
+    ) {
+      setIsOpen(true);
+    }
+  }, [currentCategory, title]);
 
   return (
     <div>


### PR DESCRIPTION
# Description

The correct page group was only expanded when the component was rendered (e.g. when navigating from another part of the webapp). When navigating through hyperlinks within the flatpages however, the component was already loaded and as such did not change. Now it does.

For a video showcasing the issue, check out the linear issue

# Result

Works on my machine ™️ 

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-606
