### PR TITLE
Move pinned over poll and quote on mobile

### DIFF
--- a/app/routes/overview/components/CompactEvents.css
+++ b/app/routes/overview/components/CompactEvents.css
@@ -12,6 +12,12 @@
   padding-right: 20px;
 }
 
+@media (--mobile-device) {
+  .compactLeft h3 {
+    margin-top: 0;
+  }
+}
+
 .compactLeft,
 .compactRight {
   flex: 1;

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -119,9 +119,9 @@ const Overview = (props: Props) => {
       <section className={styles.mobileContainer}>
         <CompactEvents events={events} />
         <NextEvent events={events} />
+        {pinnedComponent}
         <PollItem poll={poll} votePoll={votePoll} />
         <QuoteItem loggedIn={loggedIn} />
-        {pinnedComponent}
         {readMe}
         <Weekly weeklyArticle={weeklyArticle} />
         <Articles articles={articlesShown} />


### PR DESCRIPTION
# Description

Aaand remove the excessive margin top from compactevents on mobile that has been bugging me for ages.

Desktop view is unchanged.

# Result

<table>
<tr>
 <th>
 <th>Before
 <th>After
<tr>
 <td>
 <td><img width="355" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/beec212b-0060-490a-a97d-a3078a8ae39b">
 <td><img width="357" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/b887102a-78d1-4ef1-82b2-584e388c760d">
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-460
