### PR TITLE
Fix spacing issue on event author

### DIFF
--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -334,7 +334,7 @@ export default class EventDetail extends Component<Props, State> {
               <Link to={groupLink}>{event.responsibleGroup.name}</Link>
             ) : (
               event.responsibleGroup.name
-            )}
+            )}{' '}
             {event.responsibleGroup.contactEmail && (
               <a href={`mailto:${event.responsibleGroup.contactEmail}`}>
                 {event.responsibleGroup.contactEmail}


### PR DESCRIPTION
# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td>
			<img width="332" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/8c28b5cf-51e2-4ef4-8739-8ee5a6278275">		
</td>
		<td>
			<img width="332" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/f638f6de-fb71-4eb0-bb85-917377f8e383">
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above.

---

Resolves https://github.com/webkom/lego/issues/3512