### PR TITLE
Appropriately show loading indicators for events on user profile

### DIFF
--- a/app/components/EventListCompact/index.tsx
+++ b/app/components/EventListCompact/index.tsx
@@ -16,10 +16,17 @@ const EventListCompact = ({
   eventStyle = 'default',
   loading,
 }: Props) => {
-  if (loading) {
+  if (loading && (!events || events.length === 0)) {
     return <LoadingIndicator loading margin="20px auto" />;
   }
-  return events && events.length ? (
+
+  if (!events || events.length === 0) {
+    return (
+      <EmptyState className="secondaryFontColor">{noEventsMessage}</EmptyState>
+    );
+  }
+
+  return (
     <Flex column wrap>
       {events.map((event) => (
         <EventItem
@@ -30,8 +37,6 @@ const EventListCompact = ({
         />
       ))}
     </Flex>
-  ) : (
-    <EmptyState className="secondaryFontColor">{noEventsMessage}</EmptyState>
   );
 };
 export default EventListCompact;

--- a/app/reducers/__tests__/events.spec.ts
+++ b/app/reducers/__tests__/events.spec.ts
@@ -12,6 +12,8 @@ describe('reducers', () => {
     pagination: {},
     items: [1],
     fetching: false,
+    fetchingPrevious: false,
+    fetchingUpcoming: false,
     byId: {
       1: {
         id: 1,
@@ -20,6 +22,28 @@ describe('reducers', () => {
     },
   };
   describe('previous and upcoming events', () => {
+    it('Event.FETCH_PREVIOUS.BEGIN', () => {
+      const prevState = baseState;
+      const action = {
+        type: Event.FETCH_PREVIOUS.BEGIN,
+        meta: {},
+        payload: {},
+      };
+      expect(events(prevState, action)).toEqual({
+        actionGrant: [],
+        pagination: {},
+        items: [1],
+        fetching: true,
+        fetchingPrevious: true,
+        fetchingUpcoming: false,
+        byId: {
+          1: {
+            id: 1,
+            name: 'evt',
+          },
+        },
+      });
+    });
     it('Event.FETCH_PREVIOUS.SUCCESS', () => {
       const prevState = baseState;
       const action = {
@@ -42,6 +66,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1, 2],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -51,6 +77,28 @@ describe('reducers', () => {
             id: 2,
             name: 'test',
             isUsersUpcoming: false,
+          },
+        },
+      });
+    });
+    it('Event.FETCH_UPCOMING.BEGIN', () => {
+      const prevState = baseState;
+      const action = {
+        type: Event.FETCH_UPCOMING.BEGIN,
+        meta: {},
+        payload: {},
+      };
+      expect(events(prevState, action)).toEqual({
+        actionGrant: [],
+        pagination: {},
+        items: [1],
+        fetching: true,
+        fetchingPrevious: false,
+        fetchingUpcoming: true,
+        byId: {
+          1: {
+            id: 1,
+            name: 'evt',
           },
         },
       });
@@ -77,6 +125,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1, 2],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -106,6 +156,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -124,6 +176,8 @@ describe('reducers', () => {
         pagination: {},
         items: [],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -147,6 +201,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -169,6 +225,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -194,6 +252,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -218,6 +278,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -236,6 +298,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -261,6 +325,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -286,6 +352,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -311,6 +379,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -342,6 +412,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -360,6 +432,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -391,6 +465,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -409,6 +485,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -441,6 +519,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -483,6 +563,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -498,6 +580,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -517,6 +601,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,
@@ -542,6 +628,8 @@ describe('reducers', () => {
         pagination: {},
         items: [1],
         fetching: false,
+        fetchingPrevious: false,
+        fetchingUpcoming: false,
         byId: {
           1: {
             id: 1,

--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -16,6 +16,14 @@ import type { DetailedEvent } from 'app/store/models/Event';
 type State = any;
 const mutateEvent = produce((newState: State, action: any): void => {
   switch (action.type) {
+    case Event.FETCH_PREVIOUS.BEGIN:
+      newState.fetchingPrevious = true;
+      break;
+
+    case Event.FETCH_PREVIOUS.FAILURE:
+      newState.fetchingPrevious = false;
+      break;
+
     case Event.FETCH_PREVIOUS.SUCCESS:
       for (const eventId in action.payload.entities.events) {
         const event = action.payload.entities.events[eventId];
@@ -23,7 +31,16 @@ const mutateEvent = produce((newState: State, action: any): void => {
           e.isUsersUpcoming = false;
         });
       }
+      newState.fetchingPrevious = false;
 
+      break;
+
+    case Event.FETCH_UPCOMING.BEGIN:
+      newState.fetchingUpcoming = true;
+      break;
+
+    case Event.FETCH_UPCOMING.FAILURE:
+      newState.fetchingUpcoming = false;
       break;
 
     case Event.FETCH_UPCOMING.SUCCESS:
@@ -33,6 +50,7 @@ const mutateEvent = produce((newState: State, action: any): void => {
           e.isUsersUpcoming = true;
         });
       }
+      newState.fetchingUpcoming = false;
 
       break;
 
@@ -167,6 +185,10 @@ export default createEntityReducer<'events'>({
     delete: Event.DELETE,
   },
   mutate,
+  initialState: {
+    fetchingPrevious: false,
+    fetchingUpcoming: false,
+  },
 });
 
 function transformEvent(event: DetailedEvent) {

--- a/app/routes/users/components/UserProfile.tsx
+++ b/app/routes/users/components/UserProfile.tsx
@@ -185,8 +185,14 @@ const UserProfile = () => {
   const showSettings =
     (isCurrentUser || actionGrant.includes('edit')) && user?.username;
 
-  const previousEvents = useAppSelector(selectPreviousEvents);
   const upcomingEvents = useAppSelector(selectUpcomingEvents);
+  const fetchingUpcoming = useAppSelector(
+    (state) => state.events.fetchingUpcoming
+  );
+  const previousEvents = useAppSelector(selectPreviousEvents);
+  const fetchingPrevious = useAppSelector(
+    (state) => state.events.fetchingPrevious
+  );
 
   const canChangeGrade = useAppSelector((state) => state.allowed.groups);
   const canEditEmailLists = useAppSelector((state) => state.allowed.email);
@@ -196,8 +202,6 @@ const UserProfile = () => {
       groupType: 'klasse',
     })
   );
-
-  const loading = useAppSelector((state) => state.events.fetching);
 
   const dispatch = useAppDispatch();
 
@@ -251,7 +255,6 @@ const UserProfile = () => {
       </ul>
     );
   };
-
   //If you wonder what this is, ask somebody
   const FRAMEID = [6050, 5962, 7276, 7434, 7747, 8493];
 
@@ -726,26 +729,30 @@ const UserProfile = () => {
                 events={orderBy(upcomingEvents, 'startTime')}
                 noEventsMessage="Du har ingen kommende arrangementer"
                 eventStyle="compact"
-                loading={loading}
+                loading={fetchingUpcoming}
               />
               <h3>
                 Dine tidligere arrangementer (
-                {previousEvents === undefined ? 0 : previousEvents.length})
+                {!fetchingPrevious
+                  ? previousEvents === undefined
+                    ? 0
+                    : previousEvents.length
+                  : '...'}
+                )
               </h3>
               <EventListCompact
                 events={
-                  previousEvents === undefined
-                    ? []
-                    : orderBy(
-                        previousEvents
-                          .filter((e) => e.userReg.pool !== null)
-                          .filter((e) => e.userReg.presence !== 'NOT_PRESENT'),
-                        'startTime'
-                      ).reverse()
+                  previousEvents &&
+                  orderBy(
+                    previousEvents
+                      .filter((e) => e.userReg.pool !== null)
+                      .filter((e) => e.userReg.presence !== 'NOT_PRESENT'),
+                    'startTime'
+                  ).reverse()
                 }
                 noEventsMessage="Du har ingen tidligere arrangementer"
                 eventStyle="extra-compact"
-                loading={loading}
+                loading={fetchingPrevious}
               />
             </div>
           )}


### PR DESCRIPTION
# Description

`state.event.fetching` is not really accurate, and it's so annoying that it always says there are no events even though they exist. [Try it yourself](https://abakus.no/users/me), but it's mostly only noticeable without SSR hehe

The new type of the event state is currently wrong, but will (can) be fixed with https://github.com/webkom/lego-webapp/pull/4224

# Result

Loading indicators now actually load appropriately.

# Testing

- [x] I have thoroughly tested my changes.

Seems to work fine, can't imagine it breaking anything.