### PR TITLE
Implement marking events as foreign language as well as displaying

### DIFF
--- a/app/models.ts
+++ b/app/models.ts
@@ -281,6 +281,7 @@ export type Event = EventBase & {
   isUsersUpcoming?: boolean;
   documentType?: 'event';
   responsibleUsers: ID[];
+  isForeignLanguage: boolean;
 };
 
 type EventTransformPool = EventPoolBase & {
@@ -298,6 +299,7 @@ export type TransformEvent = EventBase & {
   useMazemap: boolean;
   hasFeedbackQuestion: boolean;
   responsibleUsers: DetailedUser[];
+  isForeignLanguage: boolean;
 };
 
 export type Feed = Record<string, any>;

--- a/app/routes/events/EventCreateRoute.ts
+++ b/app/routes/events/EventCreateRoute.ts
@@ -116,6 +116,7 @@ const mapStateToProps = (state, props) => {
       registrationDeadlineHours: 2,
       unregistrationDeadlineHours: 2,
       responsibleUsers: [],
+      isForeignLanguage: false,
     },
     actionGrant,
     imageGallery: imageGallery.map((e) => {

--- a/app/routes/events/EventEditRoute.ts
+++ b/app/routes/events/EventEditRoute.ts
@@ -93,6 +93,7 @@ const mapStateToProps = (state, props) => {
             value: user.id,
           };
         }),
+      isForeignLanguage: event.isForeignLanguage,
 
       eventType: event.eventType && {
         label: EVENT_CONSTANTS[event.eventType],

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -426,11 +426,16 @@ export default class EventDetail extends Component<Props, State> {
               iconName="time-outline"
               content={<FromToTime from={event.startTime} to={event.endTime} />}
             />
+            {event.isForeignLanguage !== null && event.isForeignLanguage && (
+              <TextWithIcon iconName="language-outline" content={'English'} />
+            )}
+
             <div className={styles.infoIconLocation}>
               <TextWithIcon
                 iconName="location-outline"
                 content={event.location}
               />
+
               {event.mazemapPoi && (
                 <Button
                   className={styles.mapButton}

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -357,6 +357,15 @@ function EventEditor({
               className={styles.formField}
               normalize={(v) => !!v}
             />
+            <Field
+              label="Fremmedspråklig"
+              description="Arrangementet er på et annet språk enn norsk (engelsk)."
+              name="isForeignLanguage"
+              component={CheckBox.Field}
+              fieldClassName={styles.metaField}
+              className={styles.formField}
+              normalize={(v) => !!v}
+            />
             {event.isGroupOnly && (
               <div className={styles.subSection}>
                 <Field

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -252,6 +252,7 @@ export const transformEvent = (data: TransformEvent) => ({
   feedbackDescription:
     (data.hasFeedbackQuestion && data.feedbackDescription) || '',
   feedbackRequired: data.hasFeedbackQuestion && data.feedbackRequired,
+  isForeignLanguage: data.isForeignLanguage,
 });
 export const paymentPending = 'pending';
 export const paymentSuccess = 'succeeded';

--- a/app/store/models/Event.d.ts
+++ b/app/store/models/Event.d.ts
@@ -68,6 +68,7 @@ interface Event {
   mazemapPoi?: number;
   pinned: boolean;
   responsibleUsers: DetailedUser[];
+  isForeignLanguage: boolean;
 
   // for survey
   attendedCount: number;
@@ -170,6 +171,7 @@ export type DetailedEvent = Pick<
   | 'mazemapPoi'
   | 'activationTime'
   | 'responsibleUsers'
+  | 'isForeignLanguage'
 > &
   ObjectPermissionsMixin;
 


### PR DESCRIPTION
# Description
Implement checkbox to mark event as foreign language, as well as display this in the event detail.

# Result

![image](https://github.com/webkom/lego-webapp/assets/113468143/81699bbb-d2dc-4885-893a-83a772a60088)

![image](https://github.com/webkom/lego-webapp/assets/113468143/2d50cc5a-017c-4189-baaf-2fd39124147d)


# Testing

- [x] I have thoroughly tested my changes.

---

Resolves: ABA-649
