### PR TITLE
Change meeting color indicator on meeting list

### DIFF
--- a/app/routes/meetings/components/MeetingList.tsx
+++ b/app/routes/meetings/components/MeetingList.tsx
@@ -19,7 +19,8 @@ function MeetingListItem({
   meeting: ListMeeting;
   username: string;
 }) {
-  const isDone = moment(meeting.startTime) < moment();
+  const isDone = moment(meeting.endTime) < moment();
+
   return (
     <div
       style={{


### PR DESCRIPTION
# Description

Currently it changes to gray before the meeting has ended, which in my opinion is "wrong" behaviour. Especially considering the `endTime` is used in the filtering.

# Result

This meeting that I'm currently attending has not ended:

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td>
			<img width="332" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/a125a99a-8ac5-42c5-a0a5-83a5e066483b">		
</td>
		<td>
			<img width="332" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/9784c50b-f967-42bf-a055-7e0bedf2360c">
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

This should not affect anything besides what is shown above.