### PR TITLE
Make checkboxes focusable

### DIFF
--- a/app/components/Form/CheckBox.css
+++ b/app/components/Form/CheckBox.css
@@ -44,7 +44,8 @@
   }
 }
 
-.checkbox input:hover:not(:disabled) {
+.checkbox input:hover:not(:disabled),
+.checkbox input:focus:not(:disabled) {
   --s: 2px;
   --b: var(--border-hover);
 }

--- a/app/components/Form/CheckBox.tsx
+++ b/app/components/Form/CheckBox.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import styles from './CheckBox.css';
 import { createField } from './Field';
 import type { FormProps } from './Field';
-import type { InputHTMLAttributes } from 'react';
+import type { InputHTMLAttributes, KeyboardEvent } from 'react';
 
 type Props = InputHTMLAttributes<HTMLInputElement> & {
   id?: string;
@@ -31,10 +31,26 @@ const CheckBox = ({
 }: Props) => {
   checked = checked ?? value;
   const normalizedValue = inverted ? !checked : checked;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+
+      const inputElement = event.target as HTMLInputElement;
+      inputElement.click();
+    }
+  };
+
   return (
     <Flex wrap alignItems="center" gap={7}>
       <div className={cx(styles.checkbox, styles.bounce, className)}>
-        <input {...props} id={id} checked={normalizedValue} type="checkbox" />
+        <input
+          {...props}
+          id={id}
+          checked={normalizedValue}
+          type="checkbox"
+          onKeyDown={handleKeyDown}
+        />
         <svg viewBox="0 0 21 21">
           <polyline points="5 10.75 8.5 14.25 16 6" />
         </svg>

--- a/app/components/Form/RadioButton.css
+++ b/app/components/Form/RadioButton.css
@@ -42,7 +42,8 @@
   }
 }
 
-.radioButton input:hover:not(:disabled) {
+.radioButton input:hover:not(:disabled),
+.radioButton input:focus:not(:disabled) {
   --s: 2px;
   --b: var(--border-hover);
 }

--- a/app/components/Form/RadioButton.tsx
+++ b/app/components/Form/RadioButton.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import { createField } from './Field';
 import styles from './RadioButton.css';
 import type { FormProps } from './Field';
-import type { InputHTMLAttributes } from 'react';
+import type { InputHTMLAttributes, KeyboardEvent } from 'react';
 
 type Props = {
   id: string;
@@ -27,16 +27,28 @@ function RadioButton({
   // TODO: Remove this when redux-form is gone
   checked = inputValue ? inputValue === value : checked;
   value = inputValue ?? value;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+
+      const inputElement = event.target as HTMLInputElement;
+      if (!inputElement.checked) {
+        inputElement.click();
+      }
+    }
+  };
+
   return (
     <Flex wrap alignItems="center" gap={7}>
       <div className={cx(styles.radioButton, styles.bounce, className)}>
         <input
           {...props}
-          className={styles.input}
           checked={checked}
           type="radio"
           id={id}
           value={value}
+          onKeyDown={handleKeyDown}
         />
         <svg viewBox="0 0 21 21">
           <circle cx="10.5" cy="10.5" r="7" />


### PR DESCRIPTION
# Description

With the changes, it is possible to tab through checkboxes and select them.

Turned out to be impossible to do for radio buttons, as essentially according to W3C; a radio button is a group that functions as a single element since it retains only a single value. Tabbing to a radio group will bring you to the first item and then using the arrow keys you navigate within the group.

However, I did add the similar logic for radio buttons in case there is no default value to the radio button group (e.g. in the company interest form). Despite this being bad practice.

# Result

Notice how the cursor does not move:

<video src="https://github.com/webkom/lego-webapp/assets/69514187/293907e1-13a8-46bb-a0cb-19b52a8483ff" />

# Testing

- [x] I have thoroughly tested my changes.

Checkboxes still behaves like before, but you can now focus on them by tabbing 🎉 
