### PR TITLE
Use param instead of inconsistent variable for accordion expansion

### DIFF
--- a/app/routes/pages/components/PageDetail.tsx
+++ b/app/routes/pages/components/PageDetail.tsx
@@ -69,7 +69,6 @@ class PageDetail extends Component<Props, State> {
     }
 
     const { editUrl, actionGrant = [], isComplete } = selectedPageInfo;
-    const { category } = selectedPage;
     return (
       <Content className={styles.cont}>
         <Helmet title={selectedPageInfo.title} />
@@ -79,7 +78,6 @@ class PageDetail extends Component<Props, State> {
           </button>
           <Flex className={styles.page}>
             <Sidebar
-              categorySelected={category}
               currentUrl={currentUrl}
               pageHierarchy={pageHierarchy}
               isOpen={this.state.isOpen}

--- a/app/routes/pages/components/PageHierarchy.tsx
+++ b/app/routes/pages/components/PageHierarchy.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@webkom/lego-bricks';
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import styles from './PageHierarchy.css';
 import type { ReactNode } from 'react';
@@ -16,14 +16,12 @@ export type HierarchySectionEntity = {
 type Props = {
   pageHierarchy: Array<HierarchySectionEntity>;
   currentUrl: string;
-  currentCategory: string;
   handleCloseSidebar: () => void;
 };
 
 const PageHierarchy = ({
   pageHierarchy,
   currentUrl,
-  currentCategory,
   handleCloseSidebar,
 }: Props) => {
   return (
@@ -33,7 +31,6 @@ const PageHierarchy = ({
           hierarchySection={section}
           key={key}
           currentUrl={currentUrl}
-          currentCategory={currentCategory}
           handleCloseSidebar={handleCloseSidebar}
         />
       ))}
@@ -46,18 +43,16 @@ export default PageHierarchy;
 const HierarchySection = ({
   hierarchySection: { title, items },
   currentUrl,
-  currentCategory,
   handleCloseSidebar,
 }: {
   hierarchySection: HierarchySectionEntity;
   currentUrl: string;
-  currentCategory: string;
   handleCloseSidebar: () => void;
 }) => {
   return (
     <nav className={styles.pageList}>
       {items.length > 0 && (
-        <AccordionContainer title={title} currentCategory={currentCategory}>
+        <AccordionContainer title={title}>
           {items.map((item) => (
             <Link to={item.url} key={item.url + item.title}>
               <div className={styles.links} onClick={handleCloseSidebar}>
@@ -82,25 +77,25 @@ const HierarchySection = ({
 type AccordionProps = {
   title: string;
   children: ReactNode;
-  currentCategory: string;
 };
 
-const AccordionContainer = ({
-  title,
-  children,
-  currentCategory,
-}: AccordionProps) => {
+type PageParams = {
+  section: string;
+};
+
+const AccordionContainer = ({ title, children }: AccordionProps) => {
+  const { section } = useParams<PageParams>();
+
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     if (
-      currentCategory === title.toLowerCase() ||
-      (currentCategory === 'info-om-abakus' &&
-        title.toLowerCase() === 'generelt')
+      section === title.toLowerCase() ||
+      (section === 'info-om-abakus' && title.toLowerCase() === 'generelt')
     ) {
       setIsOpen(true);
     }
-  }, [currentCategory, title]);
+  }, [section, title]);
 
   return (
     <div>

--- a/app/routes/pages/components/Sidebar.tsx
+++ b/app/routes/pages/components/Sidebar.tsx
@@ -5,20 +5,13 @@ import styles from './Sidebar.css';
 import type { HierarchySectionEntity } from './PageHierarchy';
 
 type Props = {
-  categorySelected: string;
   currentUrl: string;
   pageHierarchy: Array<HierarchySectionEntity>;
   isOpen: boolean;
   handleClose: () => void;
 };
 
-const Sidebar = ({
-  categorySelected,
-  currentUrl,
-  pageHierarchy,
-  isOpen,
-  handleClose,
-}: Props) => {
+const Sidebar = ({ currentUrl, pageHierarchy, isOpen, handleClose }: Props) => {
   return (
     <div className={cx(styles.sidebar, isOpen || styles.sidebarClosed)}>
       <button className={styles.sidebarCloseButton} onClick={handleClose}>
@@ -28,7 +21,6 @@ const Sidebar = ({
       <PageHierarchy
         pageHierarchy={pageHierarchy}
         currentUrl={currentUrl}
-        currentCategory={categorySelected}
         handleCloseSidebar={handleClose}
       />
     </div>


### PR DESCRIPTION
# Description

Found out that the variable I relied on for my last fix was incorrectly typed :'( so it turns out the variable wasn't set for groups or main pages, so now it's rather fetched straight from the sauce.

# Result

Should work better now

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-646
