### PR TITLE
Refactor query parameter handling

### DIFF
--- a/app/routes/admin/email/EmailListsRoute.ts
+++ b/app/routes/admin/email/EmailListsRoute.ts
@@ -1,23 +1,24 @@
 import { push } from 'connected-react-router';
-import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetch } from 'app/actions/EmailListActions';
 import { selectEmailLists } from 'app/reducers/emailLists';
 import { selectPaginationNext } from 'app/reducers/selectors';
+import { parseQueryString } from 'app/utils/useQuery';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import EmailLists from './components/EmailLists';
 
+export const emailListsDefaultQuery = {
+  name: '',
+  email: '',
+  requireInternalAddress: undefined as undefined | 'true' | 'false',
+};
+
 const mapStateToProps = (state) => {
-  const { search } = state.router.location;
-  const { filters: qsFilters } = qs.parse(search.slice(1));
-  const filters = JSON.parse(typeof qsFilters === 'string' ? qsFilters : '{}');
-  const { name, email, requireInternalAddress } = filters;
-  const query = {
-    name,
-    email,
-    requireInternalAddress,
-  };
+  const query = parseQueryString(
+    state.router.location.search,
+    emailListsDefaultQuery
+  );
   const { pagination } = selectPaginationNext({
     endpoint: '/email-lists/',
     entity: 'emailLists',
@@ -31,7 +32,6 @@ const mapStateToProps = (state) => {
     hasMore: pagination.hasMore,
     pagination,
     query,
-    filters,
   };
 };
 

--- a/app/routes/admin/email/EmailUsersRoute.ts
+++ b/app/routes/admin/email/EmailUsersRoute.ts
@@ -1,5 +1,4 @@
 import { push } from 'connected-react-router';
-import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetch } from 'app/actions/EmailUserActions';
@@ -8,27 +7,23 @@ import { GroupType } from 'app/models';
 import { selectEmailUsers } from 'app/reducers/emailUsers';
 import { selectGroupsWithType } from 'app/reducers/groups';
 import { selectPaginationNext } from 'app/reducers/selectors';
+import { parseQueryString } from 'app/utils/useQuery';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import EmailUsers from './components/EmailUsers';
 
+export const emailUsersDefaultQuery = {
+  enabled: undefined as undefined | 'true' | 'false',
+  userGrade: undefined as undefined | string,
+  userCommittee: undefined as undefined | string,
+  email: '',
+  userFullname: '',
+};
+
 const mapStateToProps = (state) => {
-  const { search } = state.router.location;
-  const { filters: qsFilters } = qs.parse(search.slice(1));
-  const filters = JSON.parse(typeof qsFilters === 'string' ? qsFilters : '{}');
-  const {
-    'user.fullName': userFullname,
-    internalEmail: email,
-    userCommittee,
-    userGrade,
-    internalEmailEnabled: enabled,
-  } = filters;
-  const query = {
-    userFullname,
-    email,
-    userCommittee,
-    userGrade,
-    enabled,
-  };
+  const query = parseQueryString(
+    state.router.location.search,
+    emailUsersDefaultQuery
+  );
   const { pagination } = selectPaginationNext({
     endpoint: '/email-users/',
     entity: 'emailUsers',
@@ -42,7 +37,6 @@ const mapStateToProps = (state) => {
     hasMore: pagination.hasMore,
     pagination,
     query,
-    filters,
     committees: selectGroupsWithType(state, {
       groupType: GroupType.Committee,
     }),

--- a/app/routes/admin/email/components/EmailLists.tsx
+++ b/app/routes/admin/email/components/EmailLists.tsx
@@ -1,9 +1,9 @@
 import { Button, Flex } from '@webkom/lego-bricks';
-import qs from 'qs';
-import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import Table from 'app/components/Table';
 import Tag from 'app/components/Tags/Tag';
+import { emailListsDefaultQuery } from 'app/routes/admin/email/EmailListsRoute';
+import useQuery from 'app/utils/useQuery';
 
 type Props = {
   fetching: boolean;
@@ -13,95 +13,87 @@ type Props = {
     query?: Record<string, any>;
     next?: boolean;
   }) => Promise<any>;
-  query: Record<string, any>;
-  filters: Record<string, any>;
   push: (arg0: Record<string, any>) => void;
 };
-export default class EmailLists extends Component<Props> {
-  render() {
-    const columns = [
-      {
-        title: 'Navn',
-        dataIndex: 'name',
-        search: true,
-        inlineFiltering: false,
-        render: (name: string, emailList) => (
-          <Link to={`/admin/email/lists/${emailList.id}`}>{name}</Link>
+const EmailLists = (props: Props) => {
+  const { query, setQuery } = useQuery(emailListsDefaultQuery);
+  const columns = [
+    {
+      title: 'Navn',
+      dataIndex: 'name',
+      search: true,
+      inlineFiltering: false,
+      render: (name: string, emailList) => (
+        <Link to={`/admin/email/lists/${emailList.id}`}>{name}</Link>
+      ),
+    },
+    {
+      title: 'E-post',
+      dataIndex: 'email',
+      search: true,
+      inlineFiltering: false,
+      render: (email: string) => <span>{`${email}@abakus.no`}</span>,
+    },
+    {
+      title: 'Kun for brukere med @abakus e-post',
+      dataIndex: 'requireInternalAddress',
+      filter: [
+        {
+          value: 'true',
+          label: 'Kun for @abakus.no',
+        },
+        {
+          value: 'false',
+          label: 'Alle typer adresser',
+        },
+      ],
+      inlineFiltering: false,
+      render: (internalOnly) =>
+        internalOnly ? (
+          <Tag tag="Kun for @abakus.no" color="cyan" />
+        ) : (
+          <Tag tag="Alle typer adresser" color="yellow" />
         ),
-      },
-      {
-        title: 'E-post',
-        dataIndex: 'email',
-        search: true,
-        inlineFiltering: false,
-        render: (email: string) => <span>{`${email}@abakus.no`}</span>,
-      },
-      {
-        title: 'Kun for brukere med @abakus e-post',
-        dataIndex: 'requireInternalAddress',
-        filter: [
-          {
-            value: 'true',
-            label: 'Kun for @abakus.no',
-          },
-          {
-            value: 'false',
-            label: 'Alle adresser',
-          },
-        ],
-        inlineFiltering: false,
-        render: (internalOnly) =>
-          internalOnly ? (
-            <Tag tag="Kun for @abakus.no" color="cyan" />
-          ) : (
-            <Tag tag="Alle typer adresser" color="yellow" />
-          ),
-      },
-    ];
-    return (
-      <div>
-        <p>
-          Lister brukes for permanente lister som skal mottas av definerte
-          brukere eller grupper. Lister kan ikke slettes, men mottakere kan
-          endres. Delen av adressen som kommer før @abakus.no er unik og kan
-          ikke brukes andre steder på abakus.no. Lister er åpne og alle kan
-          sende e-post til disse. Ønsker brukere å sende e-post fra en
-          @abakus.no adresse må de få opprettet en personlig adresse under
-          Brukere.
-        </p>
-        <Flex
-          justifyContent="space-between"
-          style={{
-            marginBottom: '10px',
-          }}
-        >
-          <h3>Aktive e-postlister</h3>
-          <Link to="/admin/email/lists/new">
-            <Button>Ny e-postliste</Button>
-          </Link>
-        </Flex>
-        <Table
-          infiniteScroll
-          columns={columns}
-          onLoad={() => {
-            this.props.fetch({
-              next: true,
-              query: this.props.query,
-            });
-          }}
-          filters={this.props.filters}
-          onChange={(filters) => {
-            this.props.push({
-              search: qs.stringify({
-                filters: JSON.stringify(filters),
-              }),
-            });
-          }}
-          hasMore={this.props.hasMore}
-          loading={this.props.fetching}
-          data={this.props.emailLists}
-        />
-      </div>
-    );
-  }
-}
+    },
+  ];
+  return (
+    <div>
+      <p>
+        Lister brukes for permanente lister som skal mottas av definerte brukere
+        eller grupper. Lister kan ikke slettes, men mottakere kan endres. Delen
+        av adressen som kommer før @abakus.no er unik og kan ikke brukes andre
+        steder på abakus.no. Lister er åpne og alle kan sende e-post til disse.
+        Ønsker brukere å sende e-post fra en @abakus.no adresse må de få
+        opprettet en personlig adresse under Brukere.
+      </p>
+      <Flex
+        justifyContent="space-between"
+        style={{
+          marginBottom: '10px',
+        }}
+      >
+        <h3>Aktive e-postlister</h3>
+        <Link to="/admin/email/lists/new">
+          <Button>Ny e-postliste</Button>
+        </Link>
+      </Flex>
+      <Table
+        infiniteScroll
+        columns={columns}
+        onLoad={() => {
+          props.fetch({
+            next: true,
+            query,
+          });
+        }}
+        filters={query}
+        onChange={setQuery}
+        hasMore={props.hasMore}
+        loading={props.fetching}
+        data={props.emailLists}
+      />
+    </div>
+  );
+};
+
+export default EmailLists;

--- a/app/routes/admin/email/components/EmailRoute.tsx
+++ b/app/routes/admin/email/components/EmailRoute.tsx
@@ -9,7 +9,7 @@ const EmailPage = ({ children }: PropsWithChildren) => (
     <Helmet title="E-post" />
     <NavigationTab title="E-post">
       <NavigationLink to="/admin/email">Lister</NavigationLink>
-      <NavigationLink to='/admin/email/users?filters={"internalEmailEnabled"%3A"true"}'>
+      <NavigationLink to="/admin/email/users?enabled=true">
         Brukere
       </NavigationLink>
       <NavigationLink to="/admin/email/restricted">

--- a/app/routes/admin/email/components/EmailUsers.tsx
+++ b/app/routes/admin/email/components/EmailUsers.tsx
@@ -27,6 +27,7 @@ const EmailUsers = (props: Props) => {
     {
       title: 'Navn',
       dataIndex: 'user.fullName',
+      filterIndex: 'userFullname',
       search: true,
       inlineFiltering: false,
       render: (_, emailUser) => (
@@ -38,6 +39,7 @@ const EmailUsers = (props: Props) => {
     {
       title: 'Intern e-post',
       dataIndex: 'internalEmail',
+      filterIndex: 'email',
       search: true,
       inlineFiltering: false,
       render: (internalEmail: string, emailUser) => (
@@ -104,6 +106,7 @@ const EmailUsers = (props: Props) => {
     {
       title: 'Status',
       dataIndex: 'internalEmailEnabled',
+      filterIndex: 'enabled',
       inlineFiltering: false,
       filter: [
         {
@@ -156,22 +159,8 @@ const EmailUsers = (props: Props) => {
             query,
           });
         }}
-        filters={{
-          internalEmailEnabled: query.enabled,
-          userGrade: query.userGrade,
-          userCommittee: query.userCommittee,
-          internalEmail: query.email,
-          ['user.fullName']: query.userFullname,
-        }}
-        onChange={(filters) =>
-          setQuery({
-            enabled: filters.internalEmailEnabled,
-            userGrade: filters.userGrade,
-            userCommittee: filters.userCommittee,
-            email: filters.internalEmail,
-            userFullname: filters['user.fullName'],
-          })
-        }
+        filters={query}
+        onChange={setQuery}
         hasMore={props.hasMore}
         loading={props.fetching}
         data={props.emailUsers}

--- a/app/routes/admin/email/components/EmailUsers.tsx
+++ b/app/routes/admin/email/components/EmailUsers.tsx
@@ -1,174 +1,183 @@
 import { Button, Flex } from '@webkom/lego-bricks';
-import qs from 'qs';
-import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import Table from 'app/components/Table';
 import Tag from 'app/components/Tags/Tag';
 import type { Group } from 'app/models';
 import { GroupType } from 'app/models';
+import { emailUsersDefaultQuery } from 'app/routes/admin/email/EmailUsersRoute';
+import useQuery from 'app/utils/useQuery';
 
 type Props = {
   fetching: boolean;
   hasMore: boolean;
   emailUsers: Array<Record<string, any>>;
   fetch: (arg0: {
-    filters?: Record<string, any>;
+    query?: Record<string, any>;
     next?: boolean;
   }) => Promise<any>;
   query: Record<string, any>;
-  filters: Record<string, any>;
   push: (arg0: Record<string, any>) => void;
   committees: Group[];
   grades: Group[];
 };
-export default class EmailUsers extends Component<Props> {
-  render() {
-    const columns = [
-      {
-        title: 'Navn',
-        dataIndex: 'user.fullName',
-        search: true,
-        inlineFiltering: false,
-        render: (_, emailUser) => (
-          <Link to={`/admin/email/users/${emailUser.id}`}>
-            {emailUser.user.fullName}
-          </Link>
-        ),
+const EmailUsers = (props: Props) => {
+  const { query, setQuery } = useQuery(emailUsersDefaultQuery);
+
+  const columns = [
+    {
+      title: 'Navn',
+      dataIndex: 'user.fullName',
+      search: true,
+      inlineFiltering: false,
+      render: (_, emailUser) => (
+        <Link to={`/admin/email/users/${emailUser.id}`}>
+          {emailUser.user.fullName}
+        </Link>
+      ),
+    },
+    {
+      title: 'Intern e-post',
+      dataIndex: 'internalEmail',
+      search: true,
+      inlineFiltering: false,
+      render: (internalEmail: string, emailUser) => (
+        <Link to={`/admin/email/users/${emailUser.id}`}>
+          <span>{`${internalEmail}@abakus.no`}</span>
+        </Link>
+      ),
+    },
+    {
+      title: 'Komite',
+      dataIndex: 'userCommittee',
+      inlineFiltering: false,
+      filterMessage: '- for å få brukere uten komite',
+      filter: props.committees
+        .map((committee) => ({
+          label: committee.name,
+          value: committee.name,
+        }))
+        .concat({
+          label: 'Ikke abakom',
+          value: '-',
+        }),
+      render: (_, emailUser) => {
+        const output = emailUser.user.abakusGroups
+          .filter((abakusGroup) => abakusGroup.type === GroupType.Committee)
+          .map((committee) => (
+            <Link
+              key={committee.id}
+              to={`/admin/groups/${committee.id}/members`}
+            >
+              {committee.name}{' '}
+            </Link>
+          ));
+        if (!output.length) return <i> Ikke Abakom </i>;
+        return output;
       },
-      {
-        title: 'Intern e-post',
-        dataIndex: 'internalEmail',
-        search: true,
-        inlineFiltering: false,
-        render: (internalEmail: string, emailUser) => (
-          <Link to={`/admin/email/users/${emailUser.id}`}>
-            <span>{`${internalEmail}@abakus.no`}</span>
-          </Link>
-        ),
+    },
+    {
+      title: 'Klasse',
+      dataIndex: 'userGrade',
+      filter: props.grades
+        .map((grade) => ({
+          label: grade.name,
+          value: grade.name,
+        }))
+        .concat({
+          label: 'Ikke student',
+          value: '-',
+        }),
+      inlineFiltering: false,
+      filterMessage: '- for å få brukere uten klasse',
+      render: (_, emailUser) => {
+        const output = emailUser.user.abakusGroups
+          .filter((abakusGroup) => abakusGroup.type === GroupType.Grade)
+          .map((grade) => (
+            <Link key={grade.id} to={`/admin/groups/${grade.id}/members`}>
+              {grade.name}{' '}
+            </Link>
+          ));
+        if (!output.length) return <i> Ikke student </i>;
+        return output;
       },
-      {
-        title: 'Komite',
-        dataIndex: 'userCommittee',
-        inlineFiltering: false,
-        filterMessage: '- for å få brukere uten komite',
-        filter: this.props.committees
-          .map((committee) => ({
-            label: committee.name,
-            value: committee.name,
-          }))
-          .concat({
-            label: 'Ikke abakom',
-            value: '-',
-          }),
-        render: (_, emailUser) => {
-          const output = emailUser.user.abakusGroups
-            .filter((abakusGroup) => abakusGroup.type === GroupType.Committee)
-            .map((committee) => (
-              <Link
-                key={committee.id}
-                to={`/admin/groups/${committee.id}/members`}
-              >
-                {committee.name}{' '}
-              </Link>
-            ));
-          if (!output.length) return <i> Ikke Abakom </i>;
-          return output;
+    },
+    {
+      title: 'Status',
+      dataIndex: 'internalEmailEnabled',
+      inlineFiltering: false,
+      filter: [
+        {
+          label: 'Aktiv',
+          value: 'true',
         },
-      },
-      {
-        title: 'Klasse',
-        dataIndex: 'userGrade',
-        filter: this.props.grades
-          .map((grade) => ({
-            label: grade.name,
-            value: grade.name,
-          }))
-          .concat({
-            label: 'Ikke student',
-            value: '-',
-          }),
-        inlineFiltering: false,
-        filterMessage: '- for å få brukere uten klasse',
-        render: (_, emailUser) => {
-          const output = emailUser.user.abakusGroups
-            .filter((abakusGroup) => abakusGroup.type === GroupType.Grade)
-            .map((grade) => (
-              <Link key={grade.id} to={`/admin/groups/${grade.id}/members`}>
-                {grade.name}{' '}
-              </Link>
-            ));
-          if (!output.length) return <i> Ikke student </i>;
-          return output;
+        {
+          label: 'Inaktiv',
+          value: 'false',
         },
-      },
-      {
-        title: 'Status',
-        dataIndex: 'internalEmailEnabled',
-        inlineFiltering: false,
-        filter: [
-          {
-            label: 'Aktiv',
-            value: 'true',
-          },
-          {
-            label: 'Inaktiv',
-            value: 'false',
-          },
-        ],
-        render: (enabled) =>
-          enabled ? (
-            <Tag tag="Aktiv" color="green" />
-          ) : (
-            <Tag tag="Inaktiv" color="gray" />
-          ),
-      },
-    ];
-    return (
-      <div>
-        <p>
-          Brukere som har behov for det kan få sin egen private @abakus.no
-          adresse. Denne skal være på formatet{' '}
-          <b>
-            fornavn.etternavn@abakus.no. Adressen kan ikke endres senere, så vær
-            sikker på at adressen som settes er riktig.
-          </b>{' '}
-          Alle brukere med en aktivert adresse vil motta sin e-post fra Abakus
-          på denne. Adressen kan deaktiveres når brukeren ikke lengre er aktiv i
-          Abakus, men adressen vil ikke bli tilgjengelig for andre brukere.
-        </p>
-        <Flex
-          justifyContent="space-between"
-          style={{
-            marginBottom: '10px',
-          }}
-        >
-          <h3>Aktive/Inaktive e-postkontoer</h3>
-          <Link to="/admin/email/users/new">
-            <Button>Ny bruker</Button>
-          </Link>
-        </Flex>
-        <Table
-          infiniteScroll
-          columns={columns}
-          onLoad={() => {
-            this.props.fetch({
-              next: true,
-              query: this.props.query,
-            });
-          }}
-          filters={this.props.filters}
-          onChange={(filters) => {
-            this.props.push({
-              search: qs.stringify({
-                filters: JSON.stringify(filters),
-              }),
-            });
-          }}
-          hasMore={this.props.hasMore}
-          loading={this.props.fetching}
-          data={this.props.emailUsers}
-        />
-      </div>
-    );
-  }
-}
+      ],
+      render: (enabled) =>
+        enabled ? (
+          <Tag tag="Aktiv" color="green" />
+        ) : (
+          <Tag tag="Inaktiv" color="gray" />
+        ),
+    },
+  ];
+  return (
+    <div>
+      <p>
+        Brukere som har behov for det kan få sin egen private @abakus.no
+        adresse. Denne skal være på formatet{' '}
+        <b>
+          fornavn.etternavn@abakus.no. Adressen kan ikke endres senere, så vær
+          sikker på at adressen som settes er riktig.
+        </b>{' '}
+        Alle brukere med en aktivert adresse vil motta sin e-post fra Abakus på
+        denne. Adressen kan deaktiveres når brukeren ikke lengre er aktiv i
+        Abakus, men adressen vil ikke bli tilgjengelig for andre brukere.
+      </p>
+      <Flex
+        justifyContent="space-between"
+        style={{
+          marginBottom: '10px',
+        }}
+      >
+        <h3>Aktive/Inaktive e-postkontoer</h3>
+        <Link to="/admin/email/users/new">
+          <Button>Ny bruker</Button>
+        </Link>
+      </Flex>
+      <Table
+        infiniteScroll
+        columns={columns}
+        onLoad={() => {
+          props.fetch({
+            next: true,
+            query,
+          });
+        }}
+        filters={{
+          internalEmailEnabled: query.enabled,
+          userGrade: query.userGrade,
+          userCommittee: query.userCommittee,
+          internalEmail: query.email,
+          ['user.fullName']: query.userFullname,
+        }}
+        onChange={(filters) =>
+          setQuery({
+            enabled: filters.internalEmailEnabled,
+            userGrade: filters.userGrade,
+            userCommittee: filters.userCommittee,
+            email: filters.internalEmail,
+            userFullname: filters['user.fullName'],
+          })
+        }
+        hasMore={props.hasMore}
+        loading={props.fetching}
+        data={props.emailUsers}
+      />
+    </div>
+  );
+};
+
+export default EmailUsers;

--- a/app/routes/articles/ArticleListRoute.ts
+++ b/app/routes/articles/ArticleListRoute.ts
@@ -1,4 +1,3 @@
-import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetchAll } from 'app/actions/ArticleActions';
@@ -8,19 +7,23 @@ import { selectPaginationNext } from 'app/reducers/selectors';
 import { selectPopularTags } from 'app/reducers/tags';
 import type { PublicArticle } from 'app/store/models/Article';
 import type { PublicUser } from 'app/store/models/User';
+import { parseQueryString } from 'app/utils/useQuery';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import Overview from './components/Overview';
+
+export const articlesListDefaultQuery = {
+  tag: '',
+};
 
 export type ArticleWithAuthorDetails = Omit<PublicArticle, 'authors'> & {
   authors: Array<PublicUser>;
 };
 
 const mapStateToProps = (state, props) => {
-  const query = {
-    tag: qs.parse(props.location.search, {
-      ignoreQueryPrefix: true,
-    }).tag,
-  };
+  const query = parseQueryString(
+    props.location.search,
+    articlesListDefaultQuery
+  );
   const { pagination } = selectPaginationNext({
     endpoint: `/articles/`,
     query,
@@ -52,8 +55,10 @@ export default compose(
         fetchAll({
           next: false,
           query: {
-            tag: qs.parse(props.location.search, { ignoreQueryPrefix: true })
-              .tag,
+            tag: parseQueryString(
+              props.location.search,
+              articlesListDefaultQuery
+            ),
           },
         })
       ),

--- a/app/routes/articles/components/Overview.tsx
+++ b/app/routes/articles/components/Overview.tsx
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import { Content } from 'app/components/Content';
@@ -9,7 +8,10 @@ import Tags from 'app/components/Tags';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';
 import type { ActionGrant } from 'app/models';
-import type { ArticleWithAuthorDetails } from 'app/routes/articles/ArticleListRoute';
+import type {
+  ArticleWithAuthorDetails,
+  articlesListDefaultQuery,
+} from 'app/routes/articles/ArticleListRoute';
 import styles from './Overview.css';
 
 const HEADLINE_EVENTS = 2;
@@ -61,72 +63,82 @@ type Props = {
   articles: ArticleWithAuthorDetails[];
   fetching: boolean;
   hasMore: boolean;
-  fetchAll: (arg0: { next?: boolean }) => Promise<any>;
+  fetchAll: (arg0: {
+    next?: boolean;
+    query: Record<string, string>;
+  }) => Promise<any>;
   tags: Array<Record<string, any>>;
   location: any;
   actionGrant: ActionGrant;
-  query: Record<string, any>;
+  query: typeof articlesListDefaultQuery;
 };
-export default class Overview extends Component<Props> {
-  render() {
-    const { articles, actionGrant = [], query } = this.props;
-    const headlineEvents = articles.slice(0, HEADLINE_EVENTS);
-    const normalEvents = articles.slice(HEADLINE_EVENTS);
-    return (
-      <Content>
-        <Helmet title="Artikler" />
-        <NavigationTab title="Artikler">
-          {actionGrant.includes('create') && (
-            <NavigationLink to="/articles/new">Ny artikkel</NavigationLink>
-          )}
-        </NavigationTab>
-        <Tags>
-          {this.props.tags.map((tag) => {
-            const isSelected = query && query.tag === tag.tag;
-            return (
-              <Tag
-                tag={tag.tag}
-                key={tag.tag}
-                color="blue"
-                active={isSelected}
-                link={isSelected ? '/articles/' : `/articles?tag=${tag.tag}`}
-              />
-            );
-          })}
-          <Tag
-            tag="Vis alle tags ..."
-            key="viewmore"
-            link="/tags/"
-            color="gray"
-          />
-        </Tags>
-        <section className={styles.frontpage}>
-          <Paginator
-            infiniteScroll={true}
-            hasMore={this.props.hasMore}
-            fetching={this.props.fetching}
-            fetchNext={() => {
-              this.props.fetchAll({
-                query,
-                next: true,
-              });
-            }}
-          >
-            <div className={styles.overview}>
-              <div className={styles.headline}>
-                {headlineEvents.map((article) => (
-                  <OverviewItem key={article.id} article={article} />
-                ))}
-              </div>
-              <div className={styles.normal}>
-                {normalEvents.map((article) => (
-                  <OverviewItem key={article.id} article={article} />
-                ))}
-              </div>
+const Overview = ({
+  articles,
+  actionGrant = [],
+  query,
+  tags,
+  hasMore,
+  fetching,
+  fetchAll,
+}: Props) => {
+  const headlineEvents = articles.slice(0, HEADLINE_EVENTS);
+  const normalEvents = articles.slice(HEADLINE_EVENTS);
+  return (
+    <Content>
+      <Helmet title="Artikler" />
+      <NavigationTab title="Artikler">
+        {actionGrant.includes('create') && (
+          <NavigationLink to="/articles/new">Ny artikkel</NavigationLink>
+        )}
+      </NavigationTab>
+      <Tags>
+        {tags.map((tag) => {
+          const isSelected = query.tag === tag.tag;
+          return (
+            <Tag
+              tag={tag.tag}
+              key={tag.tag}
+              color="blue"
+              active={isSelected}
+              link={isSelected ? '/articles/' : `/articles?tag=${tag.tag}`}
+            />
+          );
+        })}
+        <Tag
+          tag="Vis alle tags ..."
+          key="viewmore"
+          link="/tags/"
+          color="gray"
+        />
+      </Tags>
+      <section className={styles.frontpage}>
+        <Paginator
+          infiniteScroll={true}
+          hasMore={hasMore}
+          fetching={fetching}
+          fetchNext={() => {
+            fetchAll({
+              query,
+              next: true,
+            });
+          }}
+        >
+          <div className={styles.overview}>
+            <div className={styles.headline}>
+              {headlineEvents.map((article) => (
+                <OverviewItem key={article.id} article={article} />
+              ))}
             </div>
-          </Paginator>
-        </section>
-      </Content>
-    );
-  }
-}
+            <div className={styles.normal}>
+              {normalEvents.map((article) => (
+                <OverviewItem key={article.id} article={article} />
+              ))}
+            </div>
+          </div>
+        </Paginator>
+      </section>
+    </Content>
+  );
+};
+
+export default Overview;

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -1,7 +1,6 @@
 import { Button, Icon, LoadingIndicator } from '@webkom/lego-bricks';
 import { isEmpty, orderBy } from 'lodash';
 import moment from 'moment-timezone';
-import { Component } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Select from 'react-select';
 import EmptyState from 'app/components/EmptyState';
@@ -10,9 +9,18 @@ import { CheckBox } from 'app/components/Form/';
 import { selectTheme, selectStyles } from 'app/components/Form/SelectInput';
 import type { Event, ActionGrant, IcalToken } from 'app/models';
 import { EventTime } from 'app/models';
+import type { ListEvent } from 'app/store/models/Event';
+import useQuery from 'app/utils/useQuery';
 import EventFooter from './EventFooter';
 import styles from './EventList.css';
 import Toolbar from './Toolbar';
+
+type FilterEventType = 'company_presentation' | 'course' | 'social' | 'other';
+type FilterRegistrationsType = 'all' | 'open' | 'future';
+export const eventListDefaultQuery = {
+  eventTypes: [] as FilterEventType[],
+  registrations: 'all' as FilterRegistrationsType,
+};
 
 type GroupedEvents = {
   currentWeek?: Event[];
@@ -20,13 +28,10 @@ type GroupedEvents = {
   later?: Event[];
 };
 
-const groupEvents = ({
-  events,
-  field = EventTime.start,
-}: {
-  events: Array<Event>;
-  field?: EventTime;
-}): GroupedEvents => {
+const groupEvents = (
+  events: Array<Event>,
+  field?: EventTime = EventTime.start
+): GroupedEvents => {
   const nextWeek = moment().add(1, 'week');
   const groups = {
     currentWeek: (event) => moment(event[field]).isSame(moment(), 'week'),
@@ -85,198 +90,190 @@ type EventListProps = {
 type Option = {
   filterRegDateFunc: (arg0: Event) => boolean;
   label: string;
-  value: string;
+  value: FilterRegistrationsType;
   field: EventTime;
-};
-type State = {
-  selectedOption: Option;
-  filterEventTypesSettings: Record<string, any>;
 };
 const filterRegDateOptions: Array<Option> = [
   {
     filterRegDateFunc: (event) => !!event,
     label: 'Vis alle',
-    value: 'Vis alle',
+    value: 'all',
     field: EventTime.start,
   },
   {
     filterRegDateFunc: (event) =>
       event.activationTime != null &&
       moment(event.activationTime).isBefore(moment()),
-    label: 'P\xe5melding \xe5pnet',
-    value: 'P\xe5melding \xe5pnet',
+    label: 'Påmelding åpnet',
+    value: 'open',
     field: EventTime.start,
   },
   {
     filterRegDateFunc: (event) =>
       event.activationTime != null &&
       moment(event.activationTime).isAfter(moment()),
-    label: '\xc5pner i fremtiden',
-    value: '\xc5pner i fremtiden',
+    label: 'Åpner i fremtiden',
+    value: 'future',
     field: EventTime.activate,
   },
 ];
 
-class EventList extends Component<EventListProps, State> {
-  constructor(props: EventListProps) {
-    super(props);
-    const locationFilters = props.location.state?.filterEventType || [];
-    this.state = {
-      selectedOption: filterRegDateOptions[0],
-      filterEventTypesSettings: {
-        showCompanyPresentation: locationFilters.includes(
-          'showCompanyPresentation'
-        ),
-        showCourse: locationFilters.includes('showCourse'),
-        showSocial: locationFilters.includes('showSocial'),
-        showOther: locationFilters.includes('showOther'),
-      },
-    };
-  }
+const EventList = ({
+  icalToken,
+  showFetchMore,
+  fetchMore,
+  events,
+  loggedIn,
+  fetching,
+  actionGrant,
+}: EventListProps) => {
+  const { query, setQueryValue } = useQuery(eventListDefaultQuery);
 
-  handleChange = (selectedOption: Option): void => {
-    this.setState({
-      selectedOption,
-    });
-  };
-  handleFilterEventTypeChange = (eventType: string) => {
-    this.setState((state) => ({
-      filterEventTypesSettings: {
-        ...state.filterEventTypesSettings,
-        [eventType]: !state.filterEventTypesSettings[eventType],
-      },
-    }));
-  };
+  const regDateFilter =
+    filterRegDateOptions.find(
+      (option) => option.value === query.registrations
+    ) || filterRegDateOptions[0];
 
-  render() {
-    const { icalToken, showFetchMore, fetchMore, events, loggedIn, fetching } =
-      this.props;
+  const { field, filterRegDateFunc } = regDateFilter;
 
-    const { field, filterRegDateFunc } = this.state.selectedOption;
-    const { showCompanyPresentation, showCourse, showSocial, showOther } =
-      this.state.filterEventTypesSettings;
+  const showCourse = query.eventTypes.includes('course');
+  const showSocial = query.eventTypes.includes('social');
+  const showOther = query.eventTypes.includes('other');
+  const showCompanyPresentation = query.eventTypes.includes(
+    'company_presentation'
+  );
 
-    const filterEventTypesFunc = (event) => {
-      if (!showCompanyPresentation && !showCourse && !showSocial && !showOther)
+  const filterEventTypesFunc = (event: ListEvent) => {
+    if (!showCompanyPresentation && !showCourse && !showSocial && !showOther)
+      return true;
+
+    switch (event.eventType) {
+      case 'company_presentation':
+      case 'lunch_presentation':
+        return showCompanyPresentation;
+
+      case 'alternative_presentation':
+        return showSocial || showCompanyPresentation;
+
+      case 'course':
+      case 'breakfast_talk':
+        return showCourse;
+
+      case 'event':
+      case 'social':
+      case 'party':
+        return showSocial;
+
+      case 'other':
+      case 'kid_event':
+        return showOther;
+
+      default:
         return true;
+    }
+  };
 
-      switch (event.eventType) {
-        case 'company_presentation':
-        case 'lunch_presentation':
-          return showCompanyPresentation;
+  const groupedEvents = groupEvents(
+    orderBy(
+      events.filter(filterRegDateFunc).filter(filterEventTypesFunc),
+      field
+    ),
+    field
+  );
 
-        case 'alternative_presentation':
-          return showSocial || showCompanyPresentation;
-
-        case 'course':
-        case 'breakfast_talk':
-          return showCourse;
-
-        case 'event':
-        case 'social':
-        case 'party':
-          return showSocial;
-
-        case 'other':
-        case 'kid_event':
-          return showOther;
-
-        default:
-          return true;
-      }
+  const toggleEventType =
+    (type: 'company_presentation' | 'course' | 'social' | 'other') => () => {
+      setQueryValue('eventTypes')(
+        query.eventTypes.includes(type)
+          ? query.eventTypes.filter((t) => t !== type)
+          : [...query.eventTypes, type]
+      );
     };
 
-    const groupedEvents = groupEvents({
-      events: orderBy(
-        events.filter(filterRegDateFunc).filter(filterEventTypesFunc),
-        field
-      ),
-      field: field,
-    });
-    return (
-      <div className={styles.root}>
-        <Helmet title="Arrangementer" />
-        <Toolbar actionGrant={this.props.actionGrant} />
-        <div className={styles.filter}>
-          <div className={styles.filterButtons}>
-            <CheckBox
-              id="companyPresentation"
-              label="Bedpres"
-              value={showCompanyPresentation}
-              onChange={() =>
-                this.handleFilterEventTypeChange('showCompanyPresentation')
-              }
-            />
-            <CheckBox
-              id="course"
-              label="Kurs"
-              value={showCourse}
-              onChange={() => this.handleFilterEventTypeChange('showCourse')}
-            />
-            <CheckBox
-              id="social"
-              label="Sosialt"
-              value={showSocial}
-              onChange={() => this.handleFilterEventTypeChange('showSocial')}
-            />
-            <CheckBox
-              id="other"
-              label="Annet"
-              value={showOther}
-              onChange={() => this.handleFilterEventTypeChange('showOther')}
-            />
-          </div>
-          <Icon
-            name="funnel-outline"
-            size={25}
-            style={{
-              marginRight: '5px',
-              marginLeft: '10px',
-            }}
+  return (
+    <div className={styles.root}>
+      <Helmet title="Arrangementer" />
+      <Toolbar actionGrant={actionGrant} />
+      <div className={styles.filter}>
+        <div className={styles.filterButtons}>
+          <CheckBox
+            id="companyPresentation"
+            label="Bedpres"
+            value={showCompanyPresentation}
+            onChange={toggleEventType('company_presentation')}
           />
-          <Select
-            name="form-field-name"
-            value={this.state.selectedOption}
-            onChange={this.handleChange}
-            className={styles.select}
-            options={filterRegDateOptions}
-            isClearable={false}
-            theme={selectTheme}
-            styles={selectStyles}
+          <CheckBox
+            id="course"
+            label="Kurs"
+            value={showCourse}
+            onChange={toggleEventType('course')}
+          />
+          <CheckBox
+            id="social"
+            label="Sosialt"
+            value={showSocial}
+            onChange={toggleEventType('social')}
+          />
+          <CheckBox
+            id="other"
+            label="Annet"
+            value={showOther}
+            onChange={toggleEventType('other')}
           />
         </div>
-        <EventListGroup
-          name="Denne uken"
-          events={groupedEvents.currentWeek}
-          field={field}
-          loggedIn={loggedIn}
+        <Icon
+          name="funnel-outline"
+          size={25}
+          style={{
+            marginRight: '5px',
+            marginLeft: '10px',
+          }}
         />
-        <EventListGroup
-          name="Neste uke"
-          events={groupedEvents.nextWeek}
-          field={field}
-          loggedIn={loggedIn}
+        <Select
+          name="form-field-name"
+          value={regDateFilter}
+          onChange={(selectedOption) =>
+            selectedOption &&
+            setQueryValue('registrations')(selectedOption.value)
+          }
+          className={styles.select}
+          options={filterRegDateOptions}
+          isClearable={false}
+          theme={selectTheme}
+          styles={selectStyles}
         />
-        <EventListGroup
-          name="Senere"
-          events={groupedEvents.later}
-          field={field}
-          loggedIn={loggedIn}
-        />
-        {isEmpty(events) && fetching && <LoadingIndicator loading />}
-        {isEmpty(events) && !fetching && (
-          <EmptyState icon="book-outline" size={40}>
-            <h2 className={styles.noEvents}>Ingen kommende arrangementer</h2>
-          </EmptyState>
-        )}
-        {showFetchMore && field === 'startTime' && (
-          <Button onClick={fetchMore}>Last inn mer</Button>
-        )}
-        <div className={styles.bottomBorder} />
-        <EventFooter icalToken={icalToken} />
       </div>
-    );
-  }
-}
+      <EventListGroup
+        name="Denne uken"
+        events={groupedEvents.currentWeek}
+        field={field}
+        loggedIn={loggedIn}
+      />
+      <EventListGroup
+        name="Neste uke"
+        events={groupedEvents.nextWeek}
+        field={field}
+        loggedIn={loggedIn}
+      />
+      <EventListGroup
+        name="Senere"
+        events={groupedEvents.later}
+        field={field}
+        loggedIn={loggedIn}
+      />
+      {isEmpty(events) && fetching && <LoadingIndicator loading />}
+      {isEmpty(events) && !fetching && (
+        <EmptyState icon="book-outline" size={40}>
+          <h2 className={styles.noEvents}>Ingen kommende arrangementer</h2>
+        </EmptyState>
+      )}
+      {showFetchMore && field === 'startTime' && (
+        <Button onClick={fetchMore}>Last inn mer</Button>
+      )}
+      <div className={styles.bottomBorder} />
+      <EventFooter icalToken={icalToken} />
+    </div>
+  );
+};
 
 export default EventList;

--- a/app/routes/joblistings/JoblistingRoute.ts
+++ b/app/routes/joblistings/JoblistingRoute.ts
@@ -1,12 +1,25 @@
 import moment from 'moment-timezone';
-import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetchAll } from 'app/actions/JoblistingActions';
+import type { ListJoblisting } from 'app/store/models/Joblisting';
+import { parseQueryString } from 'app/utils/useQuery';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import JoblistingPage from './components/JoblistingPage';
 
-function filterJoblistings(joblistings, grades, jobTypes, workplaces) {
+export const defaultJoblistingsQuery = {
+  order: 'deadline',
+  grades: [] as string[],
+  jobTypes: [] as string[],
+  workplaces: [] as string[],
+};
+
+function filterJoblistings(
+  joblistings: ListJoblisting[],
+  grades: string[],
+  jobTypes: string[],
+  workplaces: string[]
+) {
   return joblistings.filter((joblisting) => {
     const gradeBoolean =
       grades.length === 0 ||
@@ -34,12 +47,12 @@ function filterJoblistings(joblistings, grades, jobTypes, workplaces) {
 }
 
 const dateSort =
-  (field, reverse = false) =>
+  (field: string, reverse = false) =>
   (a, b) => {
     if (a[field] === b[field]) return (reverse ? -1 : 1) * (a.id - b.id);
     const date1 = moment(a[field]);
     const date2 = moment(b[field]);
-    return (reverse ? -1 : 1) * (date1 - date2);
+    return (reverse ? -1 : 1) * (date1.unix() - date2.unix());
   };
 
 const companySort = (a, b) => {
@@ -54,7 +67,7 @@ const sortJoblistings = (joblistings, sortType) => {
         return companySort;
 
       case 'createdAt':
-        return dateSort('createdAt', -1);
+        return dateSort('createdAt', true);
 
       case 'deadline':
       default:
@@ -66,33 +79,24 @@ const sortJoblistings = (joblistings, sortType) => {
 };
 
 const mapStateToProps = (state, props) => {
-  let { search } = props.location;
-  search = qs.parse(search, {
-    ignoreQueryPrefix: true,
-  });
-  const { history } = props;
+  const { order, grades, jobTypes, workplaces } = parseQueryString(
+    props.location.search,
+    defaultJoblistingsQuery
+  );
   const joblistings = state.joblistings.items.map(
     (id) => state.joblistings.byId[id]
   );
-  const sortType = search.order;
-  const filterGrade = search.grades ? search.grades.split(',') : [];
-  const filterJobType = search.jobTypes ? search.jobTypes.split(',') : [];
-  const filterWorkplaces = search.workplaces
-    ? search.workplaces.split(',')
-    : [];
   const filteredJoblistings = filterJoblistings(
     joblistings,
-    filterGrade,
-    filterJobType,
-    filterWorkplaces
+    grades,
+    jobTypes,
+    workplaces
   );
-  const sortedJoblistings = sortJoblistings(filteredJoblistings, sortType);
+  const sortedJoblistings = sortJoblistings(filteredJoblistings, order);
   const actionGrant = state.joblistings.actionGrant || [];
   return {
     joblistings: sortedJoblistings,
-    search,
     actionGrant,
-    history,
   };
 };
 

--- a/app/routes/joblistings/components/JoblistingPage.tsx
+++ b/app/routes/joblistings/components/JoblistingPage.tsx
@@ -8,22 +8,10 @@ import JoblistingsRightNav from './JoblistingRightNav';
 
 type Props = {
   joblistings: ListJoblisting[];
-  search: {
-    grades?: string;
-    jobTypes?: string;
-    workplaces?: string;
-    order?: string;
-  };
   actionGrant: ActionGrant;
-  history: Record<string, any>;
 };
 
-const JoblistingsPage = ({
-  joblistings,
-  search,
-  actionGrant,
-  history,
-}: Props) => {
+const JoblistingsPage = ({ joblistings, actionGrant }: Props) => {
   if (!joblistings) {
     return <LoadingIndicator loading />;
   }
@@ -33,11 +21,7 @@ const JoblistingsPage = ({
       <Helmet title="Karriere" />
       <Flex className={styles.page}>
         <JoblistingsList joblistings={joblistings} />
-        <JoblistingsRightNav
-          query={search}
-          actionGrant={actionGrant}
-          history={history}
-        />
+        <JoblistingsRightNav actionGrant={actionGrant} />
       </Flex>
     </div>
   );

--- a/app/routes/joblistings/components/JoblistingRightNav.tsx
+++ b/app/routes/joblistings/components/JoblistingRightNav.tsx
@@ -1,125 +1,24 @@
 import { Button } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import qs from 'qs';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CheckBox, RadioButton } from 'app/components/Form/';
-import type { JobType } from 'app/components/JoblistingItem/Items';
 import type { ActionGrant } from 'app/models';
-import { jobTypes } from '../constants';
+import { defaultJoblistingsQuery } from 'app/routes/joblistings/JoblistingRoute';
+import useQuery from 'app/utils/useQuery';
+import { jobTypes as allJobTypes } from '../constants';
 import styles from './JoblistingRightNav.css';
 
-const updateFilters = (type, value, filters) => {
-  const newFilter = {
-    ...filters,
-    [type]: filters[type].includes(value)
-      ? filters[type].filter((x) => x !== value)
-      : filters[type].concat(value),
-  };
-  return {
-    ...(newFilter.grades.length > 0
-      ? {
-          grades: newFilter.grades.toString(),
-        }
-      : {}),
-    ...(newFilter.jobTypes.length > 0
-      ? {
-          jobTypes: newFilter.jobTypes.toString(),
-        }
-      : {}),
-    ...(newFilter.workplaces.length > 0
-      ? {
-          workplaces: newFilter.workplaces.toString(),
-        }
-      : {}),
-  };
-};
-
-const FilterLink = ({
-  type,
-  label,
-  value,
-  filters,
-  history,
-}: Record<string, any>) => {
-  const handleChange = () => {
-    const location = {
-      pathname: '/joblistings',
-      search: qs.stringify(updateFilters(type, value, filters)),
-    };
-    history.push(location);
-  };
-
-  return (
-    <CheckBox
-      id={label}
-      label={label}
-      value={filters[type].includes(value)}
-      onChange={handleChange}
-      readOnly
-    />
-  );
-};
-
-type Filter = {
-  grades: Array<string>;
-  jobTypes: JobType[];
-  workplaces: Array<string>;
-};
-type Order = {
-  deadline: boolean;
-  company: boolean;
-  createdAt: boolean;
-};
 type Props = {
   actionGrant: ActionGrant;
-  query: {
-    grades?: string;
-    jobTypes?: string;
-    workplaces?: string;
-    order?: string;
-  };
-  history: any;
 };
 
 const JoblistingsRightNav = (props: Props) => {
-  const [filters, setFilters] = useState<Filter>({
-    grades: [],
-    jobTypes: [],
-    workplaces: [],
-  });
-  const [order, setOrder] = useState<Order>({
-    deadline: true,
-    company: false,
-    createdAt: false,
-  });
+  const { query, setQueryValue } = useQuery(defaultJoblistingsQuery);
+
+  const { order, grades, jobTypes, workplaces } = query;
+
   const [displayOptions, setDisplayOptions] = useState<boolean>(true);
-  useEffect(() => {
-    const query = props.query;
-    setFilters({
-      grades: query.grades ? query.grades.split(',') : [],
-      jobTypes: query.jobTypes ? (query.jobTypes.split(',') as JobType[]) : [],
-      workplaces: query.workplaces ? query.workplaces.split(',') : [],
-    });
-    setOrder({
-      deadline:
-        query.order === 'deadline' || !Object.keys(query).includes('order'),
-      company: query.order === 'company',
-      createdAt: query.order === 'createdAt',
-    });
-  }, [props.query]);
-
-  const handleQuery = (type: string, value: string, remove = false) => {
-    const query = { ...props.query };
-
-    if (remove) {
-      delete query[type];
-    } else {
-      query[type] = value;
-    }
-
-    return query;
-  };
 
   return (
     <div className={styles.joblistingRightNav}>
@@ -155,77 +54,93 @@ const JoblistingsRightNav = (props: Props) => {
           name="sort"
           id="deadline"
           label="Frist"
-          checked={order.deadline}
-          onChange={() => {
-            props.history.push({
-              pathname: '/joblistings',
-              search: qs.stringify(handleQuery('order', 'deadline')),
-            });
+          checked={order === 'deadline'}
+          onChange={(value) => {
+            console.log(value);
+            setQueryValue('order')('deadline');
           }}
         />
         <RadioButton
           name="sort"
           id="company"
           label="Bedrift"
-          checked={order.company}
+          checked={order === 'company'}
           onChange={() => {
-            props.history.push({
-              pathname: '/joblistings',
-              search: qs.stringify(handleQuery('order', 'company')),
-            });
+            setQueryValue('order')('company');
           }}
         />
         <RadioButton
           name="sort"
           id="createdAt"
           label="Publisert"
-          checked={order.createdAt}
+          checked={order === 'createdAt'}
           onChange={() => {
-            props.history.push({
-              pathname: '/joblistings',
-              search: qs.stringify(handleQuery('order', 'createdAt')),
-            });
+            setQueryValue('order')('createdAt');
           }}
         />
 
         <h3 className={styles.rightHeader}>Klassetrinn</h3>
         {['1', '2', '3', '4', '5'].map((element) => (
-          <FilterLink
+          <FilterCheckbox
             key={element}
-            type="grades"
-            label={`${element}. klasse`}
             value={element}
-            filters={filters}
-            history={props.history}
+            label={element}
+            activeFilters={grades}
+            onChange={setQueryValue('grades')}
           />
         ))}
         <h3 className={styles.rightHeader}>Jobbtype</h3>
-        {jobTypes.map((el) => {
+        {allJobTypes.map((element) => {
           return (
-            <FilterLink
-              key={el.value}
-              type="jobTypes"
-              value={el.value}
-              label={el.label}
-              filters={filters}
-              history={props.history}
+            <FilterCheckbox
+              key={element.value}
+              value={element.value}
+              label={element.label}
+              activeFilters={jobTypes}
+              onChange={setQueryValue('jobTypes')}
             />
           );
         })}
         <h3 className={styles.rightHeader}>Sted</h3>
         {['Oslo', 'Trondheim', 'Bergen', 'Tromsø', 'Annet'].map((element) => (
-          <FilterLink
+          <FilterCheckbox
             key={element}
-            type="workplaces"
             value={element}
             label={element}
-            filters={filters}
-            history={props.history}
+            activeFilters={workplaces}
+            onChange={setQueryValue('workplaces')}
           />
         ))}
       </div>
     </div>
   );
 };
+
+type FilterCheckboxProps = {
+  value: string;
+  label: string;
+  activeFilters: string[];
+  onChange: (activeFilters: string[]) => void;
+};
+const FilterCheckbox = ({
+  value,
+  label,
+  activeFilters,
+  onChange,
+}: FilterCheckboxProps) => (
+  <CheckBox
+    id={value}
+    label={label}
+    checked={activeFilters.includes(value)}
+    onChange={() =>
+      onChange(
+        activeFilters.includes(value)
+          ? activeFilters.filter((e) => e !== value)
+          : [...activeFilters, value].sort()
+      )
+    }
+    readOnly
+  />
+);
 
 export default JoblistingsRightNav;

--- a/app/routes/overview/components/CompactEvents.tsx
+++ b/app/routes/overview/components/CompactEvents.tsx
@@ -4,7 +4,9 @@ import { Component } from 'react';
 import { Link } from 'react-router-dom';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
+import { eventListDefaultQuery } from 'app/routes/events/components/EventList';
 import { colorForEvent } from 'app/routes/events/utils';
+import { stringifyQuery } from 'app/utils/useQuery';
 import styles from './CompactEvents.css';
 import type { CSSProperties } from 'react';
 
@@ -85,9 +87,12 @@ export default class CompactEvents extends Component<Props> {
             <Link
               to={{
                 pathname: '/events',
-                state: {
-                  filterEventType: ['showCompanyPresentation', 'showCourse'],
-                },
+                search: stringifyQuery(
+                  {
+                    eventTypes: ['company_presentation', 'course'],
+                  },
+                  eventListDefaultQuery
+                ),
               }}
             >
               <h3 className="u-ui-heading">Bedpres og kurs</h3>
@@ -98,9 +103,12 @@ export default class CompactEvents extends Component<Props> {
             <Link
               to={{
                 pathname: '/events',
-                state: {
-                  filterEventType: ['showSocial', 'showOther'],
-                },
+                search: stringifyQuery(
+                  {
+                    eventTypes: ['social', 'other'],
+                  },
+                  eventListDefaultQuery
+                ),
               }}
             >
               <h3 className="u-ui-heading">Arrangementer</h3>

--- a/app/routes/quotes/QuoteDetailRoute.ts
+++ b/app/routes/quotes/QuoteDetailRoute.ts
@@ -1,4 +1,3 @@
-import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetchEmojis } from 'app/actions/EmojiActions';
@@ -17,15 +16,11 @@ import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import QuotePage from './components/QuotePage';
 
 const mapStateToProps = (state, props) => {
-  const query = qs.parse(props.location.search, {
-    ignoreQueryPrefix: true,
-  });
   const quoteId = props.match.params.quoteId;
   const quotes = [selectQuoteById(state, quoteId)];
   const emojis = selectEmojis(state);
   const actionGrant = state.quotes.actionGrant;
   return {
-    query,
     quotes,
     quoteId,
     emojis,

--- a/app/routes/quotes/QuotesRoute.ts
+++ b/app/routes/quotes/QuotesRoute.ts
@@ -1,4 +1,3 @@
-import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { fetchEmojis } from 'app/actions/EmojiActions';
@@ -14,23 +13,19 @@ import { selectEmojis } from 'app/reducers/emojis';
 import { selectQuotes } from 'app/reducers/quotes';
 import { selectPaginationNext } from 'app/reducers/selectors';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
+import { parseQueryString } from 'app/utils/useQuery';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import QuotePage from './components/QuotePage';
 
-const qsParamsParser = (search) => ({
-  approved:
-    qs.parse(search, {
-      ignoreQueryPrefix: true,
-    }).approved || 'true',
-  ordering: qs.parse(search, {
-    ignoreQueryPrefix: true,
-  }).ordering,
-});
+export const defaultQuotesQuery = {
+  approved: 'true',
+  ordering: '-created_at',
+};
 
 const mapStateToProps = (state, props) => {
   const { pagination } = selectPaginationNext({
     endpoint: `/quotes/`,
-    query: qsParamsParser(props.location.search),
+    query: parseQueryString(props.location.search, defaultQuotesQuery),
     entity: 'quotes',
   })(state);
   const emojis = selectEmojis(state);
@@ -38,7 +33,6 @@ const mapStateToProps = (state, props) => {
     quotes: selectQuotes(state, {
       pagination,
     }),
-    query: pagination.query,
     actionGrant: state.quotes.actionGrant,
     showFetchMore: pagination.hasMore,
     emojis,
@@ -63,7 +57,7 @@ export default compose(
     (props, dispatch) =>
       dispatch(
         fetchAll({
-          query: qsParamsParser(props.location.search),
+          query: parseQueryString(props.location.search, defaultQuotesQuery),
         })
       ),
     (props) => [props.location]

--- a/app/utils/__tests__/useQuery.spec.ts
+++ b/app/utils/__tests__/useQuery.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { parseQueryString, stringifyQuery } from 'app/utils/useQuery';
+
+describe('parseQueryString', () => {
+  it('should parse string value', () => {
+    const initialValues = {
+      foo: 'bar',
+    };
+    const queryString = '?foo=baz';
+    const query = parseQueryString(queryString, initialValues);
+    expect(query.foo).toBe('baz');
+  });
+  it('should use default value for missing key', () => {
+    const initialValues = {
+      foo: 'bar',
+    };
+    const queryString = '';
+    const query = parseQueryString(queryString, initialValues);
+    expect(query.foo).toBe('bar');
+  });
+
+  it('should parse array values', () => {
+    const initialValues = {
+      foo: ['fizz'],
+    };
+    const queryString = '?foo[]=bar&foo[]=baz';
+    const query = parseQueryString(queryString, initialValues);
+    expect(query.foo).toEqual(['bar', 'baz']);
+  });
+
+  it('should parse object values', () => {
+    const initialValues = {
+      foo: {
+        fizz: 'buzz',
+        razz: 'dazz',
+      },
+    };
+    const queryString = '?foo[fizz]=bizz&foo[razz]=bazz';
+    const query = parseQueryString(queryString, initialValues);
+    expect(query.foo).toEqual({
+      fizz: 'bizz',
+      razz: 'bazz',
+    });
+  });
+});
+
+describe('stringifyQuery', () => {
+  it('should stringify query object', () => {
+    const initialValues = {
+      foo: 'bar',
+      obj: {
+        fizz: 'buzz',
+      },
+      arr: ['fizz', 'buzz'],
+    };
+
+    const query = {
+      foo: 'baz',
+      obj: {
+        fizz: 'bizz',
+      },
+      arr: ['fizz', 'bizz'],
+    };
+
+    const queryString = stringifyQuery(query, initialValues);
+    expect(queryString).toBe('?foo=baz&obj[fizz]=bizz&arr[]=fizz&arr[]=bizz');
+  });
+
+  it('should remove default values', () => {
+    const initialValues = {
+      foo: 'bar',
+      obj: {
+        fizz: 'buzz',
+      },
+      arr: ['fizz', 'buzz'],
+    };
+
+    const query = {
+      foo: 'bar',
+      obj: {
+        fizz: 'buzz',
+      },
+      arr: ['fizz', 'buzz'],
+    };
+
+    const queryString = stringifyQuery(query, initialValues);
+    expect(queryString).toBe('');
+  });
+});

--- a/app/utils/useQuery.ts
+++ b/app/utils/useQuery.ts
@@ -1,0 +1,67 @@
+import { isEqual } from 'lodash';
+import qs from 'qs';
+import { useHistory, useLocation } from 'react-router-dom';
+import type { ParsedQs } from 'qs';
+
+/**
+ * Parse query string and return default values if key is missing
+ */
+export const parseQueryString = <Values extends ParsedQs>(
+  queryString: string,
+  defaultValues: Values
+): Values => {
+  const parsedQs = qs.parse(queryString, { ignoreQueryPrefix: true });
+  return { ...defaultValues, ...parsedQs };
+};
+
+/**
+ * Stringify query object and remove default values
+ */
+export const stringifyQuery = <Values extends ParsedQs>(
+  query: Partial<Values>,
+  defaultValues: Values
+): string => {
+  const filteredQuery: ParsedQs = {};
+  for (const key in query) {
+    if (!isEqual(query[key], defaultValues[key])) {
+      filteredQuery[key] = query[key];
+    }
+  }
+  return qs.stringify(filteredQuery, {
+    addQueryPrefix: true,
+    encodeValuesOnly: true,
+    arrayFormat: 'brackets',
+  });
+};
+
+/**
+ * Hook for fetching, parsing and updating query string
+ */
+const useQuery = <Values extends ParsedQs>(defaultValues: Values) => {
+  const location = useLocation();
+  const history = useHistory();
+  const query = parseQueryString(location.search, defaultValues);
+
+  const setQuery = (query: Partial<Values>) => {
+    history.replace({
+      search: stringifyQuery(query, defaultValues),
+    });
+  };
+
+  const setQueryValue =
+    <Key extends keyof Values>(key: Key) =>
+    (value: Values[Key]) => {
+      setQuery({
+        ...query,
+        [key]: value,
+      });
+    };
+
+  return {
+    query,
+    setQuery,
+    setQueryValue,
+  };
+};
+
+export default useQuery;


### PR DESCRIPTION
# Description

The main attraction is the new `useQuery`-hook. It handles reading, parsing and updating of query parameters automatically! It just takes some default values for the relevant query parameters, and fixes the rest for you. These default values also provide typescript types for the parameters:)

In addition I added the helper functions `parseQueryString` and `stringifyQuery`, which allows you to parse and stringify queries in the same format as the hook does, outside of a function-component. Very useful for the higher order component routes.

Other than this I rewrote some class-components to function components, and did some other minor cleanup and refactoring.

# Result

Simpler and more consistent query handling in all pages that use the new functions.

There are some routes still doing query handling manually, which should be refactored at some point, but I didn't want to go into the BDB right now.

# Testing

- [x] I have thoroughly tested my changes.

Have tested the functionality that uses query parameters on all the new routes manually. 

---

Resolves ... (either GitHub issue or Linear task)
