### PR TITLE
Move some lego-bricks' peer deps to be regular deps

### DIFF
--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/lego-bricks",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Component library for lego and other Abakus projects",
   "author": "webkom",
   "license": "MIT",

--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -40,12 +40,14 @@
     "test:watch": "vitest",
     "types": "tsc"
   },
-  "peerDependencies": {
+  "dependencies": {
     "classnames": "^2.3.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "react-overlays": "5.2.1",
     "react-router-dom": "^5.3.4"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@cfaester/enzyme-adapter-react-18": "^0.7.1",


### PR DESCRIPTION
# Description

We want these to be automatically installed by the consuming project, instead of just being hinted.

# Testing

- [x] I have thoroughly tested my changes.

Haven't tested, but prob flawless