### PR TITLE
Fix navbar dropdown visibility issue

### DIFF
--- a/app/components/Header/Navbar/Navbar.tsx
+++ b/app/components/Header/Navbar/Navbar.tsx
@@ -48,6 +48,11 @@ const Navbar = ({ loggedIn }: Props) => {
     },
   ];
 
+  const focusLinkAtIndex = (index: number) => {
+    setHoverIndex(index);
+    setVisibleDropdown(true);
+  };
+
   return (
     <div
       className={styles.navigation}
@@ -66,13 +71,13 @@ const Navbar = ({ loggedIn }: Props) => {
             key={link.to}
             to={link.to}
             activeClassName={styles.activeItem}
-            onMouseEnter={() => setHoverIndex(i)}
+            onMouseEnter={() => focusLinkAtIndex(i)}
           >
             {link.title}
           </NavLink>
         );
 
-        if (link.dropdown === null) return navLinkItem;
+        if (link.dropdown === undefined) return navLinkItem;
 
         return (
           <Dropdown


### PR DESCRIPTION
# Description
- Prevents navbar dropdown to be displayed when there is no dropdown content
- Previously, when clicking on a navbar link and then hovering over another navbar link, the dropdown would stay hidden. This is now fixed.

# Result

**before**
![image](https://github.com/webkom/lego-webapp/assets/66320400/5fc2be64-2fb9-4b54-9238-3da41dbd0b5a)

[Screencast from 2023-11-06 22-20-37.webm](https://github.com/webkom/lego-webapp/assets/66320400/d78a60bb-9d13-49f7-b57e-1fe3cf28d389)


**after**
![image](https://github.com/webkom/lego-webapp/assets/66320400/5884e018-a52f-4c28-8ce3-48d4ae868abc)

[Screencast from 2023-11-06 22-20-59.webm](https://github.com/webkom/lego-webapp/assets/66320400/eeba955b-d1e0-4804-8f45-8922ad203873)


# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-636
