### PR TITLE
Fix event statistics not wrapping on mobile

### DIFF
--- a/app/routes/events/components/EventAttendeeStatistics.css
+++ b/app/routes/events/components/EventAttendeeStatistics.css
@@ -1,3 +1,5 @@
+@import url('~app/styles/variables.css');
+
 .sectionDividerTitle {
   margin-top: 1em;
   margin-bottom: 0;
@@ -42,14 +44,12 @@
   grid-template-columns: 1fr 1fr;
   gap: 1em;
   padding: 6px;
+
+  @media (--mobile-device) {
+    grid-template-columns: 1fr;
+  }
 }
 
 .graphCard {
   margin-top: 1em;
-}
-
-@media (max-width: 1000px) {
-  .chartContainer {
-    grid-template-columns: 1fr;
-  }
 }

--- a/app/routes/events/components/EventAttendeeStatistics.css
+++ b/app/routes/events/components/EventAttendeeStatistics.css
@@ -47,3 +47,9 @@
 .graphCard {
   margin-top: 1em;
 }
+
+@media (max-width: 1000px) {
+  .chartContainer {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
# Description

Fixes the cards on the statistics page not wrapping properly when in mobile view.

# Result

| Before | After |
| -- | -- |
| ![Screenshot from 2023-11-07 15-32-22](https://github.com/webkom/lego-webapp/assets/33326578/b01dcd44-99b7-4f73-9246-1e3f188a944c) | ![Screenshot from 2023-11-07 15-32-10](https://github.com/webkom/lego-webapp/assets/33326578/4d0d101a-334a-4d81-b6d4-892183590853) |


# Testing

- [x] have thoroughly tested my changes.

1. Navigate to an event and click on "Se påmeldinger".
2. Click on "statistikk".
3. Verify that the graph cards wrap correctly in mobile view.

Resolves [ABA-644](https://linear.app/abakus-webkom/issue/ABA-644/make-pie-charts-wrap-on-the-statistics-page-for-mobile)
