### PR TITLE
Make text editor input similar to other text inputs

### DIFF
--- a/app/components/Form/TextEditor.css
+++ b/app/components/Form/TextEditor.css
@@ -1,5 +1,17 @@
 .input {
   composes: input from './TextInput.css';
   width: 100%;
-  padding: 5px;
+  max-width: 100%;
+  min-height: 70px;
+  padding: 5px 10px;
+  outline: none;
+
+  &::placeholder {
+    color: var(--color-gray-5);
+  }
+
+  &:focus::placeholder {
+    transition: opacity var(--easing-medium);
+    opacity: 0;
+  }
 }

--- a/app/components/Form/TextInput.css
+++ b/app/components/Form/TextInput.css
@@ -1,5 +1,6 @@
 .input {
-  font-size: var(--font-size);
+  font-size: var(--font-size-sm);
+  font-family: Inter, sans-serif;
   border: 1.5px solid var(--border-gray);
   border-radius: var(--border-radius-md);
   color: var(--lego-font-color);
@@ -7,6 +8,7 @@
   overflow: hidden;
 
   &:focus-within {
+    transition: border-color var(--easing-medium);
     border-color: var(--color-gray-4);
   }
 }
@@ -31,12 +33,10 @@
   background-color: inherit;
   border: none;
   outline: none;
-  box-shadow: none;
   color: var(--lego-font-color);
 
   &:focus {
     border: none;
-    box-shadow: none;
   }
 
   &::placeholder {

--- a/app/routes/company/components/CompaniesPage.css
+++ b/app/routes/company/components/CompaniesPage.css
@@ -106,12 +106,12 @@
 
 .infoText {
   display: flex;
-  font-size: var(--font-size);
+  font-size: var(--font-size-md);
 }
 
 .readMore {
   display: none;
-  font-size: var(--font-size);
+  font-size: var(--font-size-md);
   color: var(--lego-red-color);
   margin-top: 17px;
 }

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -244,7 +244,7 @@ function EventEditor({
         <Field
           name="description"
           label="Kalenderbeskrivelse"
-          placeholder="Kom på fest den..."
+          placeholder="Kom på fest den ..."
           component={TextEditor.Field}
         />
         <ContentSection>


### PR DESCRIPTION
# Description

* Fix wrong font
* Fix bad padding
* Fix bad font-size
* Prevent editor from growing out of its parent (you can currently drag and resize it out of your screen in all directions if you want)
* Add min-height

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td>
			<img width="725" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/4769406e-70da-443a-bd50-0ddf0c606add">
</td>
		<td>
			<img width="725" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/1cf46359-306b-4129-aaf2-d148695ad986">
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

The added min-height does not break editors where the height has been specified, such as on the company interest form.