### PR TITLE
Fix sidebar position on mobile

### DIFF
--- a/app/components/Content/ContentSection.css
+++ b/app/components/Content/ContentSection.css
@@ -1,0 +1,7 @@
+@import url('~app/styles/variables.css');
+
+.section {
+  @media (--medium-viewport) {
+    flex-direction: column;
+  }
+}

--- a/app/components/Content/ContentSection.tsx
+++ b/app/components/Content/ContentSection.tsx
@@ -1,4 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import styles from './ContentSection.css';
 import type { ReactNode } from 'react';
 
 type Props = {
@@ -7,11 +9,7 @@ type Props = {
 };
 
 function ContentSection({ children, className }: Props) {
-  return (
-    <Flex wrap className={className}>
-      {children}
-    </Flex>
-  );
+  return <Flex className={cx(styles.section, className)}>{children}</Flex>;
 }
 
 export default ContentSection;

--- a/app/components/Content/ContentSidebar.css
+++ b/app/components/Content/ContentSidebar.css
@@ -2,13 +2,12 @@
 
 .sidebar {
   flex: 1;
-  padding: 20px;
-  padding-top: 0;
+  padding: 0 0 0 2em;
   border-left: 1px solid var(--border-gray);
-  margin-left: 3em;
+  margin-left: 2em;
   line-height: 1.3;
 
-  @media (--small-viewport) {
+  @media (--medium-viewport) {
     border-left: none;
     margin-left: 0;
     padding: 0;


### PR DESCRIPTION
# Description

This changes the sidebar positioning from using flex-wrap to changing layout direction at a set breakpoint `--medium-viewport`. The reason for this change is that there is no way to create the border line between main content and sidebar, only when the content is not wrapped. (I don't think this has ever happened entierly in sync).

# Result

Before:
![Screenshot 2023-11-09 at 14 18 08](https://github.com/webkom/lego-webapp/assets/8343002/dbe7306f-e92d-42b0-98d5-8549bb93154e)
After:
![Screenshot 2023-11-09 at 14 19 14](https://github.com/webkom/lego-webapp/assets/8343002/0bba60bf-d3b5-4656-95cc-eeb86d4737a4)

# Testing

- [x] I have thoroughly tested my changes.

Have clicked through most of the pages using sidebar, and checked that they look good on mobile.

---

Resolves ABA-672