### PR TITLE
Fix misaligned "New" tag on joblisting items

### DIFF
--- a/app/components/JoblistingItem/index.tsx
+++ b/app/components/JoblistingItem/index.tsx
@@ -27,11 +27,16 @@ const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
     )}
     <div className={styles.listItem}>
       <div>
-        <Flex wrap gap={4}>
+        <Flex
+          wrap
+          alignItems="center"
+          gap={6}
+          className={styles.joblistingItemTitle}
+        >
           {moment(joblisting.createdAt).isAfter(
             moment().subtract(3, 'days')
           ) && <Tag tag="Ny" color="green" />}
-          <span className={styles.joblistingItemTitle}>{joblisting.title}</span>
+          <span>{joblisting.title}</span>
         </Flex>
         <div>
           {joblisting.company.name}


### PR DESCRIPTION
# Description

These damn tags ..

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td>
			<img width="779" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/4c192c45-62e5-4d5c-a57d-6ebd2bb76ce4">
</td>
		<td>
			<img width="779" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/bd53298c-03e4-4a31-bc25-be0ac599fc28">
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Should not affect any other tags or things.

Looks fine without the tag as well:
<img width="779" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/13861697-b62d-49a0-9f5b-e3f2d2c11710">