### PR TITLE
Fix bug where meeting icon in header does not appear after logging in

### DIFF
--- a/app/routes/app/AppRoute.tsx
+++ b/app/routes/app/AppRoute.tsx
@@ -214,20 +214,19 @@ export default compose(
     () => [],
     { serverOnly: true }
   ),
-  withPreparedDispatch('fetchDivData', (props, dispatch) =>
-    Promise.all([
-      dispatch(fetchNotificationData()),
-      dispatch((dispatch, getState) => {
-        if (!selectIsLoggedIn(getState())) {
-          return Promise.resolve();
-        }
-        return dispatch(
-          fetchMeetings({
-            dateAfter: moment().format('YYYY-MM-DD'),
-          })
-        );
-      }),
-    ])
-  ),
-  connect(mapStateToProps, mapDispatchToProps)
+  connect(mapStateToProps, mapDispatchToProps),
+  withPreparedDispatch(
+    'fetchDivData',
+    (props, dispatch) =>
+      Promise.all([
+        dispatch(fetchNotificationData()),
+        props.loggedIn &&
+          dispatch(
+            fetchMeetings({
+              dateAfter: moment().format('YYYY-MM-DD'),
+            })
+          ),
+      ]),
+    (props) => [props.loggedIn]
+  )
 )(App);


### PR DESCRIPTION
# Description

The users upcoming meetings were only fetched once when loading the page, so if you weren't logged in already they never get fetched, and the icon did not appear. 

The fix is to add a dependency to the meeting fetch call, so that it is run again every time the `loggedIn` state changes.

# Result

The icon now appears a few seconds after logging in:)

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-674
