### PR TITLE
Ensure array query parameters are always parsed as arrays

### DIFF
--- a/app/utils/__tests__/useQuery.spec.ts
+++ b/app/utils/__tests__/useQuery.spec.ts
@@ -23,7 +23,7 @@ describe('parseQueryString', () => {
     const initialValues = {
       foo: ['fizz'],
     };
-    const queryString = '?foo[]=bar&foo[]=baz';
+    const queryString = '?foo=bar&foo=baz';
     const query = parseQueryString(queryString, initialValues);
     expect(query.foo).toEqual(['bar', 'baz']);
   });
@@ -63,7 +63,7 @@ describe('stringifyQuery', () => {
     };
 
     const queryString = stringifyQuery(query, initialValues);
-    expect(queryString).toBe('?foo=baz&obj[fizz]=bizz&arr[]=fizz&arr[]=bizz');
+    expect(queryString).toBe('?foo=baz&obj[fizz]=bizz&arr=fizz&arr=bizz');
   });
 
   it('should remove default values', () => {

--- a/app/utils/useQuery.ts
+++ b/app/utils/useQuery.ts
@@ -11,6 +11,16 @@ export const parseQueryString = <Values extends ParsedQs>(
   defaultValues: Values
 ): Values => {
   const parsedQs = qs.parse(queryString, { ignoreQueryPrefix: true });
+
+  // ensure that all array values are arrays
+  for (const key in parsedQs) {
+    const defaultValue = defaultValues[key];
+    const parsedValue = parsedQs[key];
+    if (Array.isArray(defaultValue) && typeof parsedValue === 'string') {
+      parsedQs[key] = [parsedValue];
+    }
+  }
+
   return { ...defaultValues, ...parsedQs };
 };
 
@@ -30,7 +40,7 @@ export const stringifyQuery = <Values extends ParsedQs>(
   return qs.stringify(filteredQuery, {
     addQueryPrefix: true,
     encodeValuesOnly: true,
-    arrayFormat: 'brackets',
+    arrayFormat: 'repeat',
   });
 };
 


### PR DESCRIPTION
# Description

The new query parameter parsing I added in #4259 would parse parameters like "?grades=2" as a string, even if the defaultValue, and thus the typescript type is an array of strings.

# Result

It now parses them correctly by checking the type of the default value, and ensuring the parsed value is an array if the default value is.

I also changed the array param format to drop the square brackets, because I think they are ugly. Array parameters will look like this "?grades=1&grades=2" now instead of this "?grades[]=1&grades[]=2".

# Testing

- [x] I have thoroughly tested my changes.

Have tested with multiple different array parameter formats on the joblisting page. Filtering works well with all of them:)

---

Resolves ABA-675