### PR TITLE
Refactor redux entity-slices to use createLegoAdapter (1st batch)

### DIFF
--- a/app/actions/CompanyActions.ts
+++ b/app/actions/CompanyActions.ts
@@ -397,6 +397,7 @@ export function addSemester({
         types: Company.ADD_SEMESTER,
         endpoint: `/company-semesters/`,
         method: 'POST',
+        schema: companySemesterSchema,
         body: {
           year,
           semester,

--- a/app/components/Feed/renders/event_register.tsx
+++ b/app/components/Feed/renders/event_register.tsx
@@ -22,8 +22,8 @@ export function activityHeader(
     return null;
   }
 
-  const actorsRender = actors.map((actor) =>
-    htmlTag(contextRender[actor.contentType](actor))
+  const actorsRender = actors.map(
+    (actor) => actor && htmlTag(contextRender[actor.contentType](actor))
   );
   return (
     <b>

--- a/app/reducers/__tests__/announcements.spec.ts
+++ b/app/reducers/__tests__/announcements.spec.ts
@@ -3,6 +3,7 @@ import timekeeper from 'timekeeper';
 import { describe, it, expect } from 'vitest';
 import { Announcements } from 'app/actions/ActionTypes';
 import announcements from '../announcements';
+import type { UnknownAnnouncement } from 'app/store/models/Announcement';
 
 describe('reducers', () => {
   describe('announcements', () => {
@@ -11,13 +12,14 @@ describe('reducers', () => {
     it('Announcements.SEND.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
-        pagination: {},
-        items: [99],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [99],
+        entities: {
           99: {
             id: 99,
             sent: null,
-          },
+          } as UnknownAnnouncement,
         },
       };
       const action = {
@@ -28,9 +30,10 @@ describe('reducers', () => {
       };
       expect(announcements(prevState, action)).toEqual({
         actionGrant: [],
-        pagination: {},
-        items: [99],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [99],
+        entities: {
           99: {
             id: 99,
             sent: moment().toISOString(),

--- a/app/reducers/__tests__/companies.spec.ts
+++ b/app/reducers/__tests__/companies.spec.ts
@@ -1,22 +1,20 @@
-// Hack because we have circular dependencies
-// (companies -> events -> index -> frontpage -> events)
-// This import resolves dependencies properly..
-import 'app/reducers';
 import { describe, it, expect } from 'vitest';
 import { Company } from 'app/actions/ActionTypes';
 import companies from '../companies';
+import type { UnknownCompany } from 'app/store/models/Company';
 
 describe('reducers', () => {
   describe('companies semester status', () => {
     it('Company.ADD_SEMESTER_STATUS.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
-        pagination: {},
-        items: [2, 3],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [2, 3],
+        entities: {
           2: {
             id: 2,
-          },
+          } as UnknownCompany,
           3: {
             id: 3,
             semesterStatuses: [
@@ -26,7 +24,7 @@ describe('reducers', () => {
                 contactedStatus: ['not_interested'],
               },
             ],
-          },
+          } as UnknownCompany,
         },
       };
       const actions = [
@@ -57,9 +55,10 @@ describe('reducers', () => {
       newState = companies(newState, actions[1]);
       expect(newState).toEqual({
         actionGrant: [],
-        pagination: {},
-        items: [2, 3],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [2, 3],
+        entities: {
           2: {
             id: 2,
             semesterStatuses: [
@@ -91,9 +90,10 @@ describe('reducers', () => {
     it('Company.EDIT_SEMESTER_STATUS.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
-        pagination: {},
-        items: [3],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [3],
+        entities: {
           3: {
             id: 3,
             semesterStatuses: [
@@ -108,7 +108,7 @@ describe('reducers', () => {
                 contactedStatus: ['not_interested'],
               },
             ],
-          },
+          } as UnknownCompany,
         },
       };
       const action = {
@@ -123,35 +123,30 @@ describe('reducers', () => {
           contactedStatus: ['course'],
         },
       };
-      expect(companies(prevState, action)).toEqual({
-        actionGrant: [],
-        pagination: {},
-        items: [3],
-        byId: {
-          3: {
-            id: 3,
-            semesterStatuses: [
-              {
-                id: 1,
-                semester: 1,
-                contactedStatus: ['course'],
-              },
-              {
-                id: 2,
-                semester: 2,
-                contactedStatus: ['not_interested'],
-              },
-            ],
+      const newState = companies(prevState, action);
+      expect(newState.entities[3]).toEqual({
+        id: 3,
+        semesterStatuses: [
+          {
+            id: 1,
+            semester: 1,
+            contactedStatus: ['course'],
           },
-        },
+          {
+            id: 2,
+            semester: 2,
+            contactedStatus: ['not_interested'],
+          },
+        ],
       });
     });
     it('Company.DELETE_SEMESTER_STATUS.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
-        pagination: {},
-        items: [3],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [3],
+        entities: {
           3: {
             id: 3,
             semesterStatuses: [
@@ -166,7 +161,7 @@ describe('reducers', () => {
                 contactedStatus: ['not_interested'],
               },
             ],
-          },
+          } as UnknownCompany,
         },
       };
       const action = {
@@ -176,22 +171,16 @@ describe('reducers', () => {
           semesterStatusId: 1,
         },
       };
-      expect(companies(prevState, action)).toEqual({
-        actionGrant: [],
-        pagination: {},
-        items: [3],
-        byId: {
-          3: {
-            id: 3,
-            semesterStatuses: [
-              {
-                id: 2,
-                semester: 1,
-                contactedStatus: ['not_interested'],
-              },
-            ],
+      const newState = companies(prevState, action);
+      expect(newState.entities[3]).toEqual({
+        id: 3,
+        semesterStatuses: [
+          {
+            id: 2,
+            semester: 1,
+            contactedStatus: ['not_interested'],
           },
-        },
+        ],
       });
     });
   });
@@ -199,12 +188,13 @@ describe('reducers', () => {
     it('Company.ADD_COMPANY_CONTACT.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
-        pagination: {},
-        items: [2, 3],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [2, 3],
+        entities: {
           2: {
             id: 2,
-          },
+          } as UnknownCompany,
           3: {
             id: 3,
             companyContacts: [
@@ -213,7 +203,7 @@ describe('reducers', () => {
                 name: 'John',
               },
             ],
-          },
+          } as UnknownCompany,
         },
       };
       const actions = [
@@ -240,42 +230,36 @@ describe('reducers', () => {
       ];
       let newState = companies(prevState, actions[0]);
       newState = companies(newState, actions[1]);
-      expect(newState).toEqual({
-        actionGrant: [],
-        pagination: {},
-        items: [2, 3],
-        byId: {
-          2: {
-            id: 2,
-            companyContacts: [
-              {
-                id: 3,
-                name: 'Jake',
-              },
-            ],
-          },
-          3: {
+      expect(newState.entities[2]).toEqual({
+        id: 2,
+        companyContacts: [
+          {
             id: 3,
-            companyContacts: [
-              {
-                id: 1,
-                name: 'John',
-              },
-              {
-                id: 2,
-                name: 'Jane',
-              },
-            ],
+            name: 'Jake',
           },
-        },
+        ],
+      });
+      expect(newState.entities[3]).toEqual({
+        id: 3,
+        companyContacts: [
+          {
+            id: 1,
+            name: 'John',
+          },
+          {
+            id: 2,
+            name: 'Jane',
+          },
+        ],
       });
     });
     it('Company.EDIT_COMPANY_CONTACT.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
-        pagination: {},
-        items: [3],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [3],
+        entities: {
           3: {
             id: 3,
             companyContacts: [
@@ -289,7 +273,7 @@ describe('reducers', () => {
                 name: 'Test',
               },
             ],
-          },
+          } as UnknownCompany,
         },
       };
       const action = {
@@ -302,33 +286,26 @@ describe('reducers', () => {
           name: 'Johnny',
         },
       };
-      expect(companies(prevState, action)).toEqual({
-        actionGrant: [],
-        pagination: {},
-        items: [3],
-        byId: {
-          3: {
-            id: 3,
-            companyContacts: [
-              {
-                id: 1,
-                name: 'Johnny',
-              },
-              {
-                id: 2,
-                name: 'Test',
-              },
-            ],
+      expect(companies(prevState, action).entities[3]).toEqual({
+        id: 3,
+        companyContacts: [
+          {
+            id: 1,
+            name: 'Johnny',
           },
-        },
+          {
+            id: 2,
+            name: 'Test',
+          },
+        ],
       });
     });
     it('Company.DELETE_COMPANY_CONTACT.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
         pagination: {},
-        items: [3],
-        byId: {
+        ids: [3],
+        entities: {
           3: {
             id: 3,
             companyContacts: [
@@ -354,8 +331,8 @@ describe('reducers', () => {
       expect(companies(prevState, action)).toEqual({
         actionGrant: [],
         pagination: {},
-        items: [3],
-        byId: {
+        ids: [3],
+        entities: {
           3: {
             id: 3,
             companyContacts: [

--- a/app/reducers/__tests__/companySemester.spec.ts
+++ b/app/reducers/__tests__/companySemester.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Company } from '../../actions/ActionTypes';
+import { Company } from 'app/actions/ActionTypes';
 import companySemesters from '../companySemesters';
 
 describe('reducers', () => {
@@ -8,8 +8,8 @@ describe('reducers', () => {
       const prevState = {
         actionGrant: [],
         pagination: {},
-        items: [1],
-        byId: {
+        ids: [1],
+        entities: {
           1: {
             id: 1,
             year: 2001,
@@ -20,18 +20,27 @@ describe('reducers', () => {
       };
       const action = {
         type: Company.ADD_SEMESTER.SUCCESS,
+        meta: {
+          endpoint: '/companies/1/semesters/',
+        },
         payload: {
-          id: 2,
-          year: 2001,
-          semester: 'autumn',
-          activeInterestForm: false,
+          entities: {
+            companySemesters: {
+              2: {
+                id: 2,
+                year: 2001,
+                semester: 'autumn',
+                activeInterestForm: false,
+              },
+            },
+          },
         },
       };
       expect(companySemesters(prevState, action)).toEqual({
         actionGrant: [],
         pagination: {},
-        items: [1, 2],
-        byId: {
+        ids: [1, 2],
+        entities: {
           1: {
             id: 1,
             year: 2001,

--- a/app/reducers/articles.ts
+++ b/app/reducers/articles.ts
@@ -5,12 +5,10 @@ import { Article } from 'app/actions/ActionTypes';
 import { addCommentCases, selectCommentEntities } from 'app/reducers/comments';
 import { addReactionCases } from 'app/reducers/reactions';
 import { selectUserById } from 'app/reducers/users';
-import { typeable } from 'app/reducers/utils';
 import { EntityType } from 'app/store/models/entities';
 import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import type { ArticleWithAuthorDetails } from 'app/routes/articles/ArticleListRoute';
 import type { RootState } from 'app/store/createRootReducer';
-import type { PublicArticle, UnknownArticle } from 'app/store/models/Article';
 import type { Pagination } from 'app/utils/legoAdapter/buildPaginationReducer';
 import type { Selector } from 'reselect';
 
@@ -34,37 +32,20 @@ const articlesSlice = createSlice({
 
 export default articlesSlice.reducer;
 export const {
-  selectAll: selectAllArticles,
-  selectIds: selectArticleIds,
-  selectEntities: selectArticleEntities,
+  selectAllPaginated: selectArticles,
   selectById: selectArticleById,
 } = legoAdapter.getSelectors((state: RootState) => state.articles);
-
-type SelectArticlesOpts = {
-  pagination?: Pagination;
-};
-export const selectArticles = typeable(
-  createSelector(
-    selectArticleEntities,
-    selectArticleIds,
-    (_: RootState, props: SelectArticlesOpts) => props && props.pagination,
-    (articlesById, articleIds, pagination) =>
-      (pagination ? pagination.ids : articleIds).map(
-        (id) => articlesById[id]
-      ) as ReadonlyArray<UnknownArticle>
-  )
-);
 
 export const selectArticlesWithAuthorDetails: Selector<
   RootState,
   ArticleWithAuthorDetails[],
   [
     {
-      pagination: any;
+      pagination?: Pagination;
     }
   ]
 > = (state, props) =>
-  selectArticles<PublicArticle[]>(state, props).map((article) => ({
+  selectArticles(state, props).map((article) => ({
     ...article,
     authors: article.authors.map((e) => {
       return selectUserById(state, {

--- a/app/reducers/companies.ts
+++ b/app/reducers/companies.ts
@@ -1,14 +1,19 @@
-import { produce } from 'immer';
+import { createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
-import { mutateComments, selectCommentEntities } from 'app/reducers/comments';
+import { addCommentCases, selectCommentEntities } from 'app/reducers/comments';
 import { selectJoblistings } from 'app/reducers/joblistings';
-import createEntityReducer from 'app/utils/createEntityReducer';
-import joinReducers from 'app/utils/joinReducers';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { Company } from '../actions/ActionTypes';
 import { selectCompanySemesters } from './companySemesters';
 import { selectEvents } from './events';
+import type { AnyAction } from '@reduxjs/toolkit';
 import type { CompanySemesterContactedStatus, Semester } from 'app/models';
 import type { UserEntity } from 'app/reducers/users';
+import type { RootState } from 'app/store/createRootReducer';
+import type { ID } from 'app/store/models';
+import type { AnySemesterStatus } from 'app/store/models/Company';
+import type CompanySemester from 'app/store/models/CompanySemester';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export type BaseSemesterStatusEntity = {
@@ -64,139 +69,152 @@ export type BaseCompanyEntity = {
 export type CompanyEntity = BaseCompanyEntity & {
   id: number;
 };
-export type SubmitCompanyEntity = BaseCompanyEntity & {
-  studentContact?: number;
-};
-type State = any;
 
-function mutateCompanies(state: State, action) {
-  return produce(state, (newState: State): void => {
-    switch (action.type) {
-      case Company.DELETE.SUCCESS:
-        newState.items = newState.items.filter((id) => id !== action.meta.id);
-        break;
-
-      case Company.ADD_SEMESTER_STATUS.SUCCESS:
-        newState.byId[action.meta.companyId].semesterStatuses =
-          newState.byId[action.meta.companyId].semesterStatuses || [];
-        newState.byId[action.meta.companyId].semesterStatuses.push(
-          action.payload
-        );
-        break;
-
-      case Company.EDIT_SEMESTER_STATUS.SUCCESS: {
-        const { companyId, semesterStatusId } = action.meta;
-        const index = newState.byId[companyId].semesterStatuses.findIndex(
-          (s) => s.id === semesterStatusId
-        );
-        newState.byId[companyId].semesterStatuses[index] = action.payload;
-        break;
-      }
-
-      case Company.DELETE_SEMESTER_STATUS.SUCCESS: {
-        const companyId = action.meta.companyId;
-        newState.byId[companyId].semesterStatuses = newState.byId[
-          companyId
-        ].semesterStatuses.filter(
-          (status) => status.id !== action.meta.semesterStatusId
-        );
-        break;
-      }
-
-      case Company.ADD_COMPANY_CONTACT.SUCCESS:
-        newState.byId[action.meta.companyId].companyContacts = (
-          newState.byId[action.meta.companyId].companyContacts || []
-        ).concat(action.payload);
-        break;
-
-      case Company.EDIT_COMPANY_CONTACT.SUCCESS: {
-        const companyId = action.meta.companyId;
-        const index = newState.byId[companyId].companyContacts.findIndex(
-          (cc) => cc.id === action.payload.id
-        );
-        newState.byId[companyId].companyContacts[index] = action.payload;
-        break;
-      }
-
-      case Company.DELETE_COMPANY_CONTACT.SUCCESS: {
-        const companyId = action.meta.companyId;
-        newState.byId[companyId].companyContacts = newState.byId[
-          companyId
-        ].companyContacts.filter(
-          (contact) => contact.id !== action.meta.companyContactId
-        );
-        break;
-      }
-
-      default:
-        break;
-    }
-  });
-}
-
-const mutate = joinReducers(mutateComments('companies'), mutateCompanies);
-export default createEntityReducer({
-  key: 'companies',
-  types: {
-    fetch: Company.FETCH,
-    mutate: Company.ADD,
-    delete: Company.DELETE,
-  },
-  mutate,
+const legoAdapter = createLegoAdapter(EntityType.Companies, {
+  sortComparer: (a, b) => (a.name < b.name ? -1 : 1),
 });
-export const selectCompanies = createSelector(
-  (state) => state.companies.items,
-  (state) => state.companies.byId,
-  (state) => state.users.byId,
-  (state) => state,
-  (companyIds, companiesById, usersById, state) => {
-    if (companyIds.length === 0) return [];
-    const companySemesters = selectCompanySemesters(state);
-    return companyIds
-      .map((companyId) => {
-        const company = companiesById[companyId];
-        return {
-          ...company,
-          studentContact: usersById[company.studentContact]
-            ? usersById[company.studentContact]
-            : company.studentContact,
-          semesterStatuses:
-            company &&
-            selectSemesterStatuses(company.semesterStatuses, companySemesters),
-        };
-      })
-      .sort((a, b) => (a.name < b.name ? -1 : 1));
-  }
+
+const companiesSlice = createSlice({
+  name: 'companies',
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [Company.FETCH],
+    deleteActions: [Company.DELETE],
+    extraCases: (addCase) => {
+      addCommentCases(EntityType.Companies, addCase);
+      addCase(
+        Company.ADD_SEMESTER_STATUS.SUCCESS,
+        (state, action: AnyAction) => {
+          const { companyId } = action.meta;
+          const company = state.entities[companyId];
+          if (company) {
+            company.semesterStatuses ??= [];
+            company.semesterStatuses.push(action.payload);
+          }
+        }
+      );
+      addCase(
+        Company.EDIT_SEMESTER_STATUS.SUCCESS,
+        (state, action: AnyAction) => {
+          const { companyId, semesterStatusId } = action.meta;
+          const company = state.entities[companyId];
+          if (company && company.semesterStatuses) {
+            const index = company.semesterStatuses.findIndex(
+              (s) => s.id === semesterStatusId
+            );
+            company.semesterStatuses[index] = action.payload;
+          }
+        }
+      );
+      addCase(
+        Company.DELETE_SEMESTER_STATUS.SUCCESS,
+        (state, action: AnyAction) => {
+          const { companyId, semesterStatusId } = action.meta;
+          const company = state.entities[companyId];
+          if (company) {
+            company.semesterStatuses = company.semesterStatuses?.filter(
+              (s) => s.id !== semesterStatusId
+            );
+          }
+        }
+      );
+      addCase(
+        Company.ADD_COMPANY_CONTACT.SUCCESS,
+        (state, action: AnyAction) => {
+          const { companyId } = action.meta;
+          const company = state.entities[companyId];
+          if (company) {
+            company.companyContacts ??= [];
+            company.companyContacts.push(action.payload);
+          }
+        }
+      );
+      addCase(
+        Company.EDIT_COMPANY_CONTACT.SUCCESS,
+        (state, action: AnyAction) => {
+          const { companyId } = action.meta;
+          const company = state.entities[companyId];
+          if (company && company.companyContacts) {
+            const index = company.companyContacts.findIndex(
+              (cc) => cc.id === action.payload.id
+            );
+            company.companyContacts[index] = action.payload;
+          }
+        }
+      );
+      addCase(
+        Company.DELETE_COMPANY_CONTACT.SUCCESS,
+        (state, action: AnyAction) => {
+          const { companyId, companyContactId } = action.meta;
+          const company = state.entities[companyId];
+          if (company) {
+            company.companyContacts = company.companyContacts?.filter(
+              (cc) => cc.id !== companyContactId
+            );
+          }
+        }
+      );
+    },
+  }),
+});
+
+export default companiesSlice.reducer;
+
+const { selectAll: selectAllCompanies } = legoAdapter.getSelectors(
+  (state: RootState) => state.companies
 );
+
+export const selectCompanies = createSelector(
+  selectAllCompanies,
+  (state: RootState) => state.users.byId,
+  selectCompanySemesters,
+  (allCompanies, usersById, companySemesters) =>
+    allCompanies.map((company) => ({
+      ...company,
+      studentContact: company.studentContact
+        ? usersById[company.studentContact]
+        : undefined,
+      semesterStatuses: selectSemesterStatuses(
+        company.semesterStatuses ?? [],
+        companySemesters
+      ),
+    }))
+);
+
 export const selectActiveCompanies = createSelector(
   selectCompanies,
-  (companies) => companies.filter((company) => company.active)
+  (companies) =>
+    companies.filter((company) => 'active' in company && company.active)
 );
 
-const selectSemesterStatuses = (semesterStatuses, companySemesters) =>
-  (semesterStatuses || []).map((semester) => {
+const selectSemesterStatuses = (
+  semesterStatuses: AnySemesterStatus[],
+  companySemesters: CompanySemester[]
+) =>
+  semesterStatuses.map((semester) => {
     const companySemester = companySemesters.find(
       (companySemester) => companySemester.id === semester.semester
     );
-    return produce(semester, (draft) => {
-      if (companySemester) {
-        draft.year = companySemester.year;
-        draft.semester = companySemester.semester;
-      }
-    });
+    return companySemester
+      ? {
+          ...semester,
+          year: companySemester.year,
+          semester: companySemester.semester,
+        }
+      : semester;
   });
 
 export const selectCompanyById = createSelector(
   selectCompanies,
-  (state, props) => props.companyId,
+  (_: RootState, props: { companyId: ID }) => props.companyId,
   (companies, companyId) => {
-    const company = companies.find((company) => company.id === companyId);
-    return company || {};
+    return companies.find((company) => company.id === companyId) || {};
   }
 );
 export const selectEventsForCompany = createSelector(
-  (state, props) => selectEvents(state, props),
-  (state, props) => props.companyId,
+  selectEvents,
+  (_: RootState, props: { companyId: ID }) => props.companyId,
   (events, companyId) => {
     if (!companyId || !events) return [];
     return events.filter(
@@ -205,7 +223,7 @@ export const selectEventsForCompany = createSelector(
   }
 );
 export const selectJoblistingsForCompany = createSelector(
-  (state, props) => props.companyId,
+  (_: RootState, props: { companyId: ID }) => props.companyId,
   selectJoblistings,
   (companyId, joblistings) => {
     if (!companyId || !joblistings) return [];
@@ -217,8 +235,8 @@ export const selectJoblistingsForCompany = createSelector(
   }
 );
 export const selectCompanyContactById = createSelector(
-  (state, props) => selectCompanyById(state, props),
-  (state, props) => props.companyContactId,
+  selectCompanyById,
+  (_: RootState, props: { companyContactId: ID }) => props.companyContactId,
   (company, companyContactId) => {
     if (!company || !company.companyContacts) return {};
     return company.companyContacts.find(

--- a/app/reducers/companySemesters.ts
+++ b/app/reducers/companySemesters.ts
@@ -1,8 +1,10 @@
-import { produce } from 'immer';
+import { createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { sortSemesterChronologically } from 'app/routes/companyInterest/utils';
-import createEntityReducer from 'app/utils/createEntityReducer';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { Company } from '../actions/ActionTypes';
+import type { RootState } from 'app/store/createRootReducer';
 
 export type CompanySemesterEntity = {
   id?: number;
@@ -10,37 +12,22 @@ export type CompanySemesterEntity = {
   year: number | string;
   activeInterestForm?: boolean;
 };
-type State = any;
-export default createEntityReducer({
-  key: 'companySemesters',
-  types: {
-    fetch: Company.FETCH_SEMESTERS,
-  },
 
-  // TODO: I think this can be removed by using { types: mutate: Company.ADD_SEMESTER} above
-  mutate(state: State, action): State {
-    return produce(state, (newState: State): void => {
-      switch (action.type) {
-        case Company.ADD_SEMESTER.SUCCESS:
-          newState.byId[action.payload.id] = action.payload;
-          newState.items.push(action.payload.id);
-          break;
+const legoAdapter = createLegoAdapter(EntityType.CompanySemesters);
 
-        default:
-          break;
-      }
-    });
-  },
+const companySemestersSlice = createSlice({
+  name: 'companySemesters',
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [Company.FETCH_SEMESTERS],
+  }),
 });
-export const selectCompanySemesters = createSelector(
-  (state) => state.companySemesters.items,
-  (state) => state.companySemesters.byId,
-  (semesterIds, semestersById) => {
-    return !semesterIds || !semestersById
-      ? []
-      : semesterIds.map((id) => semestersById[id]);
-  }
-);
+
+export default companySemestersSlice.reducer;
+export const { selectAll: selectCompanySemesters } =
+  legoAdapter.getSelectors<RootState>((state) => state.companySemesters);
+
 export const selectCompanySemestersForInterestForm = createSelector(
   selectCompanySemesters,
   (companySemesters) =>

--- a/app/reducers/emailLists.ts
+++ b/app/reducers/emailLists.ts
@@ -1,7 +1,9 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
-import { mutateComments } from 'app/reducers/comments';
-import createEntityReducer from 'app/utils/createEntityReducer';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { EmailList } from '../actions/ActionTypes';
+import type { RootState } from 'app/store/createRootReducer';
 
 export type EmailListEntity = {
   id: number;
@@ -18,32 +20,28 @@ export type EmailListEntity = {
   actionGrant: Record<string, any>;
   comments: Array<number>;
 };
-const mutate = mutateComments('emailLists');
-export default createEntityReducer({
-  key: 'emailLists',
-  types: {
-    fetch: EmailList.FETCH,
-    mutate: EmailList.CREATE,
-  },
-  mutate,
-});
-export const selectEmailLists = createSelector(
-  (state) => state.emailLists.byId,
-  (state) => state.emailLists.items,
-  (_, { pagination }) => pagination,
-  (emailListsById, emailListIds, pagination) =>
-    (pagination ? pagination.items : emailListIds)
-      .map((id) => emailListsById[id])
-      .filter(Boolean)
-);
-export const selectEmailListById = createSelector(
-  (state) => state.emailLists.byId,
-  (state) => state.users.byId,
-  (state) => state.groups.byId,
-  (state, props) => props.emailListId,
-  (emailListsById, usersById, groupsById, emailListId) => {
-    const emailList = emailListsById[emailListId];
 
+const legoAdapter = createLegoAdapter(EntityType.EmailLists);
+
+const emailListSlice = createSlice({
+  name: 'emailLists',
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [EmailList.FETCH],
+  }),
+});
+
+export default emailListSlice.reducer;
+const { selectAllPaginated: selectEmailLists, selectById } =
+  legoAdapter.getSelectors<RootState>((state) => state.emailLists);
+export { selectEmailLists };
+
+export const selectEmailListById = createSelector(
+  selectById,
+  (state: RootState) => state.users.byId,
+  (state: RootState) => state.groups.byId,
+  (emailList, usersById, groupsById) => {
     if (!emailList) {
       return {};
     }

--- a/app/routes/admin/email/EmailListRoute.ts
+++ b/app/routes/admin/email/EmailListRoute.ts
@@ -8,9 +8,7 @@ import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import EmailListEditor from './components/EmailListEditor';
 
 const mapStateToProps = (state, { match: { params } }) => {
-  const emailList = selectEmailListById(state, {
-    emailListId: params.emailListId,
-  });
+  const emailList = selectEmailListById(state, params.emailListId);
   return {
     emailList,
     emailListId: params.emailListId,

--- a/app/routes/company/CompanyDetailRoute.ts
+++ b/app/routes/company/CompanyDetailRoute.ts
@@ -7,6 +7,7 @@ import {
 } from 'app/actions/CompanyActions';
 import { LoginPage } from 'app/components/LoginForm';
 import {
+  selectCompanyById,
   selectEventsForCompany,
   selectJoblistingsForCompany,
 } from 'app/reducers/companies';
@@ -15,6 +16,7 @@ import createQueryString from 'app/utils/createQueryString';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import CompanyDetail from './components/CompanyDetail';
+import type { RootState } from 'app/store/createRootReducer';
 
 const queryString = (companyId) =>
   createQueryString({
@@ -36,13 +38,16 @@ const fetchData = (props, dispatch) => {
   ]);
 };
 
-const mapStateToProps = (state, props) => {
+const mapStateToProps = (state: RootState, props) => {
   const { companyId } = props.match.params;
   const { query } = props.location;
   const showFetchMoreEvents = selectPagination('events', {
     queryString: queryString(companyId),
   })(state);
-  const company = state.companies.byId[companyId];
+  const company = selectCompanyById(state, {
+    companyId,
+  });
+  const fetching = state.companies.fetching;
   const companyEvents = selectEventsForCompany(state, {
     companyId,
   });
@@ -57,11 +62,12 @@ const mapStateToProps = (state, props) => {
     companyId,
     loggedIn: props.currentUser,
     showFetchMoreEvents,
+    fetching,
   };
 };
 
 const mapDispatchToProps = (dispatch, props) => {
-  const { companyId, loading } = props.match.params;
+  const { companyId } = props.match.params;
 
   const fetchMoreEvents = () =>
     dispatch(
@@ -73,7 +79,6 @@ const mapDispatchToProps = (dispatch, props) => {
 
   return {
     fetchMoreEvents,
-    loading,
   };
 };
 

--- a/app/routes/company/components/CompanyDetail.tsx
+++ b/app/routes/company/components/CompanyDetail.tsx
@@ -24,7 +24,7 @@ type Props = {
   joblistings: ListJoblisting[];
   showFetchMoreEvents: boolean;
   fetchMoreEvents: () => Promise<any>;
-  loading: boolean;
+  fetching: boolean;
 };
 
 const CompanyDetail = ({
@@ -33,12 +33,12 @@ const CompanyDetail = ({
   joblistings,
   fetchMoreEvents,
   showFetchMoreEvents,
-  loading,
+  fetching,
 }: Props) => {
   const [viewOldEvents, setViewOldEvents] = useState(false);
 
-  if (!company) {
-    return <LoadingIndicator loading={loading} />;
+  if (fetching) {
+    return <LoadingIndicator loading />;
   }
 
   const sortedEvents = companyEvents.sort(

--- a/app/routes/companyInterest/CompanyInterestEditRoute.ts
+++ b/app/routes/companyInterest/CompanyInterestEditRoute.ts
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { push } from 'redux-first-history';
-import { formValueSelector } from 'redux-form';
 import { fetchSemesters } from 'app/actions/CompanyActions';
 import {
   fetchCompanyInterest,
@@ -22,13 +21,9 @@ import {
 } from './components/Translations';
 import { sortSemesterChronologically } from './utils';
 
-const valueSelector = formValueSelector('CompanyInterestForm');
-
 const mapStateToProps = (state, props) => {
   const { companyInterestId } = props.match.params;
-  const companyInterest = selectCompanyInterestById(state, {
-    companyInterestId,
-  });
+  const companyInterest = selectCompanyInterestById(state, companyInterestId);
   const semesters = selectCompanySemesters(state);
   if (!companyInterest || !semesters)
     return {
@@ -105,9 +100,6 @@ const mapStateToProps = (state, props) => {
     },
     companyInterestId,
     companyInterest,
-    interestForm: {
-      events: valueSelector(state, 'events'),
-    },
     edit: true,
     language: 'norwegian',
   };

--- a/app/routes/companyInterest/CompanyInterestListRoute.ts
+++ b/app/routes/companyInterest/CompanyInterestListRoute.ts
@@ -1,4 +1,3 @@
-import qs from 'qs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { replace } from 'redux-first-history';
@@ -12,25 +11,31 @@ import { LoginPage } from 'app/components/LoginForm';
 import { selectCompanyInterestList } from 'app/reducers/companyInterest';
 import { selectCompanySemestersForInterestForm } from 'app/reducers/companySemesters';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
+import { parseQueryString } from 'app/utils/useQuery';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import CompanyInterestList from './components/CompanyInterestList';
 import { EVENT_TYPE_OPTIONS } from './components/CompanyInterestPage';
 import { semesterToText } from './utils';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
+import type { CompanyInterestEventType } from 'app/store/models/CompanyInterest';
+
+export const defaultCompanyInterestListQuery = {
+  semester: '',
+  event: '' as CompanyInterestEventType | '',
+};
 
 const mapStateToProps = (state, props) => {
-  const semesterId = Number(
-    qs.parse(props.location.search, {
-      ignoreQueryPrefix: true,
-    }).semesters
+  const query = parseQueryString(
+    props.location.search,
+    defaultCompanyInterestListQuery
   );
+  const semesterId = query.semester ? Number(query.semester) : undefined;
+  const eventValue = query.event;
+
   const semesters = selectCompanySemestersForInterestForm(state);
-  const semesterObj: CompanySemesterEntity | null | undefined = semesters.find(
+  const semesterObj: CompanySemesterEntity | undefined = semesters.find(
     (semester) => semester.id === semesterId
   );
-  const eventValue = qs.parse(props.location.search, {
-    ignoreQueryPrefix: true,
-  }).event;
   const selectedSemesterOption = {
     id: semesterId ? semesterId : 0,
     semester: semesterObj != null ? semesterObj.semester : '',
@@ -45,9 +50,9 @@ const mapStateToProps = (state, props) => {
         : 'Vis alle semestre',
   };
   const selectedEventOption = {
-    value: eventValue ? eventValue : '',
+    value: eventValue,
     label: eventValue
-      ? EVENT_TYPE_OPTIONS.find((eventType) => eventType.value === eventValue)
+      ? EVENT_TYPE_OPTIONS.find((eventType) => eventType.value === eventValue)!
           .label
       : 'Vis alle arrangementstyper',
   };

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -1,5 +1,5 @@
 import { Button, ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
-import { Component } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Select from 'react-select';
 import { Content } from 'app/components/Content';
@@ -7,11 +7,15 @@ import { selectTheme, selectStyles } from 'app/components/Form/SelectInput';
 import Table from 'app/components/Table';
 import Tooltip from 'app/components/Tooltip';
 import { ListNavigation } from 'app/routes/bdb/utils';
+import { defaultCompanyInterestListQuery } from 'app/routes/companyInterest/CompanyInterestListRoute';
+import useQuery from 'app/utils/useQuery';
 import { getCsvUrl, semesterToText } from '../utils';
 import styles from './CompanyInterest.css';
 import { EVENT_TYPE_OPTIONS } from './CompanyInterestPage';
+import type { EventTypeOption } from './CompanyInterestPage';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
+import type { CompanyInterestEventType } from 'app/store/models/CompanyInterest';
 
 type SemesterOptionType = {
   id: number;
@@ -21,7 +25,7 @@ type SemesterOptionType = {
 };
 
 type EventOptionType = {
-  value: string;
+  value: CompanyInterestEventType | '';
   label: string;
 };
 
@@ -35,240 +39,221 @@ type Props = {
   replace: (arg0: string) => void;
   selectedSemesterOption: SemesterOptionType;
   selectedEventOption: EventOptionType;
-  router: any;
   authToken: string;
 };
 
-type State = {
-  generatedCSV?: { url: string; filename: string };
+type GeneratedCSV = {
+  url: string;
+  filename: string;
 };
 
-class CompanyInterestList extends Component<Props, State> {
-  state = {
-    generatedCSV: undefined,
-  };
+const CompanyInterestList = ({
+  selectedSemesterOption,
+  selectedEventOption,
+  ...props
+}: Props) => {
+  const [generatedCSV, setGeneratedCSV] = useState<GeneratedCSV>();
 
-  handleSemesterChange = (clickedOption: SemesterOptionType): void => {
+  const { setQueryValue } = useQuery(defaultCompanyInterestListQuery);
+
+  useEffect(() => {
+    setGeneratedCSV(undefined);
+  }, [selectedSemesterOption, selectedEventOption]);
+
+  const handleSemesterChange = (clickedOption: SemesterOptionType) => {
     const { id } = clickedOption;
-    this.props
+    props
       .fetch({
         filters: {
           semesters: id !== null ? id : null,
         },
       })
       .then(() => {
-        this.props.replace(
-          `/companyInterest?semesters=${clickedOption.id}&event=${this.props.selectedEventOption.value}`
-        );
+        setQueryValue('semester')(String(id));
       });
   };
 
-  handleEventChange = (clickedOption: EventOptionType): void => {
-    this.props.replace(
-      `/companyInterest?semesters=${this.props.selectedSemesterOption.id}&event=${clickedOption.value}`
-    );
-  };
-
-  componentDidUpdate(prevProps) {
-    if (
-      this.props.selectedSemesterOption !== prevProps.selectedSemesterOption
-    ) {
-      this.setState({
-        generatedCSV: undefined,
-      });
-    }
-  }
-
-  async exportInterestList(event?: string) {
+  const exportInterestList = async (event: CompanyInterestEventType | '') => {
     const blob = await fetch(
       getCsvUrl(
-        this.props.selectedSemesterOption.year,
-        this.props.selectedSemesterOption.semester,
+        selectedSemesterOption.year,
+        selectedSemesterOption.semester,
         event
       ),
       {
         headers: {
-          Authorization: `Bearer ${this.props.authToken}`,
+          Authorization: `Bearer ${props.authToken}`,
         },
       }
     ).then((response) => response.blob());
     return {
       url: URL.createObjectURL(blob),
-      filename: `company-interests-${this.props.selectedSemesterOption.year}-${
-        this.props.selectedSemesterOption.semester
-      }${
-        this.props.selectedEventOption.value
-          ? `-${this.props.selectedEventOption.value}`
-          : ''
-      }.csv`,
+      filename: `company-interests-${selectedSemesterOption.year}-${
+        selectedSemesterOption.semester
+      }${selectedEventOption.value ? `-${selectedEventOption.value}` : ''}.csv`,
     };
-  }
+  };
 
-  render() {
-    const { generatedCSV } = this.state;
-    const columns = [
-      {
-        title: 'Bedriftsnavn',
-        dataIndex: 'companyName',
-        render: (companyName: string, companyInterest: Record<string, any>) => (
-          <Link to={`/companyInterest/${companyInterest.id}/edit`}>
-            {companyInterest.company
-              ? companyInterest.company.name
-              : companyName}
-          </Link>
-        ),
-      },
-      {
-        title: 'Kontaktperson',
-        dataIndex: 'contactPerson',
-        render: (contactPerson: string) => <span>{contactPerson}</span>,
-      },
-      {
-        title: 'E-post',
-        dataIndex: 'mail',
-        render: (mail: string) => <span>{mail}</span>,
-      },
-      {
-        title: '',
-        dataIndex: 'id',
-        render: (id) => (
-          <Flex justifyContent="center">
-            <ConfirmModal
-              title="Bekreft fjerning av interesse"
-              message={'Er du sikker på at du vil fjerne?'}
-              closeOnConfirm
-              onConfirm={() => this.props.deleteCompanyInterest(id)}
-            >
-              {({ openConfirmModal }) => (
-                <Icon onClick={openConfirmModal} name="trash" danger />
-              )}
-            </ConfirmModal>
-          </Flex>
-        ),
-      },
-    ];
-    const semesterOptions = [
-      {
-        value: 9999,
-        year: 9999,
-        semester: '',
-        label: 'Vis alle semestre',
-      },
-      ...this.props.semesters.map((semesterObj: CompanySemesterEntity) => {
-        const { id, year, semester } = semesterObj;
-        return {
-          id,
-          value: year,
-          year,
-          semester,
-          label: semesterToText({ ...semesterObj, language: 'norwegian' }),
-        };
-      }),
-    ].sort((o1, o2) => {
-      return Number(o1.year) === Number(o2.year)
-        ? o1.semester === 'spring'
-          ? -1
-          : 1
-        : Number(o1.year) > Number(o2.year)
+  const columns = [
+    {
+      title: 'Bedriftsnavn',
+      dataIndex: 'companyName',
+      render: (companyName: string, companyInterest: Record<string, any>) => (
+        <Link to={`/companyInterest/${companyInterest.id}/edit`}>
+          {companyInterest.company ? companyInterest.company.name : companyName}
+        </Link>
+      ),
+    },
+    {
+      title: 'Kontaktperson',
+      dataIndex: 'contactPerson',
+      render: (contactPerson: string) => <span>{contactPerson}</span>,
+    },
+    {
+      title: 'E-post',
+      dataIndex: 'mail',
+      render: (mail: string) => <span>{mail}</span>,
+    },
+    {
+      title: '',
+      dataIndex: 'id',
+      render: (id) => (
+        <Flex justifyContent="center">
+          <ConfirmModal
+            title="Bekreft fjerning av interesse"
+            message={'Er du sikker på at du vil fjerne?'}
+            closeOnConfirm
+            onConfirm={() => props.deleteCompanyInterest(id)}
+          >
+            {({ openConfirmModal }) => (
+              <Icon onClick={openConfirmModal} name="trash" danger />
+            )}
+          </ConfirmModal>
+        </Flex>
+      ),
+    },
+  ];
+  const semesterOptions = [
+    {
+      value: 9999,
+      year: 9999,
+      semester: '',
+      label: 'Vis alle semestre',
+    },
+    ...props.semesters.map((semesterObj: CompanySemesterEntity) => {
+      const { id, year, semester } = semesterObj;
+      return {
+        id,
+        value: year,
+        year,
+        semester,
+        label: semesterToText({ ...semesterObj, language: 'norwegian' }),
+      };
+    }),
+  ].sort((o1, o2) => {
+    return Number(o1.year) === Number(o2.year)
+      ? o1.semester === 'spring'
         ? -1
-        : 1;
-    });
+        : 1
+      : Number(o1.year) > Number(o2.year)
+      ? -1
+      : 1;
+  });
 
-    return (
-      <Content>
-        <ListNavigation title="Bedriftsinteresser" />
-        <Flex
-          wrap
-          justifyContent="space-between"
-          alignItems="flex-end"
-          className={styles.section}
-        >
-          <Flex column>
-            <p>
-              Her finner du all praktisk informasjon knyttet til
-              <strong> bedriftsinteresser</strong>.
-            </p>
-            <Select
-              name="form-semester-selector"
-              value={this.props.selectedSemesterOption}
-              onChange={this.handleSemesterChange}
-              options={semesterOptions}
-              isClearable={false}
-              theme={selectTheme}
-              styles={selectStyles}
-            />
-          </Flex>
-          <Link to="/companyInterest/semesters">
-            <Button>Endre aktive semestre</Button>
-          </Link>
-          <Link to="/companyInterest/create">
-            <Button>Opprett ny bedriftsinteresse</Button>
-          </Link>
+  return (
+    <Content>
+      <ListNavigation title="Bedriftsinteresser" />
+      <Flex
+        wrap
+        justifyContent="space-between"
+        alignItems="flex-end"
+        className={styles.section}
+      >
+        <Flex column>
+          <p>
+            Her finner du all praktisk informasjon knyttet til
+            <strong> bedriftsinteresser</strong>.
+          </p>
+          <Select
+            name="form-semester-selector"
+            value={selectedSemesterOption}
+            onChange={handleSemesterChange}
+            options={semesterOptions}
+            isClearable={false}
+            theme={selectTheme}
+            styles={selectStyles}
+          />
+        </Flex>
+        <Link to="/companyInterest/semesters">
+          <Button>Endre aktive semestre</Button>
+        </Link>
+        <Link to="/companyInterest/create">
+          <Button>Opprett ny bedriftsinteresse</Button>
+        </Link>
+      </Flex>
+
+      <Flex
+        wrap
+        justifyContent="space-between"
+        alignItems="flex-end"
+        className={styles.section}
+      >
+        <Flex column>
+          <Select
+            name="form-event-selector"
+            value={selectedEventOption}
+            onChange={(eventType: EventTypeOption) =>
+              setQueryValue('event')(eventType.value)
+            }
+            options={EVENT_TYPE_OPTIONS}
+            isClearable={false}
+            theme={selectTheme}
+            styles={selectStyles}
+          />
         </Flex>
 
-        <Flex
-          wrap
-          justifyContent="space-between"
-          alignItems="flex-end"
-          className={styles.section}
-        >
-          <Flex column>
-            <Select
-              name="form-event-selector"
-              value={this.props.selectedEventOption}
-              onChange={this.handleEventChange}
-              options={EVENT_TYPE_OPTIONS}
-              isClearable={false}
-              theme={selectTheme}
-              styles={selectStyles}
-            />
-          </Flex>
-
-          {generatedCSV ? (
-            <a href={generatedCSV.url} download={generatedCSV.filename}>
-              Last ned
-            </a>
-          ) : (
-            <Tooltip
-              disabled={!!this.props.selectedSemesterOption.id}
-              content={'Vennligst velg semester'}
+        {generatedCSV ? (
+          <a href={generatedCSV.url} download={generatedCSV.filename}>
+            Last ned
+          </a>
+        ) : (
+          <Tooltip
+            disabled={!!selectedSemesterOption.id}
+            content={'Vennligst velg semester'}
+          >
+            <Button
+              onClick={async () =>
+                setGeneratedCSV(
+                  await exportInterestList(selectedEventOption.value)
+                )
+              }
+              disabled={!selectedSemesterOption.id}
             >
-              <Button
-                onClick={async () =>
-                  this.setState({
-                    generatedCSV: await this.exportInterestList(
-                      this.props.selectedEventOption.value
-                    ),
-                  })
-                }
-                disabled={!this.props.selectedSemesterOption.id}
-              >
-                Eksporter til CSV
-              </Button>
-            </Tooltip>
-          )}
-        </Flex>
+              Eksporter til CSV
+            </Button>
+          </Tooltip>
+        )}
+      </Flex>
 
-        <Table
-          columns={columns}
-          onLoad={(filters) => {
-            this.props.fetch({
-              next: true,
-              filters,
-            });
-          }}
-          onChange={(filters) => {
-            this.props.fetch({
-              filters,
-            });
-          }}
-          hasMore={this.props.hasMore}
-          loading={this.props.fetching}
-          data={this.props.companyInterestList}
-        />
-      </Content>
-    );
-  }
-}
+      <Table
+        columns={columns}
+        onLoad={(filters) => {
+          props.fetch({
+            next: true,
+            filters,
+          });
+        }}
+        onChange={(filters) => {
+          props.fetch({
+            filters,
+          });
+        }}
+        hasMore={props.hasMore}
+        loading={props.fetching}
+        data={props.companyInterestList}
+      />
+    </Content>
+  );
+};
 
 export default CompanyInterestList;

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -9,12 +9,12 @@ import norwegian from 'app/assets/norway.svg';
 import { Content } from 'app/components/Content';
 import { FlexRow } from 'app/components/FlexBox';
 import {
+  CheckBox,
+  MultiSelectGroup,
+  RadioButton,
+  SelectInput,
   TextEditor,
   TextInput,
-  CheckBox,
-  SelectInput,
-  RadioButton,
-  MultiSelectGroup,
 } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
@@ -22,24 +22,25 @@ import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { Image } from 'app/components/Image';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import Tooltip from 'app/components/Tooltip';
+import { CompanyInterestEventType as EventType } from 'app/store/models/CompanyInterest';
 import { spyValues } from 'app/utils/formSpyUtils';
 import {
   createValidator,
-  required,
   isEmail,
+  required,
   requiredIf,
 } from 'app/utils/validation';
 import { interestText, semesterToText } from '../utils';
 import styles from './CompanyInterest.css';
 import {
   COLLABORATION_TYPES,
+  COMPANY_TYPES,
   EVENTS,
+  FORM_LABELS,
+  OFFICE_IN_TRONDHEIM,
   README,
   SURVEY_OFFERS,
   TARGET_GRADES,
-  FORM_LABELS,
-  COMPANY_TYPES,
-  OFFICE_IN_TRONDHEIM,
 } from './Translations';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
@@ -60,18 +61,22 @@ export const PARTICIPANT_RANGE_MAP = {
   fourth: [100, null],
 };
 
-export const EVENT_TYPE_OPTIONS = [
+type EventTypeOption = {
+  value: EventType | '';
+  label: string;
+};
+export const EVENT_TYPE_OPTIONS: EventTypeOption[] = [
   { value: '', label: 'Vis alle arrangementstyper' },
-  { value: 'company_presentation', label: 'Bedriftspresentasjon' },
-  { value: 'course', label: 'Kurs' },
-  { value: 'breakfast_talk', label: 'Frokostforedrag' },
-  { value: 'lunch_presentation', label: 'Lunsjpresentasjon' },
-  { value: 'bedex', label: 'BedEx' },
-  { value: 'digital_presentation', label: 'Digital presentasjon' },
-  { value: 'other', label: 'Alternativt arrangement' },
-  { value: 'sponsor', label: 'Sponser' },
-  { value: 'start_up', label: 'Start-up kveld' },
-  { value: 'company_to_company', label: 'Bedrift-til-bedrift' },
+  { value: EventType.CompanyPresentation, label: 'Bedriftspresentasjon' },
+  { value: EventType.Course, label: 'Kurs' },
+  { value: EventType.BreakfastTalk, label: 'Frokostforedrag' },
+  { value: EventType.LunchPresentation, label: 'Lunsjpresentasjon' },
+  { value: EventType.Bedex, label: 'BedEx' },
+  { value: EventType.DigitalPresentation, label: 'Digital presentasjon' },
+  { value: EventType.Other, label: 'Alternativt arrangement' },
+  { value: EventType.Sponsor, label: 'Sponser' },
+  { value: EventType.StartUp, label: 'Start-up kveld' },
+  { value: EventType.CompanyToCompany, label: 'Bedrift-til-bedrift' },
 ];
 
 const eventToString = (event) =>
@@ -258,10 +263,10 @@ type CompanyInterestFormEntity = {
   mail: string;
   phone: string;
   semesters: Array<CompanySemesterEntity>;
-  events: Array<{
-    name: string;
+  events: {
+    name: EventType;
     checked: boolean;
-  }>;
+  }[];
   companyCourseThemes: Array<{ name: string; checked: boolean }>;
   otherOffers: Array<{
     name: string;
@@ -295,7 +300,6 @@ type Props = {
   targetGrades: Array<Record<string, any>>;
   participantRange: string;
   edit: boolean;
-  interestForm: Record<string, any>;
   companyInterest?: CompanyInterestEntity;
   language: string;
   comment: string;
@@ -417,56 +421,56 @@ const CompanyInterestPage = (props: Props) => {
 
   const eventTypeEntities = [
     {
-      name: 'company_presentation',
+      name: EventType.CompanyPresentation,
       translated: EVENTS.company_presentation[language],
       description: interestText.companyPresentationDescription[language],
       commentName: 'companyPresentationComment',
       commentPlaceholder: interestText.companyPresentationComment[language],
     },
     {
-      name: 'lunch_presentation',
+      name: EventType.LunchPresentation,
       translated: EVENTS.lunch_presentation[language],
       description: interestText.lunchPresentationDescriptiont[language],
       commentName: 'lunchPresentationComment',
       commentPlaceholder: interestText.lunchPresentationComment[language],
     },
     {
-      name: 'course',
+      name: EventType.Course,
       translated: EVENTS.course[language],
       description: interestText.courseDescription[language],
       commentName: 'courseComment',
       commentPlaceholder: interestText.courseComment[language],
     },
     {
-      name: 'breakfast_talk',
+      name: EventType.BreakfastTalk,
       translated: EVENTS.breakfast_talk[language],
       description: interestText.breakfastTalkDescription[language],
       commentName: 'breakfastTalkComment',
       commentPlaceholder: interestText.breakfastTalkComment[language],
     },
     {
-      name: 'bedex',
+      name: EventType.Bedex,
       translated: EVENTS.bedex[language],
       description: interestText.bedexDescription[language],
       commentName: 'bedexComment',
       commentPlaceholder: interestText.bedexComment[language],
     },
     {
-      name: 'other',
+      name: EventType.Other,
       translated: EVENTS.other[language],
       description: interestText.otherEventDescription[language],
       commentName: 'otherEventComment',
       commentPlaceholder: interestText.otherEventComment[language],
     },
     {
-      name: 'start_up',
+      name: EventType.StartUp,
       translated: EVENTS.start_up[language],
       description: interestText.startUpDescription[language],
       commentName: 'startupComment',
       commentPlaceholder: interestText.startUpComment[language],
     },
     {
-      name: 'company_to_company',
+      name: EventType.CompanyToCompany,
       translated: EVENTS.company_to_company[language],
       description: interestText.companyToCompanyDescription[language],
       commentName: 'companyToCompanyComment',

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -61,7 +61,7 @@ export const PARTICIPANT_RANGE_MAP = {
   fourth: [100, null],
 };
 
-type EventTypeOption = {
+export type EventTypeOption = {
   value: EventType | '';
   label: string;
 };

--- a/app/routes/companyInterest/utils.tsx
+++ b/app/routes/companyInterest/utils.tsx
@@ -2,12 +2,12 @@ import qs from 'qs';
 import NavigationTab from 'app/components/NavigationTab';
 import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import config from 'app/config';
-import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
+import type CompanySemester from 'app/store/models/CompanySemester';
 import type { ReactNode } from 'react';
 
 export const sortSemesterChronologically = (
-  a: CompanySemesterEntity,
-  b: CompanySemesterEntity
+  a: CompanySemester,
+  b: CompanySemester
 ) => {
   const semesterCodeToPriority = {
     spring: 0,

--- a/app/store/models/Company.ts
+++ b/app/store/models/Company.ts
@@ -157,9 +157,16 @@ export type AdminDetailCompany = Pick<
   | 'companyContacts'
 >;
 
-export type UnknownCompany =
+export type UnknownCompany = (
   | ListCompany
   | AdminListCompany
   | DetailedCompany
   | SearchCompany
-  | AdminDetailCompany;
+  | AdminDetailCompany
+) &
+  Partial<
+    Pick<
+      Company,
+      'semesterStatuses' | 'companyContacts' | 'comments' | 'studentContact'
+    >
+  >;

--- a/app/store/models/CompanyInterest.ts
+++ b/app/store/models/CompanyInterest.ts
@@ -1,21 +1,42 @@
 import type { Dateish } from 'app/models';
-import type Company from 'app/store/models/Company';
+import type { SearchCompany } from 'app/store/models/Company';
 import type { ID } from 'app/store/models/index';
+
+export enum CompanyInterestEventType {
+  CompanyPresentation = 'company_presentation',
+  Course = 'course',
+  BreakfastTalk = 'breakfast_talk',
+  LunchPresentation = 'lunch_presentation',
+  Bedex = 'bedex',
+  DigitalPresentation = 'digital_presentation',
+  Other = 'other',
+  Sponsor = 'sponsor',
+  StartUp = 'start_up',
+  CompanyToCompany = 'company_to_company',
+}
+
+export enum CompanyInterestCompanyType {
+  SmallConsultant = 'company_types_small_consultant',
+  MediumConsultant = 'company_types_medium_consultant',
+  LargeConsultant = 'company_types_large_consultant',
+  Inhouse = 'company_types_inhouse',
+  Others = 'company_types_others',
+  StartUp = 'company_types_start_up',
+  Governmental = 'company_types_governmental',
+}
 
 interface CompleteCompanyInterest {
   id: ID;
   companyName: string;
-  company: Company | null;
+  company: SearchCompany | null;
   contactPerson: string;
   mail: string;
   phone: string;
   semesters: ID[];
-  createdAt: Dateish;
-  officeInTrondheim: string;
-  events: string[];
-  companyCourseThemes: string[];
+  events: CompanyInterestEventType[];
   otherOffers: string[];
   collaborations: string[];
+  companyType: CompanyInterestCompanyType;
   targetGrades: number[];
   participantRangeStart: number;
   participantRangeEnd: number;
@@ -24,10 +45,13 @@ interface CompleteCompanyInterest {
   breakfastTalkComment: string;
   otherEventComment: string;
   startupComment: string;
-  lunchPresentationComment: string;
-  bedexComment: string;
   companyToCompanyComment: string;
+  lunchPresentationComment: string;
   companyPresentationComment: string;
+  bedexComment: string;
+  companyCourseThemes: string[];
+  officeInTrondheim: boolean;
+  createdAt: Dateish;
 }
 
 export type DetailedCompanyInterest = Pick<
@@ -40,9 +64,9 @@ export type DetailedCompanyInterest = Pick<
   | 'phone'
   | 'semesters'
   | 'events'
-  | 'companyCourseThemes'
   | 'otherOffers'
   | 'collaborations'
+  | 'companyType'
   | 'targetGrades'
   | 'participantRangeStart'
   | 'participantRangeEnd'
@@ -51,10 +75,11 @@ export type DetailedCompanyInterest = Pick<
   | 'breakfastTalkComment'
   | 'otherEventComment'
   | 'startupComment'
-  | 'lunchPresentationComment'
-  | 'bedexComment'
   | 'companyToCompanyComment'
+  | 'lunchPresentationComment'
   | 'companyPresentationComment'
+  | 'bedexComment'
+  | 'companyCourseThemes'
   | 'officeInTrondheim'
 >;
 
@@ -67,6 +92,7 @@ export type ListCompanyInterest = Pick<
   | 'mail'
   | 'phone'
   | 'semesters'
+  | 'events'
   | 'createdAt'
 >;
 

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -52,3 +52,7 @@ export function generateTreeStructure<
     return roots;
   }, []);
 }
+
+export const isDefined = <T>(v: T | null | undefined): v is T => {
+  return v !== null && v !== undefined;
+};

--- a/app/utils/legoAdapter/createLegoAdapter.ts
+++ b/app/utils/legoAdapter/createLegoAdapter.ts
@@ -1,10 +1,12 @@
 import { createEntityAdapter } from '@reduxjs/toolkit';
+import { createSelector } from 'reselect';
+import { isDefined } from 'app/utils';
 import buildActionGrantReducer from 'app/utils/legoAdapter/buildActionGrantReducer';
 import buildDeleteEntityReducer from 'app/utils/legoAdapter/buildDeleteEntityReducer';
 import buildEntitiesReducer from 'app/utils/legoAdapter/buildEntitiesReducer';
 import buildFetchingReducer from 'app/utils/legoAdapter/buildFetchingReducer';
 import buildPaginationReducer from 'app/utils/legoAdapter/buildPaginationReducer';
-import type { EntityAdapter } from '@reduxjs/toolkit';
+import type { EntityAdapter, EntitySelectors } from '@reduxjs/toolkit';
 import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
 import type { NoInfer } from '@reduxjs/toolkit/src/tsHelpers';
@@ -22,6 +24,10 @@ interface LegoEntityState<Entity> extends EntityState<Entity> {
   paginationNext: { [key: string]: Pagination };
 }
 
+interface LegoEntitySelectors<T, V> extends EntitySelectors<T, V> {
+  selectAllPaginated: (state: V, options?: { pagination?: Pagination }) => T[];
+}
+
 // Type of the generated adapter-object
 interface LegoAdapter<Entity> extends EntityAdapter<Entity> {
   getInitialState(): LegoEntityState<Entity>;
@@ -35,6 +41,10 @@ interface LegoAdapter<Entity> extends EntityAdapter<Entity> {
     fetchActions?: AsyncActionType[];
     deleteActions?: AsyncActionType[];
   }): (builder: ReducerBuilder<Entity>) => void;
+  getSelectors(): LegoEntitySelectors<Entity, EntityState<Entity>>;
+  getSelectors<V>(
+    selectState: (state: V) => EntityState<Entity>
+  ): LegoEntitySelectors<Entity, V>;
 }
 
 // Helpers
@@ -84,6 +94,24 @@ const createLegoAdapter = <
         if (defaultCaseReducer) {
           builder.addDefaultCase(defaultCaseReducer);
         }
+      };
+    },
+    getSelectors<V>(selectState?: (state: V) => EntityState<Entity>) {
+      const selectors = selectState
+        ? entityAdapter.getSelectors<V>(selectState)
+        : entityAdapter.getSelectors();
+      return {
+        ...selectors,
+        selectAllPaginated: createSelector(
+          selectors.selectEntities,
+          selectors.selectIds,
+          (_: V, { pagination }: { pagination?: Pagination } = {}) =>
+            pagination,
+          (entities, allIds, pagination) => {
+            const ids = pagination ? pagination.ids || [] : allIds;
+            return ids.map((id) => entities[id]).filter(isDefined);
+          }
+        ),
       };
     },
   };


### PR DESCRIPTION
# Description

Refactor redux slices `annoucements`, `companies`, `companyInterests`, `companySemesters` and `emailLists` to use `cerateLegoAdapter`. 
Also refactored `auth`-slice to use redux-toolkits `createSlice` and `CompanyInterestList` to be a function-component. 

# Result

No visual or functional changes (hopefully)

# Testing

- [x] I have thoroughly tested my changes.

Have tested all the affected features.

---

ABA-688