### PR TITLE
Refactor redux entity-slices to use createLegoAdapter (2nd batch)

### DIFF
--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -13,7 +13,6 @@ type AAT = AsyncActionType;
  *
  */
 export const Event = {
-  CLEAR: 'Event.CLEAR',
   FETCH: generateStatuses('Event.FETCH') as AAT,
   FETCH_PREVIOUS: generateStatuses('Event.FETCH_PREVIOUS') as AAT,
   FETCH_UPCOMING: generateStatuses('Event.FETCH_UPCOMING') as AAT,

--- a/app/actions/CompanyActions.ts
+++ b/app/actions/CompanyActions.ts
@@ -1,3 +1,4 @@
+import qs from 'qs';
 import { push } from 'redux-first-history';
 import { startSubmit, stopSubmit } from 'redux-form';
 import { addToast } from 'app/actions/ToastActions';
@@ -70,23 +71,23 @@ export function fetchAdmin(companyId: number): Thunk<any> {
 }
 export const fetchEventsForCompany =
   ({
-    queryString,
-    loadNextPage = false,
+    query,
+    next = false,
   }: {
-    queryString: string;
-    loadNextPage: boolean;
+    query: Record<string, string>;
+    next: boolean;
   }): Thunk<any> =>
-  (dispatch, getState) => {
-    const endpoint = loadNextPage
-      ? getState().events.pagination[queryString].nextPage
-      : `/events/${queryString}`;
+  (dispatch) => {
     return dispatch(
       callAPI({
         types: Event.FETCH,
-        endpoint,
+        endpoint: '/events/',
+        query,
+        pagination: {
+          fetchNext: next,
+        },
         schema: [eventSchema],
         meta: {
-          queryString,
           errorMessage: 'Henting av tilknyttede arrangementer feilet',
         },
       })

--- a/app/actions/EmojiActions.ts
+++ b/app/actions/EmojiActions.ts
@@ -3,30 +3,13 @@ import { emojiSchema } from 'app/reducers';
 import { Emoji } from './ActionTypes';
 import type { Thunk } from 'app/types';
 
-export function fetchEmoji(shortCode: string): Thunk<any> {
-  return callAPI({
-    types: Emoji.FETCH,
-    endpoint: `/emojis/${shortCode}/`,
-    schema: emojiSchema,
-    meta: {
-      errorMessage: 'Henting av reaksjon feilet',
-    },
-    propagateError: true,
-  });
-}
-export function fetchEmojis({
-  next = false,
-}: {
-  next?: boolean;
-} = {}): Thunk<any> {
-  return (dispatch, getState) => {
-    const cursor = next ? getState().emojis.pagination.next : {};
+export function fetchEmojis(): Thunk<any> {
+  return (dispatch) => {
     return dispatch(
       callAPI({
         types: Emoji.FETCH_ALL,
         endpoint: '/emojis/',
         schema: [emojiSchema],
-        query: { ...cursor },
         meta: {
           errorMessage: 'Henting av emojis feilet',
         },

--- a/app/models.ts
+++ b/app/models.ts
@@ -1,7 +1,7 @@
 import type Comment from 'app/store/models/Comment';
 import type { ListCompany } from 'app/store/models/Company';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
-import type { DetailedUser, PublicUser } from 'app/store/models/User';
+import type { DetailedUser } from 'app/store/models/User';
 import type { RoleType } from 'app/utils/constants';
 import type { Moment } from 'moment';
 // TODO: Id handling could be opaque
@@ -363,7 +363,7 @@ export type AddPenalty = {
 
 export type FollowerItem = {
   id: ID;
-  follower: PublicUser;
+  follower: ID;
   target: ID;
 };
 

--- a/app/reducers/emailUsers.ts
+++ b/app/reducers/emailUsers.ts
@@ -1,8 +1,12 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { selectUserWithGroups } from 'app/reducers/users';
-import createEntityReducer from 'app/utils/createEntityReducer';
-import { EmailUser } from '../actions/ActionTypes';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import { EmailUser as EmailUserActions } from '../actions/ActionTypes';
 import type { UserEntity } from 'app/reducers/users';
+import type { RootState } from 'app/store/createRootReducer';
+import type EmailUser from 'app/store/models/EmailUser';
 
 export type EmailUserEntity = {
   id: number;
@@ -10,50 +14,37 @@ export type EmailUserEntity = {
   internalEmailEnabled: boolean;
   internalEmail: string;
 };
-export default createEntityReducer({
-  key: 'emailUsers',
-  types: {
-    fetch: EmailUser.FETCH,
-    mutate: EmailUser.CREATE,
-  },
+
+const legoAdapter = createLegoAdapter(EntityType.EmailUsers);
+
+const emailUserSlice = createSlice({
+  name: 'emailUsers',
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [EmailUserActions.FETCH],
+  }),
 });
-export const selectEmailUsers = createSelector(
-  (state) => state.emailUsers.byId,
-  (state) => state.users.byId,
-  (state) => state.emailUsers.items,
-  (_, { pagination }) => pagination,
-  (state) => state,
-  (
-    emailUsersById,
-    usersById,
-    emailUserIds,
-    pagination,
-    state //$FlowFixMe
-  ) =>
-    (pagination ? pagination.items || [] : emailUserIds)
-      .map((id) => emailUsersById[id])
-      .filter(Boolean)
-      .map((emailUser) => ({
-        ...emailUser,
-        //$FlowFixMe
-        user: selectUserWithGroups(state, {
-          userId: emailUser.id,
-        }),
-      }))
+
+export default emailUserSlice.reducer;
+const { selectAllPaginated, selectById } = legoAdapter.getSelectors<RootState>(
+  (state) => state.emailUsers
 );
+
+const transformEmailUser = (emailUser: EmailUser, state: RootState) => ({
+  ...emailUser,
+  user: selectUserWithGroups(state, { userId: emailUser.id }),
+});
+
+export const selectEmailUsers = createSelector(
+  selectAllPaginated,
+  (state: RootState) => state,
+  (emailUsers, state) =>
+    emailUsers.map((emailUser) => transformEmailUser(emailUser, state))
+);
+
 export const selectEmailUserById = createSelector(
-  (state) => state.emailUsers.byId,
-  (state) => state.users.byId,
-  (state, props) => props.emailUserId,
-  (emailUsersById, usersById, emailUserId) => {
-    const emailUser = emailUsersById[emailUserId];
-
-    if (!emailUser) {
-      return {
-        user: {},
-      };
-    }
-
-    return { ...emailUser, user: usersById[emailUser.user] };
-  }
+  selectById,
+  (state: RootState) => state,
+  (emailUser, state) => emailUser && transformEmailUser(emailUser, state)
 );

--- a/app/reducers/emojis.ts
+++ b/app/reducers/emojis.ts
@@ -1,25 +1,23 @@
-import { createSelector } from 'reselect';
+import { createSlice } from '@reduxjs/toolkit';
 import { Emoji } from 'app/actions/ActionTypes';
-import createEntityReducer from 'app/utils/createEntityReducer';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import type { RootState } from 'app/store/createRootReducer';
 
-export const selectEmojis = createSelector(
-  (state) => state.emojis.byId,
-  (state) => state.emojis.items,
-  (emojisById, emojiIds) => {
-    return emojiIds.map((id) => emojisById[id]);
-  }
-);
-export const selectEmojisById = createSelector(
-  selectEmojis,
-  (state, emojisId) => emojisId,
-  (emojis, emojisId) => {
-    if (!emojis || !emojisId) return {};
-    return emojis.find((emojis) => emojis.shortCode === emojisId);
-  }
-);
-export default createEntityReducer({
-  key: 'emojis',
-  types: {
-    fetch: [Emoji.FETCH, Emoji.FETCH_ALL],
-  },
+const legoAdapter = createLegoAdapter(EntityType.Emojis, {
+  selectId: (emoji) => emoji.shortCode,
 });
+
+const emojisSlice = createSlice({
+  name: 'emojis',
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [Emoji.FETCH, Emoji.FETCH_ALL],
+  }),
+});
+
+export default emojisSlice.reducer;
+export const { selectAll: selectEmojis } = legoAdapter.getSelectors<RootState>(
+  (state) => state.emojis
+);

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -7,6 +7,7 @@ import createEntityReducer from 'app/utils/createEntityReducer';
 import mergeObjects from 'app/utils/mergeObjects';
 import { User, Event } from '../actions/ActionTypes';
 import type { PhotoConsent } from '../models';
+import type { ID } from 'app/store/models';
 
 export type UserEntity = {
   id: number;
@@ -79,7 +80,7 @@ export const selectUserWithGroups = createSelector(
       userId,
     }: {
       username?: string;
-      userId?: string;
+      userId?: ID;
     }
   ) =>
     username

--- a/app/routes/admin/email/EmailUserRoute.ts
+++ b/app/routes/admin/email/EmailUserRoute.ts
@@ -9,9 +9,7 @@ import EmailUserEditor from './components/EmailUserEditor';
 
 const mapStateToProps = (state, { match: { params } }) => {
   const { emailUserId } = params;
-  const emailUser = selectEmailUserById(state, {
-    emailUserId,
-  });
+  const emailUser = selectEmailUserById(state, emailUserId);
   return {
     emailUser,
     emailUserId,

--- a/app/routes/bdb/BdbDetailRoute.ts
+++ b/app/routes/bdb/BdbDetailRoute.ts
@@ -18,17 +18,18 @@ import {
   selectCommentsForCompany,
 } from 'app/reducers/companies';
 import { selectCompanySemesters } from 'app/reducers/companySemesters';
-import { selectPagination } from 'app/reducers/selectors';
+import { selectPagination, selectPaginationNext } from 'app/reducers/selectors';
+import { EntityType } from 'app/store/models/entities';
 import createQueryString from 'app/utils/createQueryString';
 import replaceUnlessLoggedIn from 'app/utils/replaceUnlessLoggedIn';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import BdbDetail from './components/BdbDetail';
+import type { ID } from 'app/store/models';
 
-const queryString = (companyId) =>
-  createQueryString({
-    company: companyId,
-    ordering: '-start_time',
-  });
+const getQuery = (companyId: ID) => ({
+  company: String(companyId),
+  ordering: '-start_time',
+});
 
 const loadData = (
   {
@@ -42,8 +43,8 @@ const loadData = (
     dispatch(fetchSemesters()).then(() => dispatch(fetchAdmin(companyId))),
     dispatch(
       fetchEventsForCompany({
-        queryString: queryString(companyId),
-        loadNextPage: false,
+        query: getQuery(companyId),
+        next: false,
       })
     ),
   ]);
@@ -61,8 +62,10 @@ const mapStateToProps = (state, props) => {
   });
   const companySemesters = selectCompanySemesters(state, props);
   const fetching = state.companies.fetching;
-  const showFetchMoreEvents = selectPagination('events', {
-    queryString: queryString(companyId),
+  const showFetchMoreEvents = selectPaginationNext({
+    entity: EntityType.Events,
+    endpoint: '/events/',
+    query: getQuery(companyId),
   })(state);
   return {
     company,
@@ -81,8 +84,8 @@ const mapDispatchToProps = (dispatch, props) => {
   const fetchMoreEvents = () =>
     dispatch(
       fetchEventsForCompany({
-        queryString: queryString(companyId),
-        loadNextPage: true,
+        query: getQuery(companyId),
+        next: true,
       })
     );
 

--- a/app/routes/events/CalendarRoute.ts
+++ b/app/routes/events/CalendarRoute.ts
@@ -19,8 +19,8 @@ const loadData = (props, dispatch) => {
     const dateBefore = date.clone().endOf('month').endOf('week');
     return dispatch(
       fetchList({
-        dateAfter: dateAfter.format('YYYY-MM-DD'),
-        dateBefore: dateBefore.format('YYYY-MM-DD'),
+        dateAfter: dateAfter,
+        dateBefore: dateBefore,
       })
     );
   }

--- a/app/routes/events/EventDetailRoute.ts
+++ b/app/routes/events/EventDetailRoute.ts
@@ -66,12 +66,8 @@ const mapStateToProps = (state, props) => {
 
   if (!hasFullAccess) {
     const normalPools = event.isMerged
-      ? selectMergedPool(state, {
-          eventId,
-        })
-      : selectPoolsForEvent(state, {
-          eventId,
-        });
+      ? selectMergedPool(state, eventId)
+      : selectPoolsForEvent(state, eventId);
     const pools =
       event.waitingRegistrationCount > 0
         ? normalPools.concat({
@@ -90,22 +86,15 @@ const mapStateToProps = (state, props) => {
     };
   }
 
-  const comments = selectCommentsForEvent(state, {
-    eventId,
-  });
+  const comments = selectCommentsForEvent(state, eventId);
   const poolsWithRegistrations = event.isMerged
-    ? selectMergedPoolWithRegistrations(state, {
-        eventId,
-      })
-    : selectPoolsWithRegistrationsForEvent(state, {
-        eventId,
-      });
-  const registrations = selectRegistrationsFromPools(state, {
-    eventId,
-  });
-  const waitingRegistrations = selectWaitingRegistrationsForEvent(state, {
-    eventId,
-  });
+    ? selectMergedPoolWithRegistrations(state, eventId)
+    : selectPoolsWithRegistrationsForEvent(state, eventId);
+  const registrations = selectRegistrationsFromPools(state, eventId);
+  const waitingRegistrations = selectWaitingRegistrationsForEvent(
+    state,
+    eventId
+  );
   const pools =
     waitingRegistrations.length > 0
       ? poolsWithRegistrations.concat({

--- a/app/store/models/Event.d.ts
+++ b/app/store/models/Event.d.ts
@@ -70,6 +70,7 @@ interface Event {
   pinned: boolean;
   responsibleUsers: DetailedUser[];
   isForeignLanguage: boolean;
+  waitingRegistrations: ID[];
 
   // for survey
   attendedCount: number;
@@ -255,7 +256,7 @@ export type AutocompleteEvent = Pick<Event, 'title' | 'startTime' | 'id'> & {
   text: 'text';
 };
 
-export type UnknownEvent =
+export type UnknownEvent = (
   | PublicEvent
   | ListEvent
   | DetailedEvent
@@ -264,4 +265,9 @@ export type UnknownEvent =
   | AuthUserDetailedEvent
   | AdministrateEvent
   | FrontpageEvent
-  | SearchEvent;
+) & {
+  isUsersUpcoming?: boolean; // is it in upcoming events list on user profile
+  loading?: boolean; // registering/unregistering
+  useCaptcha?: boolean;
+  comments?: ID[];
+};

--- a/app/store/models/entities.ts
+++ b/app/store/models/entities.ts
@@ -1,4 +1,5 @@
 import type OAuth2Grant from './OAuth2Grant';
+import type { FollowerItem } from 'app/models';
 import type { UnknownAnnouncement } from 'app/store/models/Announcement';
 import type { UnknownArticle } from 'app/store/models/Article';
 import type Comment from 'app/store/models/Comment';
@@ -107,9 +108,9 @@ export default interface Entities {
   [EntityType.Surveys]: Record<ID, Survey>;
   [EntityType.Tags]: Record<ID, UnknownTag>;
   [EntityType.Users]: Record<ID, UnknownUser>;
-  [EntityType.FollowersCompany]: Record<ID, unknown>; // AFAIK unused
-  [EntityType.FollowersUser]: Record<ID, unknown>; // AFAIK unused
-  [EntityType.FollowersEvent]: Record<ID, unknown>; // AFAIK unused
+  [EntityType.FollowersCompany]: Record<ID, FollowerItem>; // AFAIK unused
+  [EntityType.FollowersUser]: Record<ID, FollowerItem>; // AFAIK unused
+  [EntityType.FollowersEvent]: Record<ID, FollowerItem>; // AFAIK unused
 }
 
 export interface NormalizedEntityPayload<EntityKeys extends keyof Entities> {


### PR DESCRIPTION
# Description

Refactor redux slices `emailUsers`, `emojis` and `events` to use cerateLegoAdapter.
Events required a bit of refactoring because it used the old pagination system that legoAdapter does not support.

# Result

No functional changes, but better typescript types and (hopefully) easier to maintain code.

# Testing

- [ ] I have thoroughly tested my changes.

Needs thourough testing

---

Resolves ... (either GitHub issue or Linear task)
