### PR TITLE
Give correct feedback when uploading photo to gallery

### DIFF
--- a/app/components/PhotoUploadStatus/index.tsx
+++ b/app/components/PhotoUploadStatus/index.tsx
@@ -43,7 +43,11 @@ const UploadStatusCard = ({
 
       {uploadDone ? (
         <Card.Header className={styles.header}>
-          {uploadStatus.successCount > 1 ? uploadStatus.successCount : 'Ingen'}{' '}
+          {uploadStatus.successCount > 1
+            ? uploadStatus.successCount
+            : hasFailedUploads
+            ? 'Ingen'
+            : 'Ett'}{' '}
           {hasFailedUploads ? `av ${uploadStatus.imageCount}` : ''}{' '}
           {uploadStatus.successCount === 1 ? 'bilde' : 'bilder'} ble lastet opp
         </Card.Header>


### PR DESCRIPTION
# Description

It says no photos were uploaded, even though it did in fact upload successfully. The card is even green!

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td>
			
<img width="433" src="https://github.com/webkom/lego-webapp/assets/69514187/be471a8d-5f53-40a2-91bd-accd41cca708" />

</td>
		<td>
			<img width="468" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/7d42f6ec-6754-457b-9920-f89fcba95913">
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above.