### PR TITLE
Fix header alignment on frontpage

### DIFF
--- a/app/routes/overview/components/CompactEvents.css
+++ b/app/routes/overview/components/CompactEvents.css
@@ -16,6 +16,10 @@
   .compactLeft h3 {
     margin-top: 0;
   }
+
+  .compactRight h3 {
+    margin-top: 0;
+  }
 }
 
 .compactLeft,

--- a/app/routes/overview/components/CompactEvents.css
+++ b/app/routes/overview/components/CompactEvents.css
@@ -6,6 +6,10 @@
   white-space: nowrap;
   width: 100%;
   text-align: left;
+
+  @media (--small-viewport) {
+    flex-direction: column;
+  }
 }
 
 .compactLeft {
@@ -14,10 +18,6 @@
 
 @media (--mobile-device) {
   .compactLeft h3 {
-    margin-top: 0;
-  }
-
-  .compactRight h3 {
     margin-top: 0;
   }
 }

--- a/app/styles/utilities.css
+++ b/app/styles/utilities.css
@@ -95,9 +95,14 @@ html[data-theme='dark'] .contentContainer {
     margin-bottom: 0.8rem;
 
     @media (--mobile-device) {
+      margin-top: 0;
       padding: 0;
       margin-bottom: 10px;
       margin-left: 0.5rem;
+    }
+
+    @media (--small-viewport) {
+      margin-top: 2rem;
     }
   }
 


### PR DESCRIPTION
# Description

Fixes the alignment on medium screens and makes them stack vertically on mobile

# Result

## After
<img width="460" alt="Skjermbilde 2023-11-21 kl  21 33 42" src="https://github.com/webkom/lego-webapp/assets/64247965/e8a23e90-f5a6-452a-974d-a7ce099df97a">


## Before
<img width="891" alt="Skjermbilde 2023-11-21 kl  21 21 21" src="https://github.com/webkom/lego-webapp/assets/64247965/a8043f10-2997-4b47-8226-dd6439ea498d">

# Testing

- [x] I have thoroughly tested my changes.

Looks better

---

Resolves ABA-683
