### PR TITLE
Remove `timekeeper` dependency

### DIFF
--- a/app/reducers/__tests__/announcements.spec.ts
+++ b/app/reducers/__tests__/announcements.spec.ts
@@ -1,13 +1,11 @@
-import moment from 'moment';
-import timekeeper from 'timekeeper';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Announcements } from 'app/actions/ActionTypes';
 import announcements from '../announcements';
 
 describe('reducers', () => {
   describe('announcements', () => {
-    const time = Date.now();
-    timekeeper.freeze(time);
+    vi.useFakeTimers().setSystemTime(new Date());
+
     it('Announcements.SEND.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
@@ -33,7 +31,7 @@ describe('reducers', () => {
         byId: {
           99: {
             id: 99,
-            sent: moment().toISOString(),
+            sent: new Date().toISOString(),
           },
         },
       });

--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
     "stylelint": "^15.10.1",
     "stylelint-config-standard": "^34.0.0",
     "terser-webpack-plugin": "^5.3.9",
-    "timekeeper": "^2.3.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.3.2",
     "typescript-plugin-css-modules": "^5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13176,11 +13176,6 @@ through@^2.3.6, through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-timekeeper@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/timekeeper/-/timekeeper-2.3.1.tgz#2deb6e0b95d93625fda84c18d47f84a99e4eba01"
-  integrity sha512-LeQRS7/4JcC0PgdSFnfUiStQEdiuySlCj/5SJ18D+T1n9BoY7PxKFfCwLulpHXoLUFr67HxBddQdEX47lDGx1g==
-
 tiny-invariant@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"


### PR DESCRIPTION
# Description

It is only used for one reducer test, so not really needed.

# Testing

- [x] I have thoroughly tested my changes.

Test still works.