### PR TITLE
Re-add descendants

### DIFF
--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -176,10 +176,12 @@ export function fetchAllMemberships(
 }
 export function fetchMemberships(
   groupId: number,
+  descendants = false,
   query: Record<string, any> = {}
 ): Thunk<any> {
   return fetchMembershipsPagination({
     groupId,
+    descendants,
     next: true,
     query,
   });
@@ -187,10 +189,12 @@ export function fetchMemberships(
 export function fetchMembershipsPagination({
   groupId,
   next,
+  descendants = false,
   query = {},
 }: {
   groupId: number;
   next: boolean;
+  descendants: boolean;
   query?: Record<string, string | number | boolean>;
 }): Thunk<any> {
   return (dispatch) => {
@@ -202,7 +206,7 @@ export function fetchMembershipsPagination({
         pagination: {
           fetchNext: next,
         },
-        query,
+        query: { ...query, descendants },
         meta: {
           groupId: groupId,
           errorMessage: 'Henting av medlemmene for gruppen feilet',


### PR DESCRIPTION
# Description

Re-added descendants as part of the query.

We don't use it, buuuuuuuuuuuuuuuuuuuuuuuuut selectors are tracked using that query, and since it mismatched the selector in `pages.ts`, the state was not retrieved successfully.

# Result

They're back, i promise:)

# Testing

- [x] I have thoroughly tested my changes.
- [x] Also checked that the group-form still looks as i should 

---

Resolves ABA-706