### PR TITLE
Fix changing month of date selector in cypress

### DIFF
--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -61,7 +61,7 @@ export const setDatePickerDate = (name, date, isNextMonth = false) => {
   field(name).click();
 
   if (isNextMonth) {
-    cy.get('ion-icon[arrow-forward-outline]')
+    cy.get('ion-icon[name="arrow-forward-outline"]')
       .first()
       .should('not.be.disabled')
       .click();


### PR DESCRIPTION
# Description

There was a small error in the selector, causing cypress to not find the arrow for selecting next month in the date selector. It only attempts to switch month on the last day each month, which is why it started failing now.
This one: 
![Screenshot 2023-11-30 at 16 44 52](https://github.com/webkom/lego-webapp/assets/8343002/41803648-d3f8-47e0-a995-a67d8bb28079)

# Result

No more error!

# Testing

- [x] I have thoroughly tested my changes.

If cypress works on this PR it means i fixed it:)