### PR TITLE
Fix weird overflow on auth dropdown

### DIFF
--- a/app/components/AuthSection/AuthSection.css
+++ b/app/components/AuthSection/AuthSection.css
@@ -1,4 +1,13 @@
+.dot,
+.toggleButton {
+  font-size: var(--font-size-sm);
+}
+
 .toggleButton {
   color: var(--lego-link-color);
-  font-size: var(--font-size-sm);
+  padding: 0;
+
+  &:hover {
+    color: var(--lego-red-color-hover);
+  }
 }

--- a/app/components/AuthSection/AuthSection.tsx
+++ b/app/components/AuthSection/AuthSection.tsx
@@ -40,6 +40,8 @@ const AuthSection = () => {
   return (
     <>
       <Flex
+        wrap
+        gap="0.5rem"
         component="h2"
         justifyContent="space-between"
         alignItems="center"
@@ -50,21 +52,21 @@ const AuthSection = () => {
       >
         {title}
         {authMode === AuthMode.LOGIN ? (
-          <div>
+          <Flex gap="0.5rem">
             <button
               onClick={createModeSelector(AuthMode.FORGOT_PASSWORD)}
               className={styles.toggleButton}
             >
               Glemt passord
             </button>
-            <span className={styles.toggleButton}>&bull;</span>
+            <span className={styles.dot}>&bull;</span>
             <button
               onClick={createModeSelector(AuthMode.REGISTER)}
               className={styles.toggleButton}
             >
               Jeg er ny
             </button>
-          </div>
+          </Flex>
         ) : (
           <button
             onClick={createModeSelector(AuthMode.LOGIN)}


### PR DESCRIPTION
# Description

Issue described in https://github.com/webkom/lego/issues/3532

Also improve some minor styling.

# Result

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	<tr>
		<td>
			<img width="401" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/9477ccb1-5fca-4969-8e02-8890b73100bf">
</td>
		<td>
			<img width="401" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/1585bc6e-81fe-41ce-811b-b1af2e75dc6f">
		</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

The components now wrap as they should.

---

Resolves https://github.com/webkom/lego/issues/3532