### PR TITLE
Fix debounce on search

### DIFF
--- a/app/actions/SearchActions.ts
+++ b/app/actions/SearchActions.ts
@@ -2,15 +2,13 @@ import { createAction } from '@reduxjs/toolkit';
 import callAPI from 'app/actions/callAPI';
 import { selectAutocomplete } from 'app/reducers/search';
 import { Search } from './ActionTypes';
+import type { AppDispatch } from 'app/store/createStore';
 import type { Thunk } from 'app/types';
 
 export const toggleSearch = createAction(Search.TOGGLE_OPEN);
 
-export function autocomplete(
-  query: string,
-  filter?: Array<string>
-): Thunk<Promise<Array<any>>> {
-  return (dispatch) => {
+export function autocomplete(query: string, filter?: Array<string>) {
+  return (dispatch: AppDispatch) => {
     if (!query) {
       return Promise.resolve([]);
     }

--- a/app/components/Search/index.tsx
+++ b/app/components/Search/index.tsx
@@ -1,5 +1,5 @@
 import { debounce } from 'lodash';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { push } from 'redux-first-history';
 import { autocomplete, toggleSearch } from 'app/actions/SearchActions';
 import { selectIsLoggedIn } from 'app/reducers/auth';
@@ -20,6 +20,11 @@ const Search = () => {
   const allowed = useAppSelector((state) => state.allowed);
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(-1);
+
+  const debouncedAutoComplete = useMemo(
+    () => debounce((query) => dispatch(autocomplete(query)), 300),
+    [dispatch]
+  );
 
   const onCloseSearch = () => dispatch(toggleSearch());
 
@@ -51,10 +56,10 @@ const Search = () => {
     }
   };
 
-  const onQueryChanged = debounce((query) => {
+  const onQueryChanged = (query) => {
     setQuery(query);
-    dispatch(autocomplete(query));
-  }, 300);
+    debouncedAutoComplete(query);
+  };
 
   const regularLinks = getRegularLinks({
     allowed,


### PR DESCRIPTION
# Description

The searchbar was slow, as in it only registered characters once you stopped typing

Fixed by wrapping the debounce-logic outside `setQuery`

The debounce-function also has to be memoized (`useCallback`), otherwise it will loose track of the previous callback

> I checked the [`useDispatch`-documentation](https://react-redux.js.org/api/hooks#usedispatch) and they say it is fine to not pass `dispatch` as a dependency to the memoized function the way we implement it:))

# Result

You can now search on things

# Testing

- [x] I have thoroughly tested my changes.
- [x] Typed tons of characters which updates the field AND made sure the event only fires when you stop typing

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-771
