### PR TITLE
Fix incorrect tooltip for reactions

### DIFF
--- a/app/components/LegoReactions/index.tsx
+++ b/app/components/LegoReactions/index.tsx
@@ -27,6 +27,7 @@ type Props = {
     reactions?: { author: { fullName: string }; emoji: string }[];
   };
   loggedIn: boolean;
+  showPeople?: boolean;
 };
 
 export type EmojiWithReactionData = Emoji & {
@@ -44,6 +45,7 @@ const LegoReactions = (props: Props) => {
     fetchingEmojis,
     parentEntity,
     loggedIn,
+    showPeople,
   } = props;
   let mappedEmojis: EmojiWithReactionData[] = [];
 
@@ -100,6 +102,7 @@ const LegoReactions = (props: Props) => {
             addReaction={addReaction}
             deleteReaction={deleteReaction}
             contentTarget={parentEntity.contentTarget}
+            showPeople={showPeople}
           />
         );
       })}

--- a/app/components/Reactions/Reaction.tsx
+++ b/app/components/Reactions/Reaction.tsx
@@ -28,6 +28,7 @@ type Props = {
   canReact: boolean;
   reactionId: ID;
   contentTarget: ContentTarget;
+  showPeople?: boolean;
 };
 // Note: Most use cases won't want to use this class directly. Instead, use
 // app/components/LegoReactions.
@@ -45,6 +46,7 @@ const Reaction = ({
   canReact,
   reactionId,
   contentTarget,
+  showPeople,
 }: Props) => {
   const classes = [
     className ? className : styles.reaction,
@@ -60,7 +62,7 @@ const Reaction = ({
   }
 
   let tooltipContent = '';
-  if (users && users.length > 0) {
+  if (showPeople && users && users.length > 0) {
     tooltipContent += users
       .filter((user) => user)
       .map((user) => user.fullName)

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -257,6 +257,7 @@ const MeetingDetails = ({
                   deleteReaction={deleteReaction}
                   parentEntity={meeting}
                   loggedIn={loggedIn}
+                  showPeople={true}
                 />
               </div>
               <CommentView

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -257,7 +257,7 @@ const MeetingDetails = ({
                   deleteReaction={deleteReaction}
                   parentEntity={meeting}
                   loggedIn={loggedIn}
-                  showPeople={true}
+                  showPeople
                 />
               </div>
               <CommentView


### PR DESCRIPTION
# Description

Fixes tooltip on reactions showing that "<Your name> reagerte med <emoji>" when reacting with an emoji on articles and quotes.

# Testing

- [x] I have thoroughly tested my changes.


Resolves [#ABA709](https://linear.app/abakus-webkom/issue/ABA-709/fix-incorrect-reaction-tooltip-label)
