### PR TITLE
Fix pagination loading endlessly when there's nothing left to load

### DIFF
--- a/app/actions/callAPI.ts
+++ b/app/actions/callAPI.ts
@@ -177,12 +177,9 @@ export default function callAPI<
       }
 
       const payload = 'results' in jsonData ? jsonData.results : jsonData;
-      const next =
-        'next' in jsonData && jsonData.next ? jsonData.next : undefined;
+      const next = 'next' in jsonData && jsonData.next ? jsonData.next : null;
       const previous =
-        'previous' in jsonData && jsonData.previous
-          ? jsonData.previous
-          : undefined;
+        'previous' in jsonData && jsonData.previous ? jsonData.previous : null;
       const actionGrant = jsonData.actionGrant;
 
       if (schema) {


### PR DESCRIPTION
# Description

The pagination would load endlessly when there's nothing left to load. Can for example be encountered [when searching for an email that doesn't exist](https://abakus.no/admin/email/users?enabled=true&userFullname=test)

# Result

It is fixed

# Testing

- [X] I have thoroughly tested my changes.

Resolves ABA-725
