### PR TITLE
Fix event filter overflow

### DIFF
--- a/app/routes/events/components/EventList.css
+++ b/app/routes/events/components/EventList.css
@@ -28,10 +28,12 @@
 
 .filter {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
   margin-bottom: -36px;
   margin-right: -2px;
+  gap: 0.5rem;
 
   @media (--mobile-device) {
     margin-bottom: 0;

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, LoadingIndicator } from '@webkom/lego-bricks';
+import { Button, Flex, Icon, LoadingIndicator } from '@webkom/lego-bricks';
 import { isEmpty, orderBy } from 'lodash';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
@@ -219,25 +219,27 @@ const EventList = ({
             onChange={toggleEventType('other')}
           />
         </div>
-        <Icon
-          name="funnel-outline"
-          size={25}
-          style={{
-            marginRight: '5px',
-            marginLeft: '10px',
-          }}
-        />
-        <SelectInput
-          name="form-field-name"
-          value={regDateFilter}
-          onChange={(selectedOption) =>
-            selectedOption &&
-            setQueryValue('registrations')(selectedOption.value)
-          }
-          className={styles.select}
-          options={filterRegDateOptions}
-          isClearable={false}
-        />
+        <Flex alignItems="center">
+          <Icon
+            name="funnel-outline"
+            size={25}
+            style={{
+              marginRight: '5px',
+              marginLeft: '10px',
+            }}
+          />
+          <SelectInput
+            name="form-field-name"
+            value={regDateFilter}
+            onChange={(selectedOption) =>
+              selectedOption &&
+              setQueryValue('registrations')(selectedOption.value)
+            }
+            className={styles.select}
+            options={filterRegDateOptions}
+            isClearable={false}
+          />
+        </Flex>
       </div>
       <EventListGroup
         name="Denne uken"


### PR DESCRIPTION
# Description

Fixes event filter overflow under `/events`

# Result

**before**
![image](https://github.com/webkom/lego-webapp/assets/66320400/0d370c92-9c30-43ff-abee-f4f3d139a79b)

![image](https://github.com/webkom/lego-webapp/assets/66320400/19c77206-5e57-4bb0-b094-0141c3e7d9eb)


**after**
![image](https://github.com/webkom/lego-webapp/assets/66320400/e805648f-4e49-4ef0-a49c-770d8bf0f172)

![image](https://github.com/webkom/lego-webapp/assets/66320400/45b0f9db-c1c5-4586-a4ba-de33a9f74e68)


# Testing

- [X] I have thoroughly tested my changes.

Works on both mobile and desktop

---

Resolves ABA-726
