### PR TITLE
Validate allergies in user registration form

### DIFF
--- a/app/routes/users/components/UserConfirmation.tsx
+++ b/app/routes/users/components/UserConfirmation.tsx
@@ -24,7 +24,12 @@ import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { userSchema } from 'app/reducers';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { spyValues } from 'app/utils/formSpyUtils';
-import { createValidator, required, sameAs } from 'app/utils/validation';
+import {
+  createValidator,
+  isValidAllergy,
+  required,
+  sameAs,
+} from 'app/utils/validation';
 import { validPassword } from '../utils';
 import PasswordField from './PasswordField';
 
@@ -203,6 +208,7 @@ const validate = createValidator(
     password: [required(), validPassword()],
     retypePassword: [required(), sameAs('password', 'Passordene er ikke like')],
     gender: [required()],
+    allergies: [isValidAllergy()],
   },
   undefined,
   true

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -160,7 +160,19 @@ export const isValidAllergy =
     message = 'La feltet stå tomt hvis du ikke har noen allergier/preferanser'
   ) =>
   (value: string) => {
-    const notValidAnswers = ['ingen', 'ingenting', 'nei', 'nope', 'nada'];
+    const notValidAnswers = [
+      'ingen',
+      'ingenting',
+      'nei',
+      'no',
+      'nope',
+      'none',
+      'n/a',
+      'null',
+      'nada',
+      'indøk',
+      'matte 4',
+    ];
 
     return [!notValidAnswers.includes(value.toLowerCase()), message] as const;
   };


### PR DESCRIPTION
# Description

We actually had 4 users with one of the "invalid" allergies, which I have now removed. But while snooting around I also found a bunch of other bad allergies, so I added those to the list 

# Result

<img width="459" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/4e162ec9-40c4-4b0e-a2cf-0451a2e4157f">

# Testing

- [x] I have thoroughly tested my changes.

See image above.