### PR TITLE
Allow non-logged in users to view interest group details

### DIFF
--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -22,6 +22,7 @@ import UserGrid from 'app/components/UserGrid';
 import { selectCurrentUser } from 'app/reducers/auth';
 import { selectGroup } from 'app/reducers/groups';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
+import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './InterestGroup.css';
 import InterestGroupMemberList from './InterestGroupMemberList';
@@ -120,11 +121,14 @@ const InterestGroupDetail = () => {
   const memberships = useAppSelector((state) =>
     selectMembershipsForGroup(state, { groupId })
   );
+
   const group = { ...selectedGroup, memberships };
   const canEdit = group.actionGrant?.includes('edit');
   const logo = group.logo || 'https://i.imgur.com/Is9VKjb.jpg';
 
   const dispatch = useAppDispatch();
+
+  const { loggedIn } = useUserContext();
 
   usePreparedEffect(
     'fetchInterestGroupDetail',
@@ -132,9 +136,9 @@ const InterestGroupDetail = () => {
       groupId &&
       Promise.resolve([
         dispatch(fetchGroup(groupId)),
-        dispatch(fetchAllMemberships(groupId)),
+        loggedIn && dispatch(fetchAllMemberships(groupId)),
       ]),
-    []
+    [loggedIn]
   );
 
   return (
@@ -151,8 +155,9 @@ const InterestGroupDetail = () => {
         <ContentMain>
           <p>{group.description}</p>
           <DisplayContent content={group.text} />
-          <ButtonRow group={group} />
+          {loggedIn && <ButtonRow group={group} />}
         </ContentMain>
+
         <ContentSidebar>
           <Image
             alt={`${group.name} logo`}
@@ -160,17 +165,23 @@ const InterestGroupDetail = () => {
             src={logo}
             placeholder={group.logoPlaceholder}
           />
-          <Members group={group} members={group.memberships} />
-          <Contact group={group} />
+          {group.memberships.length > 0 && (
+            <>
+              <Members group={group} members={group.memberships} />
+              <Contact group={group} />
+            </>
+          )}
 
-          <h3>Admin</h3>
           {canEdit && (
-            <Link to={`/interest-groups/${group.id}/edit`}>
-              <Button>
-                <Icon name="create-outline" size={19} />
-                Rediger
-              </Button>
-            </Link>
+            <>
+              <h3>Admin</h3>
+              <Link to={`/interest-groups/${group.id}/edit`}>
+                <Button>
+                  <Icon name="create-outline" size={19} />
+                  Rediger
+                </Button>
+              </Link>
+            </>
           )}
 
           <AnnouncementInLine group={group} />


### PR DESCRIPTION
# Description

Page will not crash on load, and it looks like it should.

This is not actually related to the react-router v6 migration, as this is actually a bug in prod as well.

# Result

Technically the user would only see the second before photo for half a second, but this illustrates the changes made - such as the "Admin" header always being shown to the user despite not being an admin at all ..

<table>
	<tr>
		 <td>Before</td>
		 <td>After</td>
	<tr>
	 <td>
		<img width="1182" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/b2169cfb-e05a-4d1b-9cd6-031f43d6ab1c">
	</td>
	 <td>
		<img width="1182" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/dabdf63d-439b-4760-b6db-2e5c27c45d3e">
	</td>
   </tr>
   <tr>
	 <td>
		<img width="1182" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/430b3826-8c00-4969-a02a-a35c77159481">
	</td>
	 <td>
		<img width="1182" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/dabdf63d-439b-4760-b6db-2e5c27c45d3e">
	</td>
	<tr>
</table>		

# Testing

- [x] I have thoroughly tested my changes.

See images above.

---

Related to ABA-744