### PR TITLE
Display sections with group members in sidebar

### DIFF
--- a/app/routes/pages/components/PageDetail.tsx
+++ b/app/routes/pages/components/PageDetail.tsx
@@ -241,18 +241,17 @@ const loadData = async (
   const { fetchItemActions } = getSection(sectionName);
 
   // Only handle flatpages and groups when user isn't authenticated
+  let actionsToDispatch = fetchItemActions;
   if (!loggedIn) {
-    const actionsToDispatch = fetchItemActions
-      .filter((action) => !action.toString().includes('fetchAllMemberships'))
-      .map((action) => dispatch(action(pageSlug)));
-
-    return Promise.all([...actionsToDispatch, dispatch(fetchAllPages())]);
+    actionsToDispatch = fetchItemActions.filter(
+      (action) => !action.toString().includes('fetchAllMemberships')
+    );
   }
 
   const itemActions: (typeof dispatch)[] = [];
 
-  for (let i = 0; i < fetchItemActions.length; i++) {
-    itemActions[i] = await dispatch(fetchItemActions[i](pageSlug));
+  for (let i = 0; i < actionsToDispatch.length; i++) {
+    itemActions[i] = await dispatch(actionsToDispatch[i](pageSlug));
   }
 
   // Avoid dispatching duplicate actions


### PR DESCRIPTION
# Description

styrer, komiteer and revy are now shown in the sidebar for non-authenticated users.

# Result

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td>
<img width="269" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/1e4d07d0-5d17-40b8-8202-898adeaad0e9">

 <td>
<img width="262" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/7d6ed3c3-157a-44de-b5bc-7aa8bca95072">


</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-745
