### PR TITLE
Optimistically update reactions

### DIFF
--- a/app/components/LegoReactions/index.tsx
+++ b/app/components/LegoReactions/index.tsx
@@ -1,7 +1,6 @@
 import Reactions from 'app/components/Reactions';
 import Reaction from 'app/components/Reactions/Reaction';
 import { selectEmojis } from 'app/reducers/emojis';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppSelector } from 'app/store/hooks';
 import type { ID } from 'app/store/models';
 import type Emoji from 'app/store/models/Emoji';
@@ -25,7 +24,6 @@ export type EmojiWithReactionData = Emoji & {
 const LegoReactions = ({ parentEntity, showPeople }: Props) => {
   const emojis = useAppSelector(selectEmojis);
   const fetchingEmojis = useAppSelector((state) => state.emojis.fetching);
-  const { loggedIn } = useUserContext();
 
   let mappedEmojis: EmojiWithReactionData[] = [];
 
@@ -57,27 +55,15 @@ const LegoReactions = ({ parentEntity, showPeople }: Props) => {
   }
 
   return (
-    <Reactions
-      emojis={mappedEmojis}
-      contentTarget={parentEntity.contentTarget}
-      loggedIn={loggedIn}
-    >
-      {parentEntity.reactionsGrouped?.map((reaction) => {
-        return (
-          <Reaction
-            key={`reaction-${reaction.emoji}`}
-            emoji={reaction.emoji}
-            count={reaction.count}
-            users={usersByReaction[reaction.emoji]}
-            unicodeString={reaction.unicodeString}
-            reactionId={reaction.reactionId}
-            hasReacted={reaction.hasReacted}
-            canReact={loggedIn}
-            contentTarget={parentEntity.contentTarget}
-            showPeople={showPeople}
-          />
-        );
-      })}
+    <Reactions emojis={mappedEmojis} contentTarget={parentEntity.contentTarget}>
+      {parentEntity.reactionsGrouped?.map((reaction) => (
+        <Reaction
+          key={`reaction-${reaction.emoji}`}
+          reaction={{ ...reaction, users: usersByReaction[reaction.emoji] }}
+          contentTarget={parentEntity.contentTarget}
+          showPeople={showPeople}
+        />
+      ))}
     </Reactions>
   );
 };

--- a/app/components/Reactions/Reaction.css
+++ b/app/components/Reactions/Reaction.css
@@ -2,6 +2,7 @@
   position: relative;
   height: 29px;
   width: 54px;
+  user-select: none;
   border-radius: var(--border-radius-lg);
   background-color: var(--additive-background);
   border: 0 solid var(--color-red-4);

--- a/app/components/Reactions/Reaction.tsx
+++ b/app/components/Reactions/Reaction.tsx
@@ -1,67 +1,76 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { useCallback } from 'react';
 import { addReaction, deleteReaction } from 'app/actions/ReactionActions';
 import Emoji from 'app/components/Emoji';
 import Tooltip from 'app/components/Tooltip';
 import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch } from 'app/store/hooks';
 import styles from './Reaction.css';
-import type { ID } from 'app/store/models';
+import type { ReactionsGrouped } from 'app/store/models/Reaction';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 type Props = {
   className?: string;
-  emoji: string;
-  count: number;
-  users?: { fullName: string }[];
-  unicodeString: string;
-  hasReacted: boolean;
-  canReact: boolean;
-  reactionId?: ID;
+  reaction: ReactionsGrouped;
   contentTarget: ContentTarget;
   showPeople?: boolean;
 };
-// Note: Most use cases won't want to use this class directly. Instead, use
-// app/components/LegoReactions.
 
+/**
+ *  Note: Most use cases won't want to use this class directly. Instead, use
+ *  app/components/LegoReactions.
+ */
 const Reaction = ({
   className,
-  emoji,
-  count,
-  users,
-  unicodeString,
-  hasReacted,
-  canReact,
-  reactionId,
+  reaction,
   contentTarget,
   showPeople,
 }: Props) => {
+  const { emoji, count, unicodeString, hasReacted, reactionId, users } =
+    reaction;
+
   const dispatch = useAppDispatch();
 
-  const { currentUser } = useUserContext();
+  const { currentUser, loggedIn } = useUserContext();
+  const canReact = loggedIn;
 
-  const classes = [
-    className ? className : styles.reaction,
-    canReact && styles.clickable,
-  ];
+  const classNames = cx({
+    [className || styles.reaction]: true,
+    [styles.clickable]: canReact,
+    [styles.reacted]: hasReacted,
+  });
 
-  if (hasReacted) {
-    classes.push(styles.reacted);
-  }
+  const handleReaction = useCallback(() => {
+    if (!canReact) {
+      return;
+    }
+
+    if (hasReacted) {
+      dispatch(deleteReaction({ reactionId, contentTarget }));
+    } else {
+      dispatch(
+        addReaction({ emoji, user: currentUser, contentTarget, unicodeString })
+      );
+    }
+  }, [
+    canReact,
+    hasReacted,
+    dispatch,
+    reactionId,
+    contentTarget,
+    emoji,
+    currentUser,
+    unicodeString,
+  ]);
 
   if (count === 0) {
     return <></>;
   }
 
-  let tooltipContent = '';
-  if (showPeople && users && users.length > 0) {
-    tooltipContent += users
-      .filter((user) => user)
-      .map((user) => user.fullName)
-      .join(', ');
-    tooltipContent += ' reagerte med ';
-  }
-
+  let tooltipContent =
+    showPeople && users?.map((user) => user.fullName).join(', ');
+  tooltipContent = tooltipContent ? `${tooltipContent} reagerte med ` : '';
   tooltipContent += emoji;
 
   return (
@@ -71,27 +80,8 @@ const Reaction = ({
           gap={4}
           justifyContent="center"
           alignItems="center"
-          className={cx(classes)}
-          onClick={
-            canReact
-              ? () =>
-                  hasReacted
-                    ? dispatch(
-                        deleteReaction({
-                          reactionId,
-                          contentTarget: contentTarget,
-                        })
-                      )
-                    : dispatch(
-                        addReaction({
-                          emoji,
-                          user: currentUser,
-                          contentTarget,
-                          unicodeString,
-                        })
-                      )
-              : undefined
-          }
+          className={classNames}
+          onClick={handleReaction}
         >
           <div>
             <Emoji unicodeString={unicodeString} />

--- a/app/components/Reactions/index.tsx
+++ b/app/components/Reactions/index.tsx
@@ -2,6 +2,7 @@ import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchEmojis } from 'app/actions/EmojiActions';
+import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch } from 'app/store/hooks';
 import reactionStyles from './Reaction.css';
 import ReactionPicker from './ReactionPicker';
@@ -16,23 +17,19 @@ type Props = {
   className?: string;
   emojis: EmojiWithReactionData[];
   contentTarget: ContentTarget;
-  loggedIn: boolean;
 };
 
-// Note: Most use cases won't want to use this class directly. Instead, use
-// app/components/LegoReactions.
-
-const Reactions = ({
-  children,
-  className,
-  emojis,
-  contentTarget,
-  loggedIn,
-}: Props) => {
+/**
+ *  Note: Most use cases won't want to use this class directly. Instead, use
+ *  app/components/LegoReactions.
+ */
+const Reactions = ({ children, className, emojis, contentTarget }: Props) => {
   const [reactionPickerOpen, setReactionPickerOpen] = useState(false);
   const [addEmojiHovered, setAddEmojiHovered] = useState(false);
   const [fetchedEmojis, setFetchedEmojis] = useState(false);
   const nodeRef = useRef<HTMLDivElement>(null);
+
+  const { loggedIn } = useUserContext();
 
   const dispatch = useAppDispatch();
 

--- a/app/routes/quotes/components/Quote.tsx
+++ b/app/routes/quotes/components/Quote.tsx
@@ -18,7 +18,6 @@ type Props = {
   actionGrant: ActionGrant;
   toggleDisplayAdmin: () => void;
   displayAdmin: boolean;
-  loggedIn: boolean;
 };
 
 const Quote = ({
@@ -26,7 +25,6 @@ const Quote = ({
   actionGrant,
   toggleDisplayAdmin,
   displayAdmin,
-  loggedIn,
 }: Props) => {
   const emojis = useAppSelector(selectEmojis);
   const fetchingEmojis = useAppSelector((state) => state.emojis.fetching);
@@ -136,25 +134,14 @@ const Quote = ({
         </div>
       </div>
       <div className={styles.quoteReactions}>
-        <Reactions
-          emojis={mappedEmojis}
-          contentTarget={quote.contentTarget}
-          loggedIn={loggedIn}
-        >
-          {quote.reactionsGrouped.map((reaction) => {
-            return (
-              <Reaction
-                key={`reaction-${reaction.emoji}`}
-                emoji={reaction.emoji}
-                count={reaction.count}
-                unicodeString={reaction.unicodeString}
-                reactionId={reaction.reactionId}
-                hasReacted={reaction.hasReacted}
-                canReact={loggedIn}
-                contentTarget={quote.contentTarget}
-              />
-            );
-          })}
+        <Reactions emojis={mappedEmojis} contentTarget={quote.contentTarget}>
+          {quote.reactionsGrouped.map((reaction) => (
+            <Reaction
+              key={`reaction-${reaction.emoji}`}
+              reaction={reaction}
+              contentTarget={quote.contentTarget}
+            />
+          ))}
         </Reactions>
       </div>
     </li>

--- a/app/routes/quotes/components/QuoteList.tsx
+++ b/app/routes/quotes/components/QuoteList.tsx
@@ -7,10 +7,9 @@ import type QuoteType from 'app/store/models/Quote';
 type Props = {
   quotes: QuoteType[];
   actionGrant: ActionGrant;
-  loggedIn: boolean;
 };
 
-const QuoteList = ({ quotes, actionGrant, loggedIn }: Props) => {
+const QuoteList = ({ quotes, actionGrant }: Props) => {
   const [displayAdminId, setDisplayAdminId] = useState<ID>();
 
   return (
@@ -26,7 +25,6 @@ const QuoteList = ({ quotes, actionGrant, loggedIn }: Props) => {
             )
           }
           displayAdmin={quote.id === displayAdminId}
-          loggedIn={loggedIn}
         />
       ))}
     </ul>

--- a/app/routes/quotes/components/QuotePage.tsx
+++ b/app/routes/quotes/components/QuotePage.tsx
@@ -6,7 +6,6 @@ import { useParams } from 'react-router-dom';
 import { fetchEmojis } from 'app/actions/EmojiActions';
 import { fetchAll, fetchQuote } from 'app/actions/QuoteActions';
 import { SelectInput } from 'app/components/Form';
-import { selectIsLoggedIn } from 'app/reducers/auth';
 import { selectQuoteById, selectQuotes } from 'app/reducers/quotes';
 import { selectPaginationNext } from 'app/reducers/selectors';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
@@ -38,9 +37,6 @@ const defaultQuotesQuery = {
 };
 
 const QuotePage = () => {
-  const dispatch = useAppDispatch();
-  const loggedIn = useAppSelector(selectIsLoggedIn);
-
   const { quoteId } = useParams();
   const isSingle = !!quoteId;
 
@@ -75,6 +71,8 @@ const QuotePage = () => {
     (option) => option.value === query.ordering
   );
 
+  const dispatch = useAppDispatch();
+
   usePreparedEffect(
     'fetchQuotePage',
     () =>
@@ -105,13 +103,7 @@ const QuotePage = () => {
         </div>
       )}
 
-      {errorMessage || (
-        <QuoteList
-          actionGrant={actionGrant}
-          quotes={quotes}
-          loggedIn={loggedIn}
-        />
-      )}
+      {errorMessage || <QuoteList actionGrant={actionGrant} quotes={quotes} />}
 
       {showFetchMore && (
         <LoadingIndicator loading={fetching}>

--- a/app/store/models/Reaction.d.ts
+++ b/app/store/models/Reaction.d.ts
@@ -1,4 +1,5 @@
 import type { ID } from 'app/store/models';
+import type { PublicUser } from 'app/store/users/User';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export default interface Reaction {
@@ -15,5 +16,5 @@ export interface ReactionsGrouped {
   count: number;
   hasReacted: boolean;
   reactionId?: ID;
-  users?: string[];
+  users?: PublicUser[];
 }


### PR DESCRIPTION
# Description

This has been bugging me for a long time - having to wait for the promise to resolve each time I react to something. This is the normal way of doing it, but it's not foolproof since the state update itself is async as well. I guess we'll have to wait for `useOptimistic`.

# Result

**Before**
The gray screen is due to an uncaught error

https://github.com/webkom/lego-webapp/assets/69514187/5248e8c1-6322-4c84-9dbe-5336ce8be735


**After**

https://github.com/webkom/lego-webapp/assets/69514187/0588eb6f-722c-4e95-b4d3-d65cbc411718

# Testing

- [x] I have thoroughly tested my changes.

Reactions still work fine, both adding and removing. Also tested that users are still shown as expected on meetings.