### PR TITLE
Configure filtering to support multiselect

### DIFF
--- a/app/components/Table/BodyCell.tsx
+++ b/app/components/Table/BodyCell.tsx
@@ -1,16 +1,16 @@
 import { get } from 'lodash';
-import type { ColumnProps, ShowColumn } from '.';
+import type { ColumnProps, ShowColumn, TableData } from '.';
 
 type CellProps = {
   column: ColumnProps;
-  data: Record<string, any>;
+  data: TableData;
   index: number;
-  showColumn?: ShowColumn;
+  showColumn: ShowColumn;
 };
 
 const BodyCell: React.FC<CellProps> = ({ column, data, index, showColumn }) => {
   if (column.columnChoices) {
-    if (!showColumn) {
+    if (Object.keys(showColumn).length === 0) {
       return null;
     }
     const columnIndex: number = showColumn[column.dataIndex];

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -156,6 +156,9 @@ const GroupMembersList = ({
       title: 'Rolle',
       dataIndex: 'role',
       filter: roleOptions,
+      filterOptions: {
+        multiSelect: true,
+      },
       search: false,
       inlineFiltering: false,
       filterMapping: (role: RoleType) =>


### PR DESCRIPTION
# Description

Replacement PR for https://github.com/webkom/lego-webapp/pull/4257, which is now obsolete.

Add a `filterOptions` attribute to columns, where they can be set to allow selecting multiple elements in the filter.

All filters are handled as arrays to simplify the divide between the two functionalities.

It wasn't possible to de-select radio-items by clicking them again, so I changed that.

If you're testing this locally, note that https://github.com/webkom/lego/pull/3518 might not be in prod/staging yet - and if it isn't you need to run the backend locally to verify that it works for membership lists in groups.

# Result

## `filterOptions.multiSelect: true`

Before

https://github.com/webkom/lego-webapp/assets/13599770/229ec033-1092-4943-a140-b5bd7d524213

After

https://github.com/webkom/lego-webapp/assets/13599770/771016f0-dff8-4bbb-b088-741d001efc6c

## `filterOptions.multiSelect: false | undefined`

Before

https://github.com/webkom/lego-webapp/assets/13599770/8e251777-b1d9-493c-9118-48fdfe89febf

After

https://github.com/webkom/lego-webapp/assets/13599770/30d511ad-90ac-4b7f-956a-597d697ae5a6


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-366
