### PR TITLE
Fix group table being cleared after adding a new member

### DIFF
--- a/app/routes/admin/groups/components/AddGroupMember.tsx
+++ b/app/routes/admin/groups/components/AddGroupMember.tsx
@@ -1,10 +1,15 @@
 import { Field } from 'react-final-form';
-import { addMember } from 'app/actions/GroupActions';
+import {
+  addMember,
+  fetchMembershipsPagination,
+} from 'app/actions/GroupActions';
 import { Form, LegoFinalForm, SelectInput } from 'app/components/Form';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
+import { defaultGroupMembersQuery } from 'app/routes/admin/groups/components/GroupMembers';
 import { useAppDispatch } from 'app/store/hooks';
 import { roleOptions } from 'app/utils/constants';
+import useQuery from 'app/utils/useQuery';
 import { createValidator, required } from 'app/utils/validation';
 
 const validate = createValidator({
@@ -18,6 +23,7 @@ type Props = {
 
 const AddGroupMember = ({ groupId }: Props) => {
   const dispatch = useAppDispatch();
+  const { query } = useQuery(defaultGroupMembersQuery);
 
   const handleSubmit = (values, form) => {
     dispatch(
@@ -26,9 +32,19 @@ const AddGroupMember = ({ groupId }: Props) => {
         userId: values.user.id,
         role: values.role.value,
       })
-    ).then(() => {
-      form.reset();
-    });
+    )
+      .then(() =>
+        dispatch(
+          fetchMembershipsPagination({
+            groupId,
+            next: true,
+            query,
+          })
+        )
+      )
+      .then(() => {
+        form.reset();
+      });
   };
 
   return (


### PR DESCRIPTION
# Description

A bug was recently implemented where the table over all the members of a group under `/admin/groups` would be cleared after adding a new member. Only a hard refresh could fix that problem. This has now been fixed.

# Result

**before**
![Screencast from 2024-01-28 14-59-34.webm](https://github.com/webkom/lego-webapp/assets/66320400/68e36584-6832-4a97-8db1-8b69a42c28ef)

**after**
![Screencast from 2024-01-28 15-00-52.webm](https://github.com/webkom/lego-webapp/assets/66320400/ca49190e-3e8a-4712-a744-42a41b72e83c)

# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-751
