### PR TITLE
Fix text color for calendar entries on dark mode

### DIFF
--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -64,12 +64,12 @@ export const EventTypeConfig: Record<EventType, ConfigProperties> = {
   [EventType.KiD_EVENT]: {
     displayName: 'KiD-arrangement',
     color: 'var(--color-event-black)',
-    textColor: '#FFF',
+    textColor: 'var(--color-white)',
   },
   [EventType.OTHER]: {
     displayName: 'Annet',
     color: 'var(--color-event-black)',
-    textColor: '#FFF',
+    textColor: 'var(--color-white)',
   },
 };
 


### PR DESCRIPTION
# Description

Fix wrong text color for 'Annet' and 'Kid' calendar entries on dark mode.

# Result

**before**
![image](https://github.com/webkom/lego-webapp/assets/66320400/1fb0e062-0721-4282-9a9d-b1527cf7d5f1)

**after**
![image](https://github.com/webkom/lego-webapp/assets/66320400/11352b27-82e3-4e90-8d27-731b5e994a17)


# Testing

- [X] I have thoroughly tested my changes.
Works like normal on light mode

---


