### PR TITLE
Add padding-left to header

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -87,6 +87,7 @@
   align-items: center;
   flex-direction: row;
   height: var(--lego-header-height);
+  padding-left: 20px;
 
   @media (--mobile-device) {
     padding: 0 10px;


### PR DESCRIPTION
# Description

Resolve issue with screens between 940px and 1040px where the logo would not have any padding to the side of the screen

This lack of padding has been bugging me for a while so lets get it outta here

# Result

The logo is now indented by 20px on the left for big screens - which means it is flush with the events under instead of being 20px to the left

<table>
<tr>
 <td>
 <th>Before
 <th>After
<tr>
 <td>Width about 1000px
 <td>
<img width="1013" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/cdbda1ba-c386-4bd2-9f3d-c37d7557bb0c">
 <td>
<img width="1013" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/0ffd10b9-614e-4b73-bc18-897dd54ca238">

<tr>
 <td>Wider screens
 <td>
<img width="1275" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/e5026f15-df7c-4349-b17e-ffbffa93683f">
 <td>
<img width="1275" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/33a7b735-7278-473c-a4e6-8f9a9856e800">

<tr>
 <td>Smol screen
 <td>No changes
 <td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
