### PR TITLE
Filter seenQuotes to only allow numbers

### DIFF
--- a/app/components/RandomQuote/RandomQuote.tsx
+++ b/app/components/RandomQuote/RandomQuote.tsx
@@ -24,6 +24,8 @@ const RandomQuote = ({ dummyQuote, useReactions = true }: Props) => {
   useEffect(() => {
     const quoteId = randomQuote.id;
 
+    if (!quoteId) return;
+
     if (!seenQuotes.current.includes(quoteId)) {
       seenQuotes.current = [...seenQuotes.current, quoteId];
     }


### PR DESCRIPTION
# Description

It appears that https://github.com/webkom/lego-webapp/commit/b959dfb7ea094e7ba4d5601c5109c01ee3e48984 might have introduced a possible state where null/undefined values are loaded into the `seen` array that is passed to the backend - rendering arrays such as `[,254]` - which the backend very much does not like.

This should resolve that.

Errors can be found in sentry. Seemed to only affect a few people for some weird reason, so I couldn't reproduce - but this seems to fix it.

Could probably also be resolved with a
```
if (!quoteId) return;
```
but I don't have that big of a preference.

# Result

I tried inserting invalid values locally and they were stripped - so I'm assuming it works ™️ 

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Fixes LEGO-Q1, LEGO-2M