### PR TITLE
Check if allergies are undefined in validator

### DIFF
--- a/app/routes/users/components/UserConfirmation.tsx
+++ b/app/routes/users/components/UserConfirmation.tsx
@@ -217,6 +217,8 @@ const validate = createValidator(
     username: [required()],
     password: [required(), validPassword()],
     retypePassword: [required(), sameAs('password', 'Passordene er ikke like')],
+    firstName: [required()],
+    lastName: [required()],
     gender: [required()],
     allergies: [isValidAllergy()],
   },

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -155,11 +155,12 @@ export const mergeTimeAfterAllPoolsActivation =
     return [isAfterAll, message] as const;
   };
 
-export const isValidAllergy =
+export const isValidAllergy: Validator<string | undefined> =
   (
     message = 'La feltet stå tomt hvis du ikke har noen allergier/preferanser'
   ) =>
-  (value: string) => {
+  (value) => {
+    if (!value) return [true] as const;
     const notValidAnswers = [
       'ingen',
       'ingenting',


### PR DESCRIPTION
# Description

This error caused the validator on the register page to fail when the user did not provide an allergy (just like we want them to), making it impossible to register a new user.

Also added validators for first and last name, as they are required by the backend but weren't validated in the frontend.

# Result

The validator works

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-771
