### PR TITLE
Store registrations as undefined if user has no access

### DIFF
--- a/app/components/UserAttendance/AttendanceStatus.tsx
+++ b/app/components/UserAttendance/AttendanceStatus.tsx
@@ -1,7 +1,6 @@
 import { Button, Flex } from '@webkom/lego-bricks';
 import Tooltip from 'app/components/Tooltip';
 import AttendanceModal from 'app/components/UserAttendance/AttendanceModal';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import styles from './AttendanceStatus.css';
 import type { Pool } from './AttendanceModalContent';
 import type { AttendanceModalProps } from 'app/components/UserAttendance/AttendanceModal';
@@ -22,16 +21,14 @@ const AttendanceElement = ({
   index,
   toggleModal,
 }: AttendanceElementProps) => {
-  const { loggedIn } = useUserContext();
-
-  const totalCount = loggedIn ? registrations.length : registrationCount;
+  const totalCount = registrations ? registrations.length : registrationCount;
 
   return (
     <Flex className={styles.poolBox}>
       <strong>{name}</strong>
       <Button
         flat
-        disabled={!loggedIn}
+        disabled={!registrations}
         onClick={() => {
           if (registrations) {
             toggleModal(index);

--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -411,13 +411,15 @@ export const selectCommentsForEvent = createSelector(
 );
 export const selectRegistrationsFromPools = createSelector(
   selectPoolsWithRegistrationsForEvent,
-  (pools) =>
-    orderBy(
-      // $FlowFixMe
-      pools.flatMap((pool) => pool.registrations || []),
+  (pools) => {
+    const registrationPools = pools.filter((pool) => pool.registrations);
+    if (registrationPools.length === 0) return;
+    return orderBy(
+      registrationPools.flatMap((pool) => pool.registrations || []),
       'sharedMemberships',
       'desc'
-    )
+    );
+  }
 );
 export const getRegistrationGroups = createSelector(
   selectAllRegistrationsForEvent,

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -71,6 +71,7 @@ import type {
   AuthUserDetailedEvent,
   UserDetailedEvent,
 } from 'app/store/models/Event';
+import type { ReadRegistration } from 'app/store/models/Registration';
 
 type InterestedButtonProps = {
   isInterested: boolean;
@@ -178,8 +179,8 @@ const EventDetail = () => {
       ? selectMergedPoolWithRegistrations(state, { eventId })
       : selectPoolsWithRegistrationsForEvent(state, { eventId })
   );
-  const registrations = useAppSelector((state) =>
-    selectRegistrationsFromPools(state, { eventId })
+  const registrations: ReadRegistration[] | undefined = useAppSelector(
+    (state) => selectRegistrationsFromPools(state, { eventId })
   );
   const waitingRegistrations = useAppSelector((state) =>
     selectWaitingRegistrationsForEvent(state, { eventId })


### PR DESCRIPTION
# Description

It would seem we missed another bug in the react-router migration.

As can be seen in LEGO https://github.com/webkom/lego/blob/master/lego/apps/events/models.py#L131, it's not enough to be logged in to be able to see registrations, you have to be either a member of abakom, creator of the event, or the event has to be in the future and you are allowed to sign up.

This became a problem when using the hook - as the return value would never become `undefined`, just an empty array - which made it seem like the user had permission even though it didn't -> crash

First reported by ludde in slack, but now it's been reported to sentry by 214 times by 94 users in the last 7 days - so it's about time to get this out of here

# Result

I've tested it locally through the staging backend where I got to reproduce it by removing myself from abakom, and it seems to work.

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-773