### PR TITLE
Catch inviting groups you can't access members of

### DIFF
--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -123,7 +123,7 @@ export function joinGroup(groupId: ID, user: CurrentUser, role = 'member') {
         },
       })
     ).then(() => {
-      return dispatch(fetchMemberships(groupId));
+      return dispatch(fetchMemberships({ groupId }));
     });
 }
 
@@ -143,7 +143,7 @@ export function leaveGroup(membership: MembershipType, groupId: ID) {
         },
       })
     ).then(() => {
-      return dispatch(fetchMemberships(groupId));
+      return dispatch(fetchMemberships({ groupId }));
     });
   };
 }
@@ -163,16 +163,23 @@ export function fetchAllMemberships(groupId: ID, descendants = false) {
   };
 }
 
-export function fetchMemberships(
-  groupId: ID,
+export function fetchMemberships({
+  groupId,
   descendants = false,
-  query: Record<string, any> = {}
-) {
+  query = {},
+  propagateError = true,
+}: {
+  groupId: ID;
+  descendants?: boolean;
+  query?: Record<string, any>;
+  propagateError?: boolean;
+}) {
   return fetchMembershipsPagination({
     groupId,
     descendants,
     next: true,
     query,
+    propagateError,
   });
 }
 
@@ -181,11 +188,13 @@ export function fetchMembershipsPagination({
   next,
   descendants = false,
   query = {},
+  propagateError = true,
 }: {
   groupId: ID;
   next: boolean;
   descendants: boolean;
   query?: Record<string, string | number | boolean>;
+  propagateError?: boolean;
 }) {
   return callAPI<MembershipType[]>({
     types: Group.MEMBERSHIP_FETCH,
@@ -199,7 +208,7 @@ export function fetchMembershipsPagination({
       groupId: groupId,
       errorMessage: 'Henting av medlemmene for gruppen feilet',
     },
-    propagateError: true,
+    propagateError,
   });
 }
 

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -132,19 +132,28 @@ const MeetingEditor = () => {
   );
 
   const fetchAndSetGroupMembers = async (groupId: number) => {
-    dispatch(fetchMemberships(groupId)).then((res) => {
-      setFetchedGroupIds((prevIds) => [...prevIds, groupId]);
+    dispatch(fetchMemberships({ groupId, propagateError: false }))
+      .then((res) => {
+        setFetchedGroupIds((prevIds) => [...prevIds, groupId]);
 
-      const members = Object.values(res.payload.entities.users || {}).map(
-        (member) => ({
-          value: member.username,
-          label: member.fullName,
-          id: member.id,
-          groupId: groupId,
-        })
-      );
-      setInvitedGroupMembers((prevMembers) => [...prevMembers, ...members]);
-    });
+        const members = Object.values(res.payload.entities.users || {}).map(
+          (member) => ({
+            value: member.username,
+            label: member.fullName,
+            id: member.id,
+            groupId: groupId,
+          })
+        );
+        setInvitedGroupMembers((prevMembers) => [...prevMembers, ...members]);
+      })
+      .catch((error) => {
+        // Allow users to invite groups they can't see the members of
+        if (error?.payload?.response?.status === 403) {
+          setFetchedGroupIds((prevIds) => [...prevIds, groupId]);
+          return;
+        }
+        throw error;
+      });
   };
 
   const navigate = useNavigate();


### PR DESCRIPTION
# Description

The feature that preloads users to allow them to be used as secretary before creating the meeting is beautiful with sudo permissions, but it crashes the page with a 403 error if you want to invite a group you don't have permission to load the members of (typically a group you're not part of)

# Result

Works on staging after demoting myself. Now the little popup on the bottom left of the screen appears to inform the user that the members were not loaded, but that's all. If you invite some groups you're a member of and some you're not the functionality is still intact for the groups you have permission to access.

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-772
