### PR TITLE
Use "correct" label on grade checkboxes on joblistings page

### DIFF
--- a/app/routes/joblistings/components/JoblistingRightNav.tsx
+++ b/app/routes/joblistings/components/JoblistingRightNav.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { CheckBox, RadioButton } from 'app/components/Form/';
 import { useAppSelector } from 'app/store/hooks';
 import useQuery from 'app/utils/useQuery';
-import { jobTypes as allJobTypes } from '../constants';
+import { jobTypes as allJobTypes, yearValues } from '../constants';
 import { defaultJoblistingsQuery } from './JoblistingPage';
 import styles from './JoblistingRightNav.css';
 
@@ -76,11 +76,11 @@ const JoblistingsRightNav = () => {
         />
 
         <h3 className={styles.rightHeader}>Klassetrinn</h3>
-        {['1', '2', '3', '4', '5'].map((element) => (
+        {yearValues.map((year) => (
           <FilterCheckbox
-            key={element}
-            value={element}
-            label={element}
+            key={year.value}
+            value={String(year.value)}
+            label={year.label}
             activeFilters={grades}
             onChange={setQueryValue('grades')}
           />

--- a/app/routes/joblistings/constants.ts
+++ b/app/routes/joblistings/constants.ts
@@ -100,6 +100,7 @@ export const places = [
     value: 'Kongsvinger',
   },
 ];
+
 export const jobTypes = [
   {
     label: 'Sommerjobb',
@@ -122,6 +123,7 @@ export const jobTypes = [
     value: 'other',
   },
 ];
+
 export const yearValues = [
   {
     value: 1,


### PR DESCRIPTION
# Description

Not sure why this stopped working? Or how it ever worked before

# Result

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="212" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/d4671c74-11d8-498d-b917-46564f7692e7">
        </td>
        <td>    
			<img width="212" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/5846fb38-db06-4d1c-a262-38a9d5c49b1d">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Filtering still works like before.