### PR TITLE
Standardize a success color

### DIFF
--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -30,7 +30,7 @@ const eventStatusObject = (event: ListEvent): statusIconProps => {
         return {
           status: 'Admitted',
           icon: 'checkmark-circle-outline',
-          color: 'var(--color-green-6)',
+          color: 'var(--success-color)',
           tooltip: 'Du er påmeldt',
         } as statusIconProps;
       }

--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -113,3 +113,7 @@
     pointer-events: none;
   }
 }
+
+.success {
+  color: var(--success-color);
+}

--- a/app/components/Poll/index.tsx
+++ b/app/components/Poll/index.tsx
@@ -123,9 +123,7 @@ const Poll = ({
             <Icon
               name="checkmark-circle-outline"
               size={20}
-              style={{
-                color: 'var(--color-green-6)',
-              }}
+              className={styles.success}
             />
           </Flex>
         )}

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -48,7 +48,7 @@
 }
 
 .dragAccept .placeholderContainer {
-  border: 3px dashed var(--color-green-6);
+  border: 3px dashed var(--success-color);
 }
 
 .dragReject .placeholderContainer {

--- a/app/routes/bdb/utils.tsx
+++ b/app/routes/bdb/utils.tsx
@@ -25,7 +25,7 @@ export const NonEventContactStatusConfig: Record<
   },
   [NonEventContactStatus.INTERESTED]: {
     displayName: 'Interessert',
-    color: 'var(--color-green-6)',
+    color: 'var(--success-color)',
     textColor: '#000',
   },
   [NonEventContactStatus.NOT_INTERESTED]: {

--- a/app/routes/events/components/EventAdministrate/Administrate.css
+++ b/app/routes/events/components/EventAdministrate/Administrate.css
@@ -64,7 +64,7 @@
 
 .greenIcon {
   font-size: 1.4em;
-  color: var(--color-green-6);
+  color: var(--success-color);
 
   &:hover {
     color: var(--color-green-7);

--- a/app/routes/events/components/Stripe.css
+++ b/app/routes/events/components/Stripe.css
@@ -43,7 +43,7 @@
 }
 
 .success {
-  background: var(--color-green-6);
+  background: var(--success-color);
   color: var(--color-absolute-white);
   text-align: center;
   padding: 5px 10px;

--- a/app/routes/photos/components/Overview.css
+++ b/app/routes/photos/components/Overview.css
@@ -55,7 +55,7 @@
 }
 
 .iconSelected {
-  color: var(--color-green-6);
+  color: var(--success-color);
 }
 
 .createState {

--- a/app/routes/polls/components/PollsList.css
+++ b/app/routes/polls/components/PollsList.css
@@ -22,3 +22,7 @@
 .heading {
   margin-left: 15px;
 }
+
+.success {
+  color: var(--success-color);
+}

--- a/app/routes/polls/components/PollsList.tsx
+++ b/app/routes/polls/components/PollsList.tsx
@@ -72,9 +72,7 @@ const PollsList = () => {
                         <Icon
                           name="checkmark-circle-outline"
                           size={20}
-                          style={{
-                            color: 'var(--color-green-6)',
-                          }}
+                          className={styles.success}
                         />
                       </>
                     ) : (

--- a/app/routes/users/components/Penalties.css
+++ b/app/routes/users/components/Penalties.css
@@ -26,7 +26,7 @@
 }
 
 .success {
-  color: var(--color-green-6);
+  color: var(--success-color);
 }
 
 .successMessage {

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -15,7 +15,9 @@
   --lego-red-color: var(--color-red-5);
   --lego-red-color-hover: var(--color-red-6);
   --lego-link-color: var(--lego-red-color);
+
   --danger-color: var(--color-red-6);
+  --success-color: var(--color-green-6);
 
   --lego-max-width: 1100px;
   --lego-default-padding: 2rem;
@@ -146,6 +148,8 @@
   --secondary-font-color: #aaa;
 
   --lego-red-color: var(--color-red-7);
+
+  --success-color: var(--color-green-5);
 
   --color-event-black: #ddd;
   --color-white: #181818;

--- a/packages/lego-bricks/src/components/Button/Button.module.css
+++ b/packages/lego-bricks/src/components/Button/Button.module.css
@@ -21,7 +21,7 @@
 
   --button-success-background: var(--color-green-4);
   --button-success-background-hover: var(--color-green-5);
-  --button-success-background-active: var(--color-green-6);
+  --button-success-background-active: var(--success-color);
   --button-success-box-shadow-focus: #2da44e44;
 }
 

--- a/packages/lego-bricks/src/components/Icon/Icon.module.css
+++ b/packages/lego-bricks/src/components/Icon/Icon.module.css
@@ -53,7 +53,7 @@
 
 .success {
   composes: clickable;
-  color: var(--color-green-6);
+  color: var(--success-color);
 
   &:hover,
   &:focus-visible {

--- a/packages/lego-bricks/src/variables.css
+++ b/packages/lego-bricks/src/variables.css
@@ -15,7 +15,9 @@
   --lego-red-color: var(--color-red-5);
   --lego-red-color-hover: var(--color-red-6);
   --lego-link-color: var(--lego-red-color);
+
   --danger-color: var(--color-red-6);
+  --success-color: var(--color-green-6);
 
   --lego-max-width: 1100px;
   --lego-default-padding: 2rem;
@@ -145,6 +147,8 @@
   --secondary-font-color: #aaa;
 
   --lego-red-color: var(--color-red-7);
+
+  --success-color: var(--color-green-5);
 
   --color-event-black: #ddd;
   --color-white: #181818;


### PR DESCRIPTION
# Description

This gives for a slightly better look on dark theme.

# Result

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            A <i>slightly</i> different color on dark theme.
        </td>
        <td>
            <img src="https://github.com/webkom/lego-webapp/assets/69514187/924b1f5d-714b-4f7f-b576-7b64f6885569" />
        </td>
        <td>         
			<img src="https://github.com/webkom/lego-webapp/assets/69514187/672f6922-6eba-4d97-8fc3-4714059d0170" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Works on both light and dark theme. This should not break anything else - even updated both duplicate variable files.