### PR TITLE
Include social media profiling to company interest form

### DIFF
--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -513,9 +513,13 @@ const CompanyInterestPage = () => {
     },
   ];
 
+  const title = edit
+    ? 'Rediger bedriftsinteresse'
+    : FORM_LABELS.mainHeading[language];
+
   return (
     <Content>
-      <Helmet title={isEnglish ? 'Company interest' : 'Bedriftsinteresse'} />
+      <Helmet title={title} />
 
       <LegoFinalForm
         onSubmit={onSubmit}
@@ -529,19 +533,22 @@ const CompanyInterestPage = () => {
         {({ handleSubmit }) => (
           <form onSubmit={handleSubmit}>
             <FlexRow alignItems="center" justifyContent="space-between">
-              <h1>{FORM_LABELS.mainHeading[language]}</h1>
+              <h1>{title}</h1>
               {!edit && (
                 <Link to={isEnglish ? '/interesse' : '/register-interest'}>
                   <LanguageFlag language={language} />
                 </Link>
               )}
             </FlexRow>
-            <Card severity="info">
-              {FORM_LABELS.subHeading[language]}
-              <a href={'mailto:bedriftskontakt@abakus.no'}>
-                bedriftskontakt@abakus.no
-              </a>
-            </Card>
+
+            {!edit && (
+              <Card severity="info">
+                {FORM_LABELS.subHeading[language]}
+                <a href={'mailto:bedriftskontakt@abakus.no'}>
+                  bedriftskontakt@abakus.no
+                </a>
+              </Card>
+            )}
 
             <Field
               name="company"

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -61,7 +61,7 @@ import {
 import styles from './CompanyInterest.css';
 import {
   EVENTS,
-  README,
+  OTHER_OFFERS,
   SURVEY_OFFERS,
   TARGET_GRADES,
   FORM_LABELS,
@@ -181,7 +181,7 @@ const OtherBox = ({
       <Field
         key={`otherOffers[${index}]`}
         name={`otherOffers[${index}].checked`}
-        label={readmeIfy(README[otherOffersToString(key)][language])}
+        label={readmeIfy(OTHER_OFFERS[otherOffersToString(key)][language])}
         type="checkbox"
         component={CheckBox.Field}
         normalize={(v) => !!v}
@@ -334,7 +334,7 @@ const CompanyInterestPage = () => {
   );
 
   const allEvents = Object.keys(EVENTS);
-  const allOtherOffers = Object.keys(README);
+  const allOtherOffers = Object.keys(OTHER_OFFERS);
   const allCollaborations = Object.keys(COLLABORATION_TYPES);
   const allTargetGrades = Object.keys(TARGET_GRADES);
   const allParticipantRanges = Object.keys(PARTICIPANT_RANGE_MAP);

--- a/app/routes/companyInterest/components/Translations.ts
+++ b/app/routes/companyInterest/components/Translations.ts
@@ -74,10 +74,14 @@ export const SURVEY_OFFERS = {
   },
 };
 
-export const README = {
+export const OTHER_OFFERS = {
   readme: {
     norwegian: 'Annonse i readme',
     english: 'Advertisement in readme',
+  },
+  social_media: {
+    norwegian: 'Profilering på sosiale medier',
+    english: 'Profiling on social media',
   },
 };
 

--- a/app/routes/companyInterest/utils.tsx
+++ b/app/routes/companyInterest/utils.tsx
@@ -5,8 +5,8 @@ import config from 'app/config';
 import {
   COLLABORATION_TYPES,
   EVENTS,
-  README,
   SURVEY_OFFERS,
+  OTHER_OFFERS,
   TARGET_GRADES,
 } from './components/Translations';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
@@ -73,7 +73,7 @@ export const surveyOffersToString = (offer) =>
   Object.keys(SURVEY_OFFERS)[Number(offer.charAt(offer.length - 2))];
 
 export const otherOffersToString = (offer) =>
-  Object.keys(README)[Number(offer.charAt(offer.length - 2))];
+  Object.keys(OTHER_OFFERS)[Number(offer.charAt(offer.length - 2))];
 
 export const collaborationToString = (collab) =>
   Object.keys(COLLABORATION_TYPES)[Number(collab.charAt(collab.length - 2))];


### PR DESCRIPTION
# Description

Option requested by Inter

[Relevant backend PR](https://github.com/webkom/lego/pull/3552)

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="350" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/a135e910-3b5d-4f18-920a-ebf906551706">
        </td>
        <td>
            <img width="350" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/7e382710-0960-4da0-b0cb-e37b747255b3">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested the creation and editing of interest forms with the new option picked.