### PR TITLE
Add to google calender button for meetings

### DIFF
--- a/app/components/AddToCalender/AddToCalender.tsx
+++ b/app/components/AddToCalender/AddToCalender.tsx
@@ -1,0 +1,50 @@
+import { Button } from 'packages/lego-bricks/src/components/Button';
+
+type AddToCalenderProps = {
+  title: string;
+  startTime: string; // Format: YYYYMMDDTHHMMSSZ
+  endTime: string; // Format: YYYYMMDDTHHMMSSZ
+  description?: string;
+  location?: string;
+};
+
+const AddToCalender = ({
+  title,
+  startTime,
+  endTime,
+  description = '',
+  location = '',
+}: AddToCalenderProps) => {
+  const createGoogleCalenderLink = () => {
+    const baseURL = 'https://calendar.google.com/calendar/event';
+    const params = new URLSearchParams({
+      action: 'TEMPLATE',
+      dates: `${formatTimeForGoogle(startTime)}/${formatTimeForGoogle(
+        endTime
+      )}`,
+      text: title,
+      details: description,
+      location: location,
+      sf: 'true',
+      output: 'xml',
+    });
+    return `${baseURL}?${params.toString()}`;
+  };
+  const formatTimeForGoogle = (dateTime: string) => {
+    return dateTime.replace(/-|:/g, '');
+  };
+
+  return (
+    <div>
+      <a
+        href={`${createGoogleCalenderLink()}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Button ghost>Legg til i Google Calender</Button>
+      </a>
+    </div>
+  );
+};
+
+export default AddToCalender;

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -4,6 +4,7 @@ import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
 import { Link, useParams } from 'react-router-dom';
 import { setInvitationStatus } from 'app/actions/MeetingActions';
+import AddToCalender from 'app/components/AddToCalender/AddToCalender';
 import AnnouncementInLine from 'app/components/AnnouncementInLine';
 import CommentView from 'app/components/Comments/CommentView';
 import {
@@ -190,6 +191,15 @@ const MeetingDetails = () => {
           <ul>
             {attendanceButtons(statusMe, meeting.startTime)}
             <InfoList items={infoItems} />
+            <li>
+              <AddToCalender
+                title={meeting.title}
+                startTime={meeting.startTime}
+                endTime={meeting.endTime}
+                description={meeting.description}
+                location={meeting.location}
+              ></AddToCalender>
+            </li>
             <li>
               <AttendanceModal
                 isMeeting


### PR DESCRIPTION
# Description
Knapp på møter for å legge til møtet i Google Calender

# Result
Knapp

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.
Før: ![image](https://github.com/webkom/lego-webapp/assets/72016436/86ec6c97-72c2-409e-97e3-449f30c9499b)

Etter![image](https://github.com/webkom/lego-webapp/assets/72016436/c7943187-3235-4d9c-a3c8-ebf97f3d0f8d)



# Testing

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.
Hadde bare muligheten til å teste med møter jeg selv er en del av, fungerer dog feilfritt med disse.
Løser
Frustrasjon over at det ikke var en knapp der.