### PR TITLE
Prevent page from crashing when no page is selected

### DIFF
--- a/app/routes/pages/components/PageDetail.tsx
+++ b/app/routes/pages/components/PageDetail.tsx
@@ -326,11 +326,11 @@ const PageDetail = () => {
     [pageSlug]
   );
 
-  const { editUrl, actionGrant = [], isComplete } = selectedPageInfo;
+  const actionGrant = selectedPageInfo?.actionGrant || [];
 
   return (
     <Content className={styles.cont}>
-      <Helmet title={selectedPageInfo.title} />
+      <Helmet title={selectedPageInfo?.title} />
       <div className={styles.main}>
         <button
           className={styles.sidebarOpenBtn}
@@ -347,15 +347,17 @@ const PageDetail = () => {
 
           <div className={styles.mainTxt}>
             <NavigationTab className={styles.navTab}>
-              {actionGrant.includes('edit') && editUrl && (
-                <NavigationLink to={editUrl}>Rediger</NavigationLink>
+              {actionGrant.includes('edit') && selectedPageInfo?.editUrl && (
+                <NavigationLink to={selectedPageInfo?.editUrl}>
+                  Rediger
+                </NavigationLink>
               )}
               {actionGrant.includes('create') && (
                 <NavigationLink to="/pages/new">Lag ny</NavigationLink>
               )}
             </NavigationTab>
 
-            {isComplete ? (
+            {selectedPageInfo?.isComplete ? (
               <MainPageRenderer
                 page={selectedPage}
                 pageInfo={selectedPageInfo}


### PR DESCRIPTION
# Description

Only applies to some pages, so this was not previously caught

# Result

No visual changes - it just doesn't crash while fetching

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

No crashing!