### PR TITLE
Properly reject promises on server

### DIFF
--- a/app/components/HeaderNotifications/index.tsx
+++ b/app/components/HeaderNotifications/index.tsx
@@ -92,7 +92,7 @@ const NotificationsDropdown = () => {
   usePreparedEffect(
     'fetchNotificationDropdownData',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchNotificationFeed()),
         dispatch(fetchNotificationData()),
       ]),

--- a/app/routes/admin/email/components/EmailUsers.tsx
+++ b/app/routes/admin/email/components/EmailUsers.tsx
@@ -50,7 +50,7 @@ const EmailUsers = () => {
   usePreparedEffect(
     'fetchEmailUsers',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchAllWithType(GroupType.Committee)),
         dispatch(fetchAllWithType(GroupType.Grade)),
         dispatch(fetch({ query })),

--- a/app/routes/admin/email/components/EmailUsers.tsx
+++ b/app/routes/admin/email/components/EmailUsers.tsx
@@ -50,12 +50,12 @@ const EmailUsers = () => {
   usePreparedEffect(
     'fetchEmailUsers',
     () =>
-      Promise.resolve([
+      Promise.all([
         dispatch(fetchAllWithType(GroupType.Committee)),
         dispatch(fetchAllWithType(GroupType.Grade)),
         dispatch(fetch({ query })),
       ]),
-    []
+    [query]
   );
 
   const columns = [

--- a/app/routes/admin/groups/components/GroupPage.tsx
+++ b/app/routes/admin/groups/components/GroupPage.tsx
@@ -63,7 +63,7 @@ const GroupPage = () => {
   usePreparedEffect(
     'fetchAllGroups',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchAll()),
         groupId && dispatch(fetchGroup(groupId)),
       ]),

--- a/app/routes/articles/components/Overview.tsx
+++ b/app/routes/articles/components/Overview.tsx
@@ -92,7 +92,7 @@ const Overview = () => {
   usePreparedEffect(
     'fetchArticlesOverview',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchPopular()),
         dispatch(fetchAll({ next: false, query })),
       ]),

--- a/app/routes/articles/components/Overview.tsx
+++ b/app/routes/articles/components/Overview.tsx
@@ -92,11 +92,11 @@ const Overview = () => {
   usePreparedEffect(
     'fetchArticlesOverview',
     () =>
-      Promise.resolve([
+      Promise.all([
         dispatch(fetchPopular()),
         dispatch(fetchAll({ next: false, query })),
       ]),
-    []
+    [query]
   );
 
   const headlineEvents = articles.slice(0, HEADLINE_EVENTS);

--- a/app/routes/bdb/components/AddSemester.tsx
+++ b/app/routes/bdb/components/AddSemester.tsx
@@ -50,7 +50,11 @@ const AddSemester = () => {
 
   usePreparedEffect(
     'fetchAddSemester',
-    () => Promise.all([dispatch(fetchSemesters()), dispatch(fetchAllAdmin())]),
+    () =>
+      Promise.allSettled([
+        dispatch(fetchSemesters()),
+        dispatch(fetchAllAdmin()),
+      ]),
     [companyId]
   );
 

--- a/app/routes/bdb/components/BdbDetail.tsx
+++ b/app/routes/bdb/components/BdbDetail.tsx
@@ -78,15 +78,15 @@ const BdbDetail = () => {
   usePreparedEffect(
     'fetchBdbDetail',
     () =>
+      companyId &&
       Promise.all([
         dispatch(fetchSemesters()).then(() => dispatch(fetchAdmin(companyId))),
-        companyId &&
-          dispatch(
-            fetchEventsForCompany({
-              endpoint: `/events/${queryString(companyId)}`,
-              queryString: queryString(companyId),
-            })
-          ),
+        dispatch(
+          fetchEventsForCompany({
+            endpoint: `/events/${queryString(companyId)}`,
+            queryString: queryString(companyId),
+          })
+        ),
       ]),
     [companyId]
   );

--- a/app/routes/bdb/components/BdbDetail.tsx
+++ b/app/routes/bdb/components/BdbDetail.tsx
@@ -79,7 +79,7 @@ const BdbDetail = () => {
     'fetchBdbDetail',
     () =>
       companyId &&
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchSemesters()).then(() => dispatch(fetchAdmin(companyId))),
         dispatch(
           fetchEventsForCompany({

--- a/app/routes/company/components/CompanyDetail.tsx
+++ b/app/routes/company/components/CompanyDetail.tsx
@@ -70,7 +70,7 @@ const CompanyDetail = () => {
     'fetchDetailedCompany',
     () =>
       companyId &&
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetch(companyId)),
         dispatch(
           fetchEventsForCompany({

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -120,7 +120,8 @@ const CompanyInterestList = () => {
 
   usePreparedEffect(
     'fetchCompanyInterestList',
-    () => Promise.all([dispatch(fetchAll()), dispatch(fetchSemesters())]),
+    () =>
+      Promise.allSettled([dispatch(fetchAll()), dispatch(fetchSemesters())]),
     []
   );
 

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -322,7 +322,7 @@ const CompanyInterestPage = () => {
   usePreparedEffect(
     'fetchCompanyInterestPage',
     () => {
-      Promise.all([
+      Promise.allSettled([
         edit && dispatch(fetchSemesters()),
         edit &&
           companyInterestId &&

--- a/app/routes/contact/components/ContactForm.tsx
+++ b/app/routes/contact/components/ContactForm.tsx
@@ -53,7 +53,7 @@ const ContactForm = () => {
   usePreparedEffect(
     'fetchGroups',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchAllWithType(GroupType.Committee)),
         // The revue board group does not exist in the local dev environment.
         // It should be added to the fixtures, so that the propagateError flag can be removed.

--- a/app/routes/events/components/EventAdministrate/Statistics.tsx
+++ b/app/routes/events/components/EventAdministrate/Statistics.tsx
@@ -14,7 +14,7 @@ const Statistics = () => {
   usePreparedEffect(
     'fetchStatisticsGroups',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchAllWithType(GroupType.Committee)),
         dispatch(fetchAllWithType(GroupType.Revue)),
       ]),

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -175,7 +175,7 @@ const EventEditor = () => {
   usePreparedEffect(
     'fetchEventEdit',
     () =>
-      Promise.all([
+      Promise.allSettled([
         eventIdOrSlug && dispatch(fetchEvent(eventIdOrSlug)),
         dispatch(fetchImageGallery()),
       ]),

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -134,11 +134,11 @@ const InterestGroupDetail = () => {
     'fetchInterestGroupDetail',
     () =>
       groupId &&
-      Promise.resolve([
+      Promise.all([
         dispatch(fetchGroup(groupId)),
         loggedIn && dispatch(fetchAllMemberships(groupId)),
       ]),
-    [loggedIn]
+    [groupId, loggedIn]
   );
 
   return (

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -134,7 +134,7 @@ const InterestGroupDetail = () => {
     'fetchInterestGroupDetail',
     () =>
       groupId &&
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchGroup(groupId)),
         loggedIn && dispatch(fetchAllMemberships(groupId)),
       ]),

--- a/app/routes/meetings/MeetingDetailWrapper.tsx
+++ b/app/routes/meetings/MeetingDetailWrapper.tsx
@@ -38,7 +38,9 @@ const MeetingDetailWrapper = () => {
         dispatch(answerMeetingInvitation(action, token));
       }
 
-      return loggedIn ? dispatch(fetchMeeting(meetingId)) : Promise.resolve();
+      return loggedIn && meetingId
+        ? dispatch(fetchMeeting(meetingId))
+        : Promise.resolve();
     },
     [meetingId, loggedIn, token, action]
   );

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -52,7 +52,7 @@ const Overview = () => {
   usePreparedEffect(
     'fetchIndex',
     () =>
-      Promise.all([
+      Promise.allSettled([
         loggedIn && shouldFetchQuote && dispatch(fetchRandomQuote()),
         dispatch(fetchReadmes(loggedIn ? 4 : 2)),
         dispatch(fetchData()),

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -35,11 +35,7 @@ const PublicFrontpage = () => {
 
   const dispatch = useAppDispatch();
 
-  usePreparedEffect(
-    'fetchIndex',
-    () => Promise.all([dispatch(fetchData())]),
-    []
-  );
+  usePreparedEffect('fetchIndex', () => dispatch(fetchData()), []);
 
   const pinned = frontpage[0];
 

--- a/app/routes/pages/components/PageEditor.tsx
+++ b/app/routes/pages/components/PageEditor.tsx
@@ -78,7 +78,7 @@ const PageEditor = () => {
 
   usePreparedEffect(
     'fetchPageEdit',
-    () => !isNew && dispatch(fetchPage(pageSlug)),
+    () => !isNew && pageSlug && dispatch(fetchPage(pageSlug)),
     [isNew, pageSlug]
   );
 

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -75,6 +75,7 @@ const GalleryDetail = () => {
   usePreparedEffect(
     'fetchGalleryDetail',
     () =>
+      galleryId &&
       Promise.all([
         dispatch(fetch(galleryId)).catch(),
         dispatch(fetchGallery(galleryId)).catch(() =>

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -76,7 +76,7 @@ const GalleryDetail = () => {
     'fetchGalleryDetail',
     () =>
       galleryId &&
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetch(galleryId)).catch(),
         dispatch(fetchGallery(galleryId)).catch(() =>
           dispatch(fetchGalleryMetadata(galleryId))

--- a/app/routes/photos/components/GalleryEditor.tsx
+++ b/app/routes/photos/components/GalleryEditor.tsx
@@ -142,7 +142,7 @@ const GalleryEditor = () => {
     () =>
       !isNew &&
       galleryId &&
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetch(Number(galleryId))),
         dispatch(fetchGallery(galleryId)),
       ]),

--- a/app/routes/photos/components/GalleryPictureEditModal.tsx
+++ b/app/routes/photos/components/GalleryPictureEditModal.tsx
@@ -56,7 +56,7 @@ const GalleryPictureEditModal = () => {
     'fetchGalleryAndGalleryPicture',
     () =>
       galleryId &&
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchGallery(galleryId)),
         pictureId && dispatch(fetchGalleryPicture(galleryId, pictureId)),
       ]),

--- a/app/routes/photos/components/GalleryPictureEditModal.tsx
+++ b/app/routes/photos/components/GalleryPictureEditModal.tsx
@@ -55,9 +55,10 @@ const GalleryPictureEditModal = () => {
   usePreparedEffect(
     'fetchGalleryAndGalleryPicture',
     () =>
+      galleryId &&
       Promise.all([
         dispatch(fetchGallery(galleryId)),
-        dispatch(fetchGalleryPicture(galleryId, pictureId)),
+        pictureId && dispatch(fetchGalleryPicture(galleryId, pictureId)),
       ]),
     [galleryId, pictureId]
   );

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -187,9 +187,10 @@ const GalleryPictureModal = () => {
   usePreparedEffect(
     'fetchGalleryPicture',
     () =>
+      galleryId &&
       Promise.all([
-        dispatch(fetchGalleryPicture(galleryId, pictureId)),
         dispatch(fetchGallery(galleryId)),
+        pictureId && dispatch(fetchGalleryPicture(galleryId, pictureId)),
       ]),
     []
   );

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -188,7 +188,7 @@ const GalleryPictureModal = () => {
     'fetchGalleryPicture',
     () =>
       galleryId &&
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchGallery(galleryId)),
         pictureId && dispatch(fetchGalleryPicture(galleryId, pictureId)),
       ]),

--- a/app/routes/polls/components/PollDetail.tsx
+++ b/app/routes/polls/components/PollDetail.tsx
@@ -23,7 +23,11 @@ const PollDetail = () => {
 
   const dispatch = useAppDispatch();
 
-  usePreparedEffect('fetchPoll', () => dispatch(fetchPoll(pollsId)), []);
+  usePreparedEffect(
+    'fetchPoll',
+    () => pollsId && dispatch(fetchPoll(pollsId)),
+    []
+  );
 
   const poll = useAppSelector((state) => selectPollById(state, pollsId));
   const fetching = useAppSelector((state) => state.polls.fetching);

--- a/app/routes/quotes/components/QuotePage.tsx
+++ b/app/routes/quotes/components/QuotePage.tsx
@@ -76,11 +76,11 @@ const QuotePage = () => {
   usePreparedEffect(
     'fetchQuotePage',
     () =>
-      Promise.resolve([
+      Promise.all([
         quoteId ? dispatch(fetchQuote(quoteId)) : dispatch(fetchAll({ query })),
         dispatch(fetchEmojis()),
       ]),
-    [query]
+    [quoteId, query]
   );
 
   return (

--- a/app/routes/quotes/components/QuotePage.tsx
+++ b/app/routes/quotes/components/QuotePage.tsx
@@ -76,7 +76,7 @@ const QuotePage = () => {
   usePreparedEffect(
     'fetchQuotePage',
     () =>
-      Promise.all([
+      Promise.allSettled([
         quoteId ? dispatch(fetchQuote(quoteId)) : dispatch(fetchAll({ query })),
         dispatch(fetchEmojis()),
       ]),

--- a/app/routes/users/components/UserProfile.tsx
+++ b/app/routes/users/components/UserProfile.tsx
@@ -208,7 +208,7 @@ const UserProfile = () => {
   usePreparedEffect(
     'fetchUserProfile',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchAllWithType(GroupType.Grade)),
         isCurrentUser && dispatch(fetchPrevious()),
         isCurrentUser && dispatch(fetchUpcoming()),

--- a/app/routes/users/components/UserSettingsNotifications.tsx
+++ b/app/routes/users/components/UserSettingsNotifications.tsx
@@ -45,7 +45,7 @@ const UserSettingsNotifications = () => {
   usePreparedEffect(
     'fetchUserSettingsNotifications',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchNotificationAlternatives()),
         dispatch(fetchNotificationSettings()),
       ]),

--- a/app/routes/users/components/UserSettingsOAuth2.tsx
+++ b/app/routes/users/components/UserSettingsOAuth2.tsx
@@ -25,7 +25,7 @@ const UserSettingsOAuth2 = () => {
   usePreparedEffect(
     'fetchUserSettingsOAuth2',
     () =>
-      Promise.all([
+      Promise.allSettled([
         dispatch(fetchOAuth2Applications()),
         dispatch(fetchOAuth2Grants()),
       ]),


### PR DESCRIPTION
# Description

`Promise.resolve()` will not reject upon any of the input promises rejecting, which can cause promises to never stop on the client if the server sends unhandled promises. Simply replacing with a `Promise.all()` fixes this issue.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

No visual changes.

# Testing

- [x] I have thoroughly tested my changes.

Spamming hard refreshes does not put page in limbo 👍🏼 

https://github.com/webkom/lego-webapp/assets/69514187/d271c68e-f5ad-450a-9775-0dd1d0726691