### PR TITLE
Fix unintended disabled email list field

### DIFF
--- a/app/routes/admin/email/components/EmailListEditor.tsx
+++ b/app/routes/admin/email/components/EmailListEditor.tsx
@@ -118,7 +118,7 @@ const EmailListEditor = () => {
           />
           <Field
             required
-            disabled={emailListId}
+            disabled={!isNew && emailListId}
             placeholder="abakus"
             suffix="@abakus.no"
             name="email"


### PR DESCRIPTION
# Description

Field was disabled when creating new email listings ;-;

# Result

[Screencast from 02-19-2024 10:29:05 AM.webm](https://github.com/webkom/lego-webapp/assets/42469466/000c0efa-160f-4a89-9f66-937643c4ce8f)

# Testing

- [x] I have thoroughly tested my changes.
- Attempted to use field when creating new email lists, and checked that you cannot edit with existing email listings

---

Resolves ABA-831
