### PR TITLE
Implement overview-styling with grid

### DIFF
--- a/app/components/Banner/Banner.css
+++ b/app/components/Banner/Banner.css
@@ -1,8 +1,17 @@
 @import url('~app/styles/variables.css');
 
+.link {
+  display: block;
+  margin: 0 var(--lego-default-padding);
+
+  @media (--mobile-device) {
+    margin: 0 1rem;
+  }
+}
+
 .header {
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--lego-default-padding);
   animation-name: wiggle;
   animation-duration: 4s;
   animation-iteration-count: infinite;

--- a/app/components/Banner/index.tsx
+++ b/app/components/Banner/index.tsx
@@ -27,9 +27,11 @@ const Banner = (props: Props) => {
 
   const LinkComponent = ({ children }: { children: ReactNode }) => {
     return internal ? (
-      <Link to={link}>{children}</Link>
+      <Link to={link} className={styles.link}>
+        {children}
+      </Link>
     ) : (
-      <a href={link} target="_blank" rel="noreferrer">
+      <a href={link} target="_blank" rel="noreferrer" className={styles.link}>
         {children}
       </a>
     );

--- a/app/routes/overview/components/ArticleItem.css
+++ b/app/routes/overview/components/ArticleItem.css
@@ -1,13 +1,18 @@
 @import url('~app/styles/variables.css');
 
-.link {
-  color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 90%);
-}
-
 .body {
+  display: flex;
   text-align: center;
   line-height: 1.3;
   min-height: 140px;
+  padding: 0;
+  flex-grow: 1;
+}
+
+.link {
+  display: flex;
+  flex-direction: column;
+  color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 90%);
 }
 
 .image {
@@ -15,10 +20,24 @@
   width: 100%;
   height: auto;
   background: white;
+  border-top-left-radius: var(--border-radius-lg);
+  border-top-right-radius: var(--border-radius-lg);
+}
+
+.infoWrapper {
+  display: flex;
+  flex-grow: 1;
+  padding: 15px 30px 20px;
+  flex-direction: column;
+  justify-content: space-around;
+}
+
+.metaWrapper {
+  margin-bottom: 0.25rem;
 }
 
 .articleTitle {
-  margin: 0 5px;
+  margin: 0 0 0.25rem;
   font-size: var(--font-size-lg);
   word-break: break-word;
 }
@@ -26,13 +45,6 @@
 .articleMeta {
   margin: 0 5px;
   margin-bottom: 8px;
-}
-
-.infoWrapper {
-  padding: 10px 10px 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
 }
 
 .articleDescription {

--- a/app/routes/overview/components/ArticleItem.tsx
+++ b/app/routes/overview/components/ArticleItem.tsx
@@ -31,16 +31,18 @@ const ArticleItem = ({ item, url, meta }: Props) => {
           alt="Article cover"
         />
         <div className={styles.infoWrapper}>
-          <h2 className={styles.articleTitle}>
-            {truncateString(item?.title, TITLE_MAX_LENGTH)}
-          </h2>
-          <span className={styles.articleMeta}>
-            Publisert - {meta.props.children?.length && meta.props.children[0]}
+          <div className={styles.metaWrapper}>
+            <h2 className={styles.articleTitle}>
+              {truncateString(item?.title, TITLE_MAX_LENGTH)}
+            </h2>
+            <span className={styles.articleMeta}>
+              Publisert {meta.props.children?.length && meta.props.children[0]}
+            </span>
+          </div>
+          <span className={styles.articleDescription}>
+            {truncateString(item?.description, DESC_MAX_LENGTH)}
           </span>
         </div>
-        <span className={styles.articleDescription}>
-          {truncateString(item?.description, DESC_MAX_LENGTH)}
-        </span>
       </Link>
     </Card>
   );

--- a/app/routes/overview/components/CompactEvents.css
+++ b/app/routes/overview/components/CompactEvents.css
@@ -6,14 +6,11 @@
   white-space: nowrap;
   width: 100%;
   text-align: left;
+  gap: 2rem;
 
   @media (--small-viewport) {
     flex-direction: column;
   }
-}
-
-.compactLeft {
-  padding-right: 20px;
 }
 
 @media (--mobile-device) {
@@ -25,10 +22,6 @@
 .compactLeft,
 .compactRight {
   flex: 1;
-
-  @media (--mobile-device) {
-    padding: 0 10px 10px;
-  }
 }
 
 .compactEvents li {

--- a/app/routes/overview/components/CompactEvents.tsx
+++ b/app/routes/overview/components/CompactEvents.tsx
@@ -13,12 +13,13 @@ import type { CSSProperties } from 'react';
 
 type Props = {
   events: FrontpageEvent[];
+  className?: string;
   style?: CSSProperties;
 };
 
 const EVENT_COLUMN_LIMIT = 5;
 
-const CompactEvents = ({ events, style }: Props) => {
+const CompactEvents = ({ events, className, style }: Props) => {
   const mapEvents = (eventTypes) => {
     return events
       .filter(
@@ -85,7 +86,7 @@ const CompactEvents = ({ events, style }: Props) => {
   );
 
   return (
-    <Flex column style={style}>
+    <Flex column className={className} style={style}>
       <Flex wrap className={styles.compactEvents}>
         <Flex column className={styles.compactLeft}>
           <Link

--- a/app/routes/overview/components/LatestReadme.css
+++ b/app/routes/overview/components/LatestReadme.css
@@ -3,8 +3,6 @@
 .latestReadme {
   flex: 1;
   position: relative;
-  overflow: hidden;
-  transition: height var(--easing-medium);
 }
 
 .heading {
@@ -17,26 +15,41 @@
   cursor: pointer;
 }
 
-.thumb {
-  width: 150px;
-  transition: transform var(--easing-fast);
-  display: block;
-  object-fit: contain;
-
-  @media (--mobile-device) {
-    width: 48%;
-    height: auto;
-  }
-
-  &:hover {
-    transform: scale(1.05);
-  }
-}
-
 .expand {
   transition: transform var(--easing-medium);
 }
 
 .rotate {
   transform: rotate(90deg);
+}
+
+.thumbnailWrapper {
+  overflow-y: hidden;
+  transition: height var(--easing-medium);
+}
+
+.thumbnailContainer {
+  padding-top: 15px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, min-content);
+  gap: 0.25rem;
+  overflow: hidden;
+
+  @media (--mobile-device) {
+    gap: 1rem;
+  }
+
+  @media (--small-viewport) {
+    gap: 0.25rem;
+  }
+}
+
+.thumb {
+  flex-basis: 48%;
+  transition: transform var(--easing-fast);
+
+  &:hover {
+    transform: scale(1.05);
+  }
 }

--- a/app/routes/overview/components/LatestReadme.tsx
+++ b/app/routes/overview/components/LatestReadme.tsx
@@ -12,6 +12,7 @@ type Props = {
   collapsible?: boolean;
   readmes: Array<Readme>;
   style?: CSSProperties;
+  displayCount?: number;
 };
 
 const LatestReadme = ({
@@ -19,9 +20,9 @@ const LatestReadme = ({
   expandedInitially = true,
   collapsible = true,
   style,
+  displayCount = 4,
 }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
-  const collapsedHeight = 85;
 
   const [expanded, setExpanded] = useState(expandedInitially);
 
@@ -30,15 +31,7 @@ const LatestReadme = ({
   }, [expandedInitially]);
 
   return (
-    <Card
-      className={styles.latestReadme}
-      style={{
-        ...style,
-        height: expanded
-          ? ref.current?.clientHeight + collapsedHeight
-          : collapsedHeight,
-      }}
-    >
+    <Card className={styles.latestReadme} style={style}>
       {collapsible ? (
         <div
           className={cx(styles.heading, styles.pointer)}
@@ -57,20 +50,19 @@ const LatestReadme = ({
         <div className={styles.heading}>{readmeIfy('readme')}</div>
       )}
 
-      <div ref={ref}>
-        <Flex
-          wrap
-          justifyContent="space-around"
-          style={{
-            paddingTop: 15,
-          }}
-        >
-          {readmes.slice(0, 4).map(({ image, pdf, title }) => (
+      <div
+        className={styles.thumbnailWrapper}
+        style={{
+          height: expanded ? ref.current?.clientHeight ?? 0 : 0,
+        }}
+      >
+        <div className={styles.thumbnailContainer} ref={ref}>
+          {readmes.slice(0, displayCount).map(({ image, pdf, title }) => (
             <a key={title} href={pdf} className={styles.thumb}>
               <Image src={image} alt={`Cover of ${title}`} />
             </a>
           ))}
-        </Flex>
+        </div>
       </div>
     </Card>
   );

--- a/app/routes/overview/components/NextEvent.css
+++ b/app/routes/overview/components/NextEvent.css
@@ -41,4 +41,8 @@
   @media (--mobile-device) {
     min-height: 0;
   }
+
+  > div:last-of-type > .eventItem {
+    margin-bottom: 0;
+  }
 }

--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -1,46 +1,68 @@
 @import url('~app/styles/variables.css');
 
-.leftColumn {
-  flex: 13;
-  margin-right: 10px;
-  padding: 0 20px;
+.wrapper {
+  display: grid;
+  grid-template:
+    'compact-events registrations'
+    'pinned poll'
+    'events quote'
+    'events readme'
+    'events weekly'
+    'events articles'
+    'events .'
+    / 2fr 1fr;
+  padding: 0 var(--lego-default-padding);
+  gap: 2rem;
+
+  @media (--mobile-device) {
+    grid-template:
+      'compact-events'
+      'registrations'
+      'pinned'
+      'poll'
+      'quote'
+      'readme'
+      'weekly'
+      'articles'
+      'events';
+    padding: 0 1rem;
+  }
+
+  h3 {
+    margin-top: 0;
+  }
 }
 
-.rightColumn {
-  flex: 7;
+.compactEvents {
+  grid-area: compact-events;
+}
+
+.registrations {
+  grid-area: registrations;
+}
+
+.poll {
+  grid-area: poll;
+}
+
+.quote {
+  grid-area: quote;
 }
 
 .readMe {
-  padding: 28px 0 0;
+  grid-area: readme;
 }
 
-.dot {
-  margin: 0 6px;
+.weekly {
+  grid-area: weekly;
 }
 
-.type {
-  margin-right: 6px;
-}
-
-.tagline {
-  margin: 0;
-  display: inline-flex;
-  gap: 7px;
-}
-
-.otherItems {
-  display: flex;
-  padding: 0 10px;
-
-  @media (--mobile-device) {
-    flex-direction: column;
-  }
+.articles {
+  grid-area: articles;
 }
 
 .events {
-  @media (--mobile-device) {
-    margin-right: 0;
-  }
+  grid-area: events;
 }
 
 .showMore {
@@ -49,18 +71,9 @@
   margin: 20px 0;
 }
 
-.desktopContainer {
-  display: flex;
-
-  @media (--mobile-device) {
-    display: none;
-  }
-}
-
-.mobileContainer {
-  display: none;
-
-  @media (--mobile-device) {
-    display: grid;
-  }
+.tagline {
+  margin: 0;
+  margin-left: 0.5rem;
+  display: inline-flex;
+  gap: 7px;
 }

--- a/app/routes/overview/components/Overview.css
+++ b/app/routes/overview/components/Overview.css
@@ -4,10 +4,10 @@
   display: grid;
   grid-template:
     'compact-events registrations'
-    'pinned poll'
+    'pinned weekly'
+    'events poll'
     'events quote'
     'events readme'
-    'events weekly'
     'events articles'
     'events .'
     / 2fr 1fr;

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -114,35 +114,16 @@ const Overview = () => {
         link="https://abakusrevyen.no/"
         color="red"
       />
-      <Flex className={styles.desktopContainer}>
-        <Flex column className={styles.leftColumn}>
-          <CompactEvents events={events} />
-          <Pinned
-            item={pinned}
-            url={itemUrl(pinned)}
-            meta={renderMeta(pinned)}
-          />
-          <Events events={eventsShown} />
-        </Flex>
-        <Flex column className={styles.rightColumn}>
-          <NextEventSection events={events} />
-          <PollItem />
-          <QuoteItem />
-          {readMe}
-          <Weekly weeklyArticle={weeklyArticle} />
-          <Articles articles={articlesShown} />
-        </Flex>
-      </Flex>
-      <section className={styles.mobileContainer}>
-        <CompactEvents events={events} />
-        <NextEvent events={events} />
+      <section className={styles.wrapper}>
+        <CompactEvents events={events} className={styles.compactEvents} />
+        <NextEventSection events={events} />
+        <Events events={eventsShown} />
         <Pinned item={pinned} url={itemUrl(pinned)} meta={renderMeta(pinned)} />
         <PollItem />
         <QuoteItem />
         {readMe}
         <Weekly weeklyArticle={weeklyArticle} />
         <Articles articles={articlesShown} />
-        <Events events={eventsShown} />
       </section>
 
       {frontpage.length > 8 && (
@@ -194,7 +175,7 @@ const Weekly = ({
   );
 
   return (
-    <Flex column>
+    <Flex column className={styles.weekly}>
       <Link to="/articles?tag=weekly">
         <h3 className="u-ui-heading">Weekly</h3>
       </Link>
@@ -223,7 +204,7 @@ const Articles = ({
   );
 
   return (
-    <Flex column>
+    <Flex column className={styles.articles}>
       <Link to="/articles">
         <h3 className="u-ui-heading">Artikler</h3>
       </Link>
@@ -247,7 +228,7 @@ const Articles = ({
 };
 
 const NextEventSection = ({ events }: { events: Event[] }) => (
-  <Flex column>
+  <Flex column className={styles.registrations}>
     <Link to="/events">
       <h3 className="u-ui-heading">Påmeldinger</h3>
     </Link>
@@ -264,7 +245,7 @@ const PollItem = () => {
 
   return (
     (fetching || poll) && (
-      <Flex column>
+      <Flex column className={styles.poll}>
         <Link to="/polls">
           <h3 className="u-ui-heading">Avstemning</h3>
         </Link>
@@ -276,7 +257,7 @@ const PollItem = () => {
 };
 
 const QuoteItem = () => (
-  <Flex column>
+  <Flex column className={styles.quote}>
     <Link to="/quotes">
       <h3 className="u-ui-heading">Overhørt</h3>
     </Link>

--- a/app/routes/overview/components/Pinned.css
+++ b/app/routes/overview/components/Pinned.css
@@ -7,7 +7,7 @@
 
 .body {
   padding: 0;
-  min-height: 280px;
+  min-height: 260px;
 }
 
 .innerLinks {

--- a/app/routes/overview/components/Pinned.css
+++ b/app/routes/overview/components/Pinned.css
@@ -1,6 +1,7 @@
 @import url('~app/styles/variables.css');
 
 .pinned {
+  grid-area: pinned;
   width: 100%;
 }
 

--- a/app/routes/overview/components/PublicFrontpage.tsx
+++ b/app/routes/overview/components/PublicFrontpage.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Container, Flex } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Link } from 'react-router-dom';
-import { fetchData } from 'app/actions/FrontpageActions';
+import { fetchData, fetchReadmes } from 'app/actions/FrontpageActions';
 import buddyWeekGraphic from 'app/assets/frontpage-graphic-buddyweek.png';
 import dataGraphic from 'app/assets/frontpage-graphic-data.png';
 import forCompaniesGraphic from 'app/assets/frontpage-graphic-for-companies.png';
@@ -35,7 +35,12 @@ const PublicFrontpage = () => {
 
   const dispatch = useAppDispatch();
 
-  usePreparedEffect('fetchIndex', () => dispatch(fetchData()), []);
+  usePreparedEffect(
+    'fetchIndex',
+    () =>
+      Promise.allSettled([dispatch(fetchReadmes(2)), dispatch(fetchData())]),
+    []
+  );
 
   const pinned = frontpage[0];
 
@@ -70,6 +75,7 @@ const PublicFrontpage = () => {
           expandedInitially
           collapsible={false}
           style={{ gridArea: 'readme' }}
+          displayCount={2}
         />
       </Container>
       <UsefulLinks />

--- a/app/store/models/Event.ts
+++ b/app/store/models/Event.ts
@@ -219,6 +219,7 @@ export type FrontpageEvent = Pick<
   Event,
   | 'id'
   | 'title'
+  | 'slug'
   | 'description'
   | 'cover'
   | 'coverPlaceholder'

--- a/packages/lego-bricks/src/components/Layout/Flex.tsx
+++ b/packages/lego-bricks/src/components/Layout/Flex.tsx
@@ -16,6 +16,7 @@ type Props = {
 
   /* Container component*/
   component?: ElementType;
+  componentRef?: React.RefObject<HTMLElement>;
 
   /** Wrap elements */
   wrap?: boolean;
@@ -44,6 +45,7 @@ const Flex = ({
   className,
   column = false,
   component: Component = 'div',
+  componentRef,
   wrap = false,
   wrapReverse = false,
   justifyContent = 'flex-start',
@@ -72,6 +74,7 @@ const Flex = ({
       gap,
       ...style,
     }}
+    ref={componentRef}
     {...htmlAttributes}
   >
     {children}


### PR DESCRIPTION
# Description

Implemented the styling of the frontpage through CSS grid. The goal of this implementation is twofold;

1.  The overview both looks like a grid and smells like a grid - so imo it should be a grid
2. Plus this separates the components from the styling between them - facilitating moving components around and replacing them with improved versions without affecting the rest of the page.

Removed the two containers used for desktop and mobile and rather merged them into one responsive container.

Also updated some of the styling to add a little bit more space to the page, and make the spacing more consistent (e.g. adding padding to the right side of the screen and not only the left).

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

## Before

**NOTE: what looks like a right-overflow in the video only appears when you change the viewport. When you keep the viewport the same, it fills the screen**

https://github.com/webkom/lego-webapp/assets/13599770/68f552f7-8087-4565-b4df-1dbd50d3adc4

## After

https://github.com/webkom/lego-webapp/assets/13599770/4672269c-679b-4781-b242-4243f6b3acca

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-832, ABA-423, ABA-727
