### PR TITLE
Fix paging and members table becoming empty

### DIFF
--- a/app/routes/admin/groups/components/AddGroupMember.tsx
+++ b/app/routes/admin/groups/components/AddGroupMember.tsx
@@ -1,15 +1,10 @@
 import { Field } from 'react-final-form';
-import {
-  addMember,
-  fetchMembershipsPagination,
-} from 'app/actions/GroupActions';
+import { addMember } from 'app/actions/GroupActions';
 import { Form, LegoFinalForm, SelectInput } from 'app/components/Form';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
-import { defaultGroupMembersQuery } from 'app/routes/admin/groups/components/GroupMembers';
 import { useAppDispatch } from 'app/store/hooks';
 import { roleOptions } from 'app/utils/constants';
-import useQuery from 'app/utils/useQuery';
 import { createValidator, required } from 'app/utils/validation';
 
 const validate = createValidator({
@@ -23,7 +18,6 @@ type Props = {
 
 const AddGroupMember = ({ groupId }: Props) => {
   const dispatch = useAppDispatch();
-  const { query } = useQuery(defaultGroupMembersQuery);
 
   const handleSubmit = (values, form) => {
     dispatch(
@@ -32,19 +26,9 @@ const AddGroupMember = ({ groupId }: Props) => {
         userId: values.user.id,
         role: values.role.value,
       })
-    )
-      .then(() =>
-        dispatch(
-          fetchMembershipsPagination({
-            groupId,
-            next: true,
-            query,
-          })
-        )
-      )
-      .then(() => {
-        form.reset();
-      });
+    ).then(() => {
+      form.reset();
+    });
   };
 
   return (

--- a/app/routes/admin/groups/components/GroupMembers.tsx
+++ b/app/routes/admin/groups/components/GroupMembers.tsx
@@ -69,6 +69,7 @@ const GroupMembers = () => {
       <LoadingIndicator loading={!memberships && fetching}>
         <h3>Brukere</h3>
         <GroupMembersList
+          groupId={groupId}
           key={Number(groupId) + Number(showDescendants)}
           hasMore={hasMore}
           groupsById={groupsById}

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -1,7 +1,11 @@
 import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { removeMember, addMember, fetchMembershipsPagination } from 'app/actions/GroupActions';
+import {
+  removeMember,
+  addMember,
+  fetchMembershipsPagination,
+} from 'app/actions/GroupActions';
 import { SelectInput } from 'app/components/Form';
 import Table from 'app/components/Table';
 import { defaultGroupMembersQuery } from 'app/routes/admin/groups/components/GroupMembers';
@@ -16,7 +20,7 @@ import type Membership from 'app/store/models/Membership';
 import type { ReactNode } from 'react';
 
 type Props = {
-  groupId,
+  groupId;
   fetching: boolean;
   hasMore: boolean;
   memberships: Membership[];

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -1,7 +1,7 @@
 import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { removeMember, addMember } from 'app/actions/GroupActions';
+import { removeMember, addMember, fetchMembershipsPagination } from 'app/actions/GroupActions';
 import { SelectInput } from 'app/components/Form';
 import Table from 'app/components/Table';
 import { defaultGroupMembersQuery } from 'app/routes/admin/groups/components/GroupMembers';
@@ -16,6 +16,7 @@ import type Membership from 'app/store/models/Membership';
 import type { ReactNode } from 'react';
 
 type Props = {
+  groupId,
   fetching: boolean;
   hasMore: boolean;
   memberships: Membership[];
@@ -29,6 +30,7 @@ type Props = {
 };
 
 const GroupMembersList = ({
+  groupId,
   memberships,
   hasMore,
   fetching,
@@ -172,6 +174,15 @@ const GroupMembersList = ({
 
   return (
     <Table
+      onLoad={() => {
+        dispatch(
+          fetchMembershipsPagination({
+            groupId,
+            next: true,
+            query,
+          })
+        );
+      }}
       onChange={setQuery}
       columns={columns}
       hasMore={hasMore}


### PR DESCRIPTION
# Description

Previously the pagination on the group members page was not working. This would also cause the members table to become empty when editing roles. 

Changes:
- Fixed paging on the group members table
- Fixed group members table becoming empty when editing user roles 

# Result

Previously:
[Screencast from 20. feb. 2024 kl. 13.18 +0100.webm](https://github.com/webkom/lego-webapp/assets/33326578/96dc148f-73be-4cb6-bdcc-1a3f8a61a9b5)

Fixed:
[Screencast from 20. feb. 2024 kl. 13.39 +0100.webm](https://github.com/webkom/lego-webapp/assets/33326578/804d8ade-44c3-4c5b-927d-f5bfa84957c1)


- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

- Navigate to `/admin/groups/11/members`
- Change the role of one of the members.
- Verify that the table does not become empty and that the role is correctly updated.
- Navigate to `/admin/groups/3/members`.
- Scroll down and verify that paging works.


Resolves ABA-793