### PR TITLE
Made the gradelist in ascending order

### DIFF
--- a/app/routes/users/components/UserProfile.tsx
+++ b/app/routes/users/components/UserProfile.tsx
@@ -521,7 +521,7 @@ const UserProfile = () => {
               <h3>Endre klasse</h3>
               <Card className={styles.infoCard}>
                 <GroupChange
-                  grades={groups}
+                  grades={groups.sort((a, b) => a.id > b.id)}
                   abakusGroups={abakusGroups}
                   username={user.username}
                 />


### PR DESCRIPTION
# Description

Under change classes on profile page the classes weren't presented in ascending order, more like in random order. I sorted the groups presented by id. And now they are in ascending order.

# Result
**Before:**
![Skjermbilde 2024-02-20 kl  21 36 58](https://github.com/webkom/lego-webapp/assets/145492323/4f223e8b-c172-46c9-9bbc-758af978da7c)

**After:**
![Skjermbilde 2024-02-20 kl  21 44 43](https://github.com/webkom/lego-webapp/assets/145492323/b8609a69-bb14-43ab-832f-d2a2d9ba50e9)

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [ x] Changes look good on both light and dark theme.
- [ x] Changes look good with different viewports (mobile, tablet, etc.).
- [x ] Changes look good with slower Internet connections.

# Testing

- [ x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-526
