### PR TITLE
Fix ordering of questions on survey

### DIFF
--- a/app/routes/surveys/components/SurveyEditor/SurveyForm.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyForm.tsx
@@ -62,10 +62,11 @@ const SurveyForm = ({
     return onSubmit({
       ...surveyData,
       event: surveyData.event.value,
-      questions: surveyData.questions.map((question) => ({
+      questions: surveyData.questions.map((question, i) => ({
         ...question,
         questionType: question.questionType.value,
         options: question.options.slice(0, -1),
+        relativeIndex: i,
       })),
     });
   };


### PR DESCRIPTION
# Description

Previously, you couldn't change the ordering of questions on surveys. This is now fixed (in a slightly hacky way).

# Result

**before**
![Screencast from 2024-02-21 19-09-16.webm](https://github.com/webkom/lego-webapp/assets/66320400/94aa49c5-4b9b-4877-9476-8152664f70c3)

**after**
![Screencast from 2024-02-21 19-10-12.webm](https://github.com/webkom/lego-webapp/assets/66320400/fb3a4fa0-b58a-442f-82c1-fd196117da08)

# Testing

- [X] I have thoroughly tested my changes.

I've tested for several surveys and it works.

---

Resolves ABA-792
