### PR TITLE
Redesign poll component

### DIFF
--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -1,15 +1,85 @@
 @import url('~app/styles/variables.css');
 
 .poll {
-  min-height: 160px;
+  background-color: var(--lego-card-color);
+  width: 100%;
+  min-width: 250px;
+  max-width: 500px;
+  min-height: 120px;
+  margin: 0 auto;
+  overflow-y: hidden;
+  border-radius: var(--border-radius-md);
+}
+
+.topBar {
+  width: 100%;
+  z-index: 2;
+}
+
+.pollIcon {
+  display: block;
+  width: 100%;
+  text-align: center;
+  background-color: var(--lego-red-color);
+  color: var(--color-white);
+  padding: 0 0.5rem 0.5rem;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 20%);
+}
+
+.titleLink {
+  position: relative;
+  display: block;
+  width: 80%;
+  top: -1.25rem;
+  margin-bottom: -2.25rem;
+  border-radius: var(--border-radius-lg);
+  color: var(--lego-font-color);
+  background-color: var(--lego-card-color);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 20%);
+  z-index: 3;
+}
+
+.title {
+  padding: 0.5rem;
+  font-weight: 500;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.contentWrapper {
+  width: 100%;
+  transition: height var(--linear-slow);
+  overflow-y: hidden;
 }
 
 .optionWrapper {
+  display: flex;
+  width: 100%;
   justify-content: center;
-  margin-top: 4px;
-  min-height: 120px;
-  position: relative;
+  align-items: center;
+  margin: 0.5rem 0;
+  margin-top: 1.5rem;
 }
+
+.description {
+  width: 90%;
+  padding-bottom: 0.5rem;
+  color: var(--secondary-font-color);
+  text-align: center;
+}
+
+/* Options visible & voting */
+
+.voteButton,
+.voteButton + .voteButton {
+  font-weight: 500;
+  width: 90%;
+  padding: 5px;
+  margin: 2px;
+  border-radius: var(--border-radius-md);
+}
+
+/* Options visible & !voting */
 
 .pollTable {
   width: 100%;
@@ -63,61 +133,41 @@
   }
 }
 
-.pollHeader a {
-  font-weight: 500;
-  color: var(--lego-font-color);
-  line-height: 1.3;
-}
-
-.voteButton {
-  width: 100%;
-  margin: 1px !important;
-}
-
-.moreOptionsLink {
-  justify-content: space-between;
-}
-
-.blurContainer {
-  display: none;
-  position: absolute;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  cursor: pointer;
-}
-
-.blurOverlay {
-  position: absolute;
-  z-index: 2;
-  font-weight: 500;
-  color: var(--color-absolute-white);
-}
-
-.optionWrapper:hover .blurContainer {
-  display: flex;
-}
-
-.optionWrapper:hover .blurEffect {
-  filter: blur(3px);
-  pointer-events: none;
+.resultsHiddenInfo {
+  color: var(--secondary-font-color);
 }
 
 .totalVotes {
   font-weight: 500;
 }
 
-@media (--mobile-device) {
-  .blurContainer {
-    display: flex;
-  }
-
-  .blurEffect {
-    filter: blur(3px);
-    pointer-events: none;
-  }
-}
-
 .success {
   color: var(--success-color);
+}
+
+.registrationCount {
+  margin-bottom: 0.5rem;
+}
+
+.bottomBar {
+  position: relative;
+  background-color: var(--lego-red-color);
+  width: 100%;
+  padding: 6.25rem 0 0.5rem;
+  top: -4.75rem;
+  margin-bottom: -5.25rem;
+  transition: padding-top var(--linear-slow), margin-bottom var(--linear-slow),
+    top var(--linear-slow);
+  z-index: 1;
+}
+
+.poll.expanded .bottomBar {
+  top: 0;
+  padding-top: 0.5rem;
+  margin-bottom: 0;
+}
+
+.arrowIcon {
+  color: var(--color-white);
+  text-shadow: 0 2px 2px rgba(0, 0, 0, 20%);
 }

--- a/app/components/Poll/index.tsx
+++ b/app/components/Poll/index.tsx
@@ -1,26 +1,30 @@
-import { Button, Card, Flex, Icon } from '@webkom/lego-bricks';
+import { Button, Flex, Icon, Skeleton } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import Linkify from 'linkify-react';
 import { sortBy } from 'lodash';
-import { useEffect, useState } from 'react';
+import moment from 'moment-timezone';
+import { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { votePoll } from 'app/actions/PollActions';
 import Tooltip from 'app/components/Tooltip';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './Poll.css';
-import type { PollEntity, OptionEntity } from 'app/reducers/polls';
+import type PollType from 'app/store/models/Poll';
+
+type PollOptionRatio = PollType['options'][0] & {
+  ratio: number;
+};
 
 // As described in: https://stackoverflow.com/questions/13483430/how-to-make-rounded-percentages-add-up-to-100
 export const perfectRatios = (
-  options: ReadonlyArray<OptionEntityRatio>
-): OptionEntityRatio[] => {
+  options: ReadonlyArray<PollOptionRatio>
+): PollOptionRatio[] => {
   const off =
     100 - options.reduce((a, option) => a + Math.floor(option.ratio), 0);
-  return sortBy<OptionEntityRatio>(
+  return sortBy<PollOptionRatio>(
     options,
-    (o: OptionEntityRatio) => Math.floor(o.ratio) - o.ratio
+    (o: PollOptionRatio) => Math.floor(o.ratio) - o.ratio
   )
-    .map((option: OptionEntityRatio, index: number) => {
+    .map((option: PollOptionRatio, index: number) => {
       return {
         ...option,
         ratio: Math.floor(option.ratio) + (index < off ? 1 : 0),
@@ -29,7 +33,7 @@ export const perfectRatios = (
     .sort((a, b) => b.ratio - a.ratio);
 };
 
-const optionsWithPerfectRatios = (options: OptionEntity[]) => {
+const optionsWithPerfectRatios = (options: PollType['options']) => {
   const totalVotes = options.reduce((a, option) => a + option.votes, 0);
   const ratios = options.map((option) => {
     return { ...option, ratio: (option.votes / totalVotes) * 100 };
@@ -38,210 +42,249 @@ const optionsWithPerfectRatios = (options: OptionEntity[]) => {
 };
 
 type Props = {
-  poll?: PollEntity;
+  poll?: PollType;
   allowedToViewHiddenResults?: boolean;
-  truncate?: number;
   details?: boolean;
-};
-
-type OptionEntityRatio = OptionEntity & {
-  ratio: number;
+  alwaysOpen?: boolean;
 };
 
 const Poll = ({
   poll,
   allowedToViewHiddenResults,
-  truncate,
   details,
+  alwaysOpen = false,
 }: Props) => {
-  const [truncateOptions, setTruncateOptions] = useState(false);
-  const [expanded, setExpanded] = useState(true);
+  const optionRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(alwaysOpen);
 
-  useEffect(() => {
-    const options = poll && optionsWithPerfectRatios(poll.options);
-
-    if (truncate && options && options.length > truncate) {
-      setTruncateOptions(true);
-      setExpanded(false);
-    } else {
-      setTruncateOptions(false);
-      setExpanded(true);
-    }
-  }, [poll, truncate]);
-
-  const toggleTruncate = () => {
+  const toggleExpanded = () => {
     setExpanded(!expanded);
   };
 
   const fetching = useAppSelector(
     (state) => state.frontpage.fetching || state.polls.fetching
   );
-  const dispatch = useAppDispatch();
 
-  const options = poll && optionsWithPerfectRatios(poll.options);
-  const orderedOptions = options;
-  const optionsToShow = expanded
-    ? orderedOptions
-    : orderedOptions?.slice(0, truncate);
-  const showResults = !poll?.resultsHidden || allowedToViewHiddenResults;
+  if (fetching && !poll) {
+    return <Skeleton className={styles.poll} />;
+  }
+
+  if (!poll) {
+    return null;
+  }
+
+  const {
+    id: pollId,
+    title,
+    description,
+    hasAnswered,
+    totalVotes,
+    resultsHidden,
+  } = poll;
+
+  const options = optionsWithPerfectRatios(poll.options);
+  const showResults = !resultsHidden || allowedToViewHiddenResults;
+  const expandedHeight = optionRef.current?.clientHeight ?? 0;
+
+  const now = moment();
+  const isValid = moment(poll.validUntil).isAfter(now);
+
+  const canAnswer = !hasAnswered && isValid;
 
   return (
-    <Card skeleton={fetching && !poll} className={styles.poll}>
-      <Flex column gap="1rem">
-        <Flex
-          alignItems="center"
-          justifyContent="space-between"
-          className={styles.pollHeader}
-        >
-          <Link to={`/polls/${poll?.id}`}>
-            <Flex alignItems="center" gap={10}>
-              <Icon name="stats-chart" size={20} />
-              <span className={styles.pollHeader}>{poll?.title}</span>
-            </Flex>
-          </Link>
-          <Tooltip content="Avstemningen er anonym">
-            <Icon name="information-circle-outline" size={20} />
-          </Tooltip>
-        </Flex>
-        {details && (
-          <div>
-            <Linkify
-              tagName="p"
-              options={{
-                rel: 'noopener noreferrer',
-                attributes: {
-                  target: '_blank',
-                },
-              }}
-            >
-              {poll?.description}
-            </Linkify>
-          </div>
-        )}
-        {poll?.hasAnswered && !showResults && (
-          <Flex justifyContent="center" alignItems="center" gap={5}>
-            Du har svart
-            <Icon
-              name="checkmark-circle-outline"
-              size={20}
-              className={styles.success}
+    <Flex
+      alignItems="center"
+      className={cx(styles.poll, expanded ? styles.expanded : undefined)}
+      column
+    >
+      <Flex
+        alignItems="center"
+        className={styles.topBar}
+        column
+        justifyContent="center"
+      >
+        <Icon
+          name={hasAnswered ? 'stats-chart' : 'help'}
+          size={28}
+          className={styles.pollIcon}
+        />
+        <Link to={`/polls/${pollId}`} className={styles.titleLink}>
+          <Flex
+            alignItems="center"
+            className={styles.title}
+            justifyContent="center"
+          >
+            {!details && description.length !== 0 ? (
+              <Tooltip content="Trykk for mer info">{title}</Tooltip>
+            ) : (
+              <>{title}</>
+            )}
+          </Flex>
+        </Link>
+      </Flex>
+      <Flex
+        column
+        className={styles.contentWrapper}
+        style={{
+          height: alwaysOpen ? `auto` : expanded ? `${expandedHeight}px` : '0',
+        }}
+      >
+        <div ref={optionRef}>
+          {canAnswer && (
+            <VoteOpen details={details} poll={poll} options={options} />
+          )}
+          {!canAnswer && showResults && (
+            <VoteResults
+              details={details}
+              poll={poll}
+              options={options}
+              resultsHidden={resultsHidden}
             />
-          </Flex>
-        )}
-        {poll?.hasAnswered && showResults && (
-          <Flex column className={styles.optionWrapper}>
-            <table className={styles.pollTable}>
-              <tbody>
-                {optionsToShow?.map(({ id, name, votes, ratio }) => {
-                  return (
-                    <tr key={id}>
-                      <td className={styles.textColumn}>{name}</td>
-                      <td className={styles.graphColumn}>
-                        {votes === 0 ? (
-                          <span className="secondaryFontColor">
-                            Ingen stemmer
-                          </span>
-                        ) : (
-                          <div className={styles.fullGraph}>
-                            <div
-                              style={{
-                                width: `${ratio}%`,
-                              }}
-                            >
-                              <div className={styles.pollGraph}>
-                                {ratio >= 18 && <span>{`${ratio}%`}</span>}
-                              </div>
-                            </div>
-                            {ratio < 18 && (
-                              <span
-                                style={{
-                                  padding: '5px',
-                                  marginLeft: '2px',
-                                }}
-                              >
-                                {`${ratio}%`}
-                              </span>
-                            )}
-                          </div>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-            {poll?.resultsHidden && (
-              <p
-                className="secondaryFontColor"
-                style={{
-                  marginTop: 15,
-                }}
-              >
-                Resultatet er skjult for vanlige brukere
-              </p>
-            )}
-          </Flex>
-        )}
-        {!poll?.hasAnswered && (
-          <Flex column className={styles.optionWrapper}>
-            {!expanded && (
-              <Flex
-                alignItems="center"
-                className={styles.blurContainer}
-                onClick={toggleTruncate}
-              >
-                <p className={styles.blurOverlay}>
-                  Klikk her for å se alle alternativene
-                </p>
-              </Flex>
-            )}
-            {options &&
-              optionsToShow?.map((option) => (
-                <Flex
-                  justifyContent="space-between"
-                  style={{ flexGrow: '1' }}
-                  className={cx(expanded ? '' : styles.blurEffect)}
-                  key={option.id}
-                >
-                  <Button
-                    dark
-                    onClick={() => dispatch(votePoll(poll.id, option.id))}
-                    className={styles.voteButton}
-                  >
-                    {option.name}
-                  </Button>
-                </Flex>
-              ))}
-          </Flex>
-        )}
-        <div>
-          <div className={styles.moreOptionsLink}>
-            {truncateOptions &&
-              (!poll?.hasAnswered ||
-                !poll?.resultsHidden ||
-                allowedToViewHiddenResults) && (
-                <Flex alignItems="center" justifyContent="center">
-                  <Icon
-                    onClick={toggleTruncate}
-                    name={expanded ? 'chevron-up' : 'chevron-down'}
-                    size={20}
-                  />
-                </Flex>
-              )}
-          </div>
-          <Flex justifyContent="space-between">
+          )}
+          {!canAnswer && !showResults && (
+            <VoteHidden details={details} poll={poll} />
+          )}
+
+          <Flex
+            alignItems="center"
+            justifyContent="center"
+            className={styles.registrationCount}
+            gap={8}
+          >
+            <Tooltip content="Avstemningen er anonym.">
+              <Icon name="information-circle-outline" size={17} />
+            </Tooltip>
             <span>
-              <span className={styles.totalVotes}>{poll?.totalVotes}</span>{' '}
-              {poll?.totalVotes === 1 ? 'stemme' : 'stemmer'}
+              <span className={styles.totalVotes}>{totalVotes}</span>{' '}
+              {totalVotes === 1 ? 'stemme' : 'stemmer'}
             </span>
-            {poll?.hasAnswered && !showResults && (
-              <span className="secondaryFontColor">Resultatet er skjult</span>
-            )}
           </Flex>
         </div>
       </Flex>
-    </Card>
+      <Flex
+        alignItems="center"
+        justifyContent="center"
+        className={styles.bottomBar}
+        style={{ cursor: alwaysOpen ? '' : 'pointer' }}
+        onClick={alwaysOpen ? undefined : toggleExpanded}
+      >
+        {!alwaysOpen && (
+          <Icon
+            className={styles.arrowIcon}
+            size={26}
+            name={expanded ? 'chevron-up' : 'chevron-down'}
+          />
+        )}
+      </Flex>
+    </Flex>
   );
 };
 
 export default Poll;
+
+type VoteOpenProps = {
+  poll: PollType;
+  details?: boolean;
+  options: PollOptionRatio[];
+};
+
+const VoteOpen = ({ details, poll, options }: VoteOpenProps) => {
+  const dispatch = useAppDispatch();
+
+  return (
+    <Flex column alignItems="center" className={styles.optionWrapper}>
+      {details && <p className={styles.description}>{poll.description}</p>}
+      {options.map((option) => (
+        <Button
+          key={option.id}
+          className={styles.voteButton}
+          dark
+          onClick={() => dispatch(votePoll(poll.id, option.id))}
+        >
+          {option.name}
+        </Button>
+      ))}
+    </Flex>
+  );
+};
+
+type VoteResultsProps = {
+  poll: PollType;
+  details?: boolean;
+  options: PollOptionRatio[];
+  resultsHidden: boolean;
+};
+
+const VoteResults = ({
+  details,
+  poll,
+  options,
+  resultsHidden,
+}: VoteResultsProps) => (
+  <Flex column className={styles.optionWrapper}>
+    {details && <p className={styles.description}>{poll.description}</p>}
+    <table className={styles.pollTable}>
+      <tbody>
+        {options.map(({ id, name, votes, ratio }) => {
+          return (
+            <tr key={id}>
+              <td className={styles.textColumn}>{name}</td>
+              <td className={styles.graphColumn}>
+                {votes === 0 ? (
+                  <span className="secondaryFontColor">Ingen stemmer</span>
+                ) : (
+                  <div className={styles.fullGraph}>
+                    <div
+                      style={{
+                        width: `${ratio}%`,
+                      }}
+                    >
+                      <div className={styles.pollGraph}>
+                        {ratio >= 18 && <span>{`${ratio}%`}</span>}
+                      </div>
+                    </div>
+                    {ratio < 18 && (
+                      <span
+                        style={{
+                          padding: '5px',
+                          marginLeft: '2px',
+                        }}
+                      >
+                        {`${ratio}%`}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+    {resultsHidden && (
+      <div className={styles.resultsHiddenInfo}>
+        Resultatet er skjult for vanlige brukere
+      </div>
+    )}
+  </Flex>
+);
+
+type VoteHiddenProps = {
+  poll: PollType;
+  details?: boolean;
+};
+
+const VoteHidden = ({ details, poll }: VoteHiddenProps) => (
+  <Flex column alignItems="center" className={styles.voteOptions}>
+    {details && <p className={styles.description}>{poll.description}</p>}
+    <Flex justifyContent="center" alignItems="center" gap={5}>
+      Du har svart
+      <Icon
+        name="checkmark-circle-outline"
+        size={20}
+        className={styles.success}
+      />
+    </Flex>
+    <div className={styles.resultsHiddenInfo}>Resultatet er skjult</div>
+  </Flex>
+);

--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -250,7 +250,7 @@ const PollItem = () => {
           <h3 className="u-ui-heading">Avstemning</h3>
         </Link>
 
-        <Poll poll={poll} truncate={3} />
+        <Poll poll={poll} />
       </Flex>
     )
   );

--- a/app/routes/polls/components/PollDetail.tsx
+++ b/app/routes/polls/components/PollDetail.tsx
@@ -69,6 +69,7 @@ const PollDetail = () => {
           poll={poll}
           allowedToViewHiddenResults={actionGrant.includes('edit')}
           details
+          alwaysOpen
         />
       ) : (
         <PollEditor poll={poll} editing toggleEdit={toggleEdit} />

--- a/cypress/e2e/poll_spec.js
+++ b/cypress/e2e/poll_spec.js
@@ -117,10 +117,11 @@ describe('Polls', () => {
     cy.visit('/');
     cy.contains('Avstemning');
     cy.contains(poll_form.title);
+    cy.get(c('Poll__arrowIcon')).first().click();
     cy.contains('0 stemmer');
     cy.contains(poll_form.choice_1).click();
     cy.contains('1 stemme');
-    cy.contains('a', poll_form.title).click();
+    cy.contains('div', poll_form.title).click();
     cy.url().should('include', '/polls');
   });
 


### PR DESCRIPTION
Shame to see updated components go to waste because of inactivity, so I have started scavenging what I could from https://github.com/webkom/lego-webapp/pull/2707 and updating it ever so slightly to merge it to master:)

With this update, no poll options are displayed until it is triggered, so the issue of showing all options while the component loads is no longer an issue.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

## Before - smol

https://github.com/webkom/lego-webapp/assets/13599770/bc07415c-7225-4a75-a0a2-fefd98ac2c9f

## After - smol

https://github.com/webkom/lego-webapp/assets/13599770/4b5e1472-0b3b-4c9a-8400-9f560ce27bb6

## Before - chunky

https://github.com/webkom/lego-webapp/assets/13599770/812ae096-7a22-412a-b41c-5b9df596ae86

## After - chunky

https://github.com/webkom/lego-webapp/assets/13599770/5347acc5-fe15-4f24-98ac-5406b61d2959


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-849, ABA-537, ABA-769
