### PR TITLE
Accurately check checkboxes on /events filter

### DIFF
--- a/app/routes/bdb/components/OptionsBox.tsx
+++ b/app/routes/bdb/components/OptionsBox.tsx
@@ -65,7 +65,7 @@ export default class OptionsBox extends Component<Props, State> {
           <div className={styles.section}>
             <CheckBox
               id="isActive"
-              value={this.state.active}
+              checked={this.state.active}
               name="active"
               label="Er aktiv"
               onChange={() => this.toggleSection('active')}
@@ -95,7 +95,7 @@ export default class OptionsBox extends Component<Props, State> {
 
             <CheckBox
               id="hasStudentContact"
-              value={this.state.studentContact}
+              checked={this.state.studentContact}
               name="studentContact"
               label="Har studentkontakt ..."
               onChange={() => this.toggleSection('studentContact')}

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -221,25 +221,25 @@ const EventList = () => {
           <CheckBox
             id="companyPresentation"
             label="Bedpres"
-            value={showCompanyPresentation}
+            checked={showCompanyPresentation}
             onChange={toggleEventType('company_presentation')}
           />
           <CheckBox
             id="course"
             label="Kurs"
-            value={showCourse}
+            checked={showCourse}
             onChange={toggleEventType('course')}
           />
           <CheckBox
             id="social"
             label="Sosialt"
-            value={showSocial}
+            checked={showSocial}
             onChange={toggleEventType('social')}
           />
           <CheckBox
             id="other"
             label="Annet"
-            value={showOther}
+            checked={showOther}
             onChange={toggleEventType('other')}
           />
         </div>


### PR DESCRIPTION
# Description

The default checked value of these checkboxes when visiting /events would be incorrect if you visit with query params, e.g. through the links on the frontpage "Bedpres og kurs" and "Arrangementer".

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/webkom/lego-webapp/assets/69514187/e10356c3-4c59-46e6-a682-0353dbccf61d


# Testing

- [x] I have thoroughly tested my changes.

The checkboxes are now given default values when visiting the page with query params.