### PR TITLE
Redesign event edit page

### DIFF
--- a/app/components/Form/DatePicker.css
+++ b/app/components/Form/DatePicker.css
@@ -11,6 +11,7 @@
   width: auto;
   max-width: 335px;
   padding: 0 15px 8px;
+  z-index: 20;
 }
 
 .inputField {

--- a/app/components/Form/ImageUploadField.css
+++ b/app/components/Form/ImageUploadField.css
@@ -1,3 +1,5 @@
+@import url('~app/styles/variables.css');
+
 .base {
   position: relative;
   overflow: hidden;
@@ -5,6 +7,6 @@
 
 .coverImage {
   width: 100%;
-  height: 300px;
+  aspect-ratio: 3.3;
   background: var(--additive-background);
 }

--- a/app/components/Form/SelectInput.tsx
+++ b/app/components/Form/SelectInput.tsx
@@ -48,6 +48,7 @@ export const selectStyles: StylesConfig = {
     color: isSelected ? 'var(--color-gray-1)' : undefined,
     fontSize: '14px',
   }),
+  menuPortal: (base) => ({ ...base, zIndex: 20 }),
 };
 export const selectTheme: ThemeConfig = (theme) => ({
   ...theme,
@@ -140,6 +141,7 @@ const SelectInput = <Option, IsMulti extends boolean = false>({
           onSearch?.(value);
           return value;
         }}
+        menuPortalTarget={document.body}
         styles={selectStyle ?? selectStyles}
         theme={selectTheme}
         blurInputOnSelect={false}

--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -119,7 +119,7 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
           className={styles.placeholderContainer}
         >
           <Icon
-            size={60}
+            size={50}
             name={multiple ? 'images-outline' : 'image-outline'}
           />
           {isDragActive ? (
@@ -239,12 +239,7 @@ export default class ImageUpload extends Component<Props, State> {
     const { cropOpen, file, files } = this.state;
     const preview = file && file.preview;
     const accept: Accept = {
-      'image/jpeg': ['*'],
-      'image/png': ['*'],
-      'image/gif': ['*'],
-      'image/tif': ['*'],
-      'image/bmp': ['*'],
-      'image/avif': ['*'],
+      'image/*': ['.jpeg', '.jpg', '.png', '.gif', '.tif', '.bmp', '.avif'],
     };
     return (
       <>

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -9,7 +9,7 @@
 
 .dropArea {
   border-radius: inherit;
-  height: inherit;
+  aspect-ratio: inherit;
   width: inherit;
   z-index: 0;
   position: absolute;
@@ -29,13 +29,17 @@
 .placeholderContainer {
   overflow: hidden;
   border-radius: inherit;
-  height: inherit;
+  aspect-ratio: inherit;
   width: inherit;
   position: absolute;
   background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 50%);
   font-weight: 500;
   padding: 10px 40px;
   text-align: center;
+
+  @media (--small-viewport) {
+    line-height: 1.3;
+  }
 }
 
 .inModalUpload .placeholderContainer {

--- a/app/routes/admin/email/components/EmailListEditor.tsx
+++ b/app/routes/admin/email/components/EmailListEditor.tsx
@@ -156,7 +156,7 @@ const EmailListEditor = () => {
             name="requireInternalAddress"
             type="checkbox"
             component={CheckBox.Field}
-            normalize={(v) => !!v}
+            parse={(v) => !!v}
           />
 
           <Field

--- a/app/routes/admin/groups/components/GroupForm/index.tsx
+++ b/app/routes/admin/groups/components/GroupForm/index.tsx
@@ -107,7 +107,7 @@ const GroupForm = ({ isInterestGroup }: Props) => {
               name="showBadge"
               type="checkbox"
               component={CheckBox.Field}
-              normalize={(v) => !!v}
+              parse={(v) => !!v}
             />
           </Tooltip>
           <Tooltip content="Er dette en aktiv gruppe?">
@@ -116,7 +116,7 @@ const GroupForm = ({ isInterestGroup }: Props) => {
               name="active"
               type="checkbox"
               component={CheckBox.Field}
-              normalize={(v) => !!v}
+              parse={(v) => !!v}
             />
           </Tooltip>
           <Field

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -180,7 +180,7 @@ const ArticleEditor = () => {
               name="pinned"
               type="checkbox"
               component={CheckBox.Field}
-              normalize={(v) => !!v}
+              parse={(v) => !!v}
             />
             <Field
               placeholder="Title"

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -85,7 +85,7 @@ const SemesterBox = ({
         label={semesterToText({ ...fields.value[index], language })}
         type="checkbox"
         component={CheckBox.Field}
-        normalize={(v) => !!v}
+        parse={(v) => !!v}
       />
     ))}
   </Flex>
@@ -106,7 +106,7 @@ const SurveyOffersBox = ({
         label={SURVEY_OFFERS[surveyOffersToString(item)][language]}
         type="checkbox"
         component={CheckBox.Field}
-        normalize={(v) => !!v}
+        parse={(v) => !!v}
       />
     ))}
   </Flex>
@@ -138,7 +138,7 @@ const EventBox = ({
               label={EVENTS[eventToString(key)][language]}
               type="checkbox"
               component={CheckBox.Field}
-              normalize={(v) => !!v}
+              parse={(v) => !!v}
             />
           ))}
         </Flex>
@@ -162,7 +162,7 @@ const TargetGradeBox = ({
         label={TARGET_GRADES[targetGradeToString(key)][language]}
         type="checkbox"
         component={CheckBox.Field}
-        normalize={(v) => !!v}
+        parse={(v) => !!v}
       />
     ))}
   </Flex>
@@ -183,7 +183,7 @@ const OtherBox = ({
         label={readmeIfy(OTHER_OFFERS[otherOffersToString(key)][language])}
         type="checkbox"
         component={CheckBox.Field}
-        normalize={(v) => !!v}
+        parse={(v) => !!v}
       />
     ))}
   </Flex>
@@ -204,7 +204,7 @@ const CollaborationBox = ({
         label={COLLABORATION_TYPES[collaborationToString(key)][language]}
         type="checkbox"
         component={CheckBox.Field}
-        normalize={(v) => !!v}
+        parse={(v) => !!v}
       />
     ))}
   </Flex>

--- a/app/routes/events/components/EventEditor/EditorSection/Descriptions.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Descriptions.tsx
@@ -1,0 +1,41 @@
+import { Flex } from '@webkom/lego-bricks';
+import { Field } from 'react-final-form';
+import { EditorField, TextEditor } from 'app/components/Form';
+import Tag from 'app/components/Tags/Tag';
+import styles from '../EventEditor.css';
+import type { UploadArgs } from 'app/actions/FileActions';
+import type { EditingEvent } from 'app/routes/events/utils';
+
+type Props = {
+  uploadFile: (uploadArgs: UploadArgs) => void;
+  values: EditingEvent;
+};
+
+const Descriptions: React.FC<Props> = ({ uploadFile, values }) => {
+  return (
+    <>
+      <Field
+        name="description"
+        label="Kalenderbeskrivelse"
+        placeholder="Kom på fest den ..."
+        component={TextEditor.Field}
+        required
+      />
+      <Field
+        name="text"
+        label="Hovedbeskrivelse"
+        component={EditorField.Field}
+        placeholder="Dette blir tidenes fest ..."
+        className={styles.descriptionEditor}
+        uploadFile={uploadFile}
+      />
+      <Flex className={styles.tagRow}>
+        {(values.tags || []).map((tag, i) => (
+          <Tag key={i} tag={tag} />
+        ))}
+      </Flex>
+    </>
+  );
+};
+
+export default Descriptions;

--- a/app/routes/events/components/EventEditor/EditorSection/Details.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Details.tsx
@@ -1,0 +1,172 @@
+import { Flex } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import { Field } from 'react-final-form';
+import {
+  SelectInput,
+  TextInput,
+  CheckBox,
+  DatePicker,
+} from 'app/components/Form';
+import fieldStyles from 'app/components/Form/Field.css';
+import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
+import Tooltip from 'app/components/Tooltip';
+import { EventTypeConfig } from 'app/routes/events/utils';
+import styles from '../EventEditor.css';
+import type { EditingEvent } from 'app/routes/events/utils';
+
+type Props = {
+  values: EditingEvent;
+};
+
+const Details: React.FC<Props> = ({ values }) => {
+  return (
+    <>
+      <Flex className={styles.editorSectionRow}>
+        <Field
+          name="eventType"
+          label="Type arrangement"
+          fieldClassName={styles.metaField}
+          component={SelectInput.Field}
+          options={Object.entries(EventTypeConfig).map(([key, config]) => ({
+            label: config.displayName,
+            value: key,
+          }))}
+          placeholder="Arrangementstype"
+          required
+        />
+        <Field
+          name="company"
+          label="Arrangerende bedrift"
+          filter={['companies.company']}
+          fieldClassName={styles.metaField}
+          component={SelectInput.AutocompleteField}
+          placeholder="Bedrift"
+          isClearable
+        />
+      </Flex>
+      <Flex className={styles.editorSectionRow}>
+        <Field
+          name="responsibleGroup"
+          label="Ansvarlig gruppe"
+          filter={['users.abakusgroup']}
+          fieldClassName={styles.metaField}
+          component={SelectInput.AutocompleteField}
+          placeholder="Ansvar for arrangement"
+          isClearable
+        />
+        <Field
+          name="responsibleUsers"
+          label="Ansvarlige brukere"
+          filter={['users.user']}
+          fieldClassName={styles.metaField}
+          component={SelectInput.AutocompleteField}
+          isMulti
+          placeholder="Velg ansvarlige brukere"
+          isClearable
+        />
+      </Flex>
+      <Flex className={styles.editorSectionRow}>
+        <Field
+          label="Starter"
+          name="startTime"
+          component={DatePicker.Field}
+          fieldClassName={styles.metaField}
+          className={styles.formField}
+          required
+        />
+        <Field
+          label="Slutter"
+          name="endTime"
+          component={DatePicker.Field}
+          fieldClassName={styles.metaField}
+          className={styles.formField}
+          required
+        />
+      </Flex>
+      <Flex className={styles.editorSectionRow}>
+        <Flex column className={styles.editorSectionColumn}>
+          <Flex alignItems="center">
+            <label
+              htmlFor="react-select-mazemapPoi-input"
+              className={styles.label}
+            >
+              Sted
+            </label>
+            <span className={fieldStyles.required}>*</span>
+          </Flex>
+          <Field
+            label="Bruk MazeMap"
+            name="useMazemap"
+            type="checkbox"
+            component={CheckBox.Field}
+            fieldClassName={cx(styles.metaField, styles.mazemap)}
+            className={styles.formField}
+            parse={(v) => !!v}
+          />
+          {!values.useMazemap ? (
+            <Field
+              id="react-select-mazemapPoi-input"
+              name="location"
+              placeholder="Den Gode Nabo, Downtown, ..."
+              component={TextInput.Field}
+              fieldClassName={styles.metaField}
+              className={styles.formField}
+            />
+          ) : (
+            <Flex alignItems="flex-start" gap="var(--spacing-sm)">
+              <Field
+                id="location"
+                name="mazemapPoi"
+                component={SelectInput.MazemapAutocomplete}
+                fieldClassName={styles.metaField}
+                placeholder="R1, Abakus, Kjel4 ..."
+              />
+              {values.mazemapPoi?.value && (
+                <Tooltip content="Åpne stedet i MazeMap">
+                  <MazemapLink
+                    mazemapPoi={values.mazemapPoi?.value}
+                    linkText="↗️"
+                  />
+                </Tooltip>
+              )}
+            </Flex>
+          )}
+        </Flex>
+      </Flex>
+      <Field
+        label="Fremmedspråklig"
+        description="Arrangementet er på et annet språk enn norsk (engelsk)"
+        name="isForeignLanguage"
+        type="checkbox"
+        component={CheckBox.Field}
+        fieldClassName={styles.metaField}
+        className={styles.formField}
+        parse={(v) => !!v}
+      />
+      <Field
+        label="Kun for spesifikk gruppe"
+        description="Gjør arrangementet synlig for kun medlemmer i spesifikke grupper"
+        name="isGroupOnly"
+        type="checkbox"
+        component={CheckBox.Field}
+        fieldClassName={styles.metaField}
+        className={styles.formField}
+        parse={(v) => !!v}
+      />
+      {values.isGroupOnly && (
+        <div className={styles.subSection}>
+          <Field
+            name="canViewGroups"
+            placeholder="Velg grupper"
+            filter={['users.abakusgroup']}
+            fieldClassName={styles.metaField}
+            component={SelectInput.AutocompleteField}
+            isMulti
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default Details;

--- a/app/routes/events/components/EventEditor/EditorSection/Header.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Header.tsx
@@ -1,0 +1,163 @@
+import { ConfirmModal, Flex, Icon, Modal } from '@webkom/lego-bricks';
+import { Field } from 'react-final-form';
+import { setSaveForUse } from 'app/actions/FileActions';
+import {
+  TextInput,
+  CheckBox,
+  Button,
+  ImageUploadField,
+} from 'app/components/Form';
+import { Image } from 'app/components/Image';
+import { colorForEventType } from 'app/routes/events/utils';
+import styles from '../EventEditor.css';
+import type { EditingEvent } from 'app/routes/events/utils';
+import type { FormApi } from 'final-form';
+
+type Props = {
+  form: FormApi<EditingEvent, Partial<EditingEvent>>;
+  values: EditingEvent;
+  useImageGallery: boolean;
+  imageGalleryUrl: string;
+  event: any;
+  showImageGallery: boolean;
+  setShowImageGallery: React.Dispatch<React.SetStateAction<boolean>>;
+  imageGallery: any;
+  setUseImageGallery: React.Dispatch<React.SetStateAction<boolean>>;
+  setImageGalleryUrl: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const Header = ({
+  form,
+  values,
+  useImageGallery,
+  imageGalleryUrl,
+  event,
+  showImageGallery,
+  setShowImageGallery,
+  imageGallery,
+  setUseImageGallery,
+  setImageGalleryUrl,
+}: Props) => {
+  return (
+    <>
+      <Field
+        label="Tittel"
+        name="title"
+        placeholder="Tittel"
+        style={{
+          borderBottom: `3px solid ${colorForEventType(
+            values.eventType?.value,
+          )}`,
+        }}
+        component={TextInput.Field}
+        required
+      />
+      <Field
+        label="Festet på forsiden"
+        name="pinned"
+        type="checkbox"
+        component={CheckBox.Field}
+        fieldClassName={styles.metaField}
+        className={styles.formField}
+      />
+
+      <Field
+        label="Cover"
+        name="cover"
+        component={ImageUploadField}
+        aspectRatio={20 / 6}
+        img={useImageGallery ? imageGalleryUrl : event?.cover}
+        required
+      />
+
+      <Modal
+        show={showImageGallery}
+        onHide={() => setShowImageGallery(false)}
+        contentClassName={styles.imageGallery}
+      >
+        <>
+          <h1>Bildegalleri</h1>
+          <Flex
+            wrap
+            alignItems="center"
+            justifyContent="space-around"
+            gap="var(--spacing-md)"
+          >
+            {imageGallery?.map((e) => (
+              <Flex key={e.key} alignItems="center" gap="var(--spacing-md)">
+                <Image
+                  src={e.cover}
+                  placeholder={e.coverPlaceholder}
+                  alt={`${e.cover} bilde`}
+                  onClick={() => {
+                    form.change('cover', `${e.key}:${e.token}`);
+                    setShowImageGallery(false);
+                    setUseImageGallery(true);
+                    setImageGalleryUrl(e.cover);
+                  }}
+                  className={styles.imageGalleryEntry}
+                />
+                <ConfirmModal
+                  title="Fjern fra galleri"
+                  message={`Er du sikker på at du vil fjerne bildet fra bildegalleriet? Bildet blir ikke slettet fra databasen.`}
+                  closeOnConfirm
+                  onConfirm={() => setSaveForUse(e.key, e.token, false)}
+                >
+                  {({ openConfirmModal }) => (
+                    <Icon onClick={openConfirmModal} name="trash" danger />
+                  )}
+                </ConfirmModal>
+              </Flex>
+            ))}
+            {imageGallery.length === 0 && (
+              <Flex
+                column
+                alignItems="center"
+                gap={'var(--spacing-xs)'}
+                className={styles.emptyGallery}
+              >
+                <Icon name="folder-open-outline" size={50} />
+                <b>Bildegalleriet er tomt ...</b>
+                <span>Hvorfor ikke laste opp et bilde?</span>
+              </Flex>
+            )}
+          </Flex>
+        </>
+      </Modal>
+
+      <Flex
+        wrap
+        gap="var(--spacing-sm)"
+        alignItems="center"
+        justifyContent="space-between"
+        margin={'0 0 var(--spacing-md) 0'}
+      >
+        <Button onClick={() => setShowImageGallery(true)}>
+          Velg bilde fra bildegalleriet
+        </Button>
+        <div>
+          <Field
+            label="Lagre til bildegalleriet"
+            description="Lagre bildet til bildegalleriet slik at det kan bli brukt til andre arrangementer"
+            name="saveToImageGallery"
+            type="checkbox"
+            component={CheckBox.Field}
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+          />
+        </div>
+      </Flex>
+
+      <Field
+        name="youtubeUrl"
+        label="Erstatt cover-bildet med video fra YouTube"
+        description="Videoen erstatter ikke coveret i listen over arrangementer"
+        placeholder="https://www.youtube.com/watch?v=bLHL75H_VEM&t=5"
+        component={TextInput.Field}
+        parse={(value) => value}
+      />
+    </>
+  );
+};
+
+export default Header;

--- a/app/routes/events/components/EventEditor/EditorSection/Registration.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Registration.tsx
@@ -1,0 +1,263 @@
+import { Flex } from '@webkom/lego-bricks';
+import moment from 'moment-timezone';
+import { Field } from 'react-final-form';
+import { FieldArray } from 'react-final-form-arrays';
+import {
+  SelectInput,
+  TextInput,
+  CheckBox,
+  DatePicker,
+} from 'app/components/Form';
+import { FormatTime } from 'app/components/Time';
+import { AttendanceStatus } from 'app/components/UserAttendance';
+import AttendanceModal from 'app/components/UserAttendance/AttendanceModal';
+import {
+  containsAllergier,
+  eventStatusTypes,
+  tooLow,
+} from 'app/routes/events/utils';
+import { spyValues } from 'app/utils/formSpyUtils';
+import styles from '../EventEditor.css';
+import renderPools from '../renderPools';
+import type { EditingEvent } from 'app/routes/events/utils';
+
+type Props = {
+  values: EditingEvent;
+};
+
+const Registrations: React.FC<Props> = ({ values }) => {
+  const initialPool = {
+    name: 'Pool #1',
+    registrations: [],
+    activationDate: moment(values.startTime)
+      .subtract(7, 'd')
+      .hour(12)
+      .minute(0)
+      .toISOString(),
+    permissionGroups: [],
+  };
+
+  return (
+    <>
+      {spyValues((values: EditingEvent) => {
+        // Adding an initial pool if the event status type allows for it and there are no current pools
+        if (['NORMAL', 'INFINITE'].includes(values.eventStatusType?.value)) {
+          if (values.pools.length === 0) {
+            values.pools = [initialPool];
+          }
+        } else {
+          // Removing all pools so that they are not validated on submit
+          if (values.pools.length > 0) {
+            values.pools = [];
+          }
+        }
+
+        return (
+          <Field
+            label="Påmeldingstype"
+            name="eventStatusType"
+            component={SelectInput.Field}
+            fieldClassName={styles.metaField}
+            options={eventStatusTypes}
+            required
+          />
+        );
+      })}
+
+      {['NORMAL', 'INFINITE'].includes(values.eventStatusType?.value) && (
+        <NormalOrInfiniteStatusType values={values} />
+      )}
+    </>
+  );
+};
+
+export default Registrations;
+
+type NormalOrInfiniteStatusTypeProps = Props;
+
+const NormalOrInfiniteStatusType: React.FC<NormalOrInfiniteStatusTypeProps> = ({
+  values,
+}) => {
+  return (
+    <>
+      <Field
+        label="Betalt arrangement"
+        name="isPriced"
+        type="checkbox"
+        component={CheckBox.Field}
+        fieldClassName={styles.metaField}
+        className={styles.formField}
+        parse={(v) => !!v}
+      />
+      {values.isPriced && (
+        <div className={styles.subSection}>
+          <Field
+            label="Betaling via Abakus.no"
+            description="Manuell betaling kan også godkjennes av oss i etterkant"
+            name="useStripe"
+            type="checkbox"
+            component={CheckBox.Field}
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+            parse={(v) => !!v}
+          />
+          <Flex className={styles.editorSectionRow}>
+            <Field
+              label="Pris"
+              name="priceMember"
+              type="number"
+              component={TextInput.Field}
+              fieldClassName={styles.metaField}
+              className={styles.formField}
+              warn={tooLow}
+              required
+            />
+            <Field
+              label="Betalingsfrist"
+              name="paymentDueDate"
+              component={DatePicker.Field}
+              fieldClassName={styles.metaField}
+              className={styles.formField}
+            />
+          </Flex>
+        </div>
+      )}
+      <Field
+        label="Bruk prikker"
+        name="heedPenalties"
+        type="checkbox"
+        component={CheckBox.Field}
+        fieldClassName={styles.metaField}
+        className={styles.formField}
+        parse={(v) => !!v}
+      />
+      {values.heedPenalties && (
+        <div className={styles.subSection}>
+          <Field
+            key="unregistrationDeadline"
+            label="Avregistreringsfrist"
+            description="Frist for avmelding - fører til prikk etterpå"
+            name="unregistrationDeadline"
+            component={DatePicker.Field}
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+          />
+        </div>
+      )}
+      <Flex className={styles.editorSectionRow}>
+        <Flex column className={styles.editorSectionColumn}>
+          <Field
+            key="registrationDeadlineHours"
+            label="Registrering antall timer før"
+            description="Frist for påmelding/avmelding - antall timer før arrangementet. Det er ikke mulig å melde seg hverken på eller av etter denne fristen (negativ verdi betyr antall timer etter starten på arrangementet)"
+            name="registrationDeadlineHours"
+            type="number"
+            component={TextInput.Field}
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+          />
+          <p className={styles.registrationDeadlineHours}>
+            Stenger <FormatTime time={moment(values.registrationDeadline)} />
+          </p>
+        </Flex>
+        <Flex column className={styles.editorSectionColumn}>
+          <Field
+            label="Separat avregistreringsfrist"
+            description="Separate frister for påmelding og avmelding - antall timer før arrangementet. Det vil ikke være mulig å melde seg av eller på etter de satte fristene (negativ verdi betyr antall timer etter starten på arrangementet)"
+            name="separateDeadlines"
+            type="checkbox"
+            component={CheckBox.Field}
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+            parse={(v) => !!v}
+          />
+          {values.separateDeadlines && (
+            <div className={styles.subSection}>
+              <Field
+                key="unregistrationDeadlineHours"
+                label="Avregistrering antall timer før"
+                description="Frist for avmelding antall timer før arrangementet (negativ verdi betyr antall timer etter starten på arrangementet)"
+                name="unregistrationDeadlineHours"
+                type="number"
+                component={TextInput.Field}
+                fieldClassName={styles.metaField}
+                className={styles.formField}
+              />
+            </div>
+          )}
+        </Flex>
+      </Flex>
+      <Field
+        label="Samtykke til bilder"
+        description="Bruk samtykke til bilder"
+        name="useConsent"
+        type="checkbox"
+        component={CheckBox.Field}
+        fieldClassName={styles.metaField}
+        className={styles.formField}
+        parse={(v) => !!v}
+      />
+      <Field
+        label="Påmeldingsspørsmål"
+        description="Still et spørsmål ved påmelding"
+        name="hasFeedbackQuestion"
+        type="checkbox"
+        component={CheckBox.Field}
+        fieldClassName={styles.metaField}
+        className={styles.formField}
+        parse={(v) => !!v}
+      />
+      {values.hasFeedbackQuestion && (
+        <div className={styles.subSection}>
+          <Field
+            name="feedbackDescription"
+            placeholder="Burger eller sushi?"
+            component={TextInput.Field}
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+            warn={containsAllergier}
+          />
+          <Field
+            name="feedbackRequired"
+            label="Obligatorisk"
+            type="checkbox"
+            component={CheckBox.Field}
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+            parse={(v) => !!v}
+          />
+        </div>
+      )}
+      <Flex column>
+        <h3>Pools</h3>
+        <AttendanceModal
+          key="modal"
+          pools={values.pools || []}
+          title="Påmeldte"
+        >
+          {({ toggleModal }) => (
+            <AttendanceStatus toggleModal={toggleModal} pools={values.pools} />
+          )}
+        </AttendanceModal>
+        <div className={styles.metaList}>
+          <FieldArray
+            name="pools"
+            component={renderPools}
+            startTime={values.startTime}
+            eventStatusType={values.eventStatusType?.value}
+          />
+        </div>
+        {values.pools?.length > 1 && (
+          <Field
+            label="Sammenslåingstidspunkt"
+            description="Tidspunkt for å slå sammen poolene"
+            name="mergeTime"
+            component={DatePicker.Field}
+            fieldClassName={styles.metaField}
+            className={styles.formField}
+          />
+        )}
+      </Flex>
+    </>
+  );
+};

--- a/app/routes/events/components/EventEditor/EditorSection/index.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/index.tsx
@@ -1,0 +1,52 @@
+import { Flex, Icon } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import { useState } from 'react';
+import styles from '../EventEditor.css';
+import type { PropsWithChildren } from 'react';
+
+type Props = {
+  title: string;
+  collapsible?: boolean;
+  initiallyExpanded?: boolean;
+};
+
+const EditorSection: React.FC<PropsWithChildren<Props>> = ({
+  children,
+  title,
+  collapsible = true,
+  initiallyExpanded = false,
+}) => {
+  const [expanded, setExpanded] = useState(!collapsible || initiallyExpanded);
+
+  return (
+    <>
+      <Flex
+        alignItems="center"
+        gap={4}
+        className={cx(
+          styles.editorSectionToggle,
+          collapsible && styles.collapsible,
+        )}
+        onClick={() => collapsible && setExpanded(!expanded)}
+      >
+        {collapsible && (
+          <Icon
+            className={cx(styles.toggleIcon, expanded && styles.expanded)}
+            name={`chevron-forward`}
+          />
+        )}
+        <h3>{title}</h3>
+      </Flex>
+      {expanded && (
+        <div className={styles.editorSectionContent}>{children}</div>
+      )}
+    </>
+  );
+};
+
+export default EditorSection;
+
+export { default as Header } from './Header';
+export { default as Details } from './Details';
+export { default as Registration } from './Registration';
+export { default as Descriptions } from './Descriptions';

--- a/app/routes/events/components/EventEditor/EventEditor.css
+++ b/app/routes/events/components/EventEditor/EventEditor.css
@@ -1,5 +1,36 @@
 @import url('../Event.css');
 
+.editorSectionToggle {
+  position: sticky;
+  top: 0;
+  background-color: var(--lego-card-color);
+  z-index: 5;
+  box-shadow: var(--shadow-bottom-md);
+  margin-bottom: var(--spacing-md);
+  cursor: default;
+}
+
+.toggleIcon {
+  transition: var(--easing-medium);
+}
+
+.toggleIcon.expanded {
+  transform: rotate(90deg);
+}
+
+.editorSectionToggle.collapsible {
+  cursor: pointer;
+}
+
+.editorSectionRow {
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+
+  @media (--medium-viewport) {
+    gap: 0;
+  }
+}
+
 .descriptionEditor {
   background: inherit;
   color: var(--lego-font-color);
@@ -16,17 +47,29 @@
 }
 
 .metaField {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-md);
+}
+
+.editorSectionRow > .metaField,
+.editorSectionRow > .editorSectionColumn {
+  flex-basis: calc(50% - var(--spacing-sm));
+
+  @media (--medium-viewport) {
+    flex-basis: 100%;
+  }
 }
 
 .metaFieldInformation {
+  margin-bottom: var(--spacing-sm);
+}
+
+.metaField.mazemap {
   margin-bottom: 0;
-  font-size: small;
 }
 
 .metaField input {
-  padding-bottom: 5px;
-  padding-top: 5px;
+  padding-bottom: var(--spacing-xs);
+  padding-top: var(--spacing-xs);
 }
 
 .metaList {
@@ -34,8 +77,27 @@
   align-items: center;
 }
 
+.metaList > ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2%;
+}
+
+.metaList > ul > li {
+  flex-basis: 100%;
+}
+
+.metaList > ul > li.poolBox {
+  flex-basis: 32%;
+}
+
 .metaList > span {
   display: flex;
+}
+
+.label {
+  cursor: default;
+  font-size: var(--font-size-lg);
 }
 
 .poolHeader {
@@ -43,26 +105,35 @@
 }
 
 .tagRow {
-  margin-top: 16px;
+  margin-top: var(--spacing-md);
 }
 
 .poolBox {
   border: 1.5px solid var(--border-gray);
   border-radius: var(--border-radius-lg);
-  padding: 10px;
-  margin-top: 10px;
+  padding: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
 }
 
 .centeredButton {
   display: flex;
   justify-content: center;
-  margin-top: 10px;
+  margin-top: var(--spacing-sm);
+}
+
+.metaField:has(+ .subSection) {
+  margin-bottom: var(--spacing-sm);
 }
 
 .subSection {
-  margin-left: 10px;
-  border-left: 4px solid var(--lego-red-color);
-  padding: 0 0 10px 10px;
+  margin-left: var(--spacing-sm);
+  border-left: var(--spacing-xs) solid var(--lego-red-color);
+  padding: var(--spacing-sm) 0 var(--spacing-sm) var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.subSection .metaField {
+  margin-bottom: var(--spacing-sm);
 }
 
 .imageGallery {

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -1,17 +1,10 @@
-import {
-  ConfirmModal,
-  Flex,
-  Icon,
-  LoadingIndicator,
-  Modal,
-} from '@webkom/lego-bricks';
+import { Flex, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import arrayMutators from 'final-form-arrays';
 import { isEmpty } from 'lodash';
 import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
 import { Field } from 'react-final-form';
-import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate, useParams, Link, useLocation } from 'react-router-dom';
 import { createEvent, editEvent, fetchEvent } from 'app/actions/EventActions';
@@ -20,50 +13,21 @@ import {
   fetchImageGallery,
   setSaveForUse,
 } from 'app/actions/FileActions';
-import {
-  Content,
-  ContentSection,
-  ContentMain,
-  ContentSidebar,
-} from 'app/components/Content';
-import {
-  Form,
-  EditorField,
-  SelectInput,
-  TextInput,
-  TextEditor,
-  CheckBox,
-  Button,
-  DatePicker,
-  ImageUploadField,
-  LegoFinalForm,
-} from 'app/components/Form';
+import { Content } from 'app/components/Content';
+import { Form, CheckBox, Button, LegoFinalForm } from 'app/components/Form';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
-import { Image } from 'app/components/Image';
-import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
 import NavigationTab from 'app/components/NavigationTab';
-import Tag from 'app/components/Tags/Tag';
-import { FormatTime } from 'app/components/Time';
-import { AttendanceStatus } from 'app/components/UserAttendance';
-import AttendanceModal from 'app/components/UserAttendance/AttendanceModal';
 import {
   selectEventByIdOrSlug,
   selectPoolsWithRegistrationsForEvent,
 } from 'app/reducers/events';
 import { selectImageGalleryEntries } from 'app/reducers/imageGallery';
 import {
-  colorForEventType,
-  containsAllergier,
-  eventStatusTypes,
-  isTBA,
-  tooLow,
   transformEvent,
   transformEventStatusType,
-  EventTypeConfig,
   displayNameForEventType,
 } from 'app/routes/events/utils';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
-import { spyValues } from 'app/utils/formSpyUtils';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import time from 'app/utils/time';
 import {
@@ -80,9 +44,15 @@ import {
   validYoutubeUrl,
 } from 'app/utils/validation';
 import Admin from '../Admin';
+import EditorSection, {
+  Header,
+  Details,
+  Registration,
+  Descriptions,
+} from './EditorSection';
 import styles from './EventEditor.css';
-import renderPools from './renderPools';
 import type { UploadArgs } from 'app/actions/FileActions';
+import type { ActionGrant } from 'app/models';
 import type { EditingEvent } from 'app/routes/events/utils';
 import type { DetailedUser } from 'app/store/models/User';
 
@@ -97,10 +67,7 @@ const validate = createValidator({
     requiredIf((allValues) => !allValues.useMazemap, 'Sted er påkrevd'),
   ],
   mazemapPoi: [
-    requiredIf(
-      (allValues) => allValues.useMazemap,
-      'Sted eller MazeMap-rom er påkrevd',
-    ),
+    requiredIf((allValues) => allValues.useMazemap, 'Sted er påkrevd'),
   ],
   cover: [required('Cover er påkrevd')],
   eventStatusType: [required('Påmeldingstype er påkrevd')],
@@ -126,7 +93,7 @@ const validate = createValidator({
       (allValues) =>
         // Only require if we are creating a new event
         allValues.id === undefined,
-      'Arrangementet må være avklart',
+      'Arrangementet må være avklart i arrangementskalenderen',
     ),
   ],
   feedbackDescription: [
@@ -165,7 +132,7 @@ const EventEditor = () => {
     selectEventByIdOrSlug(state, { eventIdOrSlug }),
   );
   const eventId = event?.id;
-  const actionGrant = event?.actionGrant || [];
+  const actionGrant: ActionGrant = event?.actionGrant || [];
   const pools = useAppSelector((state) =>
     selectPoolsWithRegistrationsForEvent(state, { eventId }),
   );
@@ -276,7 +243,7 @@ const EventEditor = () => {
           })),
         isForeignLanguage: event.isForeignLanguage,
         eventType: event.eventType && {
-          label: displayNameForEventType[event.eventType],
+          label: displayNameForEventType(event.eventType),
           value: event.eventType,
         },
         eventStatusType:
@@ -365,521 +332,39 @@ const EventEditor = () => {
       >
         {({ form, handleSubmit, values }) => (
           <Form onSubmit={handleSubmit}>
-            <Field
-              name="cover"
-              component={ImageUploadField}
-              aspectRatio={20 / 6}
-              img={useImageGallery ? imageGalleryUrl : event.cover}
-            />
-
-            <Modal
-              show={showImageGallery}
-              onHide={() => setShowImageGallery(false)}
-              contentClassName={styles.imageGallery}
+            <EditorSection
+              title="Tittel og cover"
+              initiallyExpanded={!isEditPage}
             >
-              <>
-                <h1>Bildegalleri</h1>
-                <Flex
-                  wrap
-                  alignItems="center"
-                  justifyContent="space-around"
-                  gap="var(--spacing-md)"
-                >
-                  {imageGallery?.map((e) => (
-                    <Flex
-                      key={e.key}
-                      alignItems="center"
-                      gap="var(--spacing-md)"
-                    >
-                      <Image
-                        src={e.cover}
-                        placeholder={e.coverPlaceholder}
-                        alt={`${e.cover} bilde`}
-                        onClick={() => {
-                          form.change('cover', `${e.key}:${e.token}`);
-                          setShowImageGallery(false);
-                          setUseImageGallery(true);
-                          setImageGalleryUrl(e.cover);
-                        }}
-                        className={styles.imageGalleryEntry}
-                      />
-                      <ConfirmModal
-                        title="Fjern fra galleri"
-                        message={`Er du sikker på at du vil fjerne bildet fra bildegalleriet? Bildet blir ikke slettet fra databasen.`}
-                        closeOnConfirm
-                        onConfirm={() => setSaveForUse(e.key, e.token, false)}
-                      >
-                        {({ openConfirmModal }) => (
-                          <Icon
-                            onClick={openConfirmModal}
-                            name="trash"
-                            danger
-                          />
-                        )}
-                      </ConfirmModal>
-                    </Flex>
-                  ))}
-                  {imageGallery.length === 0 && (
-                    <Flex
-                      column
-                      alignItems="center"
-                      gap={5}
-                      className={styles.emptyGallery}
-                    >
-                      <Icon name="folder-open-outline" size={50} />
-                      <b>Bildegalleriet er tomt ...</b>
-                      <span>Hvorfor ikke laste opp et bilde?</span>
-                    </Flex>
-                  )}
-                </Flex>
-              </>
-            </Modal>
+              <Header
+                form={form}
+                values={values}
+                useImageGallery={useImageGallery}
+                imageGalleryUrl={imageGalleryUrl}
+                event={event}
+                showImageGallery={showImageGallery}
+                setShowImageGallery={setShowImageGallery}
+                imageGallery={imageGallery}
+                setUseImageGallery={setUseImageGallery}
+                setImageGalleryUrl={setImageGalleryUrl}
+              />
+            </EditorSection>
 
-            <Flex alignItems="center" justifyContent="space-between">
-              <Button onClick={() => setShowImageGallery(true)}>
-                Velg bilde fra bildegalleriet
-              </Button>
-              <div>
-                <Field
-                  label="Lagre til bildegalleriet"
-                  description="Lagre bildet til bildegalleriet slik at det kan bli brukt til andre arrangementer"
-                  name="saveToImageGallery"
-                  type="checkbox"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={(v) => !!v}
-                />
-              </div>
-            </Flex>
+            <EditorSection title="Detaljer" initiallyExpanded={!isEditPage}>
+              <Details values={values} />
+            </EditorSection>
 
-            <Field
-              name="youtubeUrl"
-              label="Erstatt cover-bildet med video fra YouTube"
-              description="Videoen erstatter ikke coveret i listen over arrangementer"
-              placeholder="https://www.youtube.com/watch?v=bLHL75H_VEM&t=5"
-              component={TextInput.Field}
-            />
-            <Field
-              label="Festet på forsiden"
-              name="pinned"
-              type="checkbox"
-              component={CheckBox.Field}
-              fieldClassName={styles.metaField}
-              className={styles.formField}
-              normalize={(v) => !!v}
-            />
-            <Field
-              label="Tittel"
-              name="title"
-              placeholder="Tittel"
-              style={{
-                borderBottom: `3px solid ${colorForEventType(
-                  values.eventType?.value,
-                )}`,
-              }}
-              component={TextInput.Field}
-            />
-            <Field
-              name="description"
-              label="Kalenderbeskrivelse"
-              placeholder="Kom på fest den ..."
-              component={TextEditor.Field}
-            />
+            <EditorSection title="Påmelding" initiallyExpanded={!isEditPage}>
+              <Registration
+                values={values}
+                isEditPage={isEditPage}
+                actionGrant={actionGrant}
+              />
+            </EditorSection>
 
-            <ContentSection>
-              <ContentMain>
-                <Field
-                  name="text"
-                  component={EditorField.Field}
-                  label="Hovedbeskrivelse"
-                  placeholder="Dette blir tidenes fest ..."
-                  className={styles.descriptionEditor}
-                  uploadFile={uploadFile}
-                />
-                <Flex className={styles.tagRow}>
-                  {(values.tags || []).map((tag, i) => (
-                    <Tag key={i} tag={tag} />
-                  ))}
-                </Flex>
-              </ContentMain>
-              <ContentSidebar>
-                <Field
-                  name="eventType"
-                  label="Type arrangement"
-                  fieldClassName={styles.metaField}
-                  component={SelectInput.Field}
-                  options={Object.entries(EventTypeConfig).map(
-                    ([key, config]) => ({
-                      label: config.displayName,
-                      value: key,
-                    }),
-                  )}
-                  placeholder="Arrangementstype"
-                />
-                <Field
-                  name="company"
-                  label="Arrangerende bedrift"
-                  filter={['companies.company']}
-                  fieldClassName={styles.metaField}
-                  component={SelectInput.AutocompleteField}
-                  placeholder="Bedrift"
-                />
-                <Field
-                  name="responsibleGroup"
-                  label="Ansvarlig gruppe"
-                  filter={['users.abakusgroup']}
-                  fieldClassName={styles.metaField}
-                  component={SelectInput.AutocompleteField}
-                  placeholder="Ansvar for arrangement"
-                />
-                <Field
-                  name="responsibleUsers"
-                  label="Ansvarlige brukere"
-                  filter={['users.user']}
-                  fieldClassName={styles.metaField}
-                  component={SelectInput.AutocompleteField}
-                  isMulti
-                  placeholder="Velg ansvarlige brukere"
-                />
-                <Field
-                  label="Starter"
-                  name="startTime"
-                  component={DatePicker.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                />
-                <Field
-                  label="Slutter"
-                  name="endTime"
-                  component={DatePicker.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                />
-                <Field
-                  label="Bruk MazeMap"
-                  name="useMazemap"
-                  type="checkbox"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={(v) => !!v}
-                />
-                {!values.useMazemap ? (
-                  <Field
-                    label="Sted"
-                    name="location"
-                    placeholder="Den Gode Nabo, Downtown, ..."
-                    component={TextInput.Field}
-                    fieldClassName={styles.metaField}
-                    className={styles.formField}
-                    warn={isTBA}
-                  />
-                ) : (
-                  <Flex alignItems="flex-end">
-                    <Field
-                      label="MazeMap-rom"
-                      name="mazemapPoi"
-                      component={SelectInput.MazemapAutocomplete}
-                      fieldClassName={styles.metaField}
-                      placeholder="R1, Abakus, Kjel4 ..."
-                    />
-                    {values.mazemapPoi?.value && (
-                      <MazemapLink
-                        mazemapPoi={values.mazemapPoi?.value}
-                        linkText="↗️"
-                      />
-                    )}
-                  </Flex>
-                )}
-                <Field
-                  label="Fremmedspråklig"
-                  description="Arrangementet er på et annet språk enn norsk (engelsk)"
-                  name="isForeignLanguage"
-                  type="checkbox"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={(v) => !!v}
-                />
-                <Field
-                  label="Kun for spesifikk gruppe"
-                  description="Gjør arrangementet synlig for kun medlemmer i spesifikke grupper"
-                  name="isGroupOnly"
-                  type="checkbox"
-                  component={CheckBox.Field}
-                  fieldClassName={styles.metaField}
-                  className={styles.formField}
-                  normalize={(v) => !!v}
-                />
-                {values.isGroupOnly && (
-                  <div className={styles.subSection}>
-                    <Field
-                      name="canViewGroups"
-                      placeholder="Velg grupper"
-                      filter={['users.abakusgroup']}
-                      fieldClassName={styles.metaField}
-                      component={SelectInput.AutocompleteField}
-                      isMulti
-                    />
-                  </div>
-                )}
-                {spyValues((values: EditingEvent) => {
-                  // Adding an initial pool if the event status type allows for it and there are no current pools
-                  if (
-                    ['NORMAL', 'INFINITE'].includes(
-                      values.eventStatusType?.value,
-                    )
-                  ) {
-                    if (values.pools.length === 0) {
-                      values.pools = [
-                        {
-                          name: 'Pool #1',
-                          registrations: [],
-                          activationDate: moment(values.startTime)
-                            .subtract(7, 'd')
-                            .hour(12)
-                            .minute(0)
-                            .toISOString(),
-                          permissionGroups: [],
-                        },
-                      ];
-                    }
-                  } else {
-                    // Removing all pools so that they are not validated on submit
-                    if (values.pools.length > 0) {
-                      values.pools = [];
-                    }
-                  }
-
-                  return (
-                    <Field
-                      label="Påmeldingstype"
-                      name="eventStatusType"
-                      component={SelectInput.Field}
-                      fieldClassName={styles.metaField}
-                      options={eventStatusTypes}
-                    />
-                  );
-                })}
-
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) && (
-                  <Field
-                    label="Betalt arrangement"
-                    name="isPriced"
-                    type="checkbox"
-                    component={CheckBox.Field}
-                    fieldClassName={styles.metaField}
-                    className={styles.formField}
-                    normalize={(v) => !!v}
-                  />
-                )}
-                {values.isPriced && (
-                  <div className={styles.subSection}>
-                    <Field
-                      label="Betaling via Abakus.no"
-                      description="Manuell betaling kan også godkjennes av oss i etterkant"
-                      name="useStripe"
-                      type="checkbox"
-                      component={CheckBox.Field}
-                      fieldClassName={styles.metaField}
-                      className={styles.formField}
-                      normalize={(v) => !!v}
-                    />
-                    <Field
-                      label="Pris"
-                      name="priceMember"
-                      type="number"
-                      component={TextInput.Field}
-                      fieldClassName={styles.metaField}
-                      className={styles.formField}
-                      warn={tooLow}
-                    />
-                    <Field
-                      label="Betalingsfrist"
-                      name="paymentDueDate"
-                      component={DatePicker.Field}
-                      fieldClassName={styles.metaField}
-                      className={styles.formField}
-                    />
-                  </div>
-                )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) && (
-                  <Field
-                    label="Bruk prikker"
-                    name="heedPenalties"
-                    type="checkbox"
-                    component={CheckBox.Field}
-                    fieldClassName={styles.metaField}
-                    className={styles.formField}
-                    normalize={(v) => !!v}
-                  />
-                )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) &&
-                  values.heedPenalties && (
-                    <div className={styles.subSection}>
-                      <Field
-                        key="unregistrationDeadline"
-                        label="Avregistreringsfrist"
-                        description="Frist for avmelding - fører til prikk etterpå"
-                        name="unregistrationDeadline"
-                        component={DatePicker.Field}
-                        fieldClassName={styles.metaField}
-                        className={styles.formField}
-                      />
-                    </div>
-                  )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) && (
-                  <Field
-                    label="Separat avregistreringsfrist"
-                    description="Separate frister for påmelding og avmelding - antall timer før arrangementet. Det vil ikke være mulig å melde seg av eller på etter de satte fristene (negativ verdi betyr antall timer etter starten på arrangementet)"
-                    name="separateDeadlines"
-                    type="checkbox"
-                    component={CheckBox.Field}
-                    fieldClassName={styles.metaField}
-                    className={styles.formField}
-                    normalize={(v) => !!v}
-                  />
-                )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) &&
-                  values.separateDeadlines && (
-                    <div className={styles.subSection}>
-                      <Field
-                        key="unregistrationDeadlineHours"
-                        label="Avregistrering antall timer før"
-                        description="Frist for avmelding antall timer før arrangementet (negativ verdi betyr antall timer etter starten på arrangementet)"
-                        name="unregistrationDeadlineHours"
-                        type="number"
-                        component={TextInput.Field}
-                        fieldClassName={styles.metaField}
-                        className={styles.formField}
-                      />
-                    </div>
-                  )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) && (
-                  <>
-                    <Field
-                      key="registrationDeadlineHours"
-                      label="Registrering antall timer før"
-                      description="Frist for påmelding/avmelding - antall timer før arrangementet. Det er ikke mulig å melde seg hverken på eller av etter denne fristen (negativ verdi betyr antall timer etter starten på arrangementet)"
-                      name="registrationDeadlineHours"
-                      type="number"
-                      component={TextInput.Field}
-                      fieldClassName={styles.metaField}
-                      className={styles.formField}
-                    />
-                    <p className={styles.registrationDeadlineHours}>
-                      Stenger{' '}
-                      <FormatTime time={moment(values.registrationDeadline)} />
-                    </p>
-                  </>
-                )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) && (
-                  <Field
-                    label="Samtykke til bilder"
-                    description="Bruk samtykke til bilder"
-                    name="useConsent"
-                    type="checkbox"
-                    component={CheckBox.Field}
-                    fieldClassName={styles.metaField}
-                    className={styles.formField}
-                    normalize={(v) => !!v}
-                  />
-                )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) && (
-                  <Field
-                    label="Påmeldingsspørsmål"
-                    description="Still et spørsmål ved påmelding"
-                    name="hasFeedbackQuestion"
-                    type="checkbox"
-                    component={CheckBox.Field}
-                    fieldClassName={styles.metaField}
-                    className={styles.formField}
-                    normalize={(v) => !!v}
-                  />
-                )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) &&
-                  values.hasFeedbackQuestion && (
-                    <div className={styles.subSection}>
-                      <Field
-                        name="feedbackDescription"
-                        placeholder="Burger eller sushi?"
-                        component={TextInput.Field}
-                        fieldClassName={styles.metaField}
-                        className={styles.formField}
-                        warn={containsAllergier}
-                      />
-                      <Field
-                        name="feedbackRequired"
-                        label="Obligatorisk"
-                        type="checkbox"
-                        component={CheckBox.Field}
-                        fieldClassName={styles.metaField}
-                        className={styles.formField}
-                        normalize={(v) => !!v}
-                      />
-                    </div>
-                  )}
-                {['NORMAL', 'INFINITE'].includes(
-                  values.eventStatusType?.value,
-                ) && (
-                  <Flex column>
-                    <h3>Pools</h3>
-                    <AttendanceModal
-                      key="modal"
-                      pools={values.pools || []}
-                      title="Påmeldte"
-                    >
-                      {({ toggleModal }) => (
-                        <AttendanceStatus
-                          toggleModal={toggleModal}
-                          pools={values.pools}
-                        />
-                      )}
-                    </AttendanceModal>
-                    <div className={styles.metaList}>
-                      <FieldArray
-                        name="pools"
-                        component={renderPools}
-                        startTime={values.startTime}
-                        eventStatusType={values.eventStatusType?.value}
-                      />
-                    </div>
-                    {values.pools?.length > 1 && (
-                      <Field
-                        label="Sammenslåingstidspunkt"
-                        description="Tidspunkt for å slå sammen poolene"
-                        name="mergeTime"
-                        component={DatePicker.Field}
-                        fieldClassName={styles.metaField}
-                        className={styles.formField}
-                      />
-                    )}
-                    {isEditPage && (
-                      <Admin actionGrant={actionGrant} event={values} />
-                    )}
-                  </Flex>
-                )}
-              </ContentSidebar>
-            </ContentSection>
+            <EditorSection title="Beskrivelse" collapsible={false}>
+              <Descriptions uploadFile={uploadFile} values={values} />
+            </EditorSection>
 
             {!isEditPage && (
               <Field
@@ -917,7 +402,8 @@ const EventEditor = () => {
                 component={CheckBox.Field}
                 fieldClassName={styles.metaFieldInformation}
                 className={styles.formField}
-                normalize={(v) => !!v}
+                parse={(v) => !!v}
+                required
               />
             )}
 
@@ -931,6 +417,8 @@ const EventEditor = () => {
                 {isEditPage ? 'Lagre endringer' : 'Opprett'}
               </SubmitButton>
             </Flex>
+
+            {isEditPage && <Admin actionGrant={actionGrant} event={values} />}
           </Form>
         )}
       </TypedLegoForm>

--- a/app/routes/photos/components/GalleryEditor.tsx
+++ b/app/routes/photos/components/GalleryEditor.tsx
@@ -310,7 +310,7 @@ const GalleryEditor = () => {
               name="publicMetadata"
               type="checkbox"
               component={CheckBox.Field}
-              normalize={(v) => !!v}
+              parse={(v) => !!v}
             />
             <Fields
               names={[

--- a/app/routes/photos/components/GalleryPictureEditModal.tsx
+++ b/app/routes/photos/components/GalleryPictureEditModal.tsx
@@ -142,7 +142,7 @@ const GalleryPictureEditModal = () => {
                 type="checkbox"
                 component={CheckBox.Field}
                 id="gallery-picture-active"
-                normalize={(v) => !!v}
+                parse={(v) => !!v}
               />
               <Field
                 label="Tagg brukere"

--- a/app/routes/surveys/components/SurveyEditor/Question.tsx
+++ b/app/routes/surveys/components/SurveyEditor/Question.tsx
@@ -150,7 +150,7 @@ const Question = ({
             label="Obligatorisk"
             type="checkbox"
             component={CheckBox.Field}
-            normalize={(v) => !!v}
+            parse={(v) => !!v}
           />
 
           <ConfirmModal

--- a/app/styles/overlay.css
+++ b/app/styles/overlay.css
@@ -6,7 +6,7 @@
   border-radius: var(--border-radius-lg);
   position: absolute;
   margin-top: 10px;
-  z-index: 2;
+  z-index: 70;
 
   @media (--small-viewport) {
     width: calc(100% - 10px);

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -149,6 +149,8 @@
     0 2px 4px -1px rgba(104, 112, 118, 4%);
   --shadow-md: 0 12px 20px 6px rgba(104, 112, 118, 8%);
   --shadow-lg: 0 12px 34px 6px rgba(104, 112, 118, 18%);
+
+  --shadow-bottom-md: 0 12px 8px -8px rgba(104, 112, 118, 8%);
 }
 
 [data-theme='dark'] {

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -181,8 +181,7 @@ describe('Create event', () => {
     // Select company
     selectField('company').click();
     cy.focused().type('BEKK', { force: true });
-    selectField('company')
-      .find('[id=react-select-company-listbox]')
+    selectFieldDropdown('company')
       .should('not.contain', NO_OPTIONS_MESSAGE)
       .and('contain', 'BEKK');
     cy.focused().type('{enter}', { force: true });
@@ -276,8 +275,7 @@ describe('Create event', () => {
     field('pools[0].capacity').type('20').blur();
     selectField('pools[0]\\.permissionGroups').click();
     cy.focused().type('Webkom', { force: true });
-    selectField('pools[0]\\.permissionGroups')
-      .find(`[id=react-select-pools\\[0\\]\\.permissionGroups-listbox]`)
+    selectFieldDropdown('pools\\[0\\]\\.permissionGroups')
       .should('not.contain', NO_OPTIONS_MESSAGE)
       .and('contain', 'Webkom');
     cy.focused().type('{enter}', { force: true });
@@ -288,15 +286,13 @@ describe('Create event', () => {
     field('pools[1].capacity').type('30').blur();
     selectField('pools[1]\\.permissionGroups').click();
     cy.focused().type('Bedkom', { force: true });
-    selectField('pools[1]\\.permissionGroups')
-      .find(`[id=react-select-pools\\[1\\]\\.permissionGroups-listbox]`)
+    selectFieldDropdown('pools\\[1\\]\\.permissionGroups')
       .should('not.contain', NO_OPTIONS_MESSAGE)
       .and('contain', 'Bedkom');
     cy.focused().type('{enter}', { force: true });
     selectField('pools[1]\\.permissionGroups').click();
     cy.focused().type('Abakus', { force: true });
-    selectField('pools[1]\\.permissionGroups')
-      .find(`[id=react-select-pools\\[1\\]\\.permissionGroups-listbox]`)
+    selectFieldDropdown('pools\\[1\\]\\.permissionGroups')
       .should('not.contain', NO_OPTIONS_MESSAGE)
       .and('contain', 'Abakus');
     cy.focused().type('{enter}', { force: true });
@@ -389,8 +385,7 @@ describe('Create event', () => {
     field('pools[0].name').clear().type('Mange').blur();
     selectField('pools[0].\\permissionGroups').click();
     cy.focused().type('Abaku', { force: true });
-    selectField('pools[0]\\.permissionGroups')
-      .find(`[id=react-select-pools\\[0\\]\\.permissionGroups-listbox]`)
+    selectFieldDropdown('pools\\[0\\]\\.permissionGroups')
       .should('not.contain', NO_OPTIONS_MESSAGE)
       .and('contain', 'Abakus');
     cy.focused().type('{enter}', { force: true });

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -24,7 +24,7 @@ export const selectField = (name) =>
     .parent()
     .parent();
 export const selectFieldDropdown = (name) =>
-  selectField(name).find(`[id=react-select-${name}-listbox]`);
+  cy.get(`[id=react-select-${name}-listbox]`);
 
 export const selectFromSelectField = (name, option, search) => {
   selectField(name).click();

--- a/packages/lego-bricks/src/components/Modal/Modal.module.css
+++ b/packages/lego-bricks/src/components/Modal/Modal.module.css
@@ -13,7 +13,7 @@
   background: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 10%);
   backdrop-filter: blur(3px);
   inset: 0;
-  z-index: 3;
+  z-index: 90;
   animation: fade-in var(--easing-medium) forwards;
 }
 
@@ -46,7 +46,7 @@ html[data-theme='dark'] .backdrop {
   background: var(--color-white);
   outline: none;
   overflow-y: auto;
-  z-index: 4;
+  z-index: 100;
   box-shadow: var(--shadow-sm);
   border-radius: var(--border-radius-lg);
   animation: pop-in var(--easing-medium) forwards;

--- a/packages/lego-bricks/src/variables.css
+++ b/packages/lego-bricks/src/variables.css
@@ -148,6 +148,8 @@
     0 2px 4px -1px rgba(104, 112, 118, 4%);
   --shadow-md: 0 12px 20px 6px rgba(104, 112, 118, 8%);
   --shadow-lg: 0 12px 34px 6px rgba(104, 112, 118, 18%);
+
+  --shadow-bottom-md: 0 12px 8px -8px rgba(104, 112, 118, 8%);
 }
 
 [data-theme='dark'] {


### PR DESCRIPTION
# Description

At this point the event sidebar is getting quite cramped as we have tons of configurations. Thus this is my initial suggestion at making it more pleasant to look at.

The styling with `sticky` headers and shadows is not really consistent with the rest of the webapp, but then again we have very few places where it would be relevant - and I believe this is one of them.

The main objective with the toggle sections is to display all information on create, but initially only display the desription on edit - as I imagine that is what's used most frequently.

No changes in functionality - only ordering and styling.

Minor changes:
* `location`
	* It bugs me that the mazemap checkbox is over the location label, so I tried to implement it as a more unified field. For users it should make no difference if what they select is a location or a mazemap-location, and I feel like this represents that
* cover
	* now becomes slightly smaller on smaller screens - as the size did not match aspect ratios (still doesn't, but it's better)

Bugs found and fixed along the way;
* Fix bug from react-final-form migration. The normalize prop in `redux-form` is called `parse` in react-final-form.
* Fix bug in ImageUpload filetypes - threw annoying console warnings

Will clean up these bugs in a separate PR if this one doesn't go through.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

## New - before
https://github.com/webkom/lego-webapp/assets/13599770/99c3980b-2e5f-4682-bea6-29e467274b52

## New - after
https://github.com/webkom/lego-webapp/assets/13599770/d5469b48-4af5-48df-9921-69dc6d9c7dfe

## Edit - before
https://github.com/webkom/lego-webapp/assets/13599770/26e18af4-63e7-4444-9666-3920f4aebd26

## Edit - after
https://github.com/webkom/lego-webapp/assets/13599770/331ceaf9-f49a-4b9a-840e-6f75ba99ccf7

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-13, ABA-826