### PR TITLE
Removed button to show more events when there are no more events to s…

### DIFF
--- a/app/routes/overview/components/Overview.tsx
+++ b/app/routes/overview/components/Overview.tsx
@@ -126,7 +126,7 @@ const Overview = () => {
         <Articles articles={articlesShown} />
       </section>
 
-      {frontpage.length > 8 && (
+      {frontpage.length > 8 && events.length > eventsToShow && (
         <div className={styles.showMore}>
           <Icon onClick={showMore} name="chevron-down-outline" size={30} />
         </div>


### PR DESCRIPTION

# Description

Fixed the frontage so that when events displayed on the front-page has reached the event limit there is no longer a button to show more events. 

# Result
Before:

![Skjermbilde 2024-02-27 kl  20 38 48](https://github.com/webkom/lego-webapp/assets/145492323/58c2de93-08f7-4d28-b15d-caf46b877925)

After:

![Skjermbilde 2024-02-27 kl  20 38 21](https://github.com/webkom/lego-webapp/assets/145492323/4bece8ed-ff55-420b-ac63-dc039c46365b)


- [x ] Changes look good on both light and dark theme.
- [ x] Changes look good with different viewports (mobile, tablet, etc.).
- [ x] Changes look good with slower Internet connections.



# Testing

- [ x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-647