### PR TITLE
Refactor some simple redux-slices to use legoAdapter

### DIFF
--- a/app/actions/EmojiActions.ts
+++ b/app/actions/EmojiActions.ts
@@ -3,30 +3,13 @@ import { emojiSchema } from 'app/reducers';
 import { Emoji } from './ActionTypes';
 import type { Thunk } from 'app/types';
 
-export function fetchEmoji(shortCode: string): Thunk<any> {
-  return callAPI({
-    types: Emoji.FETCH,
-    endpoint: `/emojis/${shortCode}/`,
-    schema: emojiSchema,
-    meta: {
-      errorMessage: 'Henting av reaksjon feilet',
-    },
-    propagateError: true,
-  });
-}
-export function fetchEmojis({
-  next = false,
-}: {
-  next?: boolean;
-} = {}): Thunk<any> {
-  return (dispatch, getState) => {
-    const cursor = next ? getState().emojis.pagination.next : {};
+export function fetchEmojis(): Thunk<any> {
+  return (dispatch) => {
     return dispatch(
       callAPI({
         types: Emoji.FETCH_ALL,
         endpoint: '/emojis/',
         schema: [emojiSchema],
-        query: { ...cursor },
         meta: {
           errorMessage: 'Henting av emojis feilet',
         },

--- a/app/components/Feed/renders/event_register.tsx
+++ b/app/components/Feed/renders/event_register.tsx
@@ -22,8 +22,8 @@ export function activityHeader(
     return null;
   }
 
-  const actorsRender = actors.map((actor) =>
-    htmlTag(contextRender[actor.contentType](actor))
+  const actorsRender = actors.map(
+    (actor) => actor && htmlTag(contextRender[actor.contentType](actor))
   );
   return (
     <b>

--- a/app/reducers/__tests__/announcements.spec.ts
+++ b/app/reducers/__tests__/announcements.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Announcements } from 'app/actions/ActionTypes';
 import announcements from '../announcements';
+import type { UnknownAnnouncement } from 'app/store/models/Announcement';
 
 describe('reducers', () => {
   describe('announcements', () => {
@@ -9,13 +10,14 @@ describe('reducers', () => {
     it('Announcements.SEND.SUCCESS', () => {
       const prevState = {
         actionGrant: [],
-        pagination: {},
-        items: [99],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [99],
+        entities: {
           99: {
             id: 99,
             sent: null,
-          },
+          } as UnknownAnnouncement,
         },
       };
       const action = {
@@ -26,9 +28,10 @@ describe('reducers', () => {
       };
       expect(announcements(prevState, action)).toEqual({
         actionGrant: [],
-        pagination: {},
-        items: [99],
-        byId: {
+        paginationNext: {},
+        fetching: false,
+        ids: [99],
+        entities: {
           99: {
             id: 99,
             sent: new Date().toISOString(),

--- a/app/reducers/announcements.ts
+++ b/app/reducers/announcements.ts
@@ -1,31 +1,32 @@
-import { produce } from 'immer';
+import { createSlice } from '@reduxjs/toolkit';
 import moment from 'moment-timezone';
-import { createSelector } from 'reselect';
-import createEntityReducer from 'app/utils/createEntityReducer';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { Announcements } from '../actions/ActionTypes';
+import type { AnyAction } from '@reduxjs/toolkit';
+import type { RootState } from 'app/store/createRootReducer';
 
-type State = any;
-export default createEntityReducer({
-  key: 'announcements',
-  types: {
-    fetch: Announcements.FETCH_ALL,
-    mutate: Announcements.CREATE,
-    delete: Announcements.DELETE,
-  },
-  mutate: produce((newState: State, action: any): void => {
-    switch (action.type) {
-      case Announcements.SEND.SUCCESS:
-        newState.byId[action.meta.announcementId].sent = moment().toISOString();
-        break;
+const legoAdapter = createLegoAdapter(EntityType.Announcements);
 
-      default:
-        break;
-    }
+const announcementsSlice = createSlice({
+  name: EntityType.Announcements,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [Announcements.FETCH_ALL],
+    deleteActions: [Announcements.DELETE],
+    extraCases: (addCase) => {
+      addCase(Announcements.SEND.SUCCESS, (state, action: AnyAction) => {
+        const announcement = state.entities[action.meta.announcementId];
+        if (announcement) {
+          announcement.sent = moment().toISOString();
+        }
+      });
+    },
   }),
 });
-export const selectAnnouncements = createSelector(
-  (state) => state.announcements.byId,
-  (state) => state.announcements.items,
-  (announcementsById, announcementIds) =>
-    announcementIds.map((id) => announcementsById[id])
+
+export default announcementsSlice.reducer;
+export const { selectAll: selectAnnouncements } = legoAdapter.getSelectors(
+  (state: RootState) => state.announcements
 );

--- a/app/reducers/articles.ts
+++ b/app/reducers/articles.ts
@@ -5,11 +5,10 @@ import { Article } from 'app/actions/ActionTypes';
 import { addCommentCases, selectCommentEntities } from 'app/reducers/comments';
 import { addReactionCases } from 'app/reducers/reactions';
 import { selectUserById } from 'app/reducers/users';
-import { typeable } from 'app/reducers/utils';
 import { EntityType } from 'app/store/models/entities';
 import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import type { RootState } from 'app/store/createRootReducer';
-import type { PublicArticle, UnknownArticle } from 'app/store/models/Article';
+import type { PublicArticle } from 'app/store/models/Article';
 import type { PublicUser } from 'app/store/models/User';
 import type { Pagination } from 'app/utils/legoAdapter/buildPaginationReducer';
 import type { Selector } from 'reselect';
@@ -35,26 +34,9 @@ const articlesSlice = createSlice({
 
 export default articlesSlice.reducer;
 export const {
-  selectAll: selectAllArticles,
-  selectIds: selectArticleIds,
-  selectEntities: selectArticleEntities,
+  selectAllPaginated: selectArticles,
   selectById: selectArticleById,
 } = legoAdapter.getSelectors((state: RootState) => state.articles);
-
-type SelectArticlesOpts = {
-  pagination?: Pagination;
-};
-export const selectArticles = typeable(
-  createSelector(
-    selectArticleEntities,
-    selectArticleIds,
-    (_: RootState, props: SelectArticlesOpts) => props && props.pagination,
-    (articlesById, articleIds, pagination) =>
-      (pagination ? pagination.ids : articleIds).map(
-        (id) => articlesById[id]
-      ) as ReadonlyArray<UnknownArticle>
-  )
-);
 
 export type ArticleWithAuthorDetails = Overwrite<
   PublicArticle,
@@ -65,11 +47,11 @@ export const selectArticlesWithAuthorDetails: Selector<
   ArticleWithAuthorDetails[],
   [
     {
-      pagination: any;
+      pagination?: Pagination;
     }
   ]
 > = (state, props) =>
-  selectArticles<PublicArticle[]>(state, props).map((article) => ({
+  selectArticles(state, props).map((article) => ({
     ...article,
     authors: article.authors.map((e) => {
       return selectUserById(state, {

--- a/app/reducers/emailUsers.ts
+++ b/app/reducers/emailUsers.ts
@@ -1,8 +1,12 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { selectUserWithGroups } from 'app/reducers/users';
-import createEntityReducer from 'app/utils/createEntityReducer';
-import { EmailUser } from '../actions/ActionTypes';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import { EmailUser as EmailUserActions } from '../actions/ActionTypes';
 import type { UserEntity } from 'app/reducers/users';
+import type { RootState } from 'app/store/createRootReducer';
+import type EmailUser from 'app/store/models/EmailUser';
 
 export type EmailUserEntity = {
   id: number;
@@ -10,50 +14,37 @@ export type EmailUserEntity = {
   internalEmailEnabled: boolean;
   internalEmail: string;
 };
-export default createEntityReducer({
-  key: 'emailUsers',
-  types: {
-    fetch: EmailUser.FETCH,
-    mutate: EmailUser.CREATE,
-  },
+
+const legoAdapter = createLegoAdapter(EntityType.EmailUsers);
+
+const emailUserSlice = createSlice({
+  name: EntityType.EmailUsers,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [EmailUserActions.FETCH],
+  }),
 });
-export const selectEmailUsers = createSelector(
-  (state) => state.emailUsers.byId,
-  (state) => state.users.byId,
-  (state) => state.emailUsers.items,
-  (_, { pagination }) => pagination,
-  (state) => state,
-  (
-    emailUsersById,
-    usersById,
-    emailUserIds,
-    pagination,
-    state //$FlowFixMe
-  ) =>
-    (pagination ? pagination.items || [] : emailUserIds)
-      .map((id) => emailUsersById[id])
-      .filter(Boolean)
-      .map((emailUser) => ({
-        ...emailUser,
-        //$FlowFixMe
-        user: selectUserWithGroups(state, {
-          userId: emailUser.id,
-        }),
-      }))
+
+export default emailUserSlice.reducer;
+const { selectAllPaginated, selectById } = legoAdapter.getSelectors<RootState>(
+  (state) => state.emailUsers
 );
+
+const transformEmailUser = (emailUser: EmailUser, state: RootState) => ({
+  ...emailUser,
+  user: selectUserWithGroups(state, { userId: emailUser.id }),
+});
+
+export const selectEmailUsers = createSelector(
+  selectAllPaginated,
+  (state: RootState) => state,
+  (emailUsers, state) =>
+    emailUsers.map((emailUser) => transformEmailUser(emailUser, state))
+);
+
 export const selectEmailUserById = createSelector(
-  (state) => state.emailUsers.byId,
-  (state) => state.users.byId,
-  (state, props) => props.emailUserId,
-  (emailUsersById, usersById, emailUserId) => {
-    const emailUser = emailUsersById[emailUserId];
-
-    if (!emailUser) {
-      return {
-        user: {},
-      };
-    }
-
-    return { ...emailUser, user: usersById[emailUser.user] };
-  }
+  selectById,
+  (state: RootState) => state,
+  (emailUser, state) => emailUser && transformEmailUser(emailUser, state)
 );

--- a/app/reducers/emojis.ts
+++ b/app/reducers/emojis.ts
@@ -1,25 +1,23 @@
-import { createSelector } from 'reselect';
+import { createSlice } from '@reduxjs/toolkit';
 import { Emoji } from 'app/actions/ActionTypes';
-import createEntityReducer from 'app/utils/createEntityReducer';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import type { RootState } from 'app/store/createRootReducer';
 
-export const selectEmojis = createSelector(
-  (state) => state.emojis.byId,
-  (state) => state.emojis.items,
-  (emojisById, emojiIds) => {
-    return emojiIds.map((id) => emojisById[id]);
-  }
-);
-export const selectEmojisById = createSelector(
-  selectEmojis,
-  (state, emojisId) => emojisId,
-  (emojis, emojisId) => {
-    if (!emojis || !emojisId) return {};
-    return emojis.find((emojis) => emojis.shortCode === emojisId);
-  }
-);
-export default createEntityReducer({
-  key: 'emojis',
-  types: {
-    fetch: [Emoji.FETCH, Emoji.FETCH_ALL],
-  },
+const legoAdapter = createLegoAdapter(EntityType.Emojis, {
+  selectId: (emoji) => emoji.shortCode,
 });
+
+const emojisSlice = createSlice({
+  name: EntityType.Emojis,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [Emoji.FETCH, Emoji.FETCH_ALL],
+  }),
+});
+
+export default emojisSlice.reducer;
+export const { selectAll: selectEmojis } = legoAdapter.getSelectors<RootState>(
+  (state) => state.emojis
+);

--- a/app/reducers/restrictedMails.ts
+++ b/app/reducers/restrictedMails.ts
@@ -1,6 +1,9 @@
-import { createSelector } from 'reselect';
-import createEntityReducer from 'app/utils/createEntityReducer';
+import { createSlice } from '@reduxjs/toolkit';
+import moment from 'moment-timezone';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { RestrictedMail } from '../actions/ActionTypes';
+import type { RootState } from 'app/store/createRootReducer';
 
 export type RestrictedMailEntity = {
   id: number;
@@ -13,22 +16,23 @@ export type RestrictedMailEntity = {
   meetings: Array<number>;
   rawAddresses: Array<string>;
 };
-export default createEntityReducer({
-  key: 'restrictedMails',
-  types: {
-    fetch: RestrictedMail.FETCH,
-    mutate: RestrictedMail.CREATE,
-  },
+
+const legoAdapter = createLegoAdapter(EntityType.RestrictedMails, {
+  sortComparer: (a, b) => moment(b.createdAt).diff(moment(a.createdAt)),
 });
-export const selectRestrictedMails = createSelector(
-  (state) => state.restrictedMails.byId,
-  (state) => state.restrictedMails.items,
-  (restrictedMailsById, restrictedMailIds) =>
-    restrictedMailIds.map((id) => restrictedMailsById[id])
-);
-export const selectRestrictedMailById = createSelector(
-  (state) => state.restrictedMails.byId,
-  (state, props) => props.restrictedMailId,
-  (restrictedMailsById, restrictedMailId) =>
-    restrictedMailsById[restrictedMailId] || {}
-);
+
+const restrictedMailSlice = createSlice({
+  name: EntityType.RestrictedMails,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [RestrictedMail.FETCH],
+  }),
+});
+
+export default restrictedMailSlice.reducer;
+
+export const {
+  selectAll: selectRestrictedMails,
+  selectById: selectRestrictedMailById,
+} = legoAdapter.getSelectors<RootState>((state) => state.restrictedMails);

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -7,6 +7,7 @@ import createEntityReducer from 'app/utils/createEntityReducer';
 import mergeObjects from 'app/utils/mergeObjects';
 import { User, Event } from '../actions/ActionTypes';
 import type { PhotoConsent } from '../models';
+import type { ID } from 'app/store/models';
 
 export type UserEntity = {
   id: number;
@@ -88,7 +89,7 @@ export const selectUserWithGroups = createSelector(
       userId,
     }: {
       username?: string;
-      userId?: string;
+      userId?: ID;
     }
   ) =>
     username

--- a/app/routes/admin/email/components/EmailListEditor.tsx
+++ b/app/routes/admin/email/components/EmailListEditor.tsx
@@ -40,7 +40,7 @@ const EmailListEditor = () => {
   const { emailListId } = useParams<{ emailListId: string }>();
   const isNew = emailListId === 'new';
   const emailList = useAppSelector((state) =>
-    selectEmailListById(state, { emailListId })
+    selectEmailListById(state, emailListId!)
   );
 
   const dispatch = useAppDispatch();

--- a/app/routes/admin/email/components/EmailUserEditor.tsx
+++ b/app/routes/admin/email/components/EmailUserEditor.tsx
@@ -33,7 +33,7 @@ const EmailUserEditor = () => {
   const { emailUserId } = useParams<{ emailUserId: string }>();
   const isNew = emailUserId === undefined;
   const emailUser = useAppSelector((state) =>
-    selectEmailUserById(state, { emailUserId })
+    selectEmailUserById(state, emailUserId!)
   );
 
   const dispatch = useAppDispatch();

--- a/app/routes/admin/email/components/RestrictedMailEditor.tsx
+++ b/app/routes/admin/email/components/RestrictedMailEditor.tsx
@@ -68,7 +68,7 @@ const RestrictedMailEditor = () => {
   const { restrictedMailId } = useParams<{ restrictedMailId: string }>();
   const isNew = restrictedMailId === undefined;
   const restrictedMail = useAppSelector((state) =>
-    selectRestrictedMailById(state, { restrictedMailId })
+    selectRestrictedMailById(state, restrictedMailId!)
   );
 
   const initialValues = isNew

--- a/app/routes/admin/email/components/RestrictedMails.tsx
+++ b/app/routes/admin/email/components/RestrictedMails.tsx
@@ -9,9 +9,7 @@ import { selectRestrictedMails } from 'app/reducers/restrictedMails';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 
 const RestrictedMails = () => {
-  const restrictedMails = useAppSelector((state) =>
-    selectRestrictedMails(state)
-  );
+  const restrictedMails = useAppSelector(selectRestrictedMails);
   const fetching = useAppSelector((state) => state.restrictedMails.fetching);
   const hasMore = useAppSelector((state) => state.restrictedMails.hasMore);
 

--- a/app/utils/legoAdapter/createLegoAdapter.ts
+++ b/app/utils/legoAdapter/createLegoAdapter.ts
@@ -68,7 +68,7 @@ function createLegoAdapter<
   Entity extends Entities[Type][Id] = Entities[Type][Id]
 >(
   entityType: Type,
-  options: WithRequiredProp<LegoAdapterOptions<Type, Id>, 'selectId'>
+  options: WithRequiredProp<LegoAdapterOptions<Entity, Id>, 'selectId'>
 ): LegoAdapter<Entity, Id>;
 
 function createLegoAdapter<
@@ -78,7 +78,7 @@ function createLegoAdapter<
   } = Entities[Type][EntityId]
 >(
   entityType: Type,
-  options?: Omit<EntityAdapterOptions<Entity, Entity['id']>, 'selectId'>
+  options?: Omit<LegoAdapterOptions<Entity, Entity['id']>, 'selectId'>
 ): LegoAdapter<Entity, Entity['id']>;
 
 function createLegoAdapter<


### PR DESCRIPTION
# Description

Instead of rebasing my previous legoAdapter PRs I have just put the simple stuff into this PR and I will do the complicated (company and event) rebasing later. This refactors the following slices to use legoAdapter instead of createEntityReducer:
- announcements
- auth
- emailLists
- emailUsers
- restrictedMails

# Result

Nothing should change except that I reversed the sorting of the restricted mail list. Now the newest restricted mails are on the top, which makes it easier to find your relevant restricted mail if you have created a lot:)

- [no visual changes] Changes look good on both light and dark theme.
- [no visual changes] Changes look good with different viewports (mobile, tablet, etc.).
- [no visual changes] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

I have tested basic functionality on all the relevant pages including filtering tables and creating new entities.

---

Progress on ABA-688
