### PR TITLE
Give poll editor a background

### DIFF
--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -5,6 +5,7 @@ import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
 import { createPoll, deletePoll, editPoll } from 'app/actions/PollActions';
+import { Content } from 'app/components/Content';
 import {
   TextInput,
   SelectInput,
@@ -73,7 +74,11 @@ const validate = createValidator({
   title: [required('Du må gi avstemningen en tittel')],
 });
 
-const PollEditor = ({ poll, editing, toggleEdit = () => {} }: Props) => {
+const PollEditor = ({
+  poll,
+  editing = false,
+  toggleEdit = () => {},
+}: Props) => {
   const dispatch = useAppDispatch();
 
   const navigate = useNavigate();
@@ -131,16 +136,6 @@ const PollEditor = ({ poll, editing, toggleEdit = () => {} }: Props) => {
 
   return (
     <>
-      <Helmet title={editing ? `Redigerer avstemning` : 'Ny avstemning'} />
-      {!editing && (
-        <NavigationTab
-          title="Ny avstemning"
-          back={{
-            label: 'Tilbake',
-            path: '/polls',
-          }}
-        />
-      )}
       <LegoFinalForm
         onSubmit={onSubmit}
         initialValues={initialValues}
@@ -225,3 +220,20 @@ const PollEditor = ({ poll, editing, toggleEdit = () => {} }: Props) => {
 };
 
 export default PollEditor;
+
+export const PollCreator = () => {
+  const title = 'Ny avstemning';
+  return (
+    <Content>
+      <Helmet title={title} />
+      <NavigationTab
+        title={title}
+        back={{
+          label: 'Tilbake',
+          path: '/polls',
+        }}
+      />
+      <PollEditor />
+    </Content>
+  );
+};

--- a/app/routes/polls/index.tsx
+++ b/app/routes/polls/index.tsx
@@ -1,13 +1,13 @@
 import { Route, Routes } from 'react-router-dom';
 import PageNotFound from '../pageNotFound';
 import PollDetail from './components/PollDetail';
-import PollEditor from './components/PollEditor';
+import { PollCreator } from './components/PollEditor';
 import PollsList from './components/PollsList';
 
 const PollsRoute = () => (
   <Routes>
     <Route index element={<PollsList />} />
-    <Route path="new" element={<PollEditor />} />
+    <Route path="new" element={<PollCreator />} />
     <Route path=":pollsId" element={<PollDetail />} />
     <Route path="*" element={<PageNotFound />} />
   </Routes>


### PR DESCRIPTION
# Description

Kind of unpractical and not really something we do anywhere else on the
webapp, but when you edit a poll you render the same component as when
you create one. This caused the editor to lose its background since it
was technically not its own page ..

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
		<td width="13%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
		<td/>
        <td>
			<img width="1431" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/8fed773b-7550-4565-a875-d6b21e4b4207">
        </td>
        <td>
			<img width="1431" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/813baf6c-775b-4397-98d1-221861c3ca61">
        </td>
    </tr>
    <tr>
		<td>No changes here</td>
        <td>
			<img width="1431" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/26884b09-3797-410c-9f8f-64308a2f6c10">
        </td>
        <td>
			<img width="1431" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/fda4414d-b049-49b2-9bd3-e585b1899ee2">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above. Tested that both editing and creating polls works (i guess you never really know these days huh)