### PR TITLE
Fix minor css issues caused by recent webpack bump

### DIFF
--- a/app/components/UserAttendance/AttendanceModalContent.tsx
+++ b/app/components/UserAttendance/AttendanceModalContent.tsx
@@ -81,12 +81,7 @@ const AttendanceModalContent = ({
   );
 
   return (
-    <Flex
-      column
-      justifyContent="space-between"
-      gap={15}
-      className={styles.modal}
-    >
+    <Flex column gap="1rem" className={styles.modal}>
       <h2>{title}</h2>
       <TextInput
         type="text"

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -29,7 +29,6 @@ import {
 } from 'app/components/Form';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
-import { Image } from 'app/components/Image';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import Tooltip from 'app/components/Tooltip';
 import { selectCompanyInterestById } from 'app/reducers/companyInterest';
@@ -228,7 +227,7 @@ const LanguageFlag = ({ language }: { language: string }) => {
       break;
   }
 
-  return <Image src={flag} className={styles.flag} alt="country_flag" />;
+  return <img src={flag} className={styles.flag} alt="Country flag" />;
 };
 
 type CompanyInterestFormEntity = {

--- a/app/routes/interestgroups/components/InterestGroupMemberList.tsx
+++ b/app/routes/interestgroups/components/InterestGroupMemberList.tsx
@@ -110,12 +110,7 @@ export default class InterestGroupMemberList extends Component<Props, State> {
       <>
         <div onClick={this.toggleModal}>{this.props.children}</div>
         <Modal show={this.state.modalVisible} onHide={this.toggleModal}>
-          <Flex
-            column
-            justifyContent="space-between"
-            gap={15}
-            className={shared.modal}
-          >
+          <Flex column gap="1rem" className={shared.modal}>
             <h2>Medlemmer</h2>
             <TextInput
               type="text"


### PR DESCRIPTION
# Description

Let me know if you find any more

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="496" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/089532a1-c9f5-49d5-952f-867b427ee4e2">
        </td>
        <td>         
			<img width="496" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/70b08ef6-4920-4f9b-b71b-753bc033e44e">
        </td>
    </tr>
    <tr>
        <td>
            <img width="496" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/b9a718ed-7c2a-4373-bf48-dc8bb7f1aaec">
        </td>
        <td>         
			<img width="496" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/a7647485-0465-4b6a-9947-3403dc0049c4">
        </td>
    </tr>
</table>

# Testing

- [ ] I have thoroughly tested my changes.

Tested changes with ssr and on smaller viewports. Changes to attendance modal was also tested, but didn't bother to add a picture since the changes here were very minor (only 1px of spacing) because it has a bottom part (unlike the interest group modal) which makes the flex stretching less _sizeable_ (?).