### PR TITLE
Minor changes to event detail page

### DIFF
--- a/app/components/Content/ContentHeader.css
+++ b/app/components/Content/ContentHeader.css
@@ -1,3 +1,5 @@
+@import url('~app/styles/variables.css');
+
 .header {
   display: flex;
   justify-content: space-between;
@@ -12,4 +14,8 @@
   display: flex;
   justify-content: flex-end;
   flex-grow: 1;
+
+  @media (--mobile-device) {
+    display: none;
+  }
 }

--- a/app/components/Content/ContentHeader.tsx
+++ b/app/components/Content/ContentHeader.tsx
@@ -33,7 +33,7 @@ function ContentHeader({
       className={cx(styles.header, className)}
       {...props}
     >
-      <h2>{children}</h2>
+      {children}
       {event && (
         <strong
           style={{

--- a/app/routes/events/components/Admin.css
+++ b/app/routes/events/components/Admin.css
@@ -1,0 +1,3 @@
+.admin a {
+  width: fit-content;
+}

--- a/app/routes/events/components/Admin.tsx
+++ b/app/routes/events/components/Admin.tsx
@@ -4,7 +4,9 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { deleteEvent } from 'app/actions/EventActions';
 import AnnouncementInLine from 'app/components/AnnouncementInLine';
+import { TextInput } from 'app/components/Form';
 import { useAppDispatch } from 'app/store/hooks';
+import styles from './Admin.css';
 import type { ActionGrant } from 'app/models';
 import type { ID } from 'app/store/models';
 import type { AuthUserDetailedEvent } from 'app/store/models/Event';
@@ -21,51 +23,47 @@ const DeleteButton = ({ eventId, title }: ButtonProps) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  let deleteEventButton;
-
-  if (eventName === title) {
-    deleteEventButton = (
-      <ConfirmModal
-        title="Slett arrangement"
-        message="Er du sikker på at du vil slette dette arrangementet?"
-        onConfirm={() =>
-          dispatch(deleteEvent(eventId)).then(() => {
-            navigate('/events');
-          })
-        }
-      >
-        {({ openConfirmModal }) => (
-          <Button onClick={openConfirmModal} danger>
-            <Icon name="trash" size={19} />
-            Slett
-          </Button>
-        )}
-      </ConfirmModal>
-    );
-  }
-
   return (
-    <div>
-      {show === false && (
+    <>
+      {!show ? (
         <Button danger onClick={() => setShow(true)}>
           <Icon name="trash" size={19} />
           Slett arrangement
         </Button>
-      )}
-      {show && (
+      ) : (
         <>
-          <span>Skriv inn navnet på arrangementet du vil slette:</span>
-          <input
+          <label htmlFor="delete-event">
+            Skriv inn navnet på arrangementet du vil slette
+          </label>
+          <TextInput
+            id="delete-event"
             type="text"
-            id="slettArrangement"
+            prefix="warning"
             placeholder="Arrangementnavn"
             onChange={(e) => setEventName(e.target.value)}
-          />{' '}
-          <br />
-          {deleteEventButton}
+          />
+
+          {eventName === title && (
+            <ConfirmModal
+              title="Slett arrangement"
+              message="Er du helt sikker på at du vil slette dette arrangementet?"
+              onConfirm={() =>
+                dispatch(deleteEvent(eventId)).then(() => {
+                  navigate('/events');
+                })
+              }
+            >
+              {({ openConfirmModal }) => (
+                <Button onClick={openConfirmModal} danger>
+                  <Icon name="trash" size={19} />
+                  Slett
+                </Button>
+              )}
+            </ConfirmModal>
+          )}
         </>
       )}
-    </div>
+    </>
   );
 };
 
@@ -83,7 +81,7 @@ const Admin = ({ actionGrant, event }: Props) => {
     ) < 1;
 
   return (
-    <Flex column gap={7}>
+    <Flex column gap="0.5rem" className={styles.admin}>
       {(canEdit || canDelete) && (
         <>
           <h3>Admin</h3>

--- a/app/routes/events/components/Admin.tsx
+++ b/app/routes/events/components/Admin.tsx
@@ -131,14 +131,7 @@ const Admin = ({ actionGrant, event }: Props) => {
             </Link>
           )}
 
-          <Link
-            to={{
-              pathname: `/events/create`,
-              state: {
-                id: event.id,
-              },
-            }}
-          >
+          <Link to="/events/create" state={{ id: event.id }}>
             <Button>
               <Icon name="copy-outline" size={19} />
               Lag kopi av arrangement

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -6,7 +6,8 @@
 
 .header {
   min-width: 300px;
-  height: var(--spacing-xl);
+  min-height: var(--spacing-xl);
+  margin: var(--spacing-sm) 0;
 }
 
 .title {

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -72,23 +72,9 @@ const Line = () => <div className={styles.line} />;
 const InterestedButton = ({ isInterested }: InterestedButtonProps) => {
   const icon = isInterested ? 'star' : 'star-outline';
   return (
-    <div>
-      <Tooltip
-        content={
-          <span
-            style={{
-              fontSize: 'var(--font-size-md)',
-              fontWeight: '400',
-              padding: '0',
-            }}
-          >
-            Følg arrangementet, og få e-post når påmelding nærmer seg!
-          </span>
-        }
-      >
-        <Icon name={icon} className={styles.star} />
-      </Tooltip>
-    </div>
+    <Tooltip content="Følg arrangementet, og få e-post når påmelding nærmer seg!">
+      <Icon name={icon} className={styles.star} />
+    </Tooltip>
   );
 };
 
@@ -346,23 +332,32 @@ const EventDetail = () => {
   const groupLink =
     event.responsibleGroup && resolveGroupLink(event.responsibleGroup);
 
+  const responsibleGroupName = groupLink ? (
+    <Link to={groupLink}>{event.responsibleGroup?.name}</Link>
+  ) : (
+    event.responsibleGroup?.name
+  );
+
   const eventCreator = [
     // Responsible group
     event.responsibleGroup && {
       key: 'Arrangør',
-      value: (
-        <span>
-          {groupLink ? (
-            <Link to={groupLink}>{event.responsibleGroup.name}</Link>
-          ) : (
-            event.responsibleGroup.name
-          )}{' '}
-          {event.responsibleGroup.contactEmail && (
-            <a href={`mailto:${event.responsibleGroup.contactEmail}`}>
-              {event.responsibleGroup.contactEmail}
-            </a>
-          )}
-        </span>
+      value: event.responsibleGroup.contactEmail ? (
+        <Tooltip
+          content={
+            <span>
+              {event.responsibleGroup.contactEmail && (
+                <a href={`mailto:${event.responsibleGroup.contactEmail}`}>
+                  {event.responsibleGroup.contactEmail}
+                </a>
+              )}
+            </span>
+          }
+        >
+          {responsibleGroupName}
+        </Tooltip>
+      ) : (
+        responsibleGroupName
       ),
     },
     // Responsible users, author or anonymous
@@ -425,13 +420,13 @@ const EventDetail = () => {
         className={styles.title}
         event={event}
       >
-        <Flex
-          alignItems="center"
-          gap="var(--spacing-md)"
-          className={styles.header}
-        >
+        <Flex alignItems="center" gap="var(--spacing-md)">
           {loggedIn && <InterestedButton isInterested={!!event.following} />}
-          {showSkeleton ? <Skeleton /> : event.title}
+          {showSkeleton ? (
+            <Skeleton className={styles.header} />
+          ) : (
+            <h2 className={styles.header}>{event.title}</h2>
+          )}
         </Flex>
       </ContentHeader>
 
@@ -524,7 +519,7 @@ const EventDetail = () => {
                 minRows={minUserGridRows}
                 maxRows={MAX_USER_GRID_ROWS}
                 users={registrations?.slice(0, 14).map((reg) => reg.user)}
-                skeleton={showSkeleton}
+                skeleton={fetching && !registrations}
               />
               <AttendanceModal key="modal" pools={pools} title="Påmeldte">
                 {({ toggleModal }) => (
@@ -533,13 +528,13 @@ const EventDetail = () => {
                       toggleModal={toggleModal}
                       registrations={registrations}
                       currentRegistration={currentRegistration}
-                      skeleton={showSkeleton}
+                      skeleton={fetching && !registrations}
                     />
                     <AttendanceStatus
                       toggleModal={toggleModal}
                       pools={pools}
                       legacyRegistrationCount={event.legacyRegistrationCount}
-                      skeleton={showSkeleton}
+                      skeleton={fetching && !registrations}
                     />
                   </>
                 )}

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -101,7 +101,9 @@ const JoblistingDetail = () => {
           href={`${config?.webUrl}/joblistings/${joblisting.id}`}
         />
       </PropertyHelmet>
-      <ContentHeader>{joblisting.title}</ContentHeader>
+      <ContentHeader>
+        <h2>{joblisting.title}</h2>
+      </ContentHeader>
       <ContentSection>
         <ContentMain>
           <DisplayContent content={joblisting.description} />

--- a/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
+++ b/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
@@ -87,7 +87,9 @@ const AddSubmissionPage = () => {
   return (
     <Content banner={survey.event.cover}>
       <Helmet title={`Besvarer: ${survey.title}`} />
-      <ContentHeader>{survey.title}</ContentHeader>
+      <ContentHeader>
+        <h2>{survey.title}</h2>
+      </ContentHeader>
 
       <div className={styles.surveyTime}>
         Spørreundersøkelse for arrangementet{' '}


### PR DESCRIPTION
# Description

* Hide event type on mobile, as it took up unnecessary space
* Show skeleton components for registrations appropriately, as registrations are separated in the store
* Hide responsible group mail address in a tooltip
* Make admin buttons only clickable on the actual buttons
* Employ the actual text input component for the delete event field
* Clean up other minor stuff

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

Things look as expected, and deleting events still work.

---

Resolves ABA-866
Resolves ABA-865
Resolves ABA-817
Resolves ABA-721