### PR TITLE
Fix Article fetching forever

### DIFF
--- a/app/actions/ArticleActions.ts
+++ b/app/actions/ArticleActions.ts
@@ -72,7 +72,7 @@ export function fetchAll({
       fetchNext: next,
     },
     meta: {
-      errorMessage: 'Henting av artikler feilet',
+      errorMessage: 'Henting av artikler feilet totalt',
     },
     propagateError: true,
   });

--- a/app/routes/articles/components/Overview.tsx
+++ b/app/routes/articles/components/Overview.tsx
@@ -1,5 +1,6 @@
 import { usePreparedEffect } from '@webkom/react-prepare';
 import qs from 'qs';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useLocation, Link } from 'react-router-dom';
 import { fetchAll } from 'app/actions/ArticleActions';
@@ -65,11 +66,14 @@ export const OverviewItem = ({
 
 const Overview = () => {
   const location = useLocation();
-  const query = {
-    tag: qs.parse(location.search, {
-      ignoreQueryPrefix: true,
-    }).tag,
-  };
+  const query = useMemo(
+    () => ({
+      tag: qs.parse(location.search, {
+        ignoreQueryPrefix: true,
+      }).tag,
+    }),
+    [location]
+  );
   const { pagination } = useAppSelector((state) =>
     selectPaginationNext({
       endpoint: `/articles/`,


### PR DESCRIPTION
# Description

**bug-fix**
Article page continuously fetched due to usePreparedEffect being called on query variable change. Added useMemo to query variable such that it changes when location variable is updated, i.e. webpage.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [ ] Changes look good on both light and dark theme.
- [ ] Changes look good with different viewports (mobile, tablet, etc.).
- [ ] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

In old version simply being on the articles page and looking at the network tab you can see continuous fetch calls, even continuing when returning to homepage.

In new branch, article page will no longer tank itself by fetching.

---

Resolves ABA-864
