### PR TITLE
Add up button at the end of events on front page

### DIFF
--- a/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
+++ b/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
@@ -63,12 +63,11 @@ const AuthenticatedFrontpage = () => {
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
-    
-    setTimeout( () => {
+    //Need timeout because without page scrolls to botton of events not to top of page
+    setTimeout(() => {
       setArticlesToShow(ARTICLES_TO_SHOW);
       setEventsToShow(EVENTS_TO_SHOW);
     }, 200);
-
   };
 
   const readMe = (
@@ -98,7 +97,11 @@ const AuthenticatedFrontpage = () => {
         <Articles pinnedId={pinned?.id} numberToShow={articlesToShow} />
       </section>
 
-      <ShowMoreButton eventsToShow={eventsToShow} showMore={showMore} scrollToTop = {scrollToTop} />
+      <ShowMoreButton
+        eventsToShow={eventsToShow}
+        showMore={showMore}
+        scrollToTop={scrollToTop}
+      />
     </Container>
   );
 };
@@ -290,11 +293,11 @@ const ShowMoreButton = ({
   return (
     <div className={styles.showMore}>
       {events.length > eventsToShow && (
-          <Icon onClick={showMore} name="chevron-down-outline" size={30} />
+        <Icon onClick={showMore} name="chevron-down-outline" size={30} />
       )}
 
       {events.length < eventsToShow && (
-          <Icon onClick={scrollToTop} name="chevron-up-outline" size={30} />
+        <Icon onClick={scrollToTop} name="chevron-up-outline" size={30} />
       )}
     </div>
   );

--- a/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
+++ b/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
@@ -61,6 +61,18 @@ const AuthenticatedFrontpage = () => {
     [loggedIn, shouldFetchQuote],
   );
 
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+
+    setTimeout(function () {
+      setArticlesToShow(ARTICLES_TO_SHOW);
+    }, 200);
+
+    setTimeout(function () {
+      setEventsToShow(EVENTS_TO_SHOW);
+    }, 200);
+  };
+
   const readMe = (
     <Flex className={styles.readMe}>
       <LatestReadme expandedInitially={false} />
@@ -88,7 +100,7 @@ const AuthenticatedFrontpage = () => {
         <Articles pinnedId={pinned?.id} numberToShow={articlesToShow} />
       </section>
 
-      <ShowMoreButton eventsToShow={eventsToShow} showMore={showMore} />
+      <ShowMoreButton eventsToShow={eventsToShow} showMore={showMore} scrollToTop = {scrollToTop} />
     </Container>
   );
 };
@@ -269,17 +281,25 @@ const QuoteItem = () => (
 const ShowMoreButton = ({
   eventsToShow,
   showMore,
+  scrollToTop,
 }: {
   eventsToShow: number;
   showMore: () => void;
+  scrollToTop: () => void;
 }) => {
   const events = useAppSelector(selectEvents);
 
-  return events.length > eventsToShow ? (
+  return (
     <div className={styles.showMore}>
-      <Icon onClick={showMore} name="chevron-down-outline" size={30} />
+      {events.length > eventsToShow && (
+          <Icon onClick={showMore} name="chevron-down-outline" size={30} />
+      )}
+
+      {events.length < eventsToShow && (
+          <Icon onClick={scrollToTop} name="chevron-up-outline" size={30} />
+      )}
     </div>
-  ) : null;
+  );
 };
 
 export default guardLogin(AuthenticatedFrontpage);

--- a/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
+++ b/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
@@ -63,14 +63,12 @@ const AuthenticatedFrontpage = () => {
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
-
-    setTimeout(function () {
+    
+    setTimeout( () => {
       setArticlesToShow(ARTICLES_TO_SHOW);
-    }, 200);
-
-    setTimeout(function () {
       setEventsToShow(EVENTS_TO_SHOW);
     }, 200);
+
   };
 
   const readMe = (


### PR DESCRIPTION
# Description

Added a up button to the bottom of the shown events on front page. When clicked the button takes user to top of front-page and sets the shown events and articles to standard. 

# Result
Before:


https://github.com/webkom/lego-webapp/assets/145492323/4d4851c8-339c-4a22-ba1e-efb7b30b5e25



After:


https://github.com/webkom/lego-webapp/assets/145492323/490a48b5-bf6a-4507-be64-0e56da8f7a86



If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.


