### PR TITLE
Let users filter announcement recipients further

### DIFF
--- a/app/actions/AnnouncementsActions.ts
+++ b/app/actions/AnnouncementsActions.ts
@@ -1,7 +1,7 @@
 import callAPI from 'app/actions/callAPI';
 import { announcementsSchema } from 'app/reducers';
 import { Announcements } from './ActionTypes';
-import type { AppDispatch } from 'app/store/createStore';
+import type { FormValues as CreateAnnouncementFormValues } from 'app/routes/announcements/components/AnnouncementsCreate';
 import type { ID } from 'app/store/models';
 import type {
   DetailedAnnouncement,
@@ -20,40 +20,18 @@ export function fetchAll() {
   });
 }
 
-export function createAnnouncement({
-  message,
-  users,
-  groups,
-  events,
-  meetings,
-  fromGroup,
-  send,
-}: Record<string, any>) {
-  return (dispatch: AppDispatch) =>
-    dispatch(
-      callAPI<DetailedAnnouncement>({
-        types: Announcements.CREATE,
-        endpoint: '/announcements/',
-        method: 'POST',
-        body: {
-          message,
-          users,
-          groups,
-          events,
-          meetings,
-          fromGroup,
-        },
-        schema: announcementsSchema,
-        meta: {
-          errorMessage: 'Opprettelse av kunngjøringer feilet',
-          successMessage: 'Kunngjøring opprettet',
-        },
-      }),
-    ).then((action) => {
-      if (send) {
-        dispatch(sendAnnouncement(action.payload.result));
-      }
-    });
+export function createAnnouncement(body: CreateAnnouncementFormValues) {
+  return callAPI<DetailedAnnouncement>({
+    types: Announcements.CREATE,
+    endpoint: '/announcements/',
+    method: 'POST',
+    body,
+    schema: announcementsSchema,
+    meta: {
+      errorMessage: 'Opprettelse av kunngjøringer feilet',
+      successMessage: 'Kunngjøring opprettet',
+    },
+  });
 }
 
 export function sendAnnouncement(announcementId: ID) {

--- a/app/routes/announcements/components/AnnouncementItem.tsx
+++ b/app/routes/announcements/components/AnnouncementItem.tsx
@@ -6,6 +6,7 @@ import {
   sendAnnouncement,
 } from 'app/actions/AnnouncementsActions';
 import Time from 'app/components/Time';
+import { statusesText } from 'app/reducers/meetingInvitations';
 import { useAppDispatch } from 'app/store/hooks';
 import styles from './AnnouncementsList.css';
 import type { ActionGrant } from 'app/models';
@@ -44,9 +45,16 @@ const AnnouncementItem = ({ announcement, actionGrant }: Props) => {
           </Flex>
         )}
         <Flex column>
-          <span className={styles.recHeader}>Mottakere:</span>
-          <Flex wrap>
-            {announcement.events.length > 0 && 'Arrangementer: '}
+          <b className={styles.recHeader}>Mottakere</b>
+          <Flex alignItems="center" gap="var(--spacing-sm)" wrap>
+            {announcement.events.length > 0 && (
+              <span>
+                Arrangementer
+                {announcement.excludeWaitingList
+                  ? ' (ekskludert venteliste): '
+                  : ': '}
+              </span>
+            )}
             {announcement.events.map((event, i) => (
               <Link
                 key={i}
@@ -57,8 +65,15 @@ const AnnouncementItem = ({ announcement, actionGrant }: Props) => {
               </Link>
             ))}
           </Flex>
-          <Flex wrap>
-            {announcement.meetings.length > 0 && 'Møter: '}
+          <Flex alignItems="center" gap="var(--spacing-sm)" wrap>
+            {announcement.meetings.length > 0 && (
+              <span>
+                Møter
+                {announcement.meetingInvitationStatus
+                  ? `(${statusesText[announcement.meetingInvitationStatus]}) :`
+                  : ': '}
+              </span>
+            )}
             {announcement.meetings.map((meeting, i) => (
               <Link
                 key={i}
@@ -69,7 +84,7 @@ const AnnouncementItem = ({ announcement, actionGrant }: Props) => {
               </Link>
             ))}
           </Flex>
-          <Flex wrap>
+          <Flex alignItems="center" wrap>
             {announcement.groups.length > 0 && 'Grupper: '}
             {announcement.groups.map((group, i) => (
               <Link
@@ -81,7 +96,7 @@ const AnnouncementItem = ({ announcement, actionGrant }: Props) => {
               </Link>
             ))}
           </Flex>
-          <Flex wrap>
+          <Flex alignItems="center" wrap>
             {announcement.users.length > 0 && 'Brukere: '}
             {announcement.users.map((user, i) => (
               <Link

--- a/app/routes/announcements/components/AnnouncementsCreate.tsx
+++ b/app/routes/announcements/components/AnnouncementsCreate.tsx
@@ -2,13 +2,22 @@ import { Card, Flex } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
-import { createAnnouncement } from 'app/actions/AnnouncementsActions';
-import { ContentMain } from 'app/components/Content';
-import { LegoFinalForm, SelectInput, TextArea } from 'app/components/Form';
+import {
+  createAnnouncement,
+  sendAnnouncement,
+} from 'app/actions/AnnouncementsActions';
+import {
+  CheckBox,
+  LegoFinalForm,
+  SelectInput,
+  TextArea,
+} from 'app/components/Form';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
+import { statusesText } from 'app/reducers/meetingInvitations';
 import { selectAutocomplete } from 'app/reducers/search';
 import { useAppDispatch } from 'app/store/hooks';
 import { AutocompleteContentType } from 'app/store/models/Autocomplete';
+import { MeetingInvitationStatus } from 'app/store/models/MeetingInvitation';
 import { spyValues } from 'app/utils/formSpyUtils';
 import {
   atLeastOneFieldRequired,
@@ -16,7 +25,6 @@ import {
   required,
 } from 'app/utils/validation';
 import styles from './AnnouncementsList.css';
-import type { ActionGrant } from 'app/models';
 import type {
   AutocompleteEvent,
   SearchEvent,
@@ -35,25 +43,25 @@ import type {
 import type { AutocompleteUser } from 'app/store/models/User';
 import type { FormApi } from 'final-form';
 
-type Props = {
-  actionGrant: ActionGrant;
-};
-
 export type AnnouncementCreateLocationState = {
   group?: UnknownGroup;
   event?: UnknownEvent;
   meeting?: UnknownMeeting;
 };
 
-type FormValues = {
+export type FormValues = {
   message: string;
   users?: AutocompleteUser[];
   groups?: (AutocompleteGroup | SearchGroup)[];
   events?: (AutocompleteEvent | SearchEvent)[];
+  excludeWaitingList?: boolean;
   meetings?: (AutocompleteMeeting | SearchMeeting)[];
+  meetingInvitationStatus?: MeetingInvitationStatus;
   fromGroup?: AutocompleteGroup;
   send: boolean;
 };
+
+const TypedLegoForm = LegoFinalForm<FormValues>;
 
 const validate = createValidator({
   message: [required('Du må skrive en melding')],
@@ -65,7 +73,7 @@ const validate = createValidator({
   ],
 });
 
-const AnnouncementsCreate = ({ actionGrant }: Props) => {
+const AnnouncementsCreate = () => {
   const location = useLocation<AnnouncementCreateLocationState>();
   const dispatch = useAppDispatch();
 
@@ -96,123 +104,142 @@ const AnnouncementsCreate = ({ actionGrant }: Props) => {
       : [],
     users: [],
     message: '',
+    excludeWaitingList: false,
     send: false,
   };
 
   const onSubmit = (values: FormValues, form: FormApi<FormValues>) => {
     dispatch(
       createAnnouncement({
-        message: values.message,
-        users: values.users.map((user) => user.value),
-        groups: values.groups.map((group) => group.value),
-        meetings: values.meetings.map((meeting) => meeting.value),
-        events: values.events.map((event) => event.value),
-        fromGroup: values.fromGroup && values.fromGroup.value,
-        send: values.send,
+        ...values,
+        users: values.users?.map((user) => user.value),
+        groups: values.groups?.map((group) => group.value),
+        meetings: values.meetings?.map((meeting) => meeting.value),
+        meetingInvitationStatus: values.meetingInvitationStatus?.value,
+        events: values.events?.map((event) => event.value),
+        fromGroup: values.fromGroup?.value,
       }),
-    ).then(() => {
+    ).then((result) => {
+      if (values.send) {
+        dispatch(sendAnnouncement(result.payload.result));
+      }
       form.reset();
     });
   };
 
   return (
-    <ContentMain>
+    <>
       <Helmet title="Kunngjøringer" />
-      {actionGrant.includes('create') && (
-        <Flex column>
-          <h1>Ny kunngjøring</h1>
-          <LegoFinalForm
-            validate={validate}
-            validateOnSubmitOnly
-            onSubmit={onSubmit}
-            initialValues={initialValues}
-            className={styles.form}
-            subscription={{}}
-          >
-            {({ handleSubmit }) => (
-              <form onSubmit={handleSubmit}>
+      <h1>Ny kunngjøring</h1>
+      <TypedLegoForm
+        validate={validate}
+        validateOnSubmitOnly
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+        className={styles.form}
+        subscription={{}}
+      >
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <Field
+              name="message"
+              component={TextArea.Field}
+              placeholder="Skriv din melding her ..."
+              label="Kunngjøring"
+              required
+            />
+            <span className={styles.formHeaders}>Mottakere</span>
+            <Flex column gap="var(--spacing-sm)">
+              <Flex className={styles.rowRec}>
                 <Field
-                  className={styles.msgField}
-                  name="message"
-                  component={TextArea.Field}
-                  placeholder="Skriv din melding her ..."
-                  label="Kunngjøring"
-                  required
-                />
-                <span className={styles.formHeaders}>Mottakere</span>
-                <Flex className={styles.rowRec}>
-                  <Field
-                    className={styles.recField}
-                    name="users"
-                    placeholder="Brukere"
-                    filter={['users.user']}
-                    isMulti
-                    component={SelectInput.AutocompleteField}
-                  />
-                  <Field
-                    name="groups"
-                    placeholder="Grupper"
-                    filter={['users.abakusgroup']}
-                    isMulti
-                    component={SelectInput.AutocompleteField}
-                  />
-                </Flex>
-                <Flex className={styles.rowRec}>
-                  <Field
-                    className={styles.recField}
-                    name="events"
-                    placeholder="Arrangementer"
-                    filter={['events.event']}
-                    isMulti
-                    component={SelectInput.AutocompleteField}
-                  />
-                  <Field
-                    name="meetings"
-                    placeholder="Møter"
-                    filter={['meetings.meeting']}
-                    isMulti
-                    component={SelectInput.AutocompleteField}
-                  />
-                </Flex>
-                <Field
-                  name="fromGroup"
-                  placeholder="Fra gruppe"
-                  filter={['users.abakusgroup']}
+                  className={styles.recField}
+                  name="users"
+                  placeholder="Brukere"
+                  filter={['users.user']}
+                  isMulti
                   component={SelectInput.AutocompleteField}
-                  label="Send på vegne av"
-                  isClearable
                 />
+                <Field
+                  name="groups"
+                  placeholder="Grupper"
+                  filter={['users.abakusgroup']}
+                  isMulti
+                  component={SelectInput.AutocompleteField}
+                />
+              </Flex>
+              <Flex alignItems="center" className={styles.rowRec}>
+                <Field
+                  className={styles.recField}
+                  name="events"
+                  placeholder="Arrangementer"
+                  filter={['events.event']}
+                  isMulti
+                  component={SelectInput.AutocompleteField}
+                />
+                <Field
+                  name="excludeWaitingList"
+                  label="Ekskluder venteliste"
+                  component={CheckBox.Field}
+                />
+              </Flex>
+              <Flex className={styles.rowRec}>
+                <Field
+                  name="meetings"
+                  placeholder="Møter"
+                  filter={['meetings.meeting']}
+                  isMulti
+                  component={SelectInput.AutocompleteField}
+                />
+                <Field
+                  name="meetingInvitationStatus"
+                  placeholder="Filtrer på deltagelsesstatus"
+                  component={SelectInput.Field}
+                  options={Object.values(MeetingInvitationStatus).map(
+                    (status) => ({
+                      label: statusesText[status],
+                      value: status,
+                    }),
+                  )}
+                />
+              </Flex>
+            </Flex>
+            <Field
+              name="fromGroup"
+              placeholder="Fra gruppe"
+              filter={['users.abakusgroup']}
+              component={SelectInput.AutocompleteField}
+              label="Send på vegne av"
+              isClearable
+            />
 
-                {spyValues((values: FormValues) => (
-                  <Flex wrap>
-                    <SubmitButton
-                      onClick={(e) => {
-                        values.send = false;
-                        handleSubmit(e);
-                      }}
-                    >
-                      Opprett
-                    </SubmitButton>
-                    <SubmitButton
-                      onClick={(e) => {
-                        values.send = true;
-                        handleSubmit(e);
-                      }}
-                    >
-                      Opprett og send
-                    </SubmitButton>
-                  </Flex>
-                ))}
-                <Card severity="info">
-                  Du kan velge å sende kunngjøringen med en gang, eller lagre
-                  den og sende den senere fra listen nedenfor.
-                </Card>
-              </form>
-            )}
-          </LegoFinalForm>
-        </Flex>
-      )}
-    </ContentMain>
+            {spyValues<FormValues>((values) => (
+              <Flex wrap>
+                <SubmitButton
+                  onClick={(e) => {
+                    values.send = false;
+                    handleSubmit(e);
+                  }}
+                >
+                  Opprett
+                </SubmitButton>
+                <SubmitButton
+                  onClick={(e) => {
+                    values.send = true;
+                    handleSubmit(e);
+                  }}
+                >
+                  Opprett og send
+                </SubmitButton>
+              </Flex>
+            ))}
+            <Card severity="info">
+              Du kan velge å sende kunngjøringen med en gang, eller lagre den og
+              sende den senere fra listen nedenfor.
+            </Card>
+          </form>
+        )}
+      </TypedLegoForm>
+    </>
   );
 };
 

--- a/app/routes/announcements/components/AnnouncementsList.css
+++ b/app/routes/announcements/components/AnnouncementsList.css
@@ -11,10 +11,6 @@
   margin-bottom: 20px;
 }
 
-.msgField {
-  min-height: 70px;
-}
-
 .formHeaders {
   font-size: var(--font-size-lg);
 }
@@ -24,7 +20,10 @@
 }
 
 .rowRec {
+  gap: var(--spacing-md);
+
   @media (--mobile-device) {
+    gap: var(--spacing-sm);
     flex-direction: column;
   }
 }

--- a/app/routes/announcements/components/AnnouncementsList.tsx
+++ b/app/routes/announcements/components/AnnouncementsList.tsx
@@ -1,7 +1,7 @@
 import { Flex, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { fetchAll } from 'app/actions/AnnouncementsActions';
-import { Content, ContentMain } from 'app/components/Content';
+import { Content } from 'app/components/Content';
 import { selectAnnouncements } from 'app/reducers/announcements';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import AnnouncementItem from './AnnouncementItem';
@@ -20,26 +20,32 @@ const AnnouncementsList = () => {
   );
 
   return (
-    <LoadingIndicator loading={fetching}>
-      <Content>
-        <AnnouncementsCreate actionGrant={actionGrant} />
+    <Content>
+      <LoadingIndicator loading={fetching}>
+        {actionGrant.includes('create') && <AnnouncementsCreate />}
 
         {actionGrant.includes('list') && actionGrant.includes('delete') && (
-          <ContentMain>
-            <h1>Dine kunngjøringer</h1>
-            <Flex column className={styles.list}>
-              {announcements.map((a, i) => (
-                <AnnouncementItem
-                  key={i}
-                  announcement={a}
-                  actionGrant={actionGrant}
-                />
-              ))}
-            </Flex>
-          </ContentMain>
+          <>
+            <h2>Dine kunngjøringer</h2>
+            {announcements.length === 0 ? (
+              <span className="secondaryFontColor">
+                Du har ingen tidligere kunngjøringer
+              </span>
+            ) : (
+              <Flex column className={styles.list}>
+                {announcements.map((a, i) => (
+                  <AnnouncementItem
+                    key={i}
+                    announcement={a}
+                    actionGrant={actionGrant}
+                  />
+                ))}
+              </Flex>
+            )}
+          </>
         )}
-      </Content>
-    </LoadingIndicator>
+      </LoadingIndicator>
+    </Content>
   );
 };
 

--- a/app/store/models/Announcement.d.ts
+++ b/app/store/models/Announcement.d.ts
@@ -13,7 +13,9 @@ interface CompleteAnnouncement {
   users: PublicUser[];
   groups: PublicGroup[];
   events: ListEvent[];
+  excludeWaitingList: boolean;
   meetings: DetailedMeeting[];
+  meetingInvitationStatus: MeetingInvitationStatus;
 }
 
 export type ListAnnouncement = Pick<
@@ -25,7 +27,9 @@ export type ListAnnouncement = Pick<
   | 'users'
   | 'groups'
   | 'events'
+  | 'excludeWaitingList'
   | 'meetings'
+  | 'meetingInvitationStatus'
 >;
 
 export type DetailedAnnouncement = Pick<
@@ -37,7 +41,9 @@ export type DetailedAnnouncement = Pick<
   | 'users'
   | 'groups'
   | 'events'
+  | 'excludeWaitingList'
   | 'meetings'
+  | 'meetingInvitationStatus'
 >;
 
 export type UnknownAnnouncement = ListAnnouncement | DetailedAnnouncement;


### PR DESCRIPTION
# Description

[Related backend changes](https://github.com/webkom/lego/pull/3565)

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="1320" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/4cb35d5e-7577-4798-8243-881c663ca79c">
        </td>
        <td>
            <img width="1320" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/231dce96-19f5-478f-a290-b37877ae3de5">
        </td>
    </tr>
    <tr>
        <td>
            <img width="555" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/27cbc5bd-ab86-4965-b533-0a4f34e162c1">
        </td>
        <td>
            <img width="555" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/9ab01e82-0776-4c2c-95b9-d8712cf7b7db">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Most of the "testing" is done on the backend, but things seem to work fine here as well.