### PR TITLE
Remove 'ingen er påmeldte' from registrations when not logged in

### DIFF
--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -519,12 +519,13 @@ const EventDetail = () => {
                 users={registrations?.slice(0, 14).map((reg) => reg.user)}
                 skeleton={fetching && !registrations}
               />
+
               <AttendanceModal key="modal" pools={pools} title="Påmeldte">
                 {({ toggleModal }) => (
                   <>
                     <RegisteredSummary
                       toggleModal={toggleModal}
-                      registrations={registrations}
+                      registrations={loggedIn && registrations}
                       currentRegistration={currentRegistration}
                       skeleton={fetching && !registrations}
                     />


### PR DESCRIPTION

# Description

Removed {registrations} over the modal that shows how many are registered for an event when not logged. It just showed "ingen er påmeldt" no matter what. Now it is removed. Still works as normal when logged in. 

# Result

Before: 
![Skjermbilde 2024-03-12 kl  20 41 50](https://github.com/webkom/lego-webapp/assets/145492323/508b64e2-426b-41db-bb09-44e2c2c5bb7f)


After: 
![Skjermbilde 2024-03-12 kl  20 42 29](https://github.com/webkom/lego-webapp/assets/145492323/808b7e35-d829-4f62-9e1d-ef83c7018980)



If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.



# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-881
