### PR TITLE
Remove link to settings in calender for events

### DIFF
--- a/app/routes/events/components/EventFooter.tsx
+++ b/app/routes/events/components/EventFooter.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import Circle from 'app/components/Circle';
 import config from 'app/config';
 import { EventTypeConfig } from '../utils';
@@ -39,8 +38,8 @@ const EventFooter = ({ icalToken }: Props) => (
     {icalToken && (
       <p className={styles.section}>
         Her kan du importere arrangementer og møter til din favorittkalender!
-        For innstillinger se
-        <Link to="/users/me/settings"> her</Link>.
+        <br />
+        Trykk på en av lenkene under for å legge inn i din kalender.
       </p>
     )}
     <div className={styles.eventFooterSections}>


### PR DESCRIPTION
# Description

Removed the link to settings for the events calendar as the settings had no function. Instead added text to for user to click on one of the links to add to their calendar. 

# Result

Before (1. events calendar, 2. settings):
1:
![Skjermbilde 2024-03-12 kl  21 03 59](https://github.com/webkom/lego-webapp/assets/145492323/d429cc84-035a-4d64-a80e-a2be6dc067b9)

2:
![Skjermbilde 2024-03-12 kl  21 04 21](https://github.com/webkom/lego-webapp/assets/145492323/95e6144b-835f-4305-bab7-90040c856017)


After:
![Skjermbilde 2024-03-12 kl  21 05 05](https://github.com/webkom/lego-webapp/assets/145492323/384e7291-d835-492a-b360-246a45801337)


If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.



# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-882
