### PR TITLE
Add previous semesters to the filter under company interest

### DIFF
--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -14,7 +14,7 @@ import SelectInput from 'app/components/Form/SelectInput';
 import Table from 'app/components/Table';
 import Tooltip from 'app/components/Tooltip';
 import { selectCompanyInterestList } from 'app/reducers/companyInterest';
-import { selectCompanySemestersForInterestForm } from 'app/reducers/companySemesters';
+import { selectCompanySemesters } from 'app/reducers/companySemesters';
 import { ListNavigation } from 'app/routes/bdb/utils';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
@@ -45,9 +45,7 @@ const CompanyInterestList = () => {
       ignoreQueryPrefix: true,
     }).semesters,
   );
-  const semesters = useAppSelector((state) =>
-    selectCompanySemestersForInterestForm(state),
-  );
+  const semesters = useAppSelector((state) => selectCompanySemesters(state));
   const semesterObj: CompanySemesterEntity | null | undefined = semesters.find(
     (semester) => semester.id === semesterId,
   );


### PR DESCRIPTION
# Description

Current functionality limits filtering options for interest form responses to only active semesters. This restriction can be inconvenient for users wishing to review interest form answers from past semesters, as it necessitates setting those semesters to active status. - ChatGPT

# Result

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>Note: Høst 2024 and Høst 2023 are set as active semesters
        </td>
        <td>
            <img src="https://github.com/webkom/lego-webapp/assets/66320400/fb2eada7-3b6d-4791-8995-53f8150f626f)">
        </td>
        <td>
             <img src="https://github.com/webkom/lego-webapp/assets/66320400/edac482c-5f7f-4e9f-9cad-26ae9b97b6bc)">
        </td>
    </tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.

It works

---

Resolves ABA-841
