### PR TITLE
Add z-index to reaction picker

### DIFF
--- a/app/components/Reactions/ReactionPicker.css
+++ b/app/components/Reactions/ReactionPicker.css
@@ -2,6 +2,7 @@
 
 .reactionPicker {
   composes: popover from '~app/styles/utilities.css';
+  position: relative;
   height: 400px;
   width: 309px;
   line-height: 1.3;
@@ -9,6 +10,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  z-index: 20;
 
   @media (--mobile-device) {
     max-width: 420px;


### PR DESCRIPTION
# Description
Prevent it from appearing under poll component

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [ ] Changes look good on both light and dark theme.
- [ ] Changes look good with different viewports (mobile, tablet, etc.).
- [ ] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Werks
        </td>
        <td>
				<img width="343" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/72879852-72b0-4845-84c4-784372ac5029">
        </td>
        <td>
            <img width="350" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/a9e58eff-83f0-4e0b-984c-366f0abbaec9">
        </td>
    </tr>
</table>

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
