### PR TITLE
Separate multiple article authors only by a comma

### DIFF
--- a/app/routes/articles/components/ArticleDetail.css
+++ b/app/routes/articles/components/ArticleDetail.css
@@ -4,25 +4,8 @@
   margin-top: 8px;
 }
 
-span.detail + span.detail {
-  margin-left: 10px;
-}
-
-span.detail + span.detail::before {
-  margin-right: 10px;
-  content: '•';
-}
-
 .headerClassName {
   margin-bottom: 0;
-}
-
-.articleHeader {
-  margin-bottom: 0;
-}
-
-.articleDetails {
-  margin-bottom: 15px;
 }
 
 .articleReactions {

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -136,7 +136,6 @@ const ArticleDetail = () => {
       </PropertyHelmet>
       <NavigationTab
         headerClassName={styles.headerClassName}
-        className={styles.articleHeader}
         title={article.title}
       >
         {(article.actionGrant || []).includes('edit') && (
@@ -147,7 +146,7 @@ const ArticleDetail = () => {
       </NavigationTab>
 
       {
-        <div className={styles.articleDetails}>
+        <div>
           <span className="secondaryFontColor">
             Skrevet av{' '}
             {authors?.map((e, i) => {
@@ -155,7 +154,11 @@ const ArticleDetail = () => {
                 <span key={e.username}>
                   <Link
                     to={`/users/${e.username}`}
-                    className={sharedStyles.overviewAuthor}
+                    className={
+                      i === authors.length - 1
+                        ? sharedStyles.overviewAuthor
+                        : undefined
+                    }
                   >
                     {' '}
                     {e.fullName}


### PR DESCRIPTION
# Description

This has bugged me for a long time

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="738" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/10f77e8a-9fdb-424e-8d39-eecbd7a1d07e">
        </td>
        <td>
            <img width="738" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/5f270dff-693b-4f2e-95c9-cd89adb049dc">
        </td>
    </tr>
    <tr>
        <td>
            <img width="738" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/c0f5cdae-c4ae-4386-bb6b-bc613777be87">
        </td>
        <td>
            <img width="738" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/66d3bca7-5621-4e8d-925a-78c4f2c0a89e">
        </td>
    </tr>
</table>




# Testing

- [x] I have thoroughly tested my changes.

See images above. Works when there's just one author as well

---

Resolves https://github.com/webkom/lego/issues/3497