### PR TITLE
Add background color to mazemap embed

### DIFF
--- a/app/components/MazemapEmbed/MazemapEmbed.css
+++ b/app/components/MazemapEmbed/MazemapEmbed.css
@@ -12,4 +12,10 @@
 
 .mazemapEmbed {
   --lego-font-color: var(--color-absolute-black);
+
+  background-color: rgb(
+    248,
+    244,
+    236
+  ); /* The color of a blank area in mazemap  */
 }


### PR DESCRIPTION
# Description

Add a background to the MazeMap embed so you can see where it's supposed to appear while it is loading.

Right now there is an ugly empty area where the mazemap embed is supposed to load for a short while while it is loading. I think this would make it look a little smoother.

# Result

- [ ] Changes look good on both light and dark theme.
- [ ] Changes look good with different viewports (mobile, tablet, etc.).
- [ ] Changes look good with slower Internet connections.

&nbsp;

I'm not able to reproduce this locally, so we're gonna have to go for a "trust me bro" and rather revert it if it is not a success - or deploy it to staging before merging it

# Testing

- [ ] I have thoroughly tested my changes.


---

Resolves ... (either GitHub issue or Linear task)
