### PR TITLE
Fill placeholder background on image upload

### DIFF
--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -10,6 +10,7 @@
 .dropArea {
   border-radius: inherit;
   aspect-ratio: inherit;
+  height: inherit;
   width: inherit;
   z-index: 0;
   position: absolute;
@@ -30,6 +31,7 @@
   overflow: hidden;
   border-radius: inherit;
   aspect-ratio: inherit;
+  height: inherit;
   width: inherit;
   position: absolute;
   background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 50%);


### PR DESCRIPTION
# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="419" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/077092ad-7963-4dd5-aa9e-15a8e3968bee">
        </td>
        <td>
            <img width="419" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/02a69ab2-554f-41d0-8f72-4f37c0ca9bf5">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested that this does not break the image upload in e.g. the event editor.