### PR TITLE
Add pool suggestions displaying frequently used groups

### DIFF
--- a/app/components/Form/SelectInput.tsx
+++ b/app/components/Form/SelectInput.tsx
@@ -21,7 +21,7 @@ type Props<Option, IsMulti extends boolean = false> = {
     previousValue?: string,
     name?: string,
   ) => void;
-  onChange?: (event: ChangeEvent | string) => void;
+  onChange?: (event: ChangeEvent | string | Option[]) => void;
   onSearch: (search: string) => void;
   isValidNewOption: (arg0: string) => boolean;
   value: any;
@@ -30,7 +30,15 @@ type Props<Option, IsMulti extends boolean = false> = {
   creatable?: boolean;
   isMulti?: boolean;
   isClearable?: boolean;
+  filter?: string[];
+  SuggestionComponent?: SuggestionComponent;
 };
+
+export type SuggestionComponent<Option = { label: string; value: number }> =
+  React.ComponentType<{
+    value: Option[];
+    onChange?: (event: ChangeEvent | string | Option[]) => void;
+  }>;
 
 export const selectStyles: StylesConfig = {
   control: (styles, { isDisabled }) => ({
@@ -90,6 +98,7 @@ const SelectInput = <Option, IsMulti extends boolean = false>({
   placeholder,
   creatable,
   onSearch,
+  SuggestionComponent,
   ...props
 }: Props<Option, IsMulti>) => {
   if (props.tags) {
@@ -128,6 +137,9 @@ const SelectInput = <Option, IsMulti extends boolean = false>({
 
   return (
     <div className={style.field}>
+      {SuggestionComponent && (
+        <SuggestionComponent value={value} onChange={props.onChange} />
+      )}
       <Select
         {...props}
         isDisabled={disabled}

--- a/app/components/Pill/index.tsx
+++ b/app/components/Pill/index.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import styles from './Pill.css';
 import type { HTMLAttributes } from 'react';
 
@@ -9,10 +10,10 @@ type Props = {
 /**
  * Basic `Pill` component to wrap extra content inside
  */
-function Pill({ color, style, ...props }: Props) {
+function Pill({ color, style, className, ...props }: Props) {
   return (
     <span
-      className={styles.pill}
+      className={cx(styles.pill, className)}
       style={{
         backgroundColor: color,
         ...style,

--- a/app/routes/events/components/EventEditor/EventEditor.css
+++ b/app/routes/events/components/EventEditor/EventEditor.css
@@ -89,6 +89,14 @@
 
 .metaList > ul > li.poolBox {
   flex-basis: 32%;
+
+  @media (--medium-viewport) {
+    flex-basis: 49%;
+  }
+
+  @media (--small-viewport) {
+    flex-basis: 100%;
+  }
 }
 
 .metaList > span {
@@ -163,4 +171,24 @@
   margin: var(--spacing-md) 0;
   color: var(--secondary-font-color);
   text-align: center;
+}
+
+.groupSuggestionWrapper {
+  margin-bottom: var(--spacing-sm);
+
+  > .groupSuggestion {
+    cursor: pointer;
+    font-size: var(--font-size-xs);
+
+    &.selected {
+      background-color: var(--lego-font-color);
+      color: var(--inverted-font-color);
+    }
+
+    &.implicit {
+      cursor: not-allowed;
+      background-color: var(--color-gray-4);
+      color: var(--inverted-font-color);
+    }
+  }
 }

--- a/app/routes/events/components/EventEditor/PoolSuggestions.tsx
+++ b/app/routes/events/components/EventEditor/PoolSuggestions.tsx
@@ -1,0 +1,147 @@
+import { Flex } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import { useState } from 'react';
+import Pill from 'app/components/Pill';
+import styles from './EventEditor.css';
+import type { SuggestionComponent } from 'app/components/Form/SelectInput';
+
+type GroupSuggestion = {
+  label: string;
+  values: { label: string; value: number }[];
+  children?: number[]; // Child group ids of the suggestion (these will be removed if this suggestion is selected)
+};
+
+const suggestions: GroupSuggestion[] = [
+  {
+    label: 'Alle studenter',
+    values: [{ label: 'Students', value: 14 }],
+    children: [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+  },
+  {
+    label: 'Data',
+    values: [{ label: 'Datateknologi', value: 15 }],
+    children: [16, 17, 18, 19, 20],
+  },
+  {
+    label: 'Cybdat',
+    values: [{ label: 'Kommunikasjonsteknologi', value: 21 }],
+    children: [22, 23, 24, 25, 26],
+  },
+  {
+    label: '1. klasse',
+    values: [
+      { label: '1. klasse Datateknologi', value: 16 },
+      { label: '1. klasse Kommunikasjonsteknologi', value: 22 },
+    ],
+  },
+  {
+    label: '2. klasse',
+    values: [
+      { label: '2. klasse Datateknologi', value: 17 },
+      { label: '2. klasse Kommunikasjonsteknologi', value: 23 },
+    ],
+  },
+  {
+    label: '3. klasse',
+    values: [
+      { label: '3. klasse Datateknologi', value: 18 },
+      { label: '3. klasse Kommunikasjonsteknologi', value: 24 },
+    ],
+  },
+  {
+    label: '4. klasse',
+    values: [
+      { label: '4. klasse Datateknologi', value: 19 },
+      { label: '4. klasse Kommunikasjonsteknologi', value: 25 },
+    ],
+  },
+  {
+    label: '5. klasse',
+    values: [
+      { label: '5. klasse Datateknologi', value: 20 },
+      { label: '5. klasse Kommunikasjonsteknologi', value: 26 },
+    ],
+  },
+];
+
+const PoolSuggestion: SuggestionComponent = ({
+  value: selectedValues,
+  onChange,
+}) => {
+  const [implicitGroupIds, setImplicitGroupIds] = useState<number[]>([]);
+  const selectedValueArr = selectedValues.map(({ value }) => value);
+
+  const allSelected = (values: GroupSuggestion['values']) =>
+    values.every(
+      ({ value }) =>
+        implicitGroupIds.includes(value) || selectedValueArr.includes(value),
+    );
+
+  const implicit = (values: GroupSuggestion['values']) =>
+    values.every((value) => implicitGroupIds.includes(value.value));
+
+  /**
+   * Toggle the groups belonging to the suggestion, but ignoring groups that are implicit and preventing duplicates
+   */
+  const toggleSuggestion = ({
+    values: suggestedValues,
+    children,
+  }: GroupSuggestion) => {
+    const suggestedValueArr = suggestedValues.map(({ value }) => value);
+
+    if (allSelected(suggestedValues)) {
+      // Remove implicit groups
+      setImplicitGroupIds((prevGroups) =>
+        prevGroups.filter((group) => !children?.includes(group)),
+      );
+      // Remove all the suggested values
+      return selectedValues.filter(
+        (selectedValue) => !suggestedValueArr.includes(selectedValue.value),
+      );
+    }
+
+    // Add implicit groups
+    children &&
+      setImplicitGroupIds([...new Set([...implicitGroupIds, ...children])]);
+
+    return [
+      // Remove all selected values that are children of the toggled suggestion
+      ...selectedValues.filter(
+        (selectedValue) => !children?.includes(selectedValue.value),
+      ),
+      // Add new values that are not already implicit or selected
+      ...suggestedValues.filter(
+        (suggestedValue) =>
+          !implicit([suggestedValue]) &&
+          !selectedValueArr.includes(suggestedValue.value),
+      ),
+    ];
+  };
+
+  return (
+    <Flex
+      wrap
+      gap="var(--spacing-sm)"
+      className={styles.groupSuggestionWrapper}
+    >
+      {suggestions.map((suggestion) => (
+        <Pill
+          key={suggestion.label}
+          className={cx(
+            styles.groupSuggestion,
+            allSelected(suggestion.values) ? styles.selected : undefined,
+            implicit(suggestion.values) ? styles.implicit : undefined,
+          )}
+          onClick={() =>
+            !implicit(suggestion.values) &&
+            onChange?.(toggleSuggestion(suggestion))
+          }
+        >
+          {suggestion.label}
+        </Pill>
+      ))}
+    </Flex>
+  );
+};
+
+export default PoolSuggestion;

--- a/app/routes/events/components/EventEditor/renderPools.tsx
+++ b/app/routes/events/components/EventEditor/renderPools.tsx
@@ -7,6 +7,7 @@ import {
   Button,
 } from 'app/components/Form';
 import styles from './EventEditor.css';
+import PoolSuggestion from './PoolSuggestions';
 import type { Dateish, EventStatusType } from 'app/models';
 
 type poolProps = {
@@ -14,11 +15,6 @@ type poolProps = {
   startTime: Dateish;
   eventStatusType: EventStatusType;
 };
-
-const highWarning = (value) =>
-  value && value >= 500
-    ? 'Åpent arrangement gir uendelig plasser 😁'
-    : undefined;
 
 const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
   <ul
@@ -60,7 +56,6 @@ const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
             }}
             type="number"
             placeholder="20,30,50"
-            warn={highWarning}
             fieldClassName={styles.metaField}
             className={styles.formField}
             component={TextInput.Field}
@@ -86,6 +81,7 @@ const renderPools = ({ fields, startTime, eventStatusType }: poolProps) => (
           filter={['users.abakusgroup']}
           component={SelectInput.AutocompleteField}
           isMulti
+          SuggestionComponent={PoolSuggestion}
         />
         {['NORMAL'].includes(eventStatusType) && (
           <div className={styles.centeredButton}>


### PR DESCRIPTION
# Description

Added some suggestions of frequently used group combinations to make life simpler for event organizers.

The group combinations disable if more comprehensive groups have been selected, ensuring the the minimum amount of groups required is stored, while maintaining the group overlap and so on.

The functionality does not at all affect the input, so the users can still use it as they used to, but I believe this could resolve the errors of adding the wrong groups as this is simpler than typing them in.

The suggestions listen to the content of the list, so even if it is not used to select the groups, it can be used as an indicator of what groups you've already selected.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

## Preview

https://github.com/webkom/lego-webapp/assets/13599770/e68f0d6c-6af9-44f1-8782-8b5daed58dec

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-848
