### PR TITLE
Up z-index for toast and gallery dropdown

### DIFF
--- a/app/components/Toast/ToastContainer.tsx
+++ b/app/components/Toast/ToastContainer.tsx
@@ -44,11 +44,11 @@ function toastStyleFactory(index, style) {
       lineHeight: '20px',
       fontSize: '14px',
       boxShadow: 0,
-      zIndex: 2,
+      zIndex: 150,
     };
   }
 
-  return { ...style, bottom: `${2 + index * 4}rem`, zIndex: 2 };
+  return { ...style, bottom: `${2 + index * 4}rem`, zIndex: 150 };
 }
 
 function toastStyleFactoryInactive(index, style) {

--- a/app/routes/photos/components/GalleryPictureModal.css
+++ b/app/routes/photos/components/GalleryPictureModal.css
@@ -31,7 +31,7 @@
 }
 
 .dropdownContent {
-  z-index: 4;
+  z-index: 110;
 }
 
 .dropdownLink {


### PR DESCRIPTION
# Description

Upping the z-index so that we have more numbers to play with to conf lower laying items. Setting it pretty high as these should always be on top.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-889
