### PR TITLE
Fix bug in callAPI() breaking public survey results page

### DIFF
--- a/app/actions/callAPI.ts
+++ b/app/actions/callAPI.ts
@@ -178,7 +178,8 @@ export default function callAPI<
         return {} as T;
       }
 
-      const payload = 'results' in jsonData ? jsonData.results : jsonData;
+      const payload =
+        isArray(schema) && 'results' in jsonData ? jsonData.results : jsonData;
       const next = 'next' in jsonData && jsonData.next ? jsonData.next : null;
       const previous =
         'previous' in jsonData && jsonData.previous ? jsonData.previous : null;


### PR DESCRIPTION
Because of a bug with the `callAPI` function used for fetching data, the public survey results page got stuck loading forever.

# Description

When fetching a list of things, LEGO will return an object containing a field named "results" that contains all the requested entities. Because of this `callAPI` will look for this field and put only it's contents into the redux-action which will be used to add the data to the state. This caused an issue with the public results page, as the survey-object used on this page contains a "results"-field that is not the list of all entities, but rather just the corresponding survey-submissions to the survey. This made `callAPI` return only these survey-submissions when we were expecting a survey object.

I think this was introduced in some refactoring a few months back, that removed a `isArray()` check on the "results"-field. To fix it I did something similar, but instead of checking if the "results"-field is an array, I rather check if the schema is an array, basically checking if we are expecting an array result or not. I think this is better as it will also allow "results"-fields that are arrays in entities.

# Result

The page now loads normally.

# Testing

- [x] I have thoroughly tested my changes.

I have tested the public results page, and also clicked around a bit to ensure I didn't overlook something that could cause other stuff to break.

---

Resolves ABA-894
