### PR TITLE
Extend email-user view to show more groups

### DIFF
--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -69,10 +69,11 @@ export function fetchAll() {
   });
 }
 
-export function fetchAllWithType(type: GroupType) {
+export function fetchAllWithType(type: GroupType | GroupType[]) {
   return callAPI({
     types: Group.FETCH,
-    endpoint: `/groups/?type=${type}`,
+    endpoint: `/groups/`,
+    query: { type },
     schema: [groupSchema],
     meta: {
       errorMessage: 'Henting av grupper feilet',

--- a/app/actions/callAPI.ts
+++ b/app/actions/callAPI.ts
@@ -15,6 +15,7 @@ import type {
 } from 'app/store/middleware/promiseMiddleware';
 import type { ID } from 'app/store/models';
 import type { AsyncActionType, Thunk, NormalizedApiPayload } from 'app/types';
+import type { Query } from 'app/utils/createQueryString';
 import type {
   HttpRequestOptions,
   HttpMethod,
@@ -93,7 +94,7 @@ type CallAPIOptions<Meta extends CallAPIOptionsMeta> = {
   headers?: Record<string, string>;
   schema?: Schema;
   body?: Record<string, unknown> | string;
-  query?: Record<string, string | number | boolean | undefined>;
+  query?: Query;
   json?: boolean;
   meta?: Meta;
   files?: (string | File)[];

--- a/app/models.ts
+++ b/app/models.ts
@@ -119,6 +119,7 @@ export enum GroupType {
   Revue = 'revy',
   Interest = 'interesse',
   SubGroup = 'under',
+  Ordained = 'ordenen',
   Grade = 'klasse',
   Other = 'annen',
 }

--- a/app/reducers/selectors.ts
+++ b/app/reducers/selectors.ts
@@ -1,6 +1,7 @@
 import { get, isArray } from 'lodash';
 import createQueryString from 'app/utils/createQueryString';
 import type { RootState } from 'app/store/createRootReducer';
+import type { Query } from 'app/utils/createQueryString';
 import type { schema, Schema } from 'normalizr';
 
 export const selectPagination =
@@ -22,7 +23,7 @@ export const selectPaginationNext =
     entity,
   }: {
     endpoint: string;
-    query: Record<string, string | number | boolean | undefined>;
+    query: Query;
     schema?: Schema;
     entity?: string;
   }) =>

--- a/app/routes/events/components/EventAdministrate/Statistics.tsx
+++ b/app/routes/events/components/EventAdministrate/Statistics.tsx
@@ -13,11 +13,7 @@ const Statistics = () => {
 
   usePreparedEffect(
     'fetchStatisticsGroups',
-    () =>
-      Promise.allSettled([
-        dispatch(fetchAllWithType(GroupType.Committee)),
-        dispatch(fetchAllWithType(GroupType.Revue)),
-      ]),
+    () => dispatch(fetchAllWithType([GroupType.Committee, GroupType.Revue])),
     [],
   );
 

--- a/app/utils/createQueryString.ts
+++ b/app/utils/createQueryString.ts
@@ -1,9 +1,12 @@
 /**
  *
  */
-export default function createQueryString(
-  query: Record<string, string | number | boolean | undefined | null>,
-): string {
+export type Query = Record<
+  string,
+  string | number | boolean | undefined | null | string[]
+>;
+
+export default function createQueryString(query: Query): string {
   const queryString = Object.keys(query)
     .filter((key) => typeof query[key] === 'number' || !!query[key])
     .map(


### PR DESCRIPTION
# Description

Currently there are a lot of emails with active users that look as if they weren't supposed to have them, because only committees are shown in the list. This is stoopid - and should hereby be banished.

This shows
* committees
* boards
* ordained

and should give a more accurate view of who should have their email activated and not

Also added the option to fetch groups from multiple group types at the same time.

Relies on https://github.com/webkom/lego/pull/3577

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

Don't have too many visuals, as the changes require a fresh backend - and the groups I would need to display to preview it don't exist in the backend.

The only visual change is just that more groups are displayed in the group column.

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-490
