### PR TITLE
Add front end validation for email list recipients

### DIFF
--- a/app/routes/admin/email/components/EmailListEditor.tsx
+++ b/app/routes/admin/email/components/EmailListEditor.tsx
@@ -18,7 +18,17 @@ import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { selectEmailListById } from 'app/reducers/emailLists';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { ROLES, type RoleType, roleOptions } from 'app/utils/constants';
-import { createValidator, required, EMAIL_REGEX } from 'app/utils/validation';
+import {
+  createValidator,
+  required,
+  EMAIL_REGEX,
+  atLeastOneFieldRequired,
+} from 'app/utils/validation';
+
+const recipientRequired = atLeastOneFieldRequired(
+  ['users', 'groups', 'additionalEmails'],
+  'E-postlisten må ha minst en mottaker',
+);
 
 const validate = createValidator({
   email: [
@@ -28,12 +38,15 @@ const validate = createValidator({
   ],
   name: [required()],
   additionalEmails: [
+    recipientRequired,
     // Check if all emails entered are valid
     (value) => [
       !value || value.every((email) => EMAIL_REGEX.test(email.value)),
       'Ugyldig e-post',
     ],
   ],
+  users: [recipientRequired],
+  groups: [recipientRequired],
 });
 
 const EmailListEditor = () => {


### PR DESCRIPTION
# Description

Adds form validation requiring at least one recipient field to be filled out to avoid email lists with no repients and mirror the backend behaiviour introduced here: https://github.com/webkom/lego/pull/3578

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<img width="1170" alt="Screenshot 2024-03-20 at 15 24 58" src="https://github.com/webkom/lego-webapp/assets/8343002/d94ee7e0-2142-4a86-b475-7b4d3890ae4e">

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-897
