### PR TITLE
Fix crash on login

### DIFF
--- a/app/actions/UserActions.ts
+++ b/app/actions/UserActions.ts
@@ -76,6 +76,7 @@ export function login(username: string, password: string) {
         type: User.FETCH.SUCCESS,
         payload: normalize(user, userSchema),
         meta: {
+          endpoint: `/users/me/`,
           isCurrentUser: true,
         },
       });


### PR DESCRIPTION
This bug was introduced in https://github.com/webkom/lego-webapp/pull/4540

A small difference in how legoAdapter works compared to createEntityReducer caused the logged in user to not get added to the redux state. The page then crashed when trying to read user data.

# Description

legoAdapter does a bit more validation than createEntityReducer to make sure that the redux action is actually a `callAPI()` action. This was a problem when the login code made a fake `User.FETCH.SUCCESS` action to add the user data to the state. In this PR I just made the fake more realistic, but I think I will refactor this a bit later.

# Result

No more crash:)

# Testing

- [x] I have thoroughly tested my changes.

I have verified manually that the bug happens before this change, and not after.