### PR TITLE
Replace UserContext with redux state selectors

### DIFF
--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -6,7 +6,7 @@ import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { ProfilePicture } from 'app/components/Image';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import { createValidator, legoEditorRequired } from 'app/utils/validation';
 import styles from './CommentForm.css';
@@ -34,7 +34,8 @@ const CommentForm = ({
 }: Props) => {
   const dispatch = useAppDispatch();
 
-  const { currentUser, loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
+  const currentUser = useCurrentUser();
 
   if (!loggedIn) {
     return <div>Vennligst logg inn for å kommentere</div>;
@@ -61,7 +62,7 @@ const CommentForm = ({
           return (
             <form onSubmit={handleSubmit}>
               <Flex alignItems="center" gap="var(--spacing-md)">
-                <ProfilePicture size={40} user={currentUser} />
+                {currentUser && <ProfilePicture size={40} user={currentUser} />}
 
                 <div className={styles.field}>
                   <Field

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -9,7 +9,7 @@ import { ProfilePicture } from 'app/components/Image';
 import { Tag } from 'app/components/Tags';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import styles from './Comment.css';
 import type CommentType from 'app/store/models/Comment';
@@ -36,7 +36,7 @@ const Comment = ({
 
   const dispatch = useAppDispatch();
 
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
 
   return (
     <>

--- a/app/components/Comments/__tests__/CommentTree.spec.tsx
+++ b/app/components/Comments/__tests__/CommentTree.spec.tsx
@@ -11,6 +11,10 @@ const store = configureStore([])({
   theme: {
     theme: 'light',
   },
+  auth: {},
+  users: {
+    entities: {},
+  },
 });
 
 describe('<CommentTree />', () => {

--- a/app/components/Footer/index.tsx
+++ b/app/components/Footer/index.tsx
@@ -4,13 +4,12 @@ import { Link } from 'react-router-dom';
 import netcompany from 'app/assets/netcompany_white.svg';
 import octocat from 'app/assets/octocat.png';
 import { Image } from 'app/components/Image';
-import { selectIsLoggedIn } from 'app/reducers/auth';
-import { useAppSelector } from 'app/store/hooks';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import utilityStyles from 'app/styles/utilities.css';
 import styles from './Footer.css';
 
 const Footer = () => {
-  const loggedIn = useAppSelector(selectIsLoggedIn);
+  const loggedIn = useIsLoggedIn();
   return (
     <footer className={styles.footer}>
       <div className={styles.footerContent}>

--- a/app/components/Header/Navbar/Navbar.tsx
+++ b/app/components/Header/Navbar/Navbar.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import Dropdown from 'app/components/Dropdown';
-import { selectIsLoggedIn } from 'app/reducers/auth';
-import { useAppSelector } from 'app/store/hooks';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import AboutDropdown from './AboutDropdown';
 import CareerDropdown from './CareerDropdown';
 import EventsDropdown from './EventsDropwdown';
@@ -17,7 +16,7 @@ type NavbarLink = {
 };
 
 const Navbar = () => {
-  const loggedIn = useAppSelector(selectIsLoggedIn);
+  const loggedIn = useIsLoggedIn();
   const [visibleDropdown, setVisibleDropdown] = useState(false);
   const [hoverIndex, setHoverIndex] = useState(0);
 

--- a/app/components/Header/ToggleTheme.tsx
+++ b/app/components/Header/ToggleTheme.tsx
@@ -3,8 +3,8 @@ import cx from 'classnames';
 import { debounce } from 'lodash';
 import { useCallback } from 'react';
 import { updateUserTheme } from 'app/actions/UserActions';
-import { selectCurrentUser, selectIsLoggedIn } from 'app/reducers/auth';
-import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
+import { useAppDispatch } from 'app/store/hooks';
 import { applySelectedTheme, getTheme, useTheme } from 'app/utils/themeUtils';
 import styles from './toggleTheme.css';
 import type { ReactNode, MouseEvent } from 'react';
@@ -19,8 +19,8 @@ type Props = {
 
 const ToggleTheme = ({ className, children, isButton = true }: Props) => {
   const dispatch = useAppDispatch();
-  const loggedIn = useAppSelector(selectIsLoggedIn);
-  const username = useAppSelector(selectCurrentUser)?.username;
+  const loggedIn = useIsLoggedIn();
+  const username = useCurrentUser()?.username;
   const icon = useIcon();
 
   const handleThemeChange = useCallback(

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -11,12 +11,7 @@ import { logout } from 'app/actions/UserActions';
 import logoLightMode from 'app/assets/logo-dark.png';
 import logoDarkMode from 'app/assets/logo.png';
 import AuthSection from 'app/components/AuthSection/AuthSection';
-import {
-  selectCurrentUser,
-  selectIsLoggedIn,
-  useCurrentUser,
-  useIsLoggedIn,
-} from 'app/reducers/auth';
+import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { selectUpcomingMeetingId } from 'app/reducers/meetings';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import utilStyles from 'app/styles/utilities.css';

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -11,7 +11,12 @@ import { logout } from 'app/actions/UserActions';
 import logoLightMode from 'app/assets/logo-dark.png';
 import logoDarkMode from 'app/assets/logo.png';
 import AuthSection from 'app/components/AuthSection/AuthSection';
-import { selectCurrentUser, selectIsLoggedIn } from 'app/reducers/auth';
+import {
+  selectCurrentUser,
+  selectIsLoggedIn,
+  useCurrentUser,
+  useIsLoggedIn,
+} from 'app/reducers/auth';
 import { selectUpcomingMeetingId } from 'app/reducers/meetings';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import utilStyles from 'app/styles/utilities.css';
@@ -31,7 +36,7 @@ type AccountDropdownItemsProps = {
 const AccountDropdownItems = ({ onClose }: AccountDropdownItemsProps) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const username = useAppSelector(selectCurrentUser)?.username;
+  const username = useCurrentUser()?.username;
 
   return (
     <Dropdown.List>
@@ -127,8 +132,8 @@ const HeaderLogo = () => {
 };
 
 const AccountDropdown = () => {
-  const loggedIn = useAppSelector(selectIsLoggedIn);
-  const currentUser = useAppSelector(selectCurrentUser);
+  const loggedIn = useIsLoggedIn();
+  const currentUser = useCurrentUser();
   const [accountOpen, setAccountOpen] = useState(false);
 
   return loggedIn ? (
@@ -178,8 +183,8 @@ const SearchModal = () => {
 
 const Header = () => {
   const dispatch = useAppDispatch();
-  const loggedIn = useAppSelector(selectIsLoggedIn);
-  const currentUser = useAppSelector(selectCurrentUser);
+  const loggedIn = useIsLoggedIn();
+  const currentUser = useCurrentUser();
 
   useEffect(() => {
     if (

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -136,13 +136,15 @@ const AccountDropdown = () => {
       show={accountOpen}
       toggle={() => setAccountOpen(!accountOpen)}
       triggerComponent={
-        <ProfilePicture
-          size={24}
-          user={currentUser}
-          style={{
-            verticalAlign: 'middle',
-          }}
-        />
+        currentUser && (
+          <ProfilePicture
+            size={24}
+            user={currentUser}
+            style={{
+              verticalAlign: 'middle',
+            }}
+          />
+        )
       }
     >
       <AccountDropdownItems onClose={() => setAccountOpen(false)} />
@@ -183,7 +185,8 @@ const Header = () => {
     if (
       __CLIENT__ &&
       loggedIn &&
-      (currentUser?.selectedTheme === 'auto'
+      currentUser &&
+      (currentUser.selectedTheme === 'auto'
         ? getTheme() !== getOSTheme()
         : getTheme() !== currentUser.selectedTheme)
     ) {

--- a/app/components/Reactions/Reaction.tsx
+++ b/app/components/Reactions/Reaction.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { addReaction, deleteReaction } from 'app/actions/ReactionActions';
 import Emoji from 'app/components/Emoji';
 import Tooltip from 'app/components/Tooltip';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import styles from './Reaction.css';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
@@ -34,8 +34,9 @@ const Reaction = ({
   const [optimisticHasReacted, setOptimisticHasReacted] = useState(hasReacted);
   const [optimisticUsers, setOptimisticUsers] = useState(users);
 
-  const { currentUser, loggedIn } = useUserContext();
-  const canReact = loggedIn;
+  const loggedIn = useIsLoggedIn();
+  const currentUser = useCurrentUser();
+  const canReact = loggedIn && currentUser;
 
   const classNames = cx({
     [className || styles.reaction]: true,
@@ -55,7 +56,7 @@ const Reaction = ({
     setOptimisticCount((count) => count - 1);
     setOptimisticHasReacted(false);
     setOptimisticUsers((users) =>
-      users?.filter((user) => user.id !== currentUser.id),
+      users?.filter((user) => user.id !== currentUser?.id),
     );
   };
 

--- a/app/components/Reactions/ReactionPickerContent.tsx
+++ b/app/components/Reactions/ReactionPickerContent.tsx
@@ -1,6 +1,6 @@
 import { addReaction, deleteReaction } from 'app/actions/ReactionActions';
 import Emoji from 'app/components/Emoji';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import styles from './ReactionPickerContent.css';
 import type { EmojiWithReactionData } from 'app/components/LegoReactions';
@@ -19,7 +19,7 @@ const ReactionPickerContent = ({
 }: Props) => {
   const dispatch = useAppDispatch();
 
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
 
   return (
     <div className={styles.container}>

--- a/app/components/Reactions/index.tsx
+++ b/app/components/Reactions/index.tsx
@@ -2,7 +2,7 @@ import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchEmojis } from 'app/actions/EmojiActions';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import reactionStyles from './Reaction.css';
 import ReactionPicker from './ReactionPicker';
@@ -29,7 +29,7 @@ const Reactions = ({ children, className, emojis, contentTarget }: Props) => {
   const [fetchedEmojis, setFetchedEmojis] = useState(false);
   const nodeRef = useRef<HTMLDivElement>(null);
 
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
 
   const dispatch = useAppDispatch();
 

--- a/app/components/Search/index.tsx
+++ b/app/components/Search/index.tsx
@@ -2,7 +2,7 @@ import { debounce } from 'lodash';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { autocomplete, toggleSearch } from 'app/actions/SearchActions';
-import { selectIsLoggedIn } from 'app/reducers/auth';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import { selectAutocompleteRedux } from 'app/reducers/search';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { Keyboard } from 'app/utils/constants';
@@ -13,7 +13,7 @@ import SearchResults from './SearchResults';
 import { getExternalLinks, getAdminLinks, getRegularLinks } from './utils';
 
 const Search = () => {
-  const loggedIn = useAppSelector(selectIsLoggedIn);
+  const loggedIn = useIsLoggedIn();
   const results = useAppSelector(selectAutocompleteRedux);
   const searching = useAppSelector((state) => state.search.searching);
   const allowed = useAppSelector((state) => state.allowed);

--- a/app/reducers/auth.ts
+++ b/app/reducers/auth.ts
@@ -4,6 +4,7 @@ import { selectUserEntities } from 'app/reducers/users';
 import { User } from '../actions/ActionTypes';
 import type { AnyAction, PayloadAction, UnknownAction } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
+import type { CurrentUser } from 'app/store/models/User';
 
 type AuthState = {
   id: number | null;
@@ -78,5 +79,11 @@ export function selectIsLoggedIn(state: RootState) {
 export const selectCurrentUser = createSelector(
   selectUserEntities,
   (state: RootState) => state.auth.id,
-  (userEntities, userId) => (userId ? userEntities[userId] : {}),
+  (userEntities, userId) => {
+    if (!userId) return undefined;
+    const user = userEntities[userId];
+    // ensure we have a user object serialized with "MeSerializer" (CurrentUser type)
+    if (!user || !('icalToken' in user)) return undefined;
+    return user satisfies CurrentUser;
+  },
 );

--- a/app/reducers/auth.ts
+++ b/app/reducers/auth.ts
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { selectUserEntities } from 'app/reducers/users';
+import { useAppSelector } from 'app/store/hooks';
 import { User } from '../actions/ActionTypes';
 import type { AnyAction, PayloadAction, UnknownAction } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
@@ -73,9 +74,7 @@ const isLoginTokenAction = (
   action.type === User.CREATE_USER.SUCCESS ||
   action.type === User.REFRESH_TOKEN.SUCCESS;
 
-export function selectIsLoggedIn(state: RootState) {
-  return state.auth.token !== null;
-}
+export const selectIsLoggedIn = (state: RootState) => state.auth.token !== null;
 export const selectCurrentUser = createSelector(
   selectUserEntities,
   (state: RootState) => state.auth.id,
@@ -87,3 +86,6 @@ export const selectCurrentUser = createSelector(
     return user satisfies CurrentUser;
   },
 );
+
+export const useIsLoggedIn = () => useAppSelector(selectIsLoggedIn);
+export const useCurrentUser = () => useAppSelector(selectCurrentUser);

--- a/app/reducers/followers.ts
+++ b/app/reducers/followers.ts
@@ -1,31 +1,7 @@
-import { createSelector } from 'reselect';
 import { Event } from 'app/actions/ActionTypes';
 import { createFollowersSliceKey } from 'app/reducers/index';
 import createEntityReducer from 'app/utils/createEntityReducer';
-import { selectCurrentUser } from './auth';
 import type { EntityReducerTypes } from 'app/utils/createEntityReducer';
-
-export const selectFollowersCurrentUser = createSelector(
-  (state, props) =>
-    selectFollowers(state, {
-      ...props,
-      follower: selectCurrentUser(state) && selectCurrentUser(state).id,
-    }),
-  (follow) => follow,
-);
-export const selectFollowers = createSelector(
-  (state, { type }) => state[createFollowersSliceKey(type)],
-  (state, { target }) => target,
-  (state, { follower }) => follower,
-  (followers, target, follower) =>
-    followers.byId[
-      followers.items.find(
-        (item) =>
-          followers.byId[item].follower.toString() === follower?.toString() &&
-          followers.byId[item].target.toString() === target.toString(),
-      )
-    ],
-);
 
 const followersSchemaGenerator = (
   title,

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -9,8 +9,7 @@ import {
 import { SelectInput } from 'app/components/Form';
 import Table from 'app/components/Table';
 import { defaultGroupMembersQuery } from 'app/routes/admin/groups/components/GroupMembers';
-import { useUserContext } from 'app/routes/app/AppRoute';
-import { isCurrentUser as checkIfCurrentUser } from 'app/routes/users/utils';
+import { useIsCurrentUser } from 'app/routes/users/utils';
 import { useAppDispatch } from 'app/store/hooks';
 import { roleOptions, ROLES, type RoleType } from 'app/utils/constants';
 import useQuery from 'app/utils/useQuery';
@@ -47,8 +46,6 @@ const GroupMembersList = ({
 
   const { query, setQuery } = useQuery(defaultGroupMembersQuery);
   const showDescendants = query.descendants === 'true';
-
-  const { currentUser } = useUserContext();
 
   const GroupMembersListColumns = (
     _: unknown,
@@ -103,10 +100,7 @@ const GroupMembersList = ({
 
   const EditRender = (_: unknown, membership: Membership) => {
     const { id, user, abakusGroup } = membership;
-    const isCurrentUser = checkIfCurrentUser(
-      user.username,
-      currentUser.username,
-    );
+    const isCurrentUser = useIsCurrentUser(user.username);
 
     return (
       <Flex justifyContent="center" alignItems="center" gap={5}>

--- a/app/routes/app/AppRoute.tsx
+++ b/app/routes/app/AppRoute.tsx
@@ -38,9 +38,10 @@ const AppChildren = ({ children }: PropsWithChildren) => {
   const currentUser = useAppSelector(selectCurrentUser);
   const loggedIn = useAppSelector(selectIsLoggedIn);
 
+  // TODO: Components should just select this from redux state
   const userValue = useMemo(
     () => ({
-      currentUser,
+      currentUser: currentUser || {},
       loggedIn,
     }),
     [currentUser, loggedIn],

--- a/app/routes/app/AppRoute.tsx
+++ b/app/routes/app/AppRoute.tsx
@@ -1,6 +1,6 @@
 import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
-import { createContext, useContext, useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
 import { fetchMeta } from 'app/actions/MetaActions';
@@ -12,41 +12,14 @@ import Header from 'app/components/Header';
 import PhotoUploadStatus from 'app/components/PhotoUploadStatus';
 import ToastContainer from 'app/components/Toast/ToastContainer';
 import config from 'app/config';
-import { useIsLoggedIn, useCurrentUser } from 'app/reducers/auth';
 import { setStatusCode } from 'app/reducers/routing';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
 import HTTPError from '../errors/HTTPError';
 import styles from './AppRoute.css';
-import type { CurrentUser } from 'app/store/models/User';
 import type { PropsWithChildren } from 'react';
 
-export const UserContext = createContext<{
-  currentUser: CurrentUser | Record<string, never>;
-  loggedIn: boolean;
-}>({
-  currentUser: {},
-  loggedIn: false,
-});
-
-// Extract the type of the user context
-export type UserContextType = ReturnType<typeof useUserContext>;
-
-export const useUserContext = () => useContext(UserContext);
-
 const AppChildren = ({ children }: PropsWithChildren) => {
-  const currentUser = useCurrentUser();
-  const loggedIn = useIsLoggedIn();
-
-  // TODO: Components should just select this from redux state
-  const userValue = useMemo(
-    () => ({
-      currentUser: currentUser || {},
-      loggedIn,
-    }),
-    [currentUser, loggedIn],
-  );
-
   const dispatch = useAppDispatch();
   const statusCode = useAppSelector((state) => state.router.statusCode);
   const location = useLocation();
@@ -68,13 +41,7 @@ const AppChildren = ({ children }: PropsWithChildren) => {
     >
       <ErrorBoundary resetOnChange={location}>
         <ToastContainer />
-        {statusCode ? (
-          <HTTPError statusCode={statusCode} />
-        ) : (
-          <UserContext.Provider value={userValue}>
-            {children}
-          </UserContext.Provider>
-        )}
+        {statusCode ? <HTTPError statusCode={statusCode} /> : <>{children}</>}
       </ErrorBoundary>
     </div>
   );

--- a/app/routes/app/AppRoute.tsx
+++ b/app/routes/app/AppRoute.tsx
@@ -12,7 +12,7 @@ import Header from 'app/components/Header';
 import PhotoUploadStatus from 'app/components/PhotoUploadStatus';
 import ToastContainer from 'app/components/Toast/ToastContainer';
 import config from 'app/config';
-import { selectIsLoggedIn, selectCurrentUser } from 'app/reducers/auth';
+import { useIsLoggedIn, useCurrentUser } from 'app/reducers/auth';
 import { setStatusCode } from 'app/reducers/routing';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import withPreparedDispatch from 'app/utils/withPreparedDispatch';
@@ -35,8 +35,8 @@ export type UserContextType = ReturnType<typeof useUserContext>;
 export const useUserContext = () => useContext(UserContext);
 
 const AppChildren = ({ children }: PropsWithChildren) => {
-  const currentUser = useAppSelector(selectCurrentUser);
-  const loggedIn = useAppSelector(selectIsLoggedIn);
+  const currentUser = useCurrentUser();
+  const loggedIn = useIsLoggedIn();
 
   // TODO: Components should just select this from redux state
   const userValue = useMemo(

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -14,9 +14,9 @@ import Tags from 'app/components/Tags';
 import Tag from 'app/components/Tags/Tag';
 import config from 'app/config';
 import { selectArticleByIdOrSlug } from 'app/reducers/articles';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import { selectCommentsByIds } from 'app/reducers/comments';
 import { selectUsersByIds } from 'app/reducers/users';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import sharedStyles from 'app/routes/articles/articles.css';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './ArticleDetail.css';
@@ -79,7 +79,7 @@ const propertyGenerator: PropertyGenerator<{
 };
 
 const ArticleDetail = () => {
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
   const { articleIdOrSlug } = useParams<{ articleIdOrSlug: string }>();
   const article = useAppSelector((state) =>
     selectArticleByIdOrSlug(state, articleIdOrSlug!),

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -35,8 +35,8 @@ import {
 import { SubmitButton } from 'app/components/Form/SubmitButton';
 import NavigationTab from 'app/components/NavigationTab';
 import { selectArticleById } from 'app/reducers/articles';
+import { useCurrentUser } from 'app/reducers/auth';
 import { selectUsersByIds } from 'app/reducers/users';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { isNotNullish } from 'app/utils';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
@@ -66,7 +66,7 @@ const validate = (data) => {
 
 type ArticleEditorParams = { articleId: string };
 const ArticleEditor = () => {
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
   const { articleId } = useParams<ArticleEditorParams>() as ArticleEditorParams;
   const isNew = articleId === undefined;
   const article = useAppSelector((state) =>
@@ -76,7 +76,7 @@ const ArticleEditor = () => {
   let authors = useAppSelector((state) =>
     selectUsersByIds(state, article?.authors || []),
   );
-  if (authors.length === 0) {
+  if (authors.length === 0 && currentUser) {
     authors = [currentUser];
   }
 

--- a/app/routes/contact/components/ContactForm.tsx
+++ b/app/routes/contact/components/ContactForm.tsx
@@ -16,9 +16,9 @@ import {
 } from 'app/components/Form';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { GroupType } from 'app/models';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import { selectGroupById, selectGroupsByType } from 'app/reducers/groups';
 import { addToast } from 'app/reducers/toasts';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { isNotNullish } from 'app/utils';
 import { createValidator, maxLength, required } from 'app/utils/validation';
@@ -33,7 +33,7 @@ const validate = createValidator({
 const REVUE_BOARD_GROUP_ID = 59;
 
 const ContactForm = () => {
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
 
   const committees = useAppSelector((state) =>
     selectGroupsByType(state, GroupType.Committee),

--- a/app/routes/events/components/Calendar.tsx
+++ b/app/routes/events/components/Calendar.tsx
@@ -4,7 +4,7 @@ import moment, { type Moment } from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { fetchData } from 'app/actions/EventActions';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import createMonthlyCalendar from 'app/utils/createMonthlyCalendar';
 import styles from './Calendar.css';
@@ -34,7 +34,7 @@ const getDate = (month?: string, year?: string) => {
 const Calendar = () => {
   const pagination = useAppSelector((state) => state.events.pagination);
   const actionGrant = useAppSelector((state) => state.events.actionGrant);
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
   const icalToken = currentUser?.icalToken;
 
   const { month, year } = useParams<{ month: string; year: string }>();
@@ -90,7 +90,7 @@ const Calendar = () => {
           />
         ))}
       </div>
-      <EventFooter icalToken={icalToken} />
+      {icalToken && <EventFooter icalToken={icalToken} />}
     </div>
   );
 };

--- a/app/routes/events/components/EventAdministrate/Allergies.tsx
+++ b/app/routes/events/components/EventAdministrate/Allergies.tsx
@@ -4,8 +4,8 @@ import { isEmpty } from 'lodash';
 import { Link, useParams } from 'react-router-dom';
 import { fetchAllergies } from 'app/actions/EventActions';
 import Table from 'app/components/Table';
+import { useCurrentUser } from 'app/reducers/auth';
 import { getRegistrationGroups, selectEventById } from 'app/reducers/events';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import HTTPError from 'app/routes/errors/HTTPError';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { RegistrationPill, getRegistrationInfo } from './RegistrationTables';
@@ -40,7 +40,7 @@ const Allergies = () => {
     return registration?.user.allergies;
   });
   const fetching = useAppSelector((state) => state.events.fetching);
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
 
   const dispatch = useAppDispatch();
 

--- a/app/routes/events/components/EventAdministrate/index.tsx
+++ b/app/routes/events/components/EventAdministrate/index.tsx
@@ -4,8 +4,8 @@ import { Route, Routes, useParams } from 'react-router-dom';
 import { fetchAdministrate } from 'app/actions/EventActions';
 import { Content } from 'app/components/Content';
 import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import { useCurrentUser } from 'app/reducers/auth';
 import { selectEventById } from 'app/reducers/events';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { canSeeAllergies } from 'app/routes/events/components/EventAdministrate/Allergies';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
@@ -20,7 +20,7 @@ const EventAdministrateIndex = () => {
   const { eventId } = useParams<{ eventId: string }>();
   const event = useAppSelector((state) => selectEventById(state, { eventId }));
   const fetching = useAppSelector((state) => state.events.fetching);
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
 
   const dispatch = useAppDispatch();
 

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -26,6 +26,7 @@ import { AttendanceStatus } from 'app/components/UserAttendance';
 import AttendanceModal from 'app/components/UserAttendance/AttendanceModal';
 import UserGrid from 'app/components/UserGrid';
 import config from 'app/config';
+import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import {
   selectCommentsForEvent,
   selectEventByIdOrSlug,
@@ -40,7 +41,6 @@ import {
 import { resolveGroupLink } from 'app/reducers/groups';
 import { selectPenaltyByUserId } from 'app/reducers/penalties';
 import { selectUserWithGroups } from 'app/reducers/users';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import {
   colorForEventType,
   penaltyHours,
@@ -134,9 +134,12 @@ const EventDetail = () => {
   const actionGrant = event?.actionGrant || [];
   const hasFullAccess = Boolean(event?.waitingRegistrations);
 
-  const { currentUser, loggedIn } = useUserContext();
-  const user = useAppSelector((state) =>
-    selectUserWithGroups(state, { username: currentUser.username }),
+  const loggedIn = useIsLoggedIn();
+  const currentUser = useCurrentUser();
+  const user = useAppSelector(
+    (state) =>
+      currentUser &&
+      selectUserWithGroups(state, { username: currentUser.username }),
   );
   const penalties = useAppSelector((state) =>
     selectPenaltyByUserId(state, { userId: user?.id }),
@@ -185,7 +188,7 @@ const EventDetail = () => {
 
   const currentPool = pools.find((pool) =>
     pool.registrations?.some(
-      (registration) => registration.user?.id === currentUser.id,
+      (registration) => registration.user?.id === currentUser?.id,
     ),
   );
 
@@ -194,17 +197,19 @@ const EventDetail = () => {
 
   if (currentPool) {
     currentRegistrationIndex = currentPool.registrations.findIndex(
-      (registration) => registration.user?.id === currentUser.id,
+      (registration) => registration.user?.id === currentUser?.id,
     );
     currentRegistration = currentPool.registrations[currentRegistrationIndex];
   }
 
   const hasSimpleWaitingList = poolsWithRegistrations.length <= 1;
-  const pendingRegistration = useAppSelector((state) =>
-    selectRegistrationForEventByUserId(state, {
-      eventId,
-      userId: currentUser.id,
-    }),
+  const pendingRegistration = useAppSelector(
+    (state) =>
+      currentUser &&
+      selectRegistrationForEventByUserId(state, {
+        eventId,
+        userId: currentUser.id,
+      }),
   );
 
   const navigate = useNavigate();
@@ -625,7 +630,7 @@ const EventDetail = () => {
             <TextWithIcon
               iconName="create-outline"
               content={
-                <Link to={`/users/${currentUser.username}/settings/profile`}>
+                <Link to={`/users/${currentUser?.username}/settings/profile`}>
                   Oppdater matallergier / preferanser
                 </Link>
               }

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -8,9 +8,9 @@ import EmptyState from 'app/components/EmptyState';
 import EventItem from 'app/components/EventItem';
 import { CheckBox, SelectInput } from 'app/components/Form/';
 import { EventTime } from 'app/models';
+import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { selectSortedEvents } from 'app/reducers/events';
 import { selectPagination } from 'app/reducers/selectors';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import createQueryString from 'app/utils/createQueryString';
 import useQuery from 'app/utils/useQuery';
@@ -130,8 +130,8 @@ const EventList = () => {
     'company_presentation',
   );
 
-  const { currentUser, loggedIn } = useUserContext();
-  const icalToken = currentUser?.icalToken;
+  const loggedIn = useIsLoggedIn();
+  const icalToken = useCurrentUser()?.icalToken;
 
   const queryString = createQueryString(query);
   const showFetchMore = useAppSelector((state) =>

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -22,8 +22,8 @@ import {
 } from 'app/components/Form';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
+import { useCurrentUser } from 'app/reducers/auth';
 import { selectPenaltyByUserId } from 'app/reducers/penalties';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { spyValues } from 'app/utils/formSpyUtils';
 import { createValidator, requiredIf } from 'app/utils/validation';
@@ -189,7 +189,8 @@ const JoinEventForm = ({
   captchaOpen,
   registrationOpensIn,
 }: Props) => {
-  const { currentUser } = useUserContext();
+  const dispatch = useAppDispatch();
+  const currentUser = useCurrentUser();
 
   const fetching = useAppSelector((state) => state.events.fetching);
 
@@ -199,31 +200,6 @@ const JoinEventForm = ({
     }),
   ) as Penalty[];
   const sumPenalties = sumBy(penalties, 'weight');
-
-  const dispatch = useAppDispatch();
-
-  const onSubmit = (values) => {
-    if (registrationType === 'unregister') {
-      return (
-        registration &&
-        dispatch(
-          unregister({
-            eventId: event.id,
-            registrationId: registration.id,
-          }),
-        )
-      );
-    }
-
-    return dispatch(
-      register({
-        eventId: event.id,
-        captchaResponse: values.captchaResponse,
-        feedback: values[feedbackName],
-        userId: currentUser.id,
-      }),
-    );
-  };
 
   const joinTitle = !registration ? 'Meld deg på' : 'Avregistrer';
   const registrationType = !registration ? 'register' : 'unregister';
@@ -268,6 +244,33 @@ const JoinEventForm = ({
     const timer = setTimeout(() => setShowStripeDelayed(showStripe), 2000);
     return () => clearTimeout(timer);
   }, [showStripe]);
+
+  if (!currentUser) {
+    return null;
+  }
+
+  const onSubmit = (values) => {
+    if (registrationType === 'unregister') {
+      return (
+        registration &&
+        dispatch(
+          unregister({
+            eventId: event.id,
+            registrationId: registration.id,
+          }),
+        )
+      );
+    }
+
+    return dispatch(
+      register({
+        eventId: event.id,
+        captchaResponse: values.captchaResponse,
+        feedback: values[feedbackName],
+        userId: currentUser.id,
+      }),
+    );
+  };
 
   if (registrationIsClosed(event)) {
     return (

--- a/app/routes/events/components/__tests__/JoinEventFormCountdownProvider.spec.tsx
+++ b/app/routes/events/components/__tests__/JoinEventFormCountdownProvider.spec.tsx
@@ -60,6 +60,10 @@ const store = configureStore([])({
   theme: {
     theme: 'light',
   },
+  auth: {},
+  users: {
+    entities: {},
+  },
   events: {
     fetching: false,
   },
@@ -74,7 +78,6 @@ function renderJoinEventForm(props = {}) {
       <Provider store={store}>
         <JoinEventForm {...defaultProps} {...props} />
       </Provider>
-      ,
     </MemoryRouter>,
   );
 }

--- a/app/routes/forum/components/ThreadDetail.tsx
+++ b/app/routes/forum/components/ThreadDetail.tsx
@@ -6,9 +6,9 @@ import { CommentView } from 'app/components/Comments';
 import { Content, ContentMain } from 'app/components/Content';
 import DisplayContent from 'app/components/DisplayContent';
 import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
+import { useCurrentUser } from 'app/reducers/auth';
 import { selectCommentsByIds } from 'app/reducers/comments';
 import { selectThreadById } from 'app/reducers/threads';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import type Comment from 'app/store/models/Comment';
 import type { DetailedThread } from 'app/store/models/Forum';
@@ -22,7 +22,7 @@ const ThreadDetail = () => {
   const { forumId, threadId } =
     useParams<ThreadDetailParams>() as ThreadDetailParams;
   const dispatch = useAppDispatch();
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
   usePreparedEffect(
     'fetchDetailThread',
     () =>
@@ -51,7 +51,7 @@ const ThreadDetail = () => {
               path: `/forum/${thread.forum}/threads`,
             }}
           >
-            {(thread.createdBy?.id === currentUser.id ||
+            {((currentUser && thread.createdBy?.id === currentUser.id) ||
               detailActionGrant.includes('edit')) && (
               <NavigationLink to={`/forum/${forumId}/threads/${threadId}/edit`}>
                 Rediger

--- a/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
+++ b/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
@@ -11,6 +11,7 @@ import CountDown from 'app/components/CountDown';
 import Poll from 'app/components/Poll';
 import RandomQuote from 'app/components/RandomQuote';
 import { selectArticles, selectArticlesByTag } from 'app/reducers/articles';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import { selectEvents } from 'app/reducers/events';
 import {
   addArticleType,
@@ -19,7 +20,6 @@ import {
 } from 'app/reducers/frontpage';
 import { selectPinnedPolls } from 'app/reducers/polls';
 import { selectRandomQuote } from 'app/reducers/quotes';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import ArticleItem from './ArticleItem';
@@ -47,7 +47,7 @@ const AuthenticatedFrontpage = () => {
 
   const pinned = useAppSelector(selectPinned);
   const shouldFetchQuote = useAppSelector(selectRandomQuote) === undefined;
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
 
   const dispatch = useAppDispatch();
 

--- a/app/routes/frontpage/components/FrontpageEventItem.tsx
+++ b/app/routes/frontpage/components/FrontpageEventItem.tsx
@@ -1,7 +1,7 @@
 import { Card, Flex } from '@webkom/lego-bricks';
 import { Link } from 'react-router-dom';
 import { Image } from 'app/components/Image';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import { colorForEventType } from 'app/routes/events/utils';
 import { useAppSelector } from 'app/store/hooks';
 import { eventStatus } from 'app/utils/eventStatus';
@@ -15,7 +15,7 @@ type Props = {
 };
 
 const FrontpageEventItem = ({ item, url, meta }: Props) => {
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
   const info = item && eventStatus(item, loggedIn);
   const fetching = useAppSelector(
     (state) => state.frontpage.fetching || state.events.fetching,

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -19,7 +19,7 @@ import DisplayContent from 'app/components/DisplayContent';
 import { Image } from 'app/components/Image';
 import NavigationTab from 'app/components/NavigationTab';
 import UserGrid from 'app/components/UserGrid';
-import { selectCurrentUser, selectIsLoggedIn } from 'app/reducers/auth';
+import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { selectGroupById } from 'app/reducers/groups';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
@@ -53,7 +53,7 @@ type ButtonRowProps = {
 };
 
 const ButtonRow = ({ group }: ButtonRowProps) => {
-  const currentUser = useAppSelector(selectCurrentUser);
+  const currentUser = useCurrentUser();
   if (!currentUser) return null;
 
   const [membership] = group.memberships.filter(
@@ -126,7 +126,7 @@ const InterestGroupDetail = () => {
 
   const dispatch = useAppDispatch();
 
-  const loggedIn = useAppSelector(selectIsLoggedIn);
+  const loggedIn = useIsLoggedIn();
 
   usePreparedEffect(
     'fetchInterestGroupDetail',

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -19,10 +19,9 @@ import DisplayContent from 'app/components/DisplayContent';
 import { Image } from 'app/components/Image';
 import NavigationTab from 'app/components/NavigationTab';
 import UserGrid from 'app/components/UserGrid';
-import { selectCurrentUser } from 'app/reducers/auth';
+import { selectCurrentUser, selectIsLoggedIn } from 'app/reducers/auth';
 import { selectGroupById } from 'app/reducers/groups';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './InterestGroup.css';
 import InterestGroupMemberList from './InterestGroupMemberList';
@@ -54,13 +53,12 @@ type ButtonRowProps = {
 };
 
 const ButtonRow = ({ group }: ButtonRowProps) => {
-  const currentUser = useAppSelector((state) => selectCurrentUser(state));
+  const currentUser = useAppSelector(selectCurrentUser);
+  if (!currentUser) return null;
 
   const [membership] = group.memberships.filter(
     (m) => m.user.id === currentUser.id,
   );
-
-  const dispatch = useAppDispatch();
 
   const onClick = membership
     ? () => dispatch(leaveGroup(membership, group.id))
@@ -128,7 +126,7 @@ const InterestGroupDetail = () => {
 
   const dispatch = useAppDispatch();
 
-  const { loggedIn } = useUserContext();
+  const loggedIn = useAppSelector(selectIsLoggedIn);
 
   usePreparedEffect(
     'fetchInterestGroupDetail',

--- a/app/routes/meetings/MeetingDetailWrapper.tsx
+++ b/app/routes/meetings/MeetingDetailWrapper.tsx
@@ -5,8 +5,8 @@ import {
   fetchMeeting,
   answerMeetingInvitation,
 } from 'app/actions/MeetingActions';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import { MeetingTokenResponse } from 'app/reducers/meetings';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import MeetingAnswer from './components/MeetingAnswer';
 import MeetingDetail from './components/MeetingDetail';
@@ -23,7 +23,7 @@ const MeetingDetailWrapper = () => {
 
   const { meetingId } = useParams<Params>();
   const meetingToken = useAppSelector((state) => state.meetings.meetingToken);
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
 
   const dispatch = useAppDispatch();
 

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -37,10 +37,10 @@ import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
 import NavigationTab from 'app/components/NavigationTab';
 import { AttendanceStatus } from 'app/components/UserAttendance';
 import config from 'app/config';
+import { useCurrentUser } from 'app/reducers/auth';
 import { selectMeetingInvitationsForMeeting } from 'app/reducers/meetingInvitations';
 import { selectMeetingById } from 'app/reducers/meetings';
 import { selectUserById } from 'app/reducers/users';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import styles from 'app/routes/meetings/components/MeetingEditor.css';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { EDITOR_EMPTY } from 'app/utils/constants';
@@ -122,7 +122,7 @@ const MeetingEditor = () => {
       : undefined,
   );
 
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
 
   const [fetchedGroupIds, setFetchedGroupIds] = useState<ID[]>([]);
   const [invitedGroupMembers, setInvitedGroupMembers] = useState<
@@ -172,7 +172,7 @@ const MeetingEditor = () => {
     );
   }
 
-  const currentUserSearchable = {
+  const currentUserSearchable = currentUser && {
     value: currentUser.username,
     label: currentUser.fullName,
     id: currentUser.id,

--- a/app/routes/meetings/components/MeetingList.tsx
+++ b/app/routes/meetings/components/MeetingList.tsx
@@ -9,12 +9,12 @@ import { Content } from 'app/components/Content';
 import NavigationTab from 'app/components/NavigationTab';
 import { Tag } from 'app/components/Tags';
 import Time from 'app/components/Time';
+import { useCurrentUser } from 'app/reducers/auth';
 import {
   selectGroupedMeetings,
   type MeetingSection,
 } from 'app/reducers/meetings';
 import { selectPaginationNext } from 'app/reducers/selectors';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { EntityType } from 'app/store/models/entities';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
@@ -126,7 +126,7 @@ const MeetingList = () => {
   const meetingSections = useAppSelector(selectGroupedMeetings);
   const loading = useAppSelector((state) => state.meetings.fetching);
 
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
 
   const dispatch = useAppDispatch();
 
@@ -190,7 +190,9 @@ const MeetingList = () => {
           </Link>
         }
       />
-      {meetingSections && (
+      {!meetingSections || !currentUser || loading ? (
+        <LoadingIndicator loading={loading} />
+      ) : (
         <MeetingListView currentUser={currentUser} sections={meetingSections} />
       )}
       <LoadingIndicator loading={loading} />

--- a/app/routes/pages/components/LandingPage.tsx
+++ b/app/routes/pages/components/LandingPage.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import bannerDarkMode from 'app/assets/om-abakus-banner-dark-mode.png';
 import bannerLightMode from 'app/assets/om-abakus-banner.png';
 import { Image } from 'app/components/Image';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import styles from './LandingPage.css';
 import { DisplayVisionShort } from './subcomponents/DisplayVision';
 import EmailItem from './subcomponents/EmailItem';
@@ -16,7 +16,7 @@ import TextWithBoldTitle, {
 import type { PageRenderer } from 'app/routes/pages/components/PageDetail';
 
 const LandingPage: PageRenderer = () => {
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
 
   return (
     <div className={styles.pageContainer}>

--- a/app/routes/pages/components/PageDetail.tsx
+++ b/app/routes/pages/components/PageDetail.tsx
@@ -17,6 +17,7 @@ import { Image } from 'app/components/Image';
 import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import { GroupType } from 'app/models';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import {
   selectPagesForHierarchy,
   selectCommitteeForHierarchy,
@@ -28,7 +29,6 @@ import {
   selectNotFoundpageForPages,
   selectInfoPageForPages,
 } from 'app/reducers/pages';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import HTTPError from 'app/routes/errors/HTTPError';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import LandingPage from './LandingPage';
@@ -316,7 +316,7 @@ const PageDetail = () => {
     }),
   );
 
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
 
   const dispatch = useAppDispatch();
 

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -20,9 +20,9 @@ import PropertyHelmet, {
 } from 'app/components/PropertyHelmet';
 import ImageUpload from 'app/components/Upload/ImageUpload';
 import config from 'app/config';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import { selectGalleryById } from 'app/reducers/galleries';
 import { SelectGalleryPicturesByGalleryId } from 'app/reducers/galleryPictures';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import HTTPError from 'app/routes/errors/HTTPError';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import GalleryDetailsRow from './GalleryDetailsRow';
@@ -69,7 +69,7 @@ const GalleryDetail = () => {
     (state) => state.galleries.fetching || state.galleryPictures.fetching,
   );
   const hasMore = useAppSelector((state) => state.galleryPictures.hasMore);
-  const { loggedIn } = useUserContext();
+  const loggedIn = useIsLoggedIn();
 
   const dispatch = useAppDispatch();
 

--- a/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
+++ b/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
@@ -9,9 +9,9 @@ import {
 } from 'app/actions/SurveySubmissionActions';
 import { Content, ContentHeader } from 'app/components/Content';
 import Time from 'app/components/Time';
+import { useCurrentUser } from 'app/reducers/auth';
 import { selectSurveySubmissionForUser } from 'app/reducers/surveySubmissions';
 import { useFetchedSurvey } from 'app/reducers/surveys';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import AlreadyAnswered from 'app/routes/surveys/components/AddSubmission/AlreadyAnswered';
 import SurveySubmissionForm from 'app/routes/surveys/components/AddSubmission/SurveySubmissionForm';
 import styles from 'app/routes/surveys/components/surveys.css';
@@ -22,13 +22,15 @@ import type { FormSurveySubmission } from 'app/store/models/SurveySubmission';
 const AddSubmissionPage = () => {
   const dispatch = useAppDispatch();
   const { surveyId } = useParams<{ surveyId: string }>();
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
   const survey = useFetchedSurvey('addSubmission', surveyId);
-  const submission = useAppSelector((state) =>
-    selectSurveySubmissionForUser(state, {
-      surveyId: Number(surveyId),
-      currentUserId: currentUser.id,
-    }),
+  const submission = useAppSelector(
+    (state) =>
+      currentUser &&
+      selectSurveySubmissionForUser(state, {
+        surveyId: Number(surveyId),
+        currentUserId: currentUser.id,
+      }),
   );
 
   const fetchingSubmission = useAppSelector(
@@ -38,12 +40,12 @@ const AddSubmissionPage = () => {
   usePreparedEffect(
     'fetchAddSubmissionSurveySubmission',
     () =>
-      currentUser.id &&
+      currentUser?.id &&
       dispatch(fetchUserSubmission(Number(surveyId), Number(currentUser.id))),
-    [surveyId, currentUser.id],
+    [surveyId, currentUser?.id],
   );
 
-  if (!survey || !currentUser.id || fetchingSubmission) {
+  if (!survey || !currentUser || fetchingSubmission) {
     return <LoadingIndicator loading />;
   }
 

--- a/app/routes/users/components/ChangePassword.tsx
+++ b/app/routes/users/components/ChangePassword.tsx
@@ -4,7 +4,7 @@ import { changePassword } from 'app/actions/UserActions';
 import { TextInput } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import { createValidator, required, sameAs } from 'app/utils/validation';
 import { validPassword } from '../utils';
@@ -27,7 +27,7 @@ const ChangePasswordForm = () => {
       navigate('/users/me');
     });
 
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
 
   return (
     <TypedLegoForm onSubmit={onSubmit} validate={validate}>

--- a/app/routes/users/components/PasswordField.tsx
+++ b/app/routes/users/components/PasswordField.tsx
@@ -2,14 +2,14 @@ import { useState } from 'react';
 import { Field } from 'react-final-form';
 import { TextInput } from 'app/components/Form';
 import PasswordStrengthMeter from './PasswordStrengthMeter';
-import type { User } from 'app/store/models/User';
+import type { PublicUser } from 'app/store/models/User';
 
 export type PasswordFieldUser = Partial<
-  Pick<User, 'username' | 'firstName' | 'lastName'>
+  Pick<PublicUser, 'username' | 'firstName' | 'lastName'>
 >;
 
 type Props = {
-  user: PasswordFieldUser;
+  user?: PasswordFieldUser;
   name?: string;
   label?: string;
 };

--- a/app/routes/users/components/PasswordStrengthMeter.tsx
+++ b/app/routes/users/components/PasswordStrengthMeter.tsx
@@ -12,7 +12,7 @@ import type { PasswordFieldUser } from './PasswordField';
 
 type Props = {
   password: string;
-  user: PasswordFieldUser;
+  user?: PasswordFieldUser;
 };
 const Zxcvbn = loadable.lib(() => import('zxcvbn'), {
   ssr: false,
@@ -32,9 +32,9 @@ const PasswordStrengthMeter = ({ password, user }: Props) => {
     >
       {({ default: zxcvbn }) => {
         const zxcvbnValue = zxcvbn(password, [
-          user.username,
-          user.firstName,
-          user.lastName,
+          user?.username,
+          user?.firstName,
+          user?.lastName,
         ]);
         let tips = zxcvbnValue.feedback?.suggestions ?? [];
         tips.push(zxcvbnValue.feedback?.warning);

--- a/app/routes/users/components/StudentConfirmation.tsx
+++ b/app/routes/users/components/StudentConfirmation.tsx
@@ -9,7 +9,7 @@ import {
   updateUser,
 } from 'app/actions/UserActions';
 import { Button } from 'app/components/Form';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import styles from './UserConfirmation.css';
 import type { RejectedPromiseAction } from 'app/store/middleware/promiseMiddleware';
@@ -40,6 +40,7 @@ const NotEligibleInfo = () => (
 );
 
 const StudentConfirmation = () => {
+  const dispatch = useAppDispatch();
   const [authRes, setAuthRes] = useState<ConfirmStudentAuthResponse>();
   const [showMemberModal, setShowMemberModal] = useState(false);
 
@@ -47,20 +48,7 @@ const StudentConfirmation = () => {
   const navigate = useNavigate();
   const { code, state } = qs.parse(search, { ignoreQueryPrefix: true });
 
-  const { currentUser } = useUserContext();
-
-  const dispatch = useAppDispatch();
-
-  const performStudentAuth = async () => {
-    const auth_res = await dispatch(startStudentAuth());
-    const auth_uri = auth_res.payload.url;
-    window.location.href = auth_uri;
-  };
-
-  const setAbakusMember = async (member: boolean) => {
-    await dispatch(updateUser({ ...currentUser, isAbakusMember: member }));
-    setShowMemberModal(false);
-  };
+  const currentUser = useCurrentUser();
 
   useEffect(() => {
     const validateStudentAuth = () => {
@@ -82,6 +70,21 @@ const StudentConfirmation = () => {
   useEffect(() => {
     authRes?.status === 'success' && setShowMemberModal(true);
   }, [authRes]);
+
+  if (!currentUser) {
+    return null;
+  }
+
+  const performStudentAuth = async () => {
+    const auth_res = await dispatch(startStudentAuth());
+    const auth_uri = auth_res.payload.url;
+    window.location.href = auth_uri;
+  };
+
+  const setAbakusMember = async (member: boolean) => {
+    await dispatch(updateUser({ ...currentUser, isAbakusMember: member }));
+    setShowMemberModal(false);
+  };
 
   return (
     <>

--- a/app/routes/users/components/UserProfile.tsx
+++ b/app/routes/users/components/UserProfile.tsx
@@ -24,13 +24,13 @@ import { ProfilePicture, CircularPicture, Image } from 'app/components/Image';
 import Pill from 'app/components/Pill';
 import Tooltip from 'app/components/Tooltip';
 import { GroupType } from 'app/models';
+import { useCurrentUser } from 'app/reducers/auth';
 import {
   selectPreviousEvents,
   selectUpcomingEvents,
 } from 'app/reducers/events';
 import { resolveGroupLink, selectGroupsByType } from 'app/reducers/groups';
 import { selectUserWithGroups } from 'app/reducers/users';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useIsCurrentUser } from 'app/routes/users/utils';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
@@ -170,10 +170,9 @@ const UserProfile = () => {
   const [showAbaId, setShowAbaId] = useState(false);
 
   const params = useParams<{ username: string }>();
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
   const isCurrentUser = useIsCurrentUser(params.username);
-  const username =
-    isCurrentUser && currentUser ? currentUser?.username : params.username;
+  const username = isCurrentUser ? currentUser?.username : params.username;
   const user = useAppSelector((state) =>
     selectUserWithGroups(state, {
       username,

--- a/app/routes/users/components/UserResetPassword.tsx
+++ b/app/routes/users/components/UserResetPassword.tsx
@@ -7,7 +7,7 @@ import { Content } from 'app/components/Content';
 import { TextInput } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import { createValidator, required, sameAs } from 'app/utils/validation';
 import { validPassword } from '../utils';
@@ -31,8 +31,8 @@ const UserResetPasswordForm = () => {
       navigate('/');
     });
 
-  const { currentUser } = useUserContext();
-  const user = {
+  const currentUser = useCurrentUser();
+  const user = currentUser && {
     username: currentUser.username,
     firstName: currentUser.firstName,
     lastName: currentUser.lastName,

--- a/app/routes/users/components/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings.tsx
@@ -13,8 +13,8 @@ import {
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
+import { useCurrentUser } from 'app/reducers/auth';
 import { selectUserByUsername } from 'app/reducers/users';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import DeleteUser from 'app/routes/users/components/DeleteUser';
 import RemovePicture from 'app/routes/users/components/RemovePicture';
 import { useIsCurrentUser } from 'app/routes/users/utils';
@@ -71,10 +71,12 @@ const validate = createValidator({
 
 const UserSettings = () => {
   const params = useParams<{ username: string }>();
-  const { currentUser } = useUserContext();
-  const isCurrentUser = useIsCurrentUser(params.username!);
-  const username = isCurrentUser ? currentUser.username : params.username!;
-  const user = useAppSelector((state) => selectUserByUsername(state, username));
+  const currentUser = useCurrentUser();
+  const isCurrentUser = useIsCurrentUser(params.username);
+  const username = isCurrentUser ? currentUser?.username : params.username;
+  const user = useAppSelector(
+    (state) => username && selectUserByUsername(state, username),
+  );
 
   const dispatch = useAppDispatch();
 

--- a/app/routes/users/components/UserSettingsIndex.tsx
+++ b/app/routes/users/components/UserSettingsIndex.tsx
@@ -2,7 +2,7 @@ import { Helmet } from 'react-helmet-async';
 import { Route, Routes, useParams } from 'react-router-dom';
 import { Content } from 'app/components/Content';
 import NavigationTab, { NavigationLink } from 'app/components/NavigationTab';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser } from 'app/reducers/auth';
 import { useIsCurrentUser } from 'app/routes/users/utils';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import StudentConfirmation from './StudentConfirmation';
@@ -14,7 +14,7 @@ import UserSettingsOAuth2Form from './UserSettingsOAuth2Form';
 const UserSettingsIndex = () => {
   const { username } = useParams<{ username: string }>();
   const isCurrentUser = useIsCurrentUser(username);
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
   const base = `/users/${username}/settings`;
 
   // At the moment changing settings for other users only works
@@ -38,7 +38,7 @@ const UserSettingsIndex = () => {
             </NavigationLink>
             <NavigationLink to={`${base}/oauth2`}>OAuth2</NavigationLink>
             <NavigationLink to={`${base}/student-confirmation`}>
-              {currentUser.isStudent
+              {currentUser?.isStudent
                 ? 'Studentstatus'
                 : 'Verifiser studentstatus'}
             </NavigationLink>

--- a/app/routes/users/components/UserSettingsNotifications.tsx
+++ b/app/routes/users/components/UserSettingsNotifications.tsx
@@ -7,11 +7,11 @@ import {
 } from 'app/actions/NotificationSettingsActions';
 import { updateUser } from 'app/actions/UserActions';
 import { CheckBox } from 'app/components/Form';
+import { useCurrentUser } from 'app/reducers/auth';
 import {
   selectNotificationSettings,
   selectNotificationSettingsAlternatives,
 } from 'app/reducers/notificationSettings';
-import { useUserContext } from 'app/routes/app/AppRoute';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './UserSettingsNotifications.css';
 
@@ -61,7 +61,11 @@ const UserSettingsNotifications = () => {
     channels: alternatives.channels,
   });
 
-  const { currentUser } = useUserContext();
+  const currentUser = useCurrentUser();
+
+  if (!currentUser) {
+    return null;
+  }
 
   return (
     <div>

--- a/app/routes/users/utils.ts
+++ b/app/routes/users/utils.ts
@@ -1,4 +1,4 @@
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useCurrentUser } from 'app/reducers/auth';
 
 type Data = {
   username?: string;
@@ -27,6 +27,6 @@ export const isCurrentUser = (username?: string, currentUsername?: string) => {
 };
 
 export const useIsCurrentUser = (username?: string) => {
-  const { currentUser } = useUserContext();
-  return isCurrentUser(username, currentUser.username);
+  const currentUser = useCurrentUser();
+  return isCurrentUser(username, currentUser?.username);
 };

--- a/app/store/models/User.ts
+++ b/app/store/models/User.ts
@@ -1,7 +1,7 @@
 import type { Dateish, PhotoConsentDomain, Semester } from 'app/models';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
-import type EmailList from 'app/store/models/EmailList';
-import type Group from 'app/store/models/Group';
+import type { PublicEmailList } from 'app/store/models/EmailList';
+import type { PublicGroup } from 'app/store/models/Group';
 import type Membership from 'app/store/models/Membership';
 import type PastMembership from 'app/store/models/PastMembership';
 import type { ID } from 'app/store/models/index';
@@ -38,7 +38,7 @@ interface User {
   allergies: string;
   isActive: boolean;
   isStudent: boolean;
-  abakusEmailLists: EmailList[];
+  abakusEmailLists: PublicEmailList[];
   penalties: ID[];
   icalToken: string;
   abakusGroups: ID[];
@@ -47,10 +47,10 @@ interface User {
   pastMemberships: PastMembership[];
   selectedTheme: string;
   permissionsPerGroup: {
-    abakusGroup: Pick<Group, 'id' | 'name'>;
+    abakusGroup: Pick<PublicGroup, 'id' | 'name'>;
     permissions: string[];
     parentPermissions: {
-      abakusGroup: Pick<Group, 'id' | 'name'>;
+      abakusGroup: Pick<PublicGroup, 'id' | 'name'>;
       permissions: string[];
     }[];
   }[];
@@ -198,8 +198,7 @@ export type UnknownUser =
   | PublicUserWithGroups
   | AdministrateUser
   | AdministrateExportUser
-  | AdministrateAllergiesUser
-  | SearchUser;
+  | AdministrateAllergiesUser;
 
 export type UpdateUser = Required<
   Partial<

--- a/app/utils/replaceUnlessLoggedIn.tsx
+++ b/app/utils/replaceUnlessLoggedIn.tsx
@@ -1,5 +1,5 @@
 import { LoginRequiredPage } from 'app/components/LoginForm';
-import { useUserContext } from 'app/routes/app/AppRoute';
+import { useIsLoggedIn } from 'app/reducers/auth';
 import type { ComponentType } from 'react';
 
 const replaceUnlessLoggedIn =
@@ -8,7 +8,7 @@ const replaceUnlessLoggedIn =
   ) =>
   <P extends object>(Component: ComponentType<P>) => {
     const LoginGuard = (props: P & RP) => {
-      const { loggedIn } = useUserContext();
+      const loggedIn = useIsLoggedIn();
       if (loggedIn) {
         return <Component {...props} />;
       }

--- a/server/pageRenderer.ts
+++ b/server/pageRenderer.ts
@@ -87,7 +87,7 @@ export default function pageRenderer({
 }: PageRendererProps = {}): string {
   const isSSR = app === undefined ? 'false' : 'true';
   const selectedTheme: string =
-    (!isEmpty(state) && selectCurrentUser(state).selectedTheme) || 'auto';
+    (!isEmpty(state) && selectCurrentUser(state)?.selectedTheme) || 'auto';
   const { body, scripts, styles, links } = readyHtml(app);
   const { helmet } = helmetContext as FilledContext;
   return `


### PR DESCRIPTION
# Description

The UserContext was simply mirroring what was in the redux-state, and was completely unnecessary.

# Result

Only refactoring. I replaced all usage of `useUserContext` with either `useCurrentUser` or `useIsLoggedIn` which directly select from the redux state. I also did some minimal refactoring in the various components using `useCurrentUser`, because it now returns `undefined` instead of `{}` when the user is not yet loaded or not logged in.

Number of typescript errors reduced from 731 to 712:)

# Testing

- [x] I have thoroughly tested my changes.

I read through all my changes, and for all components where behaiviour might have changed, I did some manual testing of the component.