### PR TITLE
Fix initialvalues for joblisting editor

### DIFF
--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -150,6 +150,16 @@ const JoblistingEditor = () => {
     [isNew, joblisting?.company],
   );
 
+  const matchingJobType = jobTypes.find(
+    ({ value }) => value === joblisting?.jobType,
+  );
+  const matchingFromYear = yearValues.find(
+    ({ value }) => value === joblisting?.fromYear,
+  );
+  const matchingToYear = yearValues.find(
+    ({ value }) => value === joblisting?.toYear,
+  );
+
   const initialValues = {
     ...joblisting,
     text: joblisting?.text || '<p></p>',
@@ -165,15 +175,10 @@ const JoblistingEditor = () => {
       joblisting?.visibleTo || time({ days: 31, hours: 23, minutes: 59 }),
     deadline:
       joblisting?.deadline || time({ days: 30, hours: 23, minutes: 59 }),
-    fromYear: yearValues.find(
-      ({ value }) => value === joblisting?.fromYear || value === 1,
-    ),
-    toYear: yearValues.find(
-      ({ value }) => value === joblisting?.toYear || value === 5,
-    ),
-    jobType: jobTypes.find(
-      ({ value }) => value === joblisting?.jobType || value === 'summer_job',
-    ),
+    fromYear: matchingFromYear || yearValues.find(({ value }) => value === 1),
+    toYear: matchingToYear || yearValues.find(({ value }) => value === 5),
+    jobType:
+      matchingJobType || jobTypes.find(({ value }) => value === 'summer_job'),
     responsible: joblisting?.responsible
       ? {
           label: joblisting.responsible.name,


### PR DESCRIPTION
# Description

Resolves this issue:
<details>
  <summary>Click to see Email</summary>
 Heei, det har dukket opp et lite problem knyttet til jobbannonser på Abakus. Hvis vi trykker "rediger" på en jobbannonse for å gjøre noen endringer, endres type jobb og klassetrinn automatisk til "sommerjobb" og "1. - 5. klasse" selv om vi hadde skrevet noe annet der. Har du mulighet til å høre med WebKom om de kan se på det? Det er et nylig oppstått problem
</details>

Resolves ABA-901

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [ x] Changes look good on both light and dark theme.
- [ x] Changes look good with different viewports (mobile, tablet, etc.).
- [ x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
