### PR TITLE
Refactor and type surveys state and components

### DIFF
--- a/app/reducers/__tests__/surveySubmissions.spec.ts
+++ b/app/reducers/__tests__/surveySubmissions.spec.ts
@@ -1,18 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { SurveySubmission } from '../../actions/ActionTypes';
+import { SurveySubmission } from 'app/actions/ActionTypes';
 import surveySubmissions from '../surveySubmissions';
 
 describe('reducers', () => {
   describe('surveySubmissions', () => {
-    const baseState = {
+    const baseState: ReturnType<typeof surveySubmissions> = {
       actionGrant: [],
-      pagination: {},
       paginationNext: {},
-      items: [],
-      byId: {},
+      fetching: false,
+      ids: [],
+      entities: {},
     };
     it('SurveySubmission.ADD.SUCCESS adds survey id to submission object', () => {
-      const prevState = baseState;
       const action = {
         type: SurveySubmission.ADD.SUCCESS,
         meta: {
@@ -30,12 +29,10 @@ describe('reducers', () => {
           },
         },
       };
-      expect(surveySubmissions(prevState, action)).toEqual({
-        actionGrant: [],
-        pagination: {},
-        paginationNext: {},
-        items: [3],
-        byId: {
+      expect(surveySubmissions(baseState, action)).toEqual({
+        ...baseState,
+        ids: [3],
+        entities: {
           3: {
             id: 3,
             test: 'abc',

--- a/app/reducers/surveySubmissions.ts
+++ b/app/reducers/surveySubmissions.ts
@@ -1,53 +1,44 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { produce } from 'immer';
 import { createSelector } from 'reselect';
 import { fetchSubmissions } from 'app/actions/SurveySubmissionActions';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
-import createEntityReducer from 'app/utils/createEntityReducer';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { SurveySubmission } from '../actions/ActionTypes';
 import type { AnyAction, EntityId } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
 import type { SurveySubmission as SurveySubmissionType } from 'app/store/models/SurveySubmission';
-import type { EntityReducerState } from 'app/utils/createEntityReducer';
 
-type State = EntityReducerState<SurveySubmissionType>;
-const mutateSurveySubmissions = produce(
-  (newState: State, action: AnyAction): void => {
-    switch (action.type) {
-      case SurveySubmission.ADD.SUCCESS: {
+const legoAdapter = createLegoAdapter(EntityType.SurveySubmissions);
+
+const surveySubmissionsSlice = createSlice({
+  name: EntityType.SurveySubmissions,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [SurveySubmission.FETCH, SurveySubmission.FETCH_ALL],
+    extraCases: (addCase) => {
+      addCase(SurveySubmission.ADD.SUCCESS, (state, action: AnyAction) => {
         const { surveyId } = action.meta;
         const id = action.payload.result;
         const surveySubmission = action.payload.entities.surveySubmissions[id];
-        newState.byId[id] = { ...surveySubmission, survey: surveyId };
-        break;
-      }
-
-      default:
-        break;
-    }
-  },
-);
-export default createEntityReducer({
-  key: 'surveySubmissions',
-  types: {
-    fetch: [SurveySubmission.FETCH, SurveySubmission.FETCH_ALL],
-    mutate: SurveySubmission.ADD,
-  },
-  mutate: mutateSurveySubmissions,
+        legoAdapter.upsertOne(state, { ...surveySubmission, survey: surveyId });
+      });
+    },
+  }),
 });
 
-export const selectSurveySubmissions = createSelector(
-  (_: RootState, props: { surveyId: EntityId }) => props.surveyId,
-  (state: RootState) => state.surveySubmissions.items,
-  (state: RootState) => state.surveySubmissions.byId,
-  (surveyId, surveySubmissionIds, surveySubmissionsById) =>
-    surveySubmissionIds
-      .map((surveySubmissionId) => surveySubmissionsById[surveySubmissionId])
-      .filter((surveySubmission) => surveySubmission.survey === surveyId),
-);
+export default surveySubmissionsSlice.reducer;
+const { selectByField: selectSurveySubmissionsByField } =
+  legoAdapter.getSelectors((state: RootState) => state.surveySubmissions);
+
+export const selectSurveySubmissionsBySurveyId =
+  selectSurveySubmissionsByField('survey');
+
 export const selectSurveySubmissionForUser = createSelector(
   (state: RootState, props: { surveyId: EntityId }) =>
-    selectSurveySubmissions(state, props),
+    selectSurveySubmissionsBySurveyId(state, props.surveyId),
   (_: RootState, props: { currentUserId: EntityId }) => props.currentUserId,
   (submissions, userId) =>
     submissions.find((surveySubmission) => surveySubmission.user === userId),
@@ -64,6 +55,6 @@ export const useFetchedSurveySubmissions = (
     [surveyId],
   );
   return useAppSelector((state: RootState) =>
-    selectSurveySubmissions(state, { surveyId: Number(surveyId) }),
+    selectSurveySubmissionsBySurveyId(state, Number(surveyId)),
   );
 };

--- a/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
+++ b/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
@@ -19,11 +19,15 @@ import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import type { FormSurveySubmission } from 'app/store/models/SurveySubmission';
 
+type AddSubmissionPageParams = {
+  surveyId: string;
+};
 const AddSubmissionPage = () => {
   const dispatch = useAppDispatch();
-  const { surveyId } = useParams<{ surveyId: string }>();
+  const { surveyId } =
+    useParams<AddSubmissionPageParams>() as AddSubmissionPageParams;
   const currentUser = useCurrentUser();
-  const survey = useFetchedSurvey('addSubmission', surveyId);
+  const { survey, event } = useFetchedSurvey('addSubmission', surveyId);
   const submission = useAppSelector(
     (state) =>
       currentUser &&
@@ -45,7 +49,7 @@ const AddSubmissionPage = () => {
     [surveyId, currentUser?.id],
   );
 
-  if (!survey || !currentUser || fetchingSubmission) {
+  if (!survey || !event || !currentUser || fetchingSubmission) {
     return <LoadingIndicator loading />;
   }
 
@@ -87,7 +91,7 @@ const AddSubmissionPage = () => {
   };
 
   return (
-    <Content banner={survey.event.cover}>
+    <Content banner={event.cover}>
       <Helmet title={`Besvarer: ${survey.title}`} />
       <ContentHeader>
         <h2>{survey.title}</h2>
@@ -95,7 +99,7 @@ const AddSubmissionPage = () => {
 
       <div className={styles.surveyTime}>
         Spørreundersøkelse for arrangementet{' '}
-        <Link to={`/events/${survey.event.id}`}>{survey.event.title}</Link>
+        <Link to={`/events/${event.id}`}>{event.title}</Link>
       </div>
       <div className={styles.surveyTime}>
         Alle svar på spørreundersøkelser er anonyme.

--- a/app/routes/surveys/components/AddSubmission/AlreadyAnswered.tsx
+++ b/app/routes/surveys/components/AddSubmission/AlreadyAnswered.tsx
@@ -2,11 +2,11 @@ import { Link } from 'react-router-dom';
 import { Content } from 'app/components/Content';
 import StaticSubmission from '../StaticSubmission';
 import styles from '../surveys.css';
-import type { SelectedSurvey } from 'app/reducers/surveys';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 import type { SurveySubmission } from 'app/store/models/SurveySubmission';
 
 type Props = {
-  survey: SelectedSurvey;
+  survey: DetailedSurvey;
   submission: SurveySubmission;
 };
 

--- a/app/routes/surveys/components/AddSubmission/SurveySubmissionForm.tsx
+++ b/app/routes/surveys/components/AddSubmission/SurveySubmissionForm.tsx
@@ -11,14 +11,14 @@ import { SubmitButton } from 'app/components/Form/SubmitButton';
 import styles from 'app/routes/surveys/components/surveys.css';
 import { SurveyQuestionType } from 'app/store/models/SurveyQuestion';
 import type { EntityId } from '@reduxjs/toolkit';
-import type { SelectedSurvey } from 'app/reducers/surveys';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 import type { FormSurveyAnswer } from 'app/store/models/SurveyAnswer';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 import type { FormSurveySubmission } from 'app/store/models/SurveySubmission';
 import type { FieldArrayRenderProps } from 'react-final-form-arrays';
 
 type Props = {
-  survey: SelectedSurvey;
+  survey: DetailedSurvey;
   initialValues: FormSurveySubmission;
   onSubmit: (values: FormSurveySubmission) => Promise<unknown>;
 };
@@ -149,7 +149,7 @@ const AnswerField = ({ name, question }: AnswerFieldProps) => {
 };
 
 const createSubmissionValidator =
-  (survey: SelectedSurvey) => (values: FormSurveySubmission) => {
+  (survey: DetailedSurvey) => (values: FormSurveySubmission) => {
     const errors: { answers: string[][] } = {
       answers: [],
     };

--- a/app/routes/surveys/components/StaticSubmission.tsx
+++ b/app/routes/surveys/components/StaticSubmission.tsx
@@ -1,13 +1,13 @@
 import { RadioButton, CheckBox, TextArea } from 'app/components/Form';
 import { SurveyQuestionType } from 'app/store/models/SurveyQuestion';
 import styles from './surveys.css';
-import type { SelectedSurvey } from 'app/reducers/surveys';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 import type { SurveyAnswer } from 'app/store/models/SurveyAnswer';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 import type { SurveySubmission } from 'app/store/models/SurveySubmission';
 
 type Props = {
-  survey: SelectedSurvey;
+  survey: DetailedSurvey;
   submission?: SurveySubmission;
 };
 

--- a/app/routes/surveys/components/Submissions/Results.tsx
+++ b/app/routes/surveys/components/Submissions/Results.tsx
@@ -7,8 +7,9 @@ import DistributionPieChart from 'app/components/Chart/PieChart';
 import { CHART_COLORS } from 'app/components/Chart/utils';
 import SelectInput from 'app/components/Form/SelectInput';
 import InfoBubble from 'app/components/InfoBubble';
+import { selectEventById } from 'app/reducers/events';
 import AveragePill from 'app/routes/surveys/components/Submissions/AveragePill';
-import { useAppDispatch } from 'app/store/hooks';
+import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import {
   SurveyQuestionDisplayType,
   SurveyQuestionType,
@@ -17,17 +18,19 @@ import { QuestionTypeValue, QuestionTypeOption } from '../../utils';
 import styles from '../surveys.css';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { DistributionDataPoint } from 'app/components/Chart/utils';
-import type { SelectedSurvey } from 'app/reducers/surveys';
+import type { EventForSurvey } from 'app/store/models/Event';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
+import type { ReactNode } from 'react';
 
 export type GraphData = {
   [questionId: EntityId]: DistributionDataPoint[];
 };
 type Props = {
-  survey: SelectedSurvey;
+  survey: DetailedSurvey;
   graphData: GraphData;
   numberOfSubmissions: number;
-  generateTextAnswers: (question: SurveyQuestion) => any;
+  generateTextAnswers: (question: SurveyQuestion) => ReactNode;
 };
 type Info = {
   icon: string;
@@ -75,21 +78,24 @@ const Results = ({
   numberOfSubmissions,
 }: Props) => {
   const dispatch = useAppDispatch();
+  const event = useAppSelector((state) =>
+    selectEventById(state, { eventId: survey.event }),
+  ) as EventForSurvey;
 
   const info: Info[] = [
     {
       icon: 'person',
-      data: survey.event.registrationCount,
+      data: event.registrationCount,
       meta: 'Påmeldte',
     },
     {
       icon: 'checkmark',
-      data: survey.event.attendedCount,
+      data: event.attendedCount,
       meta: 'Møtte opp',
     },
     {
       icon: 'list',
-      data: survey.event.waitingRegistrationCount ?? 0,
+      data: event.waitingRegistrationCount ?? 0,
       meta: 'På venteliste',
     },
     {
@@ -128,7 +134,7 @@ const Results = ({
           editSurvey({
             ...newSurvey,
             surveyId: survey.id,
-            event: survey.event.id,
+            event: event.id,
           }),
         );
       }
@@ -205,7 +211,7 @@ const Results = ({
                             switchGraph(question.id, selectedType)
                           }
                           components={{
-                            Option: (props: any) => {
+                            Option: (props) => {
                               const value = props.data.value;
                               return (
                                 <QuestionTypeOption
@@ -214,7 +220,7 @@ const Results = ({
                                 />
                               );
                             },
-                            SingleValue: (props: any) => {
+                            SingleValue: (props) => {
                               const value = props.data.value;
                               return (
                                 <QuestionTypeValue

--- a/app/routes/surveys/components/Submissions/SubmissionPublicResultsPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionPublicResultsPage.tsx
@@ -9,11 +9,16 @@ import Results from './Results';
 import type { GraphData } from './Results';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
+import type { ReactNode } from 'react';
 
+type SubmissionsPublicResultsParams = {
+  surveyId: string;
+};
 const SubmissionPublicResultsPage = () => {
-  const { surveyId } = useParams<{ surveyId: string }>();
+  const { surveyId } =
+    useParams<SubmissionsPublicResultsParams>() as SubmissionsPublicResultsParams;
   const { query } = useQuery({ token: '' });
-  const survey = useFetchedSurvey(
+  const { survey, event } = useFetchedSurvey(
     'submissionPublicResults',
     surveyId,
     query.token,
@@ -24,7 +29,7 @@ const SubmissionPublicResultsPage = () => {
     return <LoadingIndicator loading />;
   }
 
-  const generateTextAnswers = (question: SurveyQuestion) => {
+  const generateTextAnswers = (question: SurveyQuestion): ReactNode => {
     const result = results[question.id];
     if (result.questionType !== SurveyQuestionType.TextField) {
       return [];
@@ -61,7 +66,7 @@ const SubmissionPublicResultsPage = () => {
     graphData[Number(questionId)] = generateQuestionData(questionId);
   });
   return (
-    <Content banner={survey.event.cover}>
+    <Content banner={event?.cover}>
       <TokenNavigation title={survey.title} surveyId={survey.id} />
 
       <ContentSection>

--- a/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
@@ -9,22 +9,28 @@ import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import { DetailNavigation, getCsvUrl } from '../../utils';
 import AdminSideBar from '../AdminSideBar';
 import styles from '../surveys.css';
-import type { SelectedSurvey } from 'app/reducers/surveys';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 import type { SurveySubmission } from 'app/store/models/SurveySubmission';
-import type { ReactNode } from 'react';
+import type { ComponentType } from 'react';
 
-type ChildrenProps = {
-  survey: SelectedSurvey;
+type ChildProps = {
+  survey: DetailedSurvey;
   submissions: SurveySubmission[];
 };
+export type SubmissionsPageChild = ComponentType<ChildProps>;
 
 type Props = {
-  children: (props: ChildrenProps) => ReactNode;
+  children: SubmissionsPageChild;
+};
+
+type SubmissionsPageParams = {
+  surveyId: string;
 };
 
 const SubmissionsPage = ({ children: Children }: Props) => {
-  const { surveyId } = useParams<{ surveyId: string }>();
-  const survey = useFetchedSurvey('surveySubmissions', surveyId);
+  const { surveyId } =
+    useParams<SubmissionsPageParams>() as SubmissionsPageParams;
+  const { survey, event } = useFetchedSurvey('surveySubmissions', surveyId);
   const submissions = useFetchedSurveySubmissions(
     'surveySubmissions',
     surveyId,
@@ -39,7 +45,7 @@ const SubmissionsPage = ({ children: Children }: Props) => {
   }
 
   return (
-    <Content banner={survey.event.cover}>
+    <Content banner={event?.cover}>
       <DetailNavigation title={survey.title} surveyId={Number(survey.id)} />
 
       <ContentSection>

--- a/app/routes/surveys/components/SurveyDetail.tsx
+++ b/app/routes/surveys/components/SurveyDetail.tsx
@@ -12,15 +12,19 @@ import AdminSideBar from './AdminSideBar';
 import StaticSubmission from './StaticSubmission';
 import styles from './surveys.css';
 
+type SurveyDetailPageParams = {
+  surveyId: string;
+};
 const SurveyDetailPage = () => {
-  const { surveyId } = useParams<{ surveyId: string }>();
-  const survey = useFetchedSurvey('surveyDetail', surveyId);
+  const { surveyId } =
+    useParams<SurveyDetailPageParams>() as SurveyDetailPageParams;
+  const { survey, event } = useFetchedSurvey('surveyDetail', surveyId);
   const fetching = useAppSelector((state) => state.surveys.fetching);
   const actionGrant = survey?.actionGrant;
 
   const navigate = useNavigate();
 
-  if (fetching || !actionGrant) {
+  if (fetching || !event || !actionGrant) {
     return <LoadingIndicator loading />;
   }
 
@@ -29,7 +33,7 @@ const SurveyDetailPage = () => {
   }
 
   return (
-    <Content banner={survey.templateType ? undefined : survey.event.cover}>
+    <Content banner={survey.templateType ? undefined : event.cover}>
       <Helmet title={survey.title} />
       <DetailNavigation title={survey.title} surveyId={Number(survey.id)} />
 
@@ -48,9 +52,7 @@ const SurveyDetailPage = () => {
             <div>
               <div className={styles.surveyTime}>
                 Spørreundersøkelse for{' '}
-                <Link to={`/events/${survey.event.id}`}>
-                  {survey.event.title}
-                </Link>
+                <Link to={`/events/${event.id}`}>{event.title}</Link>
               </div>
 
               <div className={styles.surveyTime}>

--- a/app/routes/surveys/components/SurveyEditor/EditSurveyPage.tsx
+++ b/app/routes/surveys/components/SurveyEditor/EditSurveyPage.tsx
@@ -13,12 +13,15 @@ import type { FormSubmitSurvey, FormSurvey } from 'app/store/models/Survey';
 const defaultEditSurveyQuery = {
   templateType: '' as EventType,
 };
-
+type EditSurveyPageParams = {
+  surveyId: string;
+};
 const EditSurveyPage = () => {
   const dispatch = useAppDispatch();
-  const { surveyId } = useParams<{ surveyId: string }>();
+  const { surveyId } =
+    useParams<EditSurveyPageParams>() as EditSurveyPageParams;
   const { query, setQueryValue } = useQuery(defaultEditSurveyQuery);
-  const survey = useFetchedSurvey('editSurvey', surveyId);
+  const { survey, event } = useFetchedSurvey('editSurvey', surveyId);
   const { templateType } = query;
   const template = useFetchedTemplate('addSurvey', templateType);
 
@@ -34,7 +37,7 @@ const EditSurveyPage = () => {
 
   const initialValues: Partial<FormSurvey> = {
     ...survey,
-    event: { value: survey.event?.id ?? 0, label: survey.event?.title ?? '' },
+    event: { value: event?.id ?? 0, label: event?.title ?? '' },
     questions: (template ?? survey).questions.map((question) => ({
       ...question,
       questionType: {

--- a/app/routes/surveys/components/SurveyList/SurveyItem.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyItem.tsx
@@ -1,23 +1,26 @@
 import { Link } from 'react-router-dom';
 import { Image } from 'app/components/Image';
 import Time from 'app/components/Time';
+import { selectEventById } from 'app/reducers/events';
 import { colorForEventType } from 'app/routes/events/utils';
+import { useAppSelector } from 'app/store/hooks';
 import styles from '../surveys.css';
-import type { SelectedSurvey } from 'app/reducers/surveys';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 
 type Props = {
-  survey: SelectedSurvey;
+  survey: DetailedSurvey;
 };
 
-const SurveyItem = (props: Props) => {
-  const { survey } = props;
+const SurveyItem = ({ survey }: Props) => {
+  const event = useAppSelector((state) =>
+    selectEventById(state, { eventId: survey.event }),
+  );
+
   return (
     <div
       className={styles.surveyItem}
       style={{
-        borderColor: colorForEventType(
-          survey.templateType || survey.event.eventType,
-        ),
+        borderColor: colorForEventType(survey.templateType || event.eventType),
       }}
     >
       <div>
@@ -33,9 +36,7 @@ const SurveyItem = (props: Props) => {
           <div>
             <div className={styles.surveyTime}>
               For arrangement{' '}
-              <Link to={`/events/${survey.event.id}`}>
-                {survey.event.title}
-              </Link>
+              <Link to={`/events/${event.id}`}>{event.title}</Link>
             </div>
 
             <div className={styles.surveyTime}>
@@ -47,10 +48,7 @@ const SurveyItem = (props: Props) => {
 
       {!survey.templateType && (
         <div className={styles.companyLogo}>
-          <Image
-            src={survey.event.cover}
-            alt={`Cover image for: ${survey.event.title}`}
-          />
+          <Image src={event.cover} alt={`Cover image for: ${event.title}`} />
         </div>
       )}
     </div>

--- a/app/routes/surveys/components/SurveyList/SurveyList.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyList.tsx
@@ -1,9 +1,9 @@
 import { isEmpty } from 'lodash';
 import SurveyItem from './SurveyItem';
-import type { SelectedSurvey } from 'app/reducers/surveys';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 
 type Props = {
-  surveys: SelectedSurvey[];
+  surveys: DetailedSurvey[];
   fetching: boolean;
 };
 

--- a/app/routes/surveys/components/SurveyList/SurveyListPage.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyListPage.tsx
@@ -7,12 +7,13 @@ import {
 import { Content } from 'app/components/Content';
 import Paginator from 'app/components/Paginator';
 import { selectPaginationNext } from 'app/reducers/selectors';
-import { selectSurveys, selectSurveyTemplates } from 'app/reducers/surveys';
+import { selectAllSurveys, selectSurveyTemplates } from 'app/reducers/surveys';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { EntityType } from 'app/store/models/entities';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import { ListNavigation } from '../../utils';
 import SurveyList from './SurveyList';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 
 type Props = {
   templates?: boolean;
@@ -26,8 +27,8 @@ const SurveyListPage = ({ templates }: Props) => {
   const surveys = useAppSelector((state) =>
     templates
       ? selectSurveyTemplates(state)
-      : selectSurveys(state).filter((survey) => !survey.templateType),
-  );
+      : selectAllSurveys(state).filter((survey) => !survey.templateType),
+  ) as DetailedSurvey[];
 
   const fetching = useAppSelector((state) => state.surveys.fetching);
   const { pagination } = useAppSelector(

--- a/app/routes/surveys/index.tsx
+++ b/app/routes/surveys/index.tsx
@@ -1,7 +1,7 @@
 import loadable from '@loadable/component';
 import { type RouteObject, Outlet } from 'react-router-dom';
 import pageNotFound from '../pageNotFound';
-import type { SelectedSurvey } from 'app/reducers/surveys';
+import type { DetailedSurvey } from 'app/store/models/Survey';
 import type { SurveySubmission } from 'app/store/models/SurveySubmission';
 
 const SurveyListPage = loadable(
@@ -32,7 +32,7 @@ const SubmissionPublicResultsPage = loadable(
 
 export type SurveysRouteContext = {
   submissions: SurveySubmission[];
-  survey: SelectedSurvey;
+  survey: DetailedSurvey;
 };
 
 const surveysRoute: RouteObject[] = [
@@ -47,7 +47,9 @@ const surveysRoute: RouteObject[] = [
     Component: () => (
       <SubmissionsPage>
         {({ submissions, survey }) => (
-          <Outlet context={{ submissions, survey }} />
+          <Outlet
+            context={{ submissions, survey } satisfies SurveysRouteContext}
+          />
         )}
       </SubmissionsPage>
     ),

--- a/app/store/models/Survey.d.ts
+++ b/app/store/models/Survey.d.ts
@@ -26,6 +26,7 @@ export type PublicSurvey = Pick<
   'id' | 'title' | 'event' | 'templateType'
 >;
 
+// Used on admin-pages
 export type DetailedSurvey = Pick<
   Survey,
   | 'id'
@@ -48,6 +49,7 @@ interface PublicTextQuestionResult {
   questionType: SurveyQuestionType.TextField;
   answers: string[];
 }
+// Used on the public (shared) results page
 export type PublicResultsSurvey = Omit<
   DetailedSurvey,
   'actionGrant' | 'token'
@@ -58,7 +60,7 @@ export type PublicResultsSurvey = Omit<
   submissionCount: number;
 };
 
-export type UnknownSurvey = PublicSurvey | DetailedSurvey;
+export type UnknownSurvey = PublicSurvey | PublicResultsSurvey | DetailedSurvey;
 
 export type FormSubmitSurvey = Overwrite<
   Optional<Survey, 'id'>,

--- a/app/store/models/entities.ts
+++ b/app/store/models/entities.ts
@@ -29,7 +29,7 @@ import type Quote from 'app/store/models/Quote';
 import type Reaction from 'app/store/models/Reaction';
 import type { UnknownRegistration } from 'app/store/models/Registration';
 import type { UnknownRestrictedMail } from 'app/store/models/RestrictedMail';
-import type { Survey } from 'app/store/models/Survey';
+import type { UnknownSurvey } from 'app/store/models/Survey';
 import type { SurveySubmission } from 'app/store/models/SurveySubmission';
 import type { UnknownTag } from 'app/store/models/Tag';
 import type { UnknownUser } from 'app/store/models/User';
@@ -105,7 +105,7 @@ export default interface Entities {
   [EntityType.Registrations]: Record<EntityId, UnknownRegistration>;
   [EntityType.RestrictedMails]: Record<EntityId, UnknownRestrictedMail>;
   [EntityType.SurveySubmissions]: Record<EntityId, SurveySubmission>;
-  [EntityType.Surveys]: Record<EntityId, Survey>;
+  [EntityType.Surveys]: Record<EntityId, UnknownSurvey>;
   [EntityType.Tags]: Record<EntityId, UnknownTag>;
   [EntityType.Thread]: Record<EntityId, UnknownThread>;
   [EntityType.Users]: Record<EntityId, UnknownUser>;


### PR DESCRIPTION
# Description

Refactored `surveys` and `surveySubmissions`-slices in redux to use `legoAdapter` and `createSlice`.

Changed the survey-selector so that it no longer puts the relevant event into the survey. This can instead be selected separately if necessary. This is mainly to simplify and reduce the number of different types.

# Result

No visual or functional changes
Reduces number of typescript errors by 7

# Testing

- [x] I have thoroughly tested my changes.

I did all the survey things and they still work. 

Some survey things don't well for non-admins, but that's unrelated to this PR. F.ex. the page for reviewing your survey submission gets a 403 error from the backend. 

---

ABA-688