### PR TITLE
Use createAsyncThunk to fully type readme fetch action

### DIFF
--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -368,9 +368,6 @@ export const Meta = {
 export const Frontpage = {
   FETCH: generateStatuses('Frontpage.FETCH') as AAT,
 };
-export const Readme = {
-  FETCH: generateStatuses('Readme.FETCH') as AAT,
-};
 export const Tag = {
   FETCH: generateStatuses('Tag.FETCH') as AAT,
   POPULAR: generateStatuses('Tag.POPULAR') as AAT,

--- a/app/actions/FrontpageActions.ts
+++ b/app/actions/FrontpageActions.ts
@@ -1,7 +1,8 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
 import callAPI from 'app/actions/callAPI';
 import { frontpageSchema } from 'app/reducers';
-import { Frontpage, Readme } from './ActionTypes';
-import type { AppDispatch } from 'app/store/createStore';
+import { Frontpage } from './ActionTypes';
+import type { Readme } from 'app/models';
 
 const gql = String.raw;
 export function fetchData() {
@@ -33,33 +34,25 @@ const readmeUtgaver = gql`
   }
   ${readmeFragment}
 `;
-export function fetchReadmes(first: number) {
-  return async (dispatch: AppDispatch) => {
-    try {
-      dispatch({
-        type: Readme.FETCH.BEGIN,
-      });
-      const res = await fetch(readmeUrl, {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
+
+export const fetchReadmes = createAsyncThunk(
+  'readme/fetch',
+  async (first: number) => {
+    const res = await fetch(readmeUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        operationName: null,
+        query: readmeUtgaver,
+        variables: {
+          first,
         },
-        body: JSON.stringify({
-          operationName: null,
-          query: readmeUtgaver,
-          variables: {
-            first,
-          },
-        }),
-      });
-      const output = await res.json();
-      dispatch({
-        type: Readme.FETCH.SUCCESS,
-        payload: output.data.readmeUtgaver,
-      });
-    } catch (e) {
-      //
-    }
-  };
-}
+      }),
+    });
+    const output = (await res.json()) as { data: { readmeUtgaver: Readme[] } };
+    return output.data.readmeUtgaver;
+  },
+);

--- a/app/reducers/__tests__/readme.spec.ts
+++ b/app/reducers/__tests__/readme.spec.ts
@@ -1,19 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { Readme } from '../../actions/ActionTypes';
+import { fetchReadmes } from 'app/actions/FrontpageActions';
 import readme from '../readme';
+import type { Readme } from 'app/models';
 
 describe('reducers', () => {
   describe('readme', () => {
     const prevState = undefined;
     it('Readme should populate default state correctly', () => {
-      const randomAction = {};
+      const randomAction = {
+        type: 'random',
+      };
       expect(readme(prevState, randomAction)).toEqual([]);
     });
     it('Readme should populate state correctly after fetch', () => {
-      const action = {
-        type: Readme.FETCH.SUCCESS,
-        payload: [1, 2, 3],
-      };
+      const action = fetchReadmes.fulfilled(
+        [1, 2, 3] as unknown as Readme[],
+        'test',
+        2,
+      );
       expect(readme(prevState, action)).toEqual([1, 2, 3]);
     });
   });

--- a/app/reducers/readme.ts
+++ b/app/reducers/readme.ts
@@ -1,16 +1,13 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { Readme } from 'app/actions/ActionTypes';
-import type { AnyAction } from '@reduxjs/toolkit';
-import type { Readme as ReadmeType } from 'app/models';
+import { fetchReadmes } from 'app/actions/FrontpageActions';
+import type { Readme } from 'app/models';
 
 const readmeSlice = createSlice({
   name: 'readme',
-  initialState: [] as ReadmeType[],
+  initialState: [] as Readme[],
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(Readme.FETCH.SUCCESS, (_, action: AnyAction) => {
-      return action.payload;
-    });
+    builder.addCase(fetchReadmes.fulfilled, (_, action) => action.payload);
   },
 });
 


### PR DESCRIPTION
# Description

`createAsyncThunk` is redux-toolkits way to do asynchronous actions like fetching data. It is very similar to how `callAPI` does it and readme fetching used to do it, but fully typed. Since `fetchReadmes` doesn't use `callAPI`, I could type it using `createAsyncThunk`:)

# Result

Improves type safety

# Testing

- [x] I have thoroughly tested my changes.

Readmes are still fetched successfully