### PR TITLE
Fix error when updating event

### DIFF
--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -37,6 +37,7 @@ const usersSlice = createSlice({
     extraCases: (addCase) => {
       addCase(Event.SOCKET_EVENT_UPDATED, (state, action: AnyAction) => {
         const users = normalize(action.payload, eventSchema).entities.users!;
+        if (!users) return;
         legoAdapter.upsertMany(state, users);
       });
     },


### PR DESCRIPTION
After updating an event, it is broadcast to all active users through websockets. This dispatches the same action as a user registering, but does not include a list of registered users.

# Description

I made a small mistake in #4540 causing an error to be logged in the console whenever you are on the event page, and the event is updated. I assumed that the update object would always include the registered users, turns out it only does when the update is a new registered user.

# Result

<img width="1060" alt="Screenshot 2024-03-23 at 20 09 25" src="https://github.com/webkom/lego-webapp/assets/8343002/3d734934-754c-4600-9d8f-12d54f1ea185">

# Testing

- [x] I have thoroughly tested my changes.

Updated event in staging and after fixing.

---

Resolves https://abakus.sentry.io/issues/5093947048/