### PR TITLE
Fix fetching of company contacts in joblisting editor

### DIFF
--- a/app/actions/CompanyActions.ts
+++ b/app/actions/CompanyActions.ts
@@ -183,8 +183,8 @@ export function deleteSemesterStatus(
   });
 }
 
-export function fetchCompanyContacts({ companyId }: { companyId: EntityId }) {
-  return callAPI<CompanyContact[]>({
+export function fetchCompanyContacts(companyId: EntityId) {
+  return callAPI<{ results: CompanyContact[] }>({
     types: Company.FETCH_COMPANY_CONTACT,
     endpoint: `/companies/${companyId}/company-contacts/`,
     method: 'GET',


### PR DESCRIPTION
# Description

Two issues fixed here. When creating a new joblisting, the company contacts would not be fetched since the company id would be in `company.value` instead of `company.id`. Secondly, once you've managed to fetch, you would also get an error since it was trying to map over the payload instead of the results.

Also, 

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

No visual changes.

# Testing

- [x] I have thoroughly tested my changes.

Editing and creating joblistings now work without any errors.