### PR TITLE
Remove penalty divider for users missing action grant

### DIFF
--- a/app/routes/users/components/Penalties.tsx
+++ b/app/routes/users/components/Penalties.tsx
@@ -27,7 +27,7 @@ const Penalties = ({ userId }: Props) => {
     <Flex column gap="var(--spacing-md)">
       {penalties.length ? (
         <>
-          {penalties.map((penalty) => (
+          {penalties.map((penalty, index) => (
             <>
               <Flex key={penalty.id} column gap="var(--spacing-sm)">
                 <Flex column className={styles.info}>
@@ -78,7 +78,9 @@ const Penalties = ({ userId }: Props) => {
                 )}
               </Flex>
 
-              <div className={styles.divider} />
+              {index !== penalties.length - 1 && (
+                <div className={styles.divider} />
+              )}
             </>
           ))}
         </>
@@ -95,8 +97,6 @@ const Penalties = ({ userId }: Props) => {
               <span>Du har ingen prikker!</span>
             </Flex>
           </Flex>
-
-          <div className={styles.divider} />
         </>
       )}
 

--- a/app/routes/users/components/PenaltyForm.tsx
+++ b/app/routes/users/components/PenaltyForm.tsx
@@ -74,6 +74,8 @@ const PenaltyForm = ({ userId }: Props) => {
 
   return (
     <Flex column gap="var(--spacing-md)">
+      <div className={styles.divider} />
+
       <div>
         {!sent ? (
           <Button onClick={handleHide}>


### PR DESCRIPTION
# Description

Very small styling error that has bugged me for some time. If the user is missing the action grant and does not have a "add penalty" button, the divider is not needed.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="361" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/ed6f5efb-a586-41d1-a094-c9d97a383a68">
        </td>
        <td>
            <img width="361" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/e2af5eeb-a188-4c94-b917-bfa463e9aeb7">
        </td>
    </tr>
    <tr>
        <td>
            <img width="361" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/445555b8-f5ec-4d42-a831-6296e99a04c0">
        </td>
        <td>
            <img width="361" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/d1168187-4b56-40c0-adb0-806137d7c385">
        </td>
    </tr>
    <tr>
        <td>
            <img width="361" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/7b7a29f6-5127-49c1-b94b-fe07e659bfb8">
        </td>
        <td>
            <img width="361" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/3a180e07-3ca3-4aa9-80c3-7eae157cfb0b">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above. Works fine with (multiple) penalties as well