### PR TITLE
Fix joining and leaving interest groups

### DIFF
--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -53,6 +53,7 @@ type ButtonRowProps = {
 };
 
 const ButtonRow = ({ group }: ButtonRowProps) => {
+  const dispatch = useAppDispatch();
   const currentUser = useCurrentUser();
   if (!currentUser) return null;
 


### PR DESCRIPTION
# Description

I noticed this little bug while refactoring some other stuff. The missing dispatch definition makes it impossible to join or leave interest groups. 

# Result

It is once again possible to join or leave interest groups.

# Testing

- [x] I have thoroughly tested my changes.

It previously threw an error when attempting to join or leave, it now doesn't. 