### PR TITLE
Improve lego adaptor selectors

### DIFF
--- a/app/reducers/comments.ts
+++ b/app/reducers/comments.ts
@@ -97,6 +97,6 @@ export const { selectEntities: selectCommentEntities } =
 
 export const selectCommentsByIds = createSelector(
   selectCommentEntities,
-  (_: RootState, ids: EntityId[]) => ids,
+  (_: RootState, ids: EntityId[] = []) => ids,
   (entities, ids) => ids.map((id) => entities[id]),
 );

--- a/app/reducers/groups.ts
+++ b/app/reducers/groups.ts
@@ -81,7 +81,7 @@ export const {
 
 export const selectGroupsByIds = createSelector(
   selectGroupEntities,
-  (_: RootState, groupIds: EntityId[]) => groupIds,
+  (_: RootState, groupIds: EntityId[] = []) => groupIds,
   (groupsById, groupIds) => groupIds.map((id) => groupsById[id]),
 );
 export const selectGroupsByType = selectGroupsByField('type');

--- a/app/reducers/restrictedMails.ts
+++ b/app/reducers/restrictedMails.ts
@@ -35,4 +35,4 @@ export default restrictedMailSlice.reducer;
 export const {
   selectAll: selectRestrictedMails,
   selectById: selectRestrictedMailById,
-} = legoAdapter.getSelectors<RootState>((state) => state.restrictedMails);
+} = legoAdapter.getSelectors((state: RootState) => state.restrictedMails);

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -68,7 +68,7 @@ export const selectUserByUsername = selectUsersByField('username').single;
 
 export const selectUsersByIds = createSelector(
   selectUserEntities,
-  (_: RootState, userIds: EntityId[]) => userIds,
+  (_: RootState, userIds: EntityId[] = []) => userIds,
   (userEntities, userIds) => userIds.map((userId) => userEntities[userId]),
 );
 
@@ -85,7 +85,7 @@ export const selectUserWithGroups = createSelector(
   ) =>
     username
       ? selectUserByUsername(state, username)
-      : selectUserById(state, userId!),
+      : selectUserById(state, userId),
   selectGroupEntities,
   (user, groupEntities) => {
     if (!user) return;

--- a/app/routes/admin/email/components/EmailListEditor.tsx
+++ b/app/routes/admin/email/components/EmailListEditor.tsx
@@ -58,13 +58,13 @@ const EmailListEditor = () => {
   const { emailListId } = useParams<{ emailListId: string }>();
   const isNew = emailListId === 'new';
   const emailList = useAppSelector((state) =>
-    selectEmailListById(state, emailListId!),
-  ) as DetailedEmailList | undefined;
+    selectEmailListById<DetailedEmailList>(state, emailListId),
+  );
   const users = useAppSelector((state) =>
-    selectUsersByIds(state, emailList?.users || []),
+    selectUsersByIds(state, emailList?.users),
   );
   const groups = useAppSelector((state) =>
-    selectGroupsByIds(state, emailList?.groups || []),
+    selectGroupsByIds(state, emailList?.groups),
   );
 
   const dispatch = useAppDispatch();

--- a/app/routes/admin/email/components/EmailUserEditor.tsx
+++ b/app/routes/admin/email/components/EmailUserEditor.tsx
@@ -21,6 +21,7 @@ import { selectUserById } from 'app/reducers/users';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { AutocompleteContentType } from 'app/store/models/Autocomplete';
 import { createValidator, required } from 'app/utils/validation';
+import type { PublicUser } from 'app/store/models/User';
 
 type AutocompleteUserValue = {
   title: string;
@@ -36,10 +37,10 @@ const EmailUserEditor = () => {
   const isNew = emailUserId === undefined;
   const fetching = useAppSelector((state) => state.emailUsers.fetching);
   const emailUser = useAppSelector((state) =>
-    selectEmailUserById(state, emailUserId!),
+    selectEmailUserById(state, emailUserId),
   );
   const user = useAppSelector((state) =>
-    selectUserById(state, emailUser?.user),
+    selectUserById<PublicUser>(state, emailUser?.user),
   );
 
   const dispatch = useAppDispatch();

--- a/app/routes/admin/email/components/RestrictedMailEditor.tsx
+++ b/app/routes/admin/email/components/RestrictedMailEditor.tsx
@@ -68,7 +68,7 @@ const RestrictedMailEditor = () => {
   const { restrictedMailId } = useParams<{ restrictedMailId: string }>();
   const isNew = restrictedMailId === undefined;
   const restrictedMail = useAppSelector((state) =>
-    selectRestrictedMailById(state, restrictedMailId!),
+    selectRestrictedMailById(state, restrictedMailId),
   );
 
   const initialValues = isNew

--- a/app/routes/admin/groups/components/GroupForm/index.tsx
+++ b/app/routes/admin/groups/components/GroupForm/index.tsx
@@ -18,6 +18,7 @@ import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { EDITOR_EMPTY } from 'app/utils/constants';
 import { createValidator, required } from 'app/utils/validation';
 import styles from './index.css';
+import type { DetailedGroup } from 'app/store/models/Group';
 
 type FormValues = {
   name: string;
@@ -44,8 +45,10 @@ type Props = {
 
 const GroupForm = ({ isInterestGroup }: Props) => {
   const { groupId } = useParams<{ groupId: string }>();
-  const group = useAppSelector((state) => selectGroupById(state, groupId!));
-  const isNew = !group;
+  const group = useAppSelector((state) =>
+    selectGroupById<DetailedGroup>(state, groupId),
+  );
+  const isNew = !groupId;
 
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
@@ -55,7 +58,7 @@ const GroupForm = ({ isInterestGroup }: Props) => {
       values.type = GroupType.Interest;
     }
     dispatch(isNew ? createGroup(values) : editGroup(values)).then(() => {
-      if (group.type === 'interesse') {
+      if (group?.type === 'interesse') {
         navigate(`/interest-groups/${group.id}`);
       }
     });
@@ -76,7 +79,7 @@ const GroupForm = ({ isInterestGroup }: Props) => {
       initialValues={
         isNew
           ? initialValues
-          : { ...group, text: group.text ? group.text : EDITOR_EMPTY } // editor does not render if text is empty string
+          : { ...group, text: group?.text ? group.text : EDITOR_EMPTY } // editor does not render if text is empty string
       }
     >
       {({ handleSubmit }) => (

--- a/app/routes/admin/groups/components/GroupPage.tsx
+++ b/app/routes/admin/groups/components/GroupPage.tsx
@@ -14,6 +14,7 @@ import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import { selectGroupById, selectAllGroups } from 'app/reducers/groups';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './GroupPage.css';
+import type { DetailedGroup, PublicGroup } from 'app/store/models/Group';
 
 const GroupForm = loadable(() => import('./GroupForm'));
 const GroupMembers = loadable(() => import('./GroupMembers'));
@@ -60,8 +61,10 @@ const GroupPageNavigation = ({
 
 const GroupPage = () => {
   const { groupId } = useParams<{ groupId?: string }>();
-  const group = useAppSelector((state) => selectGroupById(state, groupId!));
-  const groups = useAppSelector(selectAllGroups);
+  const group = useAppSelector((state) =>
+    selectGroupById<DetailedGroup>(state, groupId),
+  );
+  const groups = useAppSelector(selectAllGroups<PublicGroup>);
 
   const location = useLocation();
 

--- a/app/routes/admin/groups/components/GroupPermissions.tsx
+++ b/app/routes/admin/groups/components/GroupPermissions.tsx
@@ -123,7 +123,9 @@ const PermissionList = ({ group }: PermissionListProps) => {
 
 const GroupPermissions = () => {
   const { groupId } = useParams<{ groupId: string }>();
-  const group = useAppSelector((state) => selectGroupById(state, groupId!));
+  const group = useAppSelector((state) =>
+    selectGroupById<DetailedGroup>(state, groupId),
+  );
 
   return (
     <div>

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -86,10 +86,10 @@ const ArticleDetail = () => {
   ) as DetailedArticle | undefined;
 
   const comments = useAppSelector((state) =>
-    selectCommentsByIds(state, article?.comments ?? []),
+    selectCommentsByIds(state, article?.comments),
   );
   const authors = useAppSelector((state) =>
-    selectUsersByIds(state, article?.authors ?? []),
+    selectUsersByIds(state, article?.authors),
   );
 
   const navigate = useNavigate();

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -66,12 +66,12 @@ const ArticleEditor = () => {
   const isNew = articleId === undefined;
 
   const article = useAppSelector((state) =>
-    selectArticleById(state, articleId),
-  ) as AdminDetailedArticle | undefined;
+    selectArticleById<AdminDetailedArticle>(state, articleId),
+  );
   const fetching = useAppSelector((state) => state.articles.fetching);
 
   let authors = useAppSelector((state) =>
-    selectUsersByIds(state, article?.authors || []),
+    selectUsersByIds(state, article?.authors),
   );
   if (authors.length === 0 && currentUser) {
     authors = [currentUser];

--- a/app/routes/forum/components/ForumDetail.tsx
+++ b/app/routes/forum/components/ForumDetail.tsx
@@ -23,8 +23,8 @@ const ForumDetail = () => {
   );
 
   const forum = useAppSelector((state) =>
-    selectForumById(state, forumId),
-  ) as DetailedForum;
+    selectForumById<DetailedForum>(state, forumId),
+  );
   const detailActionGrant = forum?.actionGrant;
 
   if (!forum || !detailActionGrant) {

--- a/app/routes/forum/components/ForumList.tsx
+++ b/app/routes/forum/components/ForumList.tsx
@@ -14,7 +14,7 @@ const ForumList = () => {
 
   usePreparedEffect('fetchAllForums', () => dispatch(fetchForums()), []);
 
-  const forums: PublicForum[] = useAppSelector(selectAllForums);
+  const forums = useAppSelector(selectAllForums<PublicForum>);
   const fetching = useAppSelector((state) => state.forums.fetching);
   const actionGrant = useAppSelector((state) => state.forums.actionGrant);
 

--- a/app/routes/forum/components/ThreadDetail.tsx
+++ b/app/routes/forum/components/ThreadDetail.tsx
@@ -10,7 +10,6 @@ import { useCurrentUser } from 'app/reducers/auth';
 import { selectCommentsByIds } from 'app/reducers/comments';
 import { selectThreadById } from 'app/reducers/threads';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
-import type Comment from 'app/store/models/Comment';
 import type { DetailedThread } from 'app/store/models/Forum';
 
 type ThreadDetailParams = {
@@ -31,11 +30,11 @@ const ThreadDetail = () => {
   );
 
   const thread = useAppSelector((state) =>
-    selectThreadById(state, threadId),
-  ) as DetailedThread;
+    selectThreadById<DetailedThread>(state, threadId),
+  );
 
-  const comments: Comment[] = useAppSelector((state) =>
-    selectCommentsByIds(state, thread?.comments || []),
+  const comments = useAppSelector((state) =>
+    selectCommentsByIds(state, thread?.comments),
   );
 
   const detailActionGrant = thread?.actionGrant;

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -26,7 +26,10 @@ import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './InterestGroup.css';
 import InterestGroupMemberList from './InterestGroupMemberList';
 import type { Group, GroupMembership } from 'app/models';
-import type { DetailedGroup } from 'app/store/models/Group';
+import type {
+  DetailedGroup,
+  PublicDetailedGroup,
+} from 'app/store/models/Group';
 import type Membership from 'app/store/models/Membership';
 
 type MembersProps = {
@@ -115,7 +118,7 @@ const Contact = ({ group }: { group: Group }) => {
 const InterestGroupDetail = () => {
   const { groupId } = useParams();
   const selectedGroup = useAppSelector((state) =>
-    selectGroupById(state, groupId!),
+    selectGroupById<PublicDetailedGroup>(state, groupId),
   );
   const memberships = useAppSelector((state) =>
     selectMembershipsForGroup(state, { groupId }),

--- a/app/routes/interestgroups/components/InterestGroupEdit.tsx
+++ b/app/routes/interestgroups/components/InterestGroupEdit.tsx
@@ -9,11 +9,12 @@ import { selectGroupById } from 'app/reducers/groups';
 import GroupForm from 'app/routes/admin/groups/components/GroupForm';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
+import type { PublicDetailedGroup } from 'app/store/models/Group';
 
 const InterestGroupEdit = () => {
   const { groupId } = useParams<{ groupId: string }>();
   const interestGroup = useAppSelector((state) =>
-    selectGroupById(state, groupId!),
+    selectGroupById<PublicDetailedGroup>(state, groupId),
   );
   const editing = groupId !== undefined;
 

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -39,7 +39,7 @@ import type { Dateish } from 'app/models';
 import type { DetailedMeeting } from 'app/store/models/Meeting';
 import type { PublicUser } from 'app/store/models/User';
 
-const UserLink = ({ user }: { user: PublicUser }) =>
+const UserLink = ({ user }: { user?: PublicUser }) =>
   user && !isEmpty(user) ? (
     <Link to={`/users/${user.username}`}>{user.fullName}</Link>
   ) : (
@@ -55,18 +55,16 @@ const MeetingDetails = () => {
   const currentUser = useCurrentUser();
   const icalToken = currentUser?.icalToken;
   const meeting = useAppSelector((state) =>
-    selectMeetingById(state, meetingId),
-  ) as DetailedMeeting | undefined;
+    selectMeetingById<DetailedMeeting>(state, meetingId),
+  );
   const comments = useAppSelector((state) =>
-    selectCommentsByIds(state, meeting?.comments ?? []),
+    selectCommentsByIds(state, meeting?.comments),
   );
   const reportAuthor = useAppSelector((state) =>
-    meeting?.reportAuthor
-      ? selectUserById(state, meeting.reportAuthor)
-      : undefined,
+    selectUserById<PublicUser>(state, meeting?.reportAuthor),
   );
   const createdBy = useAppSelector((state) =>
-    meeting?.createdBy ? selectUserById(state, meeting?.createdBy) : undefined,
+    selectUserById<PublicUser>(state, meeting?.createdBy),
   );
   const meetingInvitations = useAppSelector((state) =>
     selectMeetingInvitationsForMeeting(state, meetingId),
@@ -76,7 +74,7 @@ const MeetingDetails = () => {
       currentUser &&
       selectMeetingInvitationByMeetingIdAndUserId(
         state,
-        meetingId!,
+        meetingId,
         currentUser.id,
       ),
   );

--- a/app/routes/tags/components/TagCloud.tsx
+++ b/app/routes/tags/components/TagCloud.tsx
@@ -7,6 +7,7 @@ import { fetchAll } from 'app/actions/TagActions';
 import { Content } from 'app/components/Content';
 import { selectAllTags } from 'app/reducers/tags';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import type { ListTag } from 'app/store/models/Tag';
 import type { RendererFunction, Tag as CloudTag } from 'react-tagcloud';
 
 const tagRenderer: RendererFunction = (tag, size, color) => (
@@ -25,7 +26,7 @@ const tagRenderer: RendererFunction = (tag, size, color) => (
 );
 
 const TagCloud = () => {
-  const tags = useAppSelector(selectAllTags);
+  const tags = useAppSelector(selectAllTags<ListTag>);
   const fetching = useAppSelector((state) => state.tags.fetching);
 
   const dispatch = useAppDispatch();

--- a/app/routes/tags/components/TagDetail.tsx
+++ b/app/routes/tags/components/TagDetail.tsx
@@ -37,9 +37,9 @@ type TagDetailParams = {
 };
 const TagDetail = () => {
   const { tagId } = useParams<TagDetailParams>() as TagDetailParams;
-  const tag = useAppSelector((state) => selectTagById(state, tagId)) as
-    | DetailedTag
-    | undefined;
+  const tag = useAppSelector((state) =>
+    selectTagById<DetailedTag>(state, tagId),
+  );
   const fetching = useAppSelector((state) => state.tags.fetching);
 
   const dispatch = useAppDispatch();

--- a/app/routes/users/components/UserSettingsOAuth2Form.tsx
+++ b/app/routes/users/components/UserSettingsOAuth2Form.tsx
@@ -32,9 +32,7 @@ const UserSettingsOAuth2Form = () => {
   const { applicationId } = useParams<{ applicationId?: string }>();
   const isNew = applicationId === undefined;
   const application = useAppSelector((state) =>
-    applicationId
-      ? selectOAuth2ApplicationById(state, applicationId)
-      : undefined,
+    selectOAuth2ApplicationById(state, applicationId),
   );
 
   const dispatch = useAppDispatch();

--- a/app/store/models/RestrictedMail.d.ts
+++ b/app/store/models/RestrictedMail.d.ts
@@ -26,13 +26,13 @@ export type ListRestrictedMail = Pick<
 
 export type NormalRestrictedMail = Pick<
   CompleteRestrictedMail,
-  'users',
-  'groups',
-  'events',
-  'meetings',
-  'rawAddresses',
-  'weekly',
-  'hideSender'
+  | 'users'
+  | 'groups'
+  | 'events'
+  | 'meetings'
+  | 'rawAddresses'
+  | 'weekly'
+  | 'hideSender'
 > &
   ListRestrictedMail;
 

--- a/app/store/models/entities.ts
+++ b/app/store/models/entities.ts
@@ -70,9 +70,6 @@ export enum EntityType {
   Tags = 'tags',
   Thread = 'threads',
   Users = 'users',
-  FollowersCompany = 'followersCompany',
-  FollowersUser = 'followersUser',
-  FollowersEvent = 'followersEvent',
 }
 
 // Most fetch success redux actions are normalized such that payload.entities is a subset of this interface.
@@ -112,9 +109,6 @@ export default interface Entities {
   [EntityType.Tags]: Record<ID, UnknownTag>;
   [EntityType.Thread]: Record<ID, UnknownThread>;
   [EntityType.Users]: Record<ID, UnknownUser>;
-  [EntityType.FollowersCompany]: Record<ID, unknown>; // AFAIK unused
-  [EntityType.FollowersUser]: Record<ID, unknown>; // AFAIK unused
-  [EntityType.FollowersEvent]: Record<ID, unknown>; // AFAIK unused
 }
 
 type InferEntityType<T> = {

--- a/app/utils/legoAdapter/buildPaginationReducer.ts
+++ b/app/utils/legoAdapter/buildPaginationReducer.ts
@@ -16,9 +16,9 @@ interface Query {
   [key: string]: string;
 }
 
-export type Pagination = {
+export type Pagination<Id extends EntityId = EntityId> = {
   query: ParsedQs;
-  ids: EntityId[];
+  ids: Id[];
   hasMore: boolean;
   hasMoreBackwards: boolean;
   next?: ParsedQs;


### PR DESCRIPTION
# Description

The entities contained in the redux-store are of unknown type, meaning a meeting might f.ex. either be from a meeting list or the detailed model used on the meeting page. When selecting them we usually know what type we are expecting, meaning we will need to typecast it (or do some insane type checking to make typescript infer it). With this new API this typecast is easier, and less error-prone as you can't forget to include the possibility of `undefined`!

```typescript
const detailedMeeting = useAppSelector((state) => selectMeetingById<DetailedMeeting>(state, meetingId));
const listMeetings = useAppSelector(selectAllMeetings<ListMeeting>);
```
These will get the following types:
```typescript
detailedMeeting: DetailedMeeting | undefined
listMeetings: ListMeeting[]
```

`selectById()`  now also allows `undefined` as Id, and in that case simply returns `undefined`.
Some `selectByIds`-functions now also allows undefined, which defaults to an empty list of ids.

# Result

Easier type overrides when using selectors, and less `undefined` checking in ids.

# Testing

- [x] I have thoroughly tested my changes.

Have tested a bit, don't see why this should break anything