### PR TITLE
Type and refactor notificationSettings redux slice

### DIFF
--- a/app/reducers/__tests__/notificationSettings.spec.ts
+++ b/app/reducers/__tests__/notificationSettings.spec.ts
@@ -3,7 +3,7 @@ import { NotificationSettings } from 'app/actions/ActionTypes';
 import notificationSettings from '../notificationSettings';
 
 describe('reducers', () => {
-  const prevState = {
+  const prevState: ReturnType<typeof notificationSettings> = {
     channels: [],
     notificationTypes: [],
     settings: {},

--- a/app/reducers/notificationSettings.ts
+++ b/app/reducers/notificationSettings.ts
@@ -1,45 +1,63 @@
-import { produce } from 'immer';
-import keyBy from 'lodash/keyBy';
+import { createSlice } from '@reduxjs/toolkit';
+import { keyBy } from 'lodash';
+import { createSelector } from 'reselect';
 import { NotificationSettings } from 'app/actions/ActionTypes';
-import type { Reducer } from '@reduxjs/toolkit';
+import type { RootState } from 'app/store/createRootReducer';
+import type { AnyAction } from 'redux';
 
 type State = {
-  channels: Array<string>;
-  notificationTypes: Array<string>;
-  settings: Record<string, any>;
+  channels: string[];
+  notificationTypes: string[];
+  settings: Record<
+    string,
+    {
+      notificationType: string;
+      enabled: boolean;
+      channels: string[];
+    }
+  >;
 };
-const initialState = {
+const initialState: State = {
   channels: [],
   notificationTypes: [],
   settings: {},
 };
-const notificationSettings: Reducer<State> = produce((newState, action) => {
-  switch (action.type) {
-    case NotificationSettings.FETCH_ALTERNATIVES.SUCCESS:
-      newState.channels = action.payload.channels;
-      newState.notificationTypes = action.payload.notificationTypes;
-      break;
-
-    case NotificationSettings.FETCH.SUCCESS:
-      newState.settings = transform(action.payload);
-      break;
-
-    case NotificationSettings.UPDATE.SUCCESS: {
-      newState.settings[action.payload.notificationType] = action.payload;
-      break;
-    }
-
-    default:
-      break;
-  }
-}, initialState);
-export default notificationSettings;
-export const transform = (settings: any) => keyBy(settings, 'notificationType');
-export const selectNotificationSettingsAlternatives = (
-  state: Record<string, any>,
-) => ({
-  channels: state.notificationSettings.channels,
-  notificationTypes: state.notificationSettings.notificationTypes,
+const notificationSettingsSlice = createSlice({
+  name: 'notificationSettings',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(
+      NotificationSettings.FETCH_ALTERNATIVES.SUCCESS,
+      (state, action: AnyAction) => {
+        state.channels = action.payload.channels;
+        state.notificationTypes = action.payload.notificationTypes;
+      },
+    );
+    builder.addCase(
+      NotificationSettings.FETCH.SUCCESS,
+      (state, action: AnyAction) => {
+        state.settings = keyBy(action.payload, 'notificationType');
+      },
+    );
+    builder.addCase(
+      NotificationSettings.UPDATE.SUCCESS,
+      (state, action: AnyAction) => {
+        state.settings[action.payload.notificationType] = action.payload;
+      },
+    );
+  },
 });
-export const selectNotificationSettings = (state: Record<string, any>) =>
-  state.notificationSettings.settings || {};
+
+export default notificationSettingsSlice.reducer;
+
+export const selectNotificationSettingsAlternatives = createSelector(
+  (state: RootState) => state.notificationSettings.channels,
+  (state: RootState) => state.notificationSettings.notificationTypes,
+  (channels, notificationTypes) => ({
+    channels,
+    notificationTypes,
+  }),
+);
+export const selectNotificationSettings = (state: RootState) =>
+  state.notificationSettings.settings;


### PR DESCRIPTION
# Description

Refactor the notificationSettings reducer/slice to use `createSlice`, and fully type the state (not the actions unfortunately).

# Result

See diff. Slightly better type safety, and easier to improve typing in the future.

# Testing

- [x] I have thoroughly tested my changes.

Have tested the notification settings page manually, it seems to both display and update correctly.

---

ABA-688