### PR TITLE
Add reactions to comments

### DIFF
--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -15,6 +15,7 @@ import styles from './Comment.css';
 import type CommentType from 'app/store/models/Comment';
 import type { ContentAuthors } from 'app/store/models/Comment';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
+import LegoReactions from '../LegoReactions';
 
 type Props = {
   comment: CommentType;
@@ -109,6 +110,9 @@ const Comment = ({
           content={text ? text : '<p>Kommentar slettet</p>'}
         />
 
+        <LegoReactions
+          parentEntity={{ ...comment, contentTarget: comment.contentSelf }}
+        />
         {author && (
           <Button flat onPress={() => setReplyOpen(!replyOpen)}>
             {replyOpen ? (

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -11,11 +11,11 @@ import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
 import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
+import LegoReactions from '../LegoReactions';
 import styles from './Comment.css';
 import type CommentType from 'app/store/models/Comment';
 import type { ContentAuthors } from 'app/store/models/Comment';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
-import LegoReactions from '../LegoReactions';
 
 type Props = {
   comment: CommentType;

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -111,7 +111,10 @@ const Comment = ({
         />
 
         <LegoReactions
-          parentEntity={{ ...comment, contentTarget: comment.contentSelf }}
+          parentEntity={{
+            ...comment,
+            contentTarget: comment.contentTargetSelf,
+          }}
         />
         {author && (
           <Button flat onPress={() => setReplyOpen(!replyOpen)}>

--- a/app/components/Comments/__tests__/CommentTree.spec.tsx
+++ b/app/components/Comments/__tests__/CommentTree.spec.tsx
@@ -15,6 +15,10 @@ const store = configureStore([])({
   users: {
     entities: {},
   },
+  emojis: {
+    ids: [],
+    entities: {},
+  },
 });
 
 describe('<CommentTree />', () => {

--- a/app/reducers/comments.ts
+++ b/app/reducers/comments.ts
@@ -9,6 +9,7 @@ import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
 import type { RootState } from 'app/store/createRootReducer';
 import type { AnyAction } from 'redux';
+import { addReactionCases } from './reactions';
 
 export const addCommentCases = (
   forTargetType: EntityType,
@@ -39,6 +40,8 @@ const commentSlice = createSlice({
   reducers: {},
   extraReducers: legoAdapter.buildReducers({
     extraCases: (addCase) => {
+      addReactionCases(EntityType.Comments, addCase);
+
       addCase(Comment.DELETE.SUCCESS, (state, action: AnyAction) => {
         const comment = state.entities[action.meta.id];
         if (comment) {

--- a/app/reducers/comments.ts
+++ b/app/reducers/comments.ts
@@ -4,12 +4,12 @@ import { Comment } from 'app/actions/ActionTypes';
 import { EntityType } from 'app/store/models/entities';
 import { parseContentTarget } from 'app/store/utils/contentTarget';
 import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import { addReactionCases } from './reactions';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
 import type { RootState } from 'app/store/createRootReducer';
 import type { AnyAction } from 'redux';
-import { addReactionCases } from './reactions';
 
 export const addCommentCases = (
   forTargetType: EntityType,

--- a/app/store/models/Comment.d.ts
+++ b/app/store/models/Comment.d.ts
@@ -9,7 +9,7 @@ export interface Comment {
   text: string | null;
   author: PublicUser | null;
   contentTarget: ContentTarget;
-  contentSelf: ContentTarget;
+  contentTargetSelf: ContentTarget;
   createdAt: Dateish;
   updatedAt: Dateish;
   parent: EntityId | null;

--- a/app/store/models/Comment.d.ts
+++ b/app/store/models/Comment.d.ts
@@ -1,8 +1,8 @@
 import type { EntityId } from '@reduxjs/toolkit';
+import type { ReactionsGrouped } from './store/models/Reaction';
 import type { Dateish } from 'app/models';
 import type { PublicUser } from 'app/store/models/User';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
-import type { ReactionsGrouped } from './store/models/Reaction';
 
 export interface Comment {
   id: EntityId;

--- a/app/store/models/Comment.d.ts
+++ b/app/store/models/Comment.d.ts
@@ -1,5 +1,5 @@
-import type { EntityId } from '@reduxjs/toolkit';
 import type { ReactionsGrouped } from './store/models/Reaction';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { PublicUser } from 'app/store/models/User';
 import type { ContentTarget } from 'app/store/utils/contentTarget';

--- a/app/store/models/Comment.d.ts
+++ b/app/store/models/Comment.d.ts
@@ -2,15 +2,18 @@ import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { PublicUser } from 'app/store/models/User';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
+import type { ReactionsGrouped } from './store/models/Reaction';
 
 export interface Comment {
   id: EntityId;
   text: string | null;
   author: PublicUser | null;
   contentTarget: ContentTarget;
+  contentSelf: ContentTarget;
   createdAt: Dateish;
   updatedAt: Dateish;
   parent: EntityId | null;
+  reactionsGrouped?: ReactionsGrouped;
 }
 
 export default Comment;

--- a/app/utils/getEntityType.ts
+++ b/app/utils/getEntityType.ts
@@ -8,6 +8,7 @@ const entityTypeMappings = {
   'meetings.meeting': EntityType.Meetings,
   'gallery.gallerypicture': EntityType.GalleryPictures,
   'forums.thread': EntityType.Thread,
+  'comments.comment': EntityType.Comments,
 };
 export type EntityServerName = keyof typeof entityTypeMappings;
 export default function getEntityType(


### PR DESCRIPTION
# Description

Adds reactions to comments.

I faced a small issue and came up with a "hacky" solution: Models that can be reacted on, like articles and meetings, have a contentTarget property that determines what model the reaction should be added to. This property points to the model itself, so that if you react to an article, the reaction is added to that article. I imagined that I could to the same thing for comments: adding a contentTarget property that points back to the comment itself. However, comments already have a contentTarget property that is used to link to the parent model, like an article, causing reactions to be added to the article instead of the comment (never really tested that this actually happened, but it's my guess). My workaround was to add a contentSelf property and pass it to LegoReactions as the contentTarget property. Do you guys think this implementation is alright?


# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [ ] Changes look good with slower Internet connections.

![Screencast from 2024-03-28 13-23-09.webm](https://github.com/webkom/lego-webapp/assets/66320400/67e7e77c-dcb6-4c66-802a-aec226271d1e)

# Testing

- [ ] I have thoroughly tested my changes.

Adding and deletion works.

I haven't tested for comments that were made before these changes yet.

---

Resolves ABA-678
