### PR TITLE
Replace all other id types with EntityId

### DIFF
--- a/app/actions/AnnouncementsActions.ts
+++ b/app/actions/AnnouncementsActions.ts
@@ -1,8 +1,8 @@
 import callAPI from 'app/actions/callAPI';
 import { announcementsSchema } from 'app/reducers';
 import { Announcements } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { FormValues as CreateAnnouncementFormValues } from 'app/routes/announcements/components/AnnouncementsCreate';
-import type { ID } from 'app/store/models';
 import type {
   DetailedAnnouncement,
   ListAnnouncement,
@@ -34,7 +34,7 @@ export function createAnnouncement(body: CreateAnnouncementFormValues) {
   });
 }
 
-export function sendAnnouncement(announcementId: ID) {
+export function sendAnnouncement(announcementId: EntityId) {
   return callAPI<{ status: string }>({
     types: Announcements.SEND,
     endpoint: `/announcements/${announcementId}/send/`,
@@ -47,7 +47,7 @@ export function sendAnnouncement(announcementId: ID) {
   });
 }
 
-export function deleteAnnouncement(id: ID) {
+export function deleteAnnouncement(id: EntityId) {
   return callAPI({
     types: Announcements.DELETE,
     endpoint: `/announcements/${id}/`,

--- a/app/actions/ArticleActions.ts
+++ b/app/actions/ArticleActions.ts
@@ -2,10 +2,10 @@ import { omit } from 'lodash';
 import callAPI from 'app/actions/callAPI';
 import { articleSchema } from 'app/reducers';
 import { Article } from './ActionTypes';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { DetailedArticle } from 'app/store/models/Article';
 
-export function fetchArticle(articleId: ID) {
+export function fetchArticle(articleId: EntityId) {
   return callAPI<DetailedArticle>({
     types: Article.FETCH,
     endpoint: `/articles/${articleId}/`,
@@ -30,7 +30,7 @@ export function createArticle(data) {
   });
 }
 
-export function deleteArticle(id: ID) {
+export function deleteArticle(id: EntityId) {
   return callAPI({
     types: Article.DELETE,
     endpoint: `/articles/${id}/`,

--- a/app/actions/CommentActions.ts
+++ b/app/actions/CommentActions.ts
@@ -1,7 +1,7 @@
 import callAPI from 'app/actions/callAPI';
 import { commentSchema } from 'app/reducers';
 import { Comment } from './ActionTypes';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type CommentType from 'app/store/models/Comment';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
@@ -12,7 +12,7 @@ export function addComment({
 }: {
   text: string;
   contentTarget: ContentTarget;
-  parent?: ID;
+  parent?: EntityId;
 }) {
   return callAPI<CommentType>({
     types: Comment.ADD,
@@ -35,7 +35,10 @@ export function addComment({
   });
 }
 
-export function deleteComment(commentId: ID, contentTarget: ContentTarget) {
+export function deleteComment(
+  commentId: EntityId,
+  contentTarget: ContentTarget,
+) {
   return callAPI({
     types: Comment.DELETE,
     endpoint: `/comments/${commentId}/`,

--- a/app/actions/CompanyActions.ts
+++ b/app/actions/CompanyActions.ts
@@ -7,9 +7,9 @@ import {
 import createQueryString from 'app/utils/createQueryString';
 import { semesterToText } from '../routes/companyInterest/utils';
 import { Company, Event } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
 import type { FormValues as CompanyContactEditorFormValues } from 'app/routes/bdb/components/CompanyContactEditor';
-import type { ID } from 'app/store/models';
 import type {
   AdminListCompany,
   CompanyContact,
@@ -46,7 +46,7 @@ export function fetchAllAdmin() {
   });
 }
 
-export function fetch(companyId: ID) {
+export function fetch(companyId: EntityId) {
   return callAPI<DetailedCompany>({
     types: Company.FETCH,
     endpoint: `/companies/${companyId}/`,
@@ -58,7 +58,7 @@ export function fetch(companyId: ID) {
   });
 }
 
-export function fetchAdmin(companyId: ID) {
+export function fetchAdmin(companyId: EntityId) {
   return callAPI({
     types: Company.FETCH,
     endpoint: `/bdb/${companyId}/`,
@@ -114,7 +114,7 @@ export function editCompany({ companyId, ...data }: Record<string, any>) {
   });
 }
 
-export function deleteCompany(companyId: ID) {
+export function deleteCompany(companyId: EntityId) {
   return callAPI({
     types: Company.DELETE,
     endpoint: `/bdb/${companyId}/`,
@@ -144,8 +144,8 @@ export function editSemesterStatus({
   semesterStatusId,
   ...data
 }: {
-  companyId: ID;
-  semesterStatusId: ID;
+  companyId: EntityId;
+  semesterStatusId: EntityId;
   data: Record<string, any>;
 }) {
   return callAPI<DetailedSemesterStatus>({
@@ -161,7 +161,10 @@ export function editSemesterStatus({
   });
 }
 
-export function deleteSemesterStatus(companyId: ID, semesterStatusId: ID) {
+export function deleteSemesterStatus(
+  companyId: EntityId,
+  semesterStatusId: EntityId,
+) {
   return callAPI({
     types: Company.DELETE_SEMESTER_STATUS,
     endpoint: `/companies/${companyId}/semester-statuses/${semesterStatusId}/`,
@@ -175,7 +178,7 @@ export function deleteSemesterStatus(companyId: ID, semesterStatusId: ID) {
   });
 }
 
-export function fetchCompanyContacts({ companyId }: { companyId: ID }) {
+export function fetchCompanyContacts({ companyId }: { companyId: EntityId }) {
   return callAPI<CompanyContact[]>({
     types: Company.FETCH_COMPANY_CONTACT,
     endpoint: `/companies/${companyId}/company-contacts/`,
@@ -187,8 +190,8 @@ export function fetchCompanyContacts({ companyId }: { companyId: ID }) {
 }
 
 type CompanyContactEditorSubmitBody = {
-  companyId: ID;
-  companyContactId: ID;
+  companyId: EntityId;
+  companyContactId: EntityId;
 } & CompanyContactEditorFormValues;
 
 export function addCompanyContact({
@@ -240,7 +243,10 @@ export function editCompanyContact({
   });
 }
 
-export function deleteCompanyContact(companyId: ID, companyContactId: ID) {
+export function deleteCompanyContact(
+  companyId: EntityId,
+  companyContactId: EntityId,
+) {
   return callAPI({
     types: Company.DELETE_COMPANY_CONTACT,
     endpoint: `/companies/${companyId}/company-contacts/${companyContactId}/`,
@@ -300,7 +306,7 @@ export function editSemester({
   semester,
   activeInterestForm,
 }: {
-  id: ID;
+  id: EntityId;
   year: string;
   semester: string;
   activeInterestForm: boolean;

--- a/app/actions/CompanyInterestActions.ts
+++ b/app/actions/CompanyInterestActions.ts
@@ -2,9 +2,9 @@ import callAPI from 'app/actions/callAPI';
 import { companyInterestSchema } from 'app/reducers';
 import { addToast } from 'app/reducers/toasts';
 import { CompanyInterestForm } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
 import type { AppDispatch } from 'app/store/createStore';
-import type { ID } from 'app/store/models';
 import type {
   DetailedCompanyInterest,
   ListCompanyInterest,
@@ -22,7 +22,7 @@ export function fetchAll() {
   });
 }
 
-export function fetchCompanyInterest(companyInterestId: ID) {
+export function fetchCompanyInterest(companyInterestId: EntityId) {
   return callAPI<DetailedCompanyInterest>({
     types: CompanyInterestForm.FETCH,
     endpoint: `/company-interests/${companyInterestId}/`,
@@ -61,7 +61,7 @@ export function createCompanyInterest(
   };
 }
 
-export function deleteCompanyInterest(id: ID) {
+export function deleteCompanyInterest(id: EntityId) {
   return (dispatch: AppDispatch) => {
     return dispatch(
       callAPI({
@@ -83,7 +83,10 @@ export function deleteCompanyInterest(id: ID) {
   };
 }
 
-export function updateCompanyInterest(id: ID, data: CompanyInterestEntity) {
+export function updateCompanyInterest(
+  id: EntityId,
+  data: CompanyInterestEntity,
+) {
   return (dispatch: AppDispatch) => {
     return dispatch(
       callAPI({

--- a/app/actions/EmailListActions.ts
+++ b/app/actions/EmailListActions.ts
@@ -1,13 +1,13 @@
 import callAPI from 'app/actions/callAPI';
 import { emailListSchema } from 'app/reducers';
 import { EmailList } from './ActionTypes';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type {
   CreateEmailList,
   EditEmailList,
 } from 'app/store/models/EmailList';
 
-export function fetchEmailList(emailListId: ID) {
+export function fetchEmailList(emailListId: EntityId) {
   return callAPI({
     types: EmailList.FETCH,
     endpoint: `/email-lists/${emailListId}/`,

--- a/app/actions/EmailUserActions.ts
+++ b/app/actions/EmailUserActions.ts
@@ -1,11 +1,11 @@
 import callAPI from 'app/actions/callAPI';
 import { emailUserSchema } from 'app/reducers';
 import { EmailUser } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { EmailUserEntity } from 'app/reducers/emailUsers';
-import type { ID } from 'app/store/models';
 import type { Thunk } from 'app/types';
 
-export function fetchEmailUser(userId: ID) {
+export function fetchEmailUser(userId: EntityId) {
   return callAPI({
     types: EmailUser.FETCH,
     endpoint: `/email-users/${userId}/`,

--- a/app/actions/EventActions.ts
+++ b/app/actions/EventActions.ts
@@ -6,8 +6,8 @@ import {
 } from 'app/reducers';
 import createQueryString from 'app/utils/createQueryString';
 import { Event } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { AppDispatch } from 'app/store/createStore';
-import type { ID } from 'app/store/models';
 import type {
   DetailedEvent,
   ListEvent,
@@ -18,7 +18,7 @@ import type { Thunk, Action } from 'app/types';
 
 export const waitinglistPoolId = -1;
 
-export function fetchEvent(eventId: ID) {
+export function fetchEvent(eventId: EntityId) {
   return callAPI<DetailedEvent>({
     types: Event.FETCH,
     endpoint: `/events/${eventId}/`,
@@ -134,7 +134,7 @@ export const fetchList = ({
   });
 };
 
-export function fetchAdministrate(eventId: ID) {
+export function fetchAdministrate(eventId: EntityId) {
   return callAPI({
     types: Event.FETCH,
     endpoint: `/events/${eventId}/administrate/`,
@@ -145,7 +145,7 @@ export function fetchAdministrate(eventId: ID) {
   });
 }
 
-export function fetchAllergies(eventId: ID) {
+export function fetchAllergies(eventId: EntityId) {
   return callAPI({
     types: Event.FETCH,
     endpoint: `/events/${eventId}/allergies/`,
@@ -181,7 +181,7 @@ export function editEvent(event: Record<string, any>) {
   });
 }
 
-export function deleteEvent(eventId: ID) {
+export function deleteEvent(eventId: EntityId) {
   return callAPI({
     types: Event.DELETE,
     endpoint: `/events/${eventId}/`,
@@ -199,10 +199,10 @@ export function register({
   feedback,
   userId,
 }: {
-  eventId: ID;
+  eventId: EntityId;
   captchaResponse: string;
   feedback: string;
-  userId: ID;
+  userId: EntityId;
 }) {
   return callAPI({
     types: Event.REQUEST_REGISTER,
@@ -225,8 +225,8 @@ export function unregister({
   registrationId,
   admin = false,
 }: {
-  eventId: ID;
-  registrationId: ID;
+  eventId: EntityId;
+  registrationId: EntityId;
   admin?: boolean;
 }) {
   return callAPI({
@@ -243,9 +243,9 @@ export function unregister({
 }
 
 export function adminRegister(
-  eventId: ID,
-  userId: ID,
-  poolId: ID | undefined,
+  eventId: EntityId,
+  userId: EntityId,
+  poolId: EntityId | undefined,
   feedback: string,
   adminRegistrationReason: string,
 ) {
@@ -266,7 +266,7 @@ export function adminRegister(
   });
 }
 
-export function payment(eventId: ID) {
+export function payment(eventId: EntityId) {
   return callAPI({
     types: Event.PAYMENT_QUEUE,
     endpoint: `/events/${eventId}/payment/`,
@@ -278,8 +278,8 @@ export function payment(eventId: ID) {
 }
 
 export function updateFeedback(
-  eventId: ID,
-  registrationId: ID,
+  eventId: EntityId,
+  registrationId: EntityId,
   feedback: string,
 ) {
   return callAPI({
@@ -296,7 +296,7 @@ export function updateFeedback(
   });
 }
 
-export function markUsernamePresent(eventId: ID, username: string) {
+export function markUsernamePresent(eventId: EntityId, username: string) {
   return callAPI({
     types: Event.UPDATE_REGISTRATION,
     endpoint: `/events/${eventId}/registration_search/`,
@@ -308,8 +308,8 @@ export function markUsernamePresent(eventId: ID, username: string) {
 }
 
 export function updatePresence(
-  eventId: ID,
-  registrationId: ID,
+  eventId: EntityId,
+  registrationId: EntityId,
   presence: Presence,
 ) {
   return callAPI({
@@ -327,8 +327,8 @@ export function updatePresence(
 }
 
 export function updatePayment(
-  eventId: ID,
-  registrationId: ID,
+  eventId: EntityId,
+  registrationId: EntityId,
   paymentStatus: string,
 ): Thunk<Promise<Action | null | undefined>> {
   return callAPI({
@@ -344,7 +344,7 @@ export function updatePayment(
   });
 }
 
-export function follow(userId: ID, eventId: ID) {
+export function follow(userId: EntityId, eventId: EntityId) {
   return callAPI({
     types: Event.FOLLOW,
     enableOptimistic: true,
@@ -361,7 +361,7 @@ export function follow(userId: ID, eventId: ID) {
   });
 }
 
-export function unfollow(followId: ID, eventId: ID) {
+export function unfollow(followId: EntityId, eventId: EntityId) {
   return callAPI({
     types: Event.UNFOLLOW,
     endpoint: `/followers-event/${followId}/`,
@@ -375,7 +375,7 @@ export function unfollow(followId: ID, eventId: ID) {
   });
 }
 
-export function isUserFollowing(eventId: ID) {
+export function isUserFollowing(eventId: EntityId) {
   return callAPI<boolean>({
     types: Event.IS_USER_FOLLOWING,
     endpoint: `/followers-event/?target=${eventId}`,
@@ -387,7 +387,7 @@ export function isUserFollowing(eventId: ID) {
   });
 }
 
-export function fetchAnalytics(eventId: ID) {
+export function fetchAnalytics(eventId: EntityId) {
   return callAPI<
     {
       bounceRate: number | null;

--- a/app/actions/ForumActions.ts
+++ b/app/actions/ForumActions.ts
@@ -1,7 +1,7 @@
 import { forumSchema, threadSchema } from 'app/reducers';
 import { Forum, Thread } from './ActionTypes';
 import callAPI from './callAPI';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type {
   CreateForum,
   CreateThread,
@@ -27,7 +27,7 @@ export function fetchForums() {
   });
 }
 
-export function fetchForum(forumId: ID) {
+export function fetchForum(forumId: EntityId) {
   return callAPI<DetailedForum>({
     types: Forum.FETCH,
     endpoint: `/forums/${forumId}/`,
@@ -65,7 +65,7 @@ export function editForum(forum: UpdateForum) {
   });
 }
 
-export function deleteForum(forumId: ID) {
+export function deleteForum(forumId: EntityId) {
   return callAPI({
     types: Forum.DELETE,
     endpoint: `/forums/${forumId}/`,
@@ -90,7 +90,7 @@ export function fetchThreads() {
   });
 }
 
-export function fetchThreadsByForum(forumId: ID) {
+export function fetchThreadsByForum(forumId: EntityId) {
   return callAPI<PublicThread[]>({
     types: Thread.FETCH_ALL,
     endpoint: `/forums/${forumId}/threads/`,
@@ -103,7 +103,7 @@ export function fetchThreadsByForum(forumId: ID) {
   });
 }
 
-export function fetchThread(threadId: ID) {
+export function fetchThread(threadId: EntityId) {
   return callAPI<DetailedThread>({
     types: Thread.FETCH,
     endpoint: `/threads/${threadId}/`,
@@ -115,7 +115,7 @@ export function fetchThread(threadId: ID) {
   });
 }
 
-export function fetchThreadByForum(forumId: ID, threadId: ID) {
+export function fetchThreadByForum(forumId: EntityId, threadId: EntityId) {
   return callAPI<PublicThread[]>({
     types: Thread.FETCH,
     endpoint: `/forums/${forumId}/threads/${threadId}`,
@@ -157,7 +157,7 @@ export function editThread(thread: UpdateThread) {
   });
 }
 
-export function deleteThread(threadId: ID) {
+export function deleteThread(threadId: EntityId) {
   return callAPI({
     types: Thread.DELETE,
     endpoint: `/threads/${threadId}/`,

--- a/app/actions/GalleryActions.ts
+++ b/app/actions/GalleryActions.ts
@@ -1,8 +1,8 @@
 import callAPI from 'app/actions/callAPI';
 import { gallerySchema } from 'app/reducers';
 import { Gallery } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { FormValues as GalleryEditorFormValues } from 'app/routes/photos/components/GalleryEditor';
-import type { ID } from 'app/store/models';
 import type { DetailedGallery } from 'app/store/models/Gallery';
 import type { Thunk } from 'app/types';
 
@@ -30,7 +30,7 @@ export function fetch({
   };
 }
 
-export function fetchGallery(galleryId: ID) {
+export function fetchGallery(galleryId: EntityId) {
   return callAPI<DetailedGallery>({
     types: Gallery.FETCH,
     endpoint: `/galleries/${galleryId}/`,
@@ -42,7 +42,7 @@ export function fetchGallery(galleryId: ID) {
   });
 }
 
-export function fetchGalleryMetadata(galleryId: ID) {
+export function fetchGalleryMetadata(galleryId: EntityId) {
   return callAPI({
     types: Gallery.FETCH,
     endpoint: `/galleries/${galleryId}/metadata/`,
@@ -65,7 +65,10 @@ export function createGallery(gallery: GalleryEditorFormValues) {
   });
 }
 
-export function updateGallery(galleryId: ID, gallery: GalleryEditorFormValues) {
+export function updateGallery(
+  galleryId: EntityId,
+  gallery: GalleryEditorFormValues,
+) {
   return callAPI<DetailedGallery>({
     types: Gallery.EDIT,
     endpoint: `/galleries/${galleryId}/`,
@@ -78,7 +81,7 @@ export function updateGallery(galleryId: ID, gallery: GalleryEditorFormValues) {
   });
 }
 
-export function updateGalleryCover(id: ID, cover: ID) {
+export function updateGalleryCover(id: EntityId, cover: EntityId) {
   return callAPI({
     types: Gallery.EDIT,
     endpoint: `/galleries/${id}/`,
@@ -93,7 +96,7 @@ export function updateGalleryCover(id: ID, cover: ID) {
   });
 }
 
-export function deleteGallery(id: ID) {
+export function deleteGallery(id: EntityId) {
   return callAPI({
     types: Gallery.DELETE,
     endpoint: `/galleries/${id}/`,

--- a/app/actions/GalleryPictureActions.ts
+++ b/app/actions/GalleryPictureActions.ts
@@ -3,14 +3,14 @@ import callAPI from 'app/actions/callAPI';
 import { galleryPictureSchema } from 'app/reducers';
 import { GalleryPicture, Gallery } from './ActionTypes';
 import { uploadFile } from './FileActions';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { GalleryPictureEntity } from 'app/reducers/galleryPictures';
 import type { AppDispatch } from 'app/store/createStore';
-import type { ID } from 'app/store/models';
 import type { GalleryListPicture } from 'app/store/models/GalleryPicture';
 import type { Thunk } from 'app/types';
 
 export function fetch(
-  galleryId: ID,
+  galleryId: EntityId,
   {
     next,
     filters,
@@ -37,8 +37,8 @@ export function fetch(
 }
 
 export function fetchSiblingGallerPicture(
-  galleryId: ID,
-  currentPictureId: ID,
+  galleryId: EntityId,
+  currentPictureId: EntityId,
   next: boolean,
 ) {
   const rawCursor = `p=${currentPictureId}&r=${next ? 0 : 1}`;
@@ -58,7 +58,7 @@ export function fetchSiblingGallerPicture(
   });
 }
 
-export function fetchGalleryPicture(galleryId: ID, pictureId: ID) {
+export function fetchGalleryPicture(galleryId: EntityId, pictureId: EntityId) {
   return callAPI({
     types: GalleryPicture.FETCH,
     endpoint: `/galleries/${galleryId}/pictures/${pictureId}/`,
@@ -87,7 +87,7 @@ export function updatePicture(
   });
 }
 
-export function deletePicture(galleryId: ID, pictureId: ID) {
+export function deletePicture(galleryId: EntityId, pictureId: EntityId) {
   return callAPI({
     types: GalleryPicture.DELETE,
     endpoint: `/galleries/${galleryId}/pictures/${pictureId}/`,
@@ -103,7 +103,7 @@ export function deletePicture(galleryId: ID, pictureId: ID) {
 }
 
 export function CreateGalleryPicture(galleryPicture: {
-  galleryId: ID;
+  galleryId: EntityId;
   file: string;
   active: boolean;
 }) {
@@ -164,7 +164,7 @@ function uploadGalleryPicturesInTurn(files, galleryId, dispatch) {
 }
 
 export function uploadAndCreateGalleryPicture(
-  galleryId: ID,
+  galleryId: EntityId,
   files: Array<Record<string, any>>,
 ) {
   return (dispatch: AppDispatch) => {
@@ -178,7 +178,7 @@ export function uploadAndCreateGalleryPicture(
   };
 }
 
-export function clear(galleryId: ID) {
+export function clear(galleryId: EntityId) {
   return (dispatch: AppDispatch) =>
     dispatch({
       type: GalleryPicture.CLEAR,

--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -1,16 +1,16 @@
 import callAPI from 'app/actions/callAPI';
 import { groupSchema, membershipSchema } from 'app/reducers';
 import { Group, Membership } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { GroupType } from 'app/models';
 import type { AppDispatch } from 'app/store/createStore';
-import type { ID } from 'app/store/models';
 import type MembershipType from 'app/store/models/Membership';
 import type { CurrentUser } from 'app/store/models/User';
 import type { RoleType } from 'app/utils/constants';
 
 export type AddMemberArgs = {
-  groupId: ID;
-  userId: ID;
+  groupId: EntityId;
+  userId: EntityId;
   role: RoleType;
 };
 export function addMember({ groupId, userId, role }: AddMemberArgs) {
@@ -45,7 +45,7 @@ export function removeMember(membership: MembershipType) {
   });
 }
 
-export function fetchGroup(groupId: ID, { propagateError = true } = {}) {
+export function fetchGroup(groupId: EntityId, { propagateError = true } = {}) {
   return callAPI({
     types: Group.FETCH,
     endpoint: `/groups/${groupId}/`,
@@ -103,7 +103,11 @@ export function editGroup(group: Record<string, any>) {
   });
 }
 
-export function joinGroup(groupId: ID, user: CurrentUser, role = 'member') {
+export function joinGroup(
+  groupId: EntityId,
+  user: CurrentUser,
+  role = 'member',
+) {
   return (dispatch: AppDispatch) =>
     dispatch(
       callAPI({
@@ -128,7 +132,7 @@ export function joinGroup(groupId: ID, user: CurrentUser, role = 'member') {
     });
 }
 
-export function leaveGroup(membership: MembershipType, groupId: ID) {
+export function leaveGroup(membership: MembershipType, groupId: EntityId) {
   return (dispatch: AppDispatch) => {
     return dispatch(
       callAPI({
@@ -149,7 +153,7 @@ export function leaveGroup(membership: MembershipType, groupId: ID) {
   };
 }
 
-export function fetchAllMemberships(groupId: ID, descendants = false) {
+export function fetchAllMemberships(groupId: EntityId, descendants = false) {
   return (dispatch: AppDispatch) => {
     return dispatch(
       fetchMembershipsPagination({
@@ -170,7 +174,7 @@ export function fetchMemberships({
   query = {},
   propagateError = true,
 }: {
-  groupId: ID;
+  groupId: EntityId;
   descendants?: boolean;
   query?: Record<string, any>;
   propagateError?: boolean;
@@ -191,7 +195,7 @@ export function fetchMembershipsPagination({
   query = {},
   propagateError = true,
 }: {
-  groupId: ID;
+  groupId: EntityId;
   next: boolean;
   descendants: boolean;
   query?: Record<string, string | number | boolean>;

--- a/app/actions/JoblistingActions.ts
+++ b/app/actions/JoblistingActions.ts
@@ -2,13 +2,13 @@ import moment from 'moment-timezone';
 import callAPI from 'app/actions/callAPI';
 import { joblistingsSchema } from 'app/reducers';
 import { Joblistings } from './ActionTypes';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type {
   DetailedJoblisting,
   ListJoblisting,
 } from 'app/store/models/Joblisting';
 
-export function fetchAll(query?: { company?: ID; timeFilter?: boolean }) {
+export function fetchAll(query?: { company?: EntityId; timeFilter?: boolean }) {
   return callAPI<ListJoblisting[]>({
     types: Joblistings.FETCH,
     endpoint: '/joblistings/',
@@ -21,7 +21,7 @@ export function fetchAll(query?: { company?: ID; timeFilter?: boolean }) {
   });
 }
 
-export function fetchJoblisting(id: ID) {
+export function fetchJoblisting(id: EntityId) {
   return callAPI<DetailedJoblisting>({
     types: Joblistings.FETCH,
     endpoint: `/joblistings/${id}/`,
@@ -33,7 +33,7 @@ export function fetchJoblisting(id: ID) {
   });
 }
 
-export function deleteJoblisting(id: ID) {
+export function deleteJoblisting(id: EntityId) {
   return callAPI({
     types: Joblistings.DELETE,
     endpoint: `/joblistings/${id}/`,

--- a/app/actions/MeetingActions.ts
+++ b/app/actions/MeetingActions.ts
@@ -2,8 +2,8 @@ import moment from 'moment-timezone';
 import callAPI from 'app/actions/callAPI';
 import { meetingSchema } from 'app/reducers';
 import { Meeting } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { MeetingFormValues } from 'app/routes/meetings/components/MeetingEditor';
-import type { ID } from 'app/store/models';
 import type { DetailedMeeting, ListMeeting } from 'app/store/models/Meeting';
 import type { MeetingInvitationStatus } from 'app/store/models/MeetingInvitation';
 import type { CurrentUser } from 'app/store/models/User';
@@ -43,7 +43,7 @@ export function fetchAll({
 }
 
 export function setInvitationStatus(
-  meetingId: ID,
+  meetingId: EntityId,
   status: MeetingInvitationStatus,
   user: CurrentUser,
 ) {
@@ -64,7 +64,7 @@ export function setInvitationStatus(
   });
 }
 
-export function deleteMeeting(id: ID) {
+export function deleteMeeting(id: EntityId) {
   return callAPI({
     types: Meeting.DELETE,
     endpoint: `/meetings/${id}/`,
@@ -113,19 +113,19 @@ export function inviteUsersAndGroups({
   users,
   groups,
 }: {
-  id: ID;
+  id: EntityId;
   users: [
     {
-      id: ID;
+      id: EntityId;
     },
   ];
   groups: [
     {
-      value: ID;
+      value: EntityId;
     },
   ];
 }) {
-  return callAPI<{ users: ID[]; groups: ID[] }>({
+  return callAPI<{ users: EntityId[]; groups: EntityId[] }>({
     types: Meeting.EDIT,
     endpoint: `/meetings/${id}/bulk_invite/`,
     method: 'POST',

--- a/app/actions/PollActions.ts
+++ b/app/actions/PollActions.ts
@@ -1,9 +1,9 @@
 import { pollSchema } from '../reducers';
 import { Poll } from './ActionTypes';
 import callAPI from './callAPI';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Tags } from 'app/models';
 import type { OptionEntity } from 'app/reducers/polls';
-import type { ID } from 'app/store/models';
 import type { Poll as PollType } from 'app/store/models/Poll';
 import type { Thunk } from 'app/types';
 
@@ -28,7 +28,7 @@ export function fetchAll({
   };
 }
 
-export function fetchPoll(pollId: ID) {
+export function fetchPoll(pollId: EntityId) {
   return callAPI<PollType>({
     types: Poll.FETCH,
     endpoint: `/polls/${pollId}/`,
@@ -62,7 +62,7 @@ export function createPoll(data: {
 }
 
 export function editPoll(data: {
-  pollId: ID;
+  pollId: EntityId;
   description: string;
   pinned: boolean;
   tags: Tags;
@@ -86,7 +86,7 @@ export function editPoll(data: {
   });
 }
 
-export function deletePoll(id: ID) {
+export function deletePoll(id: EntityId) {
   return callAPI({
     types: Poll.DELETE,
     endpoint: `/polls/${id}/`,
@@ -98,7 +98,7 @@ export function deletePoll(id: ID) {
   });
 }
 
-export function votePoll(pollId: ID, optionId: ID) {
+export function votePoll(pollId: EntityId, optionId: EntityId) {
   return callAPI({
     types: Poll.UPDATE,
     endpoint: `/polls/${pollId}/vote/`,

--- a/app/actions/QuoteActions.ts
+++ b/app/actions/QuoteActions.ts
@@ -1,7 +1,7 @@
 import callAPI from 'app/actions/callAPI';
 import { quoteSchema } from 'app/reducers';
 import { Quote } from './ActionTypes';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type QuoteType from 'app/store/models/Quote';
 
 export function fetchAll({
@@ -26,7 +26,7 @@ export function fetchAll({
   });
 }
 
-export function fetchQuote(quoteId: ID) {
+export function fetchQuote(quoteId: EntityId) {
   return callAPI<QuoteType>({
     types: Quote.FETCH,
     endpoint: `/quotes/${quoteId}/`,
@@ -40,7 +40,7 @@ export function fetchQuote(quoteId: ID) {
   });
 }
 
-export function fetchRandomQuote(seenQuotes: ID[] = []) {
+export function fetchRandomQuote(seenQuotes: EntityId[] = []) {
   const queryString = `?seen=[${String(seenQuotes)}]`;
   return callAPI<QuoteType>({
     types: Quote.FETCH_RANDOM,
@@ -54,7 +54,7 @@ export function fetchRandomQuote(seenQuotes: ID[] = []) {
   });
 }
 
-export function approve(quoteId: ID) {
+export function approve(quoteId: EntityId) {
   return callAPI({
     types: Quote.APPROVE,
     endpoint: `/quotes/${quoteId}/approve/`,
@@ -66,7 +66,7 @@ export function approve(quoteId: ID) {
   });
 }
 
-export function unapprove(quoteId: ID) {
+export function unapprove(quoteId: EntityId) {
   return callAPI({
     types: Quote.UNAPPROVE,
     endpoint: `/quotes/${quoteId}/unapprove/`,
@@ -94,7 +94,7 @@ export function addQuotes({ text, source }: { text: string; source: string }) {
   });
 }
 
-export function deleteQuote(id: ID) {
+export function deleteQuote(id: EntityId) {
   return callAPI({
     types: Quote.DELETE,
     endpoint: `/quotes/${id}/`,

--- a/app/actions/ReactionActions.ts
+++ b/app/actions/ReactionActions.ts
@@ -1,8 +1,8 @@
 import callAPI from 'app/actions/callAPI';
 import { Reaction } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { AppDispatch } from 'app/store/createStore';
 import type { RejectedPromiseAction } from 'app/store/middleware/promiseMiddleware';
-import type { ID } from 'app/store/models';
 import type { ReactionResponse } from 'app/store/models/Reaction';
 import type { CurrentUser } from 'app/store/models/User';
 import type { HttpError } from 'app/utils/fetchJSON';
@@ -56,7 +56,7 @@ export function deleteReaction({
   reactionId,
   contentTarget,
 }: {
-  reactionId: ID;
+  reactionId: EntityId;
   contentTarget: string;
 }) {
   return callAPI<void>({

--- a/app/actions/RestrictedMailActions.ts
+++ b/app/actions/RestrictedMailActions.ts
@@ -1,11 +1,11 @@
 import callAPI from 'app/actions/callAPI';
 import { restrictedMailSchema } from 'app/reducers';
 import { RestrictedMail } from './ActionTypes';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { RestrictedMailEntity } from 'app/reducers/restrictedMails';
-import type { ID } from 'app/store/models';
 import type { Thunk } from 'app/types';
 
-export function fetchRestrictedMail(restrictedMailId: ID) {
+export function fetchRestrictedMail(restrictedMailId: EntityId) {
   return callAPI({
     types: RestrictedMail.FETCH,
     endpoint: `/restricted-mail/${restrictedMailId}/`,

--- a/app/actions/SurveyActions.ts
+++ b/app/actions/SurveyActions.ts
@@ -2,7 +2,7 @@ import moment from 'moment-timezone';
 import callAPI from 'app/actions/callAPI';
 import { surveySchema } from 'app/reducers';
 import { Survey } from './ActionTypes';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type {
   DetailedSurvey,
   FormSubmitSurvey,
@@ -10,7 +10,7 @@ import type {
   PublicSurvey,
 } from 'app/store/models/Survey';
 
-export function fetchSurvey(surveyId: ID) {
+export function fetchSurvey(surveyId: EntityId) {
   return callAPI<DetailedSurvey>({
     types: Survey.FETCH,
     endpoint: `/surveys/${surveyId}/`,
@@ -21,7 +21,7 @@ export function fetchSurvey(surveyId: ID) {
     propagateError: true,
   });
 }
-export function fetchWithToken(surveyId: ID, token: string) {
+export function fetchWithToken(surveyId: EntityId, token: string) {
   return callAPI<PublicResultsSurvey>({
     types: Survey.FETCH,
     endpoint: `/survey-results/${surveyId}/`,
@@ -66,7 +66,7 @@ export function addSurvey(data: FormSubmitSurvey) {
 export function editSurvey({
   surveyId,
   ...data
-}: Partial<FormSubmitSurvey> & { surveyId: ID }) {
+}: Partial<FormSubmitSurvey> & { surveyId: EntityId }) {
   return callAPI<DetailedSurvey>({
     types: Survey.EDIT,
     endpoint: `/surveys/${surveyId}/`,
@@ -109,7 +109,7 @@ export function fetchTemplate(template: string) {
     propagateError: true,
   });
 }
-export function shareSurvey(surveyId: ID) {
+export function shareSurvey(surveyId: EntityId) {
   return callAPI({
     types: Survey.SHARE,
     endpoint: `/surveys/${surveyId}/share/`,
@@ -121,7 +121,7 @@ export function shareSurvey(surveyId: ID) {
     propagateError: true,
   });
 }
-export function hideSurvey(surveyId: ID) {
+export function hideSurvey(surveyId: EntityId) {
   return callAPI({
     types: Survey.HIDE,
     endpoint: `/surveys/${surveyId}/hide/`,

--- a/app/actions/SurveySubmissionActions.ts
+++ b/app/actions/SurveySubmissionActions.ts
@@ -1,13 +1,13 @@
 import callAPI from 'app/actions/callAPI';
 import { surveySubmissionSchema } from 'app/reducers';
 import { SurveySubmission } from './ActionTypes';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type {
   FormSurveySubmission,
   SurveySubmission as SurveySubmissionType,
 } from 'app/store/models/SurveySubmission';
 
-export function fetchSubmissions(surveyId: ID) {
+export function fetchSubmissions(surveyId: EntityId) {
   return callAPI<SurveySubmissionType>({
     types: SurveySubmission.FETCH_ALL,
     endpoint: `/surveys/${surveyId}/submissions/`,
@@ -18,7 +18,7 @@ export function fetchSubmissions(surveyId: ID) {
     propagateError: true,
   });
 }
-export function fetchUserSubmission(surveyId: ID, user: ID) {
+export function fetchUserSubmission(surveyId: EntityId, user: EntityId) {
   return callAPI<SurveySubmissionType>({
     types: SurveySubmission.FETCH,
     endpoint: `/surveys/${surveyId}/submissions/?user=${user}`,
@@ -35,7 +35,7 @@ export function fetchUserSubmission(surveyId: ID, user: ID) {
 export function addSubmission({
   surveyId,
   ...data
-}: FormSurveySubmission & { surveyId: ID }) {
+}: FormSurveySubmission & { surveyId: EntityId }) {
   return callAPI<SurveySubmissionType>({
     types: SurveySubmission.ADD,
     endpoint: `/surveys/${surveyId}/submissions/`,
@@ -49,7 +49,7 @@ export function addSubmission({
     },
   });
 }
-export function deleteSubmission(surveyId: ID, submissionId: ID) {
+export function deleteSubmission(surveyId: EntityId, submissionId: EntityId) {
   return callAPI({
     types: SurveySubmission.DELETE,
     endpoint: `/surveys/${surveyId}/submissions/${submissionId}/`,
@@ -62,7 +62,11 @@ export function deleteSubmission(surveyId: ID, submissionId: ID) {
     },
   });
 }
-export function hideAnswer(surveyId: ID, submissionId: ID, answerId: ID) {
+export function hideAnswer(
+  surveyId: EntityId,
+  submissionId: EntityId,
+  answerId: EntityId,
+) {
   return callAPI({
     types: SurveySubmission.HIDE_ANSWER,
     endpoint: `/surveys/${surveyId}/submissions/${submissionId}/hide/?answer=${answerId}`,
@@ -77,7 +81,11 @@ export function hideAnswer(surveyId: ID, submissionId: ID, answerId: ID) {
     },
   });
 }
-export function showAnswer(surveyId: ID, submissionId: ID, answerId: ID) {
+export function showAnswer(
+  surveyId: EntityId,
+  submissionId: EntityId,
+  answerId: EntityId,
+) {
   return callAPI({
     types: SurveySubmission.SHOW_ANSWER,
     endpoint: `/surveys/${surveyId}/submissions/${submissionId}/show/?answer=${answerId}`,

--- a/app/actions/UserActions.ts
+++ b/app/actions/UserActions.ts
@@ -9,12 +9,12 @@ import { setStatusCode } from 'app/reducers/routing';
 import { User, Penalty } from './ActionTypes';
 import { uploadFile } from './FileActions';
 import { fetchMeta } from './MetaActions';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { PhotoConsent } from 'app/models';
 import type { FormValues as ChangePasswordFormValues } from 'app/routes/users/components/ChangePassword';
 import type { FormValues as UserConfirmationFormValues } from 'app/routes/users/components/UserConfirmation';
 import type { AppDispatch } from 'app/store/createStore';
 import type { RejectedPromiseAction } from 'app/store/middleware/promiseMiddleware';
-import type { ID } from 'app/store/models';
 import type { Penalty as PenaltyType } from 'app/store/models/Penalty';
 import type { CurrentUser, UpdateUser } from 'app/store/models/User';
 import type { Thunk, Token, EncodedToken, GetCookie } from 'app/types';
@@ -168,7 +168,7 @@ export function changePassword({
     },
   });
 }
-export function changeGrade(groupId: ID, username: string) {
+export function changeGrade(groupId: EntityId, username: string) {
   return callAPI({
     types: User.UPDATE,
     endpoint: `/users/${username}/change_grade/`,
@@ -457,10 +457,10 @@ export function sendForgotPasswordEmail({ email }: { email: string }) {
 }
 
 export type AddPenaltyBody = {
-  user: ID;
+  user: EntityId;
   reason: string;
   weight: number;
-  sourceEvent: ID;
+  sourceEvent: EntityId;
 };
 export function addPenalty(body: AddPenaltyBody) {
   return callAPI<PenaltyType>({
@@ -475,7 +475,7 @@ export function addPenalty(body: AddPenaltyBody) {
   });
 }
 
-export function deletePenalty(id: ID) {
+export function deletePenalty(id: EntityId) {
   return callAPI({
     types: Penalty.DELETE,
     endpoint: `/penalties/${id}/`,

--- a/app/actions/callAPI.ts
+++ b/app/actions/callAPI.ts
@@ -7,13 +7,13 @@ import { selectPaginationNext } from 'app/reducers/selectors';
 import createQueryString from 'app/utils/createQueryString';
 import fetchJSON, { HttpError } from 'app/utils/fetchJSON';
 import { configWithSSR } from '../config';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant } from 'app/models';
 import type { AppDispatch } from 'app/store/createStore';
 import type {
   PromiseAction,
   ResolvedPromiseAction,
 } from 'app/store/middleware/promiseMiddleware';
-import type { ID } from 'app/store/models';
 import type { AsyncActionType, Thunk, NormalizedApiPayload } from 'app/types';
 import type { Query } from 'app/utils/createQueryString';
 import type {
@@ -76,7 +76,7 @@ type CallAPIMeta<ExtraMeta = Record<string, never>> = ExtraMeta & {
   query?: Record<string, string | number | boolean | undefined>;
   paginationKey?: string;
   cursor: string;
-  optimisticId?: ID;
+  optimisticId?: EntityId;
   enableOptimistic: boolean;
   endpoint: string;
   body?: Record<string, unknown> | string;

--- a/app/components/CommentForm/index.tsx
+++ b/app/components/CommentForm/index.tsx
@@ -10,14 +10,14 @@ import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
 import { createValidator, legoEditorRequired } from 'app/utils/validation';
 import styles from './CommentForm.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 type Props = {
   contentTarget: ContentTarget;
   submitText?: string;
   autoFocus?: boolean;
-  parent?: ID;
+  parent?: EntityId;
   placeholder?: string;
 };
 

--- a/app/components/LegoReactions/index.tsx
+++ b/app/components/LegoReactions/index.tsx
@@ -2,7 +2,7 @@ import Reactions from 'app/components/Reactions';
 import Reaction from 'app/components/Reactions/Reaction';
 import { selectEmojis } from 'app/reducers/emojis';
 import { useAppSelector } from 'app/store/hooks';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type Emoji from 'app/store/models/Emoji';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
@@ -18,7 +18,7 @@ type Props = {
 
 export type EmojiWithReactionData = Emoji & {
   hasReacted: boolean;
-  reactionId: ID;
+  reactionId: EntityId;
 };
 
 const LegoReactions = ({ parentEntity, showPeople }: Props) => {

--- a/app/components/RandomQuote/RandomQuote.tsx
+++ b/app/components/RandomQuote/RandomQuote.tsx
@@ -7,7 +7,7 @@ import { selectRandomQuote } from 'app/reducers/quotes';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import styles from './RandomQuote.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type Quote from 'app/store/models/Quote';
 
 type Props = {
@@ -16,7 +16,7 @@ type Props = {
 };
 
 const RandomQuote = ({ dummyQuote, useReactions = true }: Props) => {
-  const seenQuotes = useRef<ID[]>([]);
+  const seenQuotes = useRef<EntityId[]>([]);
 
   const [animation, setAnimation] = useState(false);
 

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -5,7 +5,7 @@ import InfiniteScroll from 'react-infinite-scroller';
 import BodyCell from './BodyCell';
 import HeadCell from './HeadCell';
 import styles from './Table.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ReactNode } from 'react';
 
 export type Sort = {
@@ -51,7 +51,7 @@ export type ColumnProps<T = unknown> = {
   columnChoices?: ColumnProps[];
 };
 
-type TableProps<T extends { id: ID }> = {
+type TableProps<T extends { id: EntityId }> = {
   rowKey?: string;
   columns: ColumnProps<T>[];
   data: T[];
@@ -85,7 +85,7 @@ const queryFiltersToFilters: (queryFilters?: QueryFilters) => Filters = (
   return filters;
 };
 
-const Table = <T extends { id: ID }>({
+const Table = <T extends { id: EntityId }>({
   columns,
   data,
   rowKey = 'id',

--- a/app/components/UserAttendance/AttendanceModalContent.tsx
+++ b/app/components/UserAttendance/AttendanceModalContent.tsx
@@ -6,11 +6,11 @@ import { Link } from 'react-router-dom';
 import { TextInput } from 'app/components/Form';
 import { ProfilePicture } from 'app/components/Image';
 import styles from './AttendanceModalContent.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { PublicUser } from 'app/store/models/User';
 
 export type Registration = {
-  id: ID;
+  id: EntityId;
   user: PublicUser;
   pool?: Pool;
 };
@@ -116,7 +116,7 @@ const AttendanceModalContent = ({
         {amendedPools.map((pool, i) => (
           <Tab
             name={pool.name}
-            key={pool.name} // TODO: Once typed better it shouldn't be too hard to change this into an ID
+            key={pool.name} // TODO: Once typed better it shouldn't be too hard to change this into an id
             index={i}
             activePoolIndex={selectedPool}
             togglePool={togglePool}

--- a/app/models.ts
+++ b/app/models.ts
@@ -1,5 +1,6 @@
 import type { EventType } from './store/models/Event';
 import type { Presence } from './store/models/Registration';
+import type { EntityId } from '@reduxjs/toolkit';
 import type Comment from 'app/store/models/Comment';
 import type { ListCompany } from 'app/store/models/Company';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
@@ -7,7 +8,6 @@ import type { DetailedUser, PublicUser } from 'app/store/models/User';
 import type { RoleType } from 'app/utils/constants';
 import type { Moment } from 'moment';
 // TODO: Id handling could be opaque
-export type ID = number;
 export type Dateish = Moment | Date | string;
 export type ActionGrant = (
   | 'create'
@@ -46,9 +46,9 @@ export type GroupMembership = {
 };
 
 export type UserMembership = {
-  id: ID;
+  id: EntityId;
   user: User;
-  abakusGroup: ID;
+  abakusGroup: EntityId;
   role: RoleType;
   isActive: boolean;
   emailListsEnabled: boolean;
@@ -75,17 +75,17 @@ export type PermissionPerGroup = {
 };
 
 export type EmailList = {
-  id: ID;
-  users: ID[];
+  id: EntityId;
+  users: EntityId[];
   name: string;
   email: string;
-  groups: ID[];
+  groups: EntityId[];
   groupRoles: string[];
   requireInternalEmailAddress: boolean[];
 };
 
 export type User = {
-  id: ID;
+  id: EntityId;
   firstName: string;
   lastName: string;
   fullName: string;
@@ -124,7 +124,7 @@ export enum GroupType {
   Other = 'annen',
 }
 export type Group = {
-  id: ID;
+  id: EntityId;
   actionGrant: ActionGrant;
   type: GroupType;
   name: string;
@@ -145,7 +145,7 @@ export type Cover = {
 };
 
 type EventBase = {
-  id: ID;
+  id: EntityId;
   title: string;
   slug: string;
   cover: Cover;
@@ -201,7 +201,7 @@ export type EventRegistrationStatus =
   | 'FAILURE_UNREGISTER';
 
 export type EventRegistration = {
-  id: ID;
+  id: EntityId;
   user: User;
   createdBy?: User;
   updatedBy?: User;
@@ -220,7 +220,7 @@ export type EventRegistration = {
 };
 
 type EventPoolBase = {
-  id: ID;
+  id: EntityId;
   name: string;
   capacity: number;
   activationDate: Dateish;
@@ -245,7 +245,7 @@ export type Event = EventBase & {
   actionGrant: ActionGrant;
   activationTime: Dateish | null | undefined;
   isAdmitted: boolean | null | undefined;
-  following: false | ID;
+  following: false | EntityId;
   activeCapacity: number;
   eventType: EventType;
   eventStatusType: EventStatusType;
@@ -258,10 +258,10 @@ export type Event = EventBase & {
   comments: Comment[];
   contentTarget: string;
   pools: Array<EventPool>;
-  survey: ID | null | undefined;
+  survey: EntityId | null | undefined;
   userReg: EventRegistration;
   useConsent: boolean;
-  unansweredSurveys: Array<ID>;
+  unansweredSurveys: Array<EntityId>;
   responsibleGroup: Group;
   price?: number;
   registrationCloseTime?: Dateish | null | undefined;
@@ -270,7 +270,7 @@ export type Event = EventBase & {
   photoConsents?: Array<PhotoConsent>;
   isUsersUpcoming?: boolean;
   documentType?: 'event';
-  responsibleUsers: ID[];
+  responsibleUsers: EntityId[];
   isForeignLanguage: boolean;
 };
 
@@ -296,34 +296,34 @@ export type Workplace = {
 };
 
 export type Joblisting = {
-  id: ID;
+  id: EntityId;
   fromYear: number;
   toYear: number;
   workplaces: Array<Workplace>;
 };
 
 export type Meeting = {
-  id: ID;
-  createdBy: ID;
+  id: EntityId;
+  createdBy: EntityId;
   title: string;
   location: string;
   startTime: Dateish;
   endTime: Dateish;
-  reportAuthor: ID | null;
+  reportAuthor: EntityId | null;
   mazemapPoi: number | null;
   description?: string;
   report?: string;
   invitations: string[];
-  comments?: ID[];
+  comments?: EntityId[];
   contentTarget?: string;
   actionGrant?: ActionGrant;
   reactionsGrouped?: ReactionsGrouped;
 };
 
 export type FollowerItem = {
-  id: ID;
+  id: EntityId;
   follower: PublicUser;
-  target: ID;
+  target: EntityId;
 };
 
 export type Readme = {

--- a/app/reducers/__tests__/comments.spec.ts
+++ b/app/reducers/__tests__/comments.spec.ts
@@ -172,7 +172,7 @@ describe('addCommentCases', () => {
     },
   });
 
-  it('should add comment ID to the correct entity', () => {
+  it('should add comment id to the correct entity', () => {
     expect(reducer(undefined, action('articles.article-3'))).toEqual({
       articles: {
         ...articlesAdapter.getInitialState(),
@@ -193,7 +193,7 @@ describe('addCommentCases', () => {
       events: eventsAdapter.getInitialState(),
     });
   });
-  it('should not add comment ID with different contentTarget', () => {
+  it('should not add comment id with different contentTarget', () => {
     expect(reducer(undefined, action('events.event-3'))).toEqual({
       articles: initialArticlesState,
       events: eventsAdapter.getInitialState(),

--- a/app/reducers/comments.ts
+++ b/app/reducers/comments.ts
@@ -10,7 +10,6 @@ import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { EntityState } from '@reduxjs/toolkit/src/entities/models';
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit/src/mapBuilders';
-import type { ID } from 'app/models';
 import type { RootState } from 'app/store/createRootReducer';
 import type { Comment as CommentType } from 'app/store/models/Comment';
 import type { AnyAction } from 'redux';
@@ -18,7 +17,7 @@ import type { AnyAction } from 'redux';
 type WithComments<T> = T & { comments: CommentType[] };
 
 type StateWithComments<T, S> = S & {
-  byId: Record<ID, WithComments<T>>;
+  byId: Record<EntityId, WithComments<T>>;
 };
 
 /**

--- a/app/reducers/galleryPictures.ts
+++ b/app/reducers/galleryPictures.ts
@@ -3,14 +3,14 @@ import { Gallery, GalleryPicture } from 'app/actions/ActionTypes';
 import { mutateComments, selectCommentEntities } from 'app/reducers/comments';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import joinReducers from 'app/utils/joinReducers';
-import type { ID } from 'app/models';
+import type { EntityId } from '@reduxjs/toolkit';
 
 export type UploadStatus = {
   imageCount: number;
   successCount: number;
   failCount: number;
   failedImages: Array<string>;
-  lastUploadedImage?: ID;
+  lastUploadedImage?: EntityId;
   showStatus: boolean;
 };
 export const initialUploadStatus: UploadStatus = {

--- a/app/reducers/groups.ts
+++ b/app/reducers/groups.ts
@@ -5,10 +5,9 @@ import { EntityType } from 'app/store/models/entities';
 import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { Group, Membership } from '../actions/ActionTypes';
 import type { EntityId, AnyAction } from '@reduxjs/toolkit';
-import type { ID } from 'app/models';
 import type { RootState } from 'app/store/createRootReducer';
 
-export const resolveGroupLink = (group: { type: GroupType; id: ID }) => {
+export const resolveGroupLink = (group: { type: GroupType; id: EntityId }) => {
   switch (group.type) {
     case GroupType.Interest:
       return `/interest-groups/${group.id}`;

--- a/app/reducers/meetingInvitations.ts
+++ b/app/reducers/meetingInvitations.ts
@@ -8,7 +8,6 @@ import { Meeting } from '../actions/ActionTypes';
 import { selectMeetingById } from './meetings';
 import type { AnyAction, EntityId } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
-import type { ID } from 'app/store/models';
 import type {
   MeetingInvitation,
   MeetingInvitationStatus,
@@ -66,7 +65,7 @@ export const selectMeetingInvitationByMeetingIdAndUserId = (
   );
 
 export type MeetingInvitationWithUser = Omit<MeetingInvitation, 'user'> & {
-  id: ID;
+  id: EntityId;
   user: PublicUser;
 };
 

--- a/app/reducers/meetings.ts
+++ b/app/reducers/meetings.ts
@@ -6,8 +6,8 @@ import { EntityType } from 'app/store/models/entities';
 import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { Meeting } from '../actions/ActionTypes';
 import { addReactionCases } from './reactions';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
-import type { ID } from 'app/store/models';
 import type { ListMeeting } from 'app/store/models/Meeting';
 import type { MeetingInvitationStatus } from 'app/store/models/MeetingInvitation';
 import type { PublicUser } from 'app/store/models/User';
@@ -21,7 +21,7 @@ export enum MeetingTokenResponse {
 export type MeetingTokenSuccessState = {
   response: MeetingTokenResponse.Success;
   user: PublicUser;
-  meeting: ID;
+  meeting: EntityId;
   status: MeetingInvitationStatus;
 };
 export type MeetingTokenState =
@@ -197,5 +197,5 @@ export const selectUpcomingMeetings = (state: RootState) =>
 
 export const selectUpcomingMeetingId = createSelector(
   selectUpcomingMeetings,
-  (upcomingMeetings) => upcomingMeetings[0]?.id as ID | undefined,
+  (upcomingMeetings) => upcomingMeetings[0]?.id as EntityId | undefined,
 );

--- a/app/reducers/polls.ts
+++ b/app/reducers/polls.ts
@@ -1,7 +1,8 @@
 import { createSelector } from 'reselect';
 import { Poll } from '../actions/ActionTypes';
 import createEntityReducer from '../utils/createEntityReducer';
-import type { Tags, ID } from 'app/models';
+import type { EntityId } from '@reduxjs/toolkit';
+import type { Tags } from 'app/models';
 
 export type OptionEntity = {
   id: number;
@@ -9,7 +10,7 @@ export type OptionEntity = {
   votes: number;
 };
 export type PollEntity = {
-  id: ID;
+  id: EntityId;
   title: string;
   description: string;
   resultsHidden: boolean;

--- a/app/reducers/surveySubmissions.ts
+++ b/app/reducers/surveySubmissions.ts
@@ -5,9 +5,8 @@ import { fetchSubmissions } from 'app/actions/SurveySubmissionActions';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { SurveySubmission } from '../actions/ActionTypes';
-import type { AnyAction } from '@reduxjs/toolkit';
+import type { AnyAction, EntityId } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
-import type { ID } from 'app/store/models';
 import type { SurveySubmission as SurveySubmissionType } from 'app/store/models/SurveySubmission';
 import type { EntityReducerState } from 'app/utils/createEntityReducer';
 
@@ -38,7 +37,7 @@ export default createEntityReducer({
 });
 
 export const selectSurveySubmissions = createSelector(
-  (_: RootState, props: { surveyId: ID }) => props.surveyId,
+  (_: RootState, props: { surveyId: EntityId }) => props.surveyId,
   (state: RootState) => state.surveySubmissions.items,
   (state: RootState) => state.surveySubmissions.byId,
   (surveyId, surveySubmissionIds, surveySubmissionsById) =>
@@ -47,16 +46,16 @@ export const selectSurveySubmissions = createSelector(
       .filter((surveySubmission) => surveySubmission.survey === surveyId),
 );
 export const selectSurveySubmissionForUser = createSelector(
-  (state: RootState, props: { surveyId: ID }) =>
+  (state: RootState, props: { surveyId: EntityId }) =>
     selectSurveySubmissions(state, props),
-  (_: RootState, props: { currentUserId: ID }) => props.currentUserId,
+  (_: RootState, props: { currentUserId: EntityId }) => props.currentUserId,
   (submissions, userId) =>
     submissions.find((surveySubmission) => surveySubmission.user === userId),
 );
 
 export const useFetchedSurveySubmissions = (
   prepareId: string,
-  surveyId?: ID,
+  surveyId?: EntityId,
 ): SurveySubmissionType[] => {
   const dispatch = useAppDispatch();
   usePreparedEffect(

--- a/app/reducers/surveys.ts
+++ b/app/reducers/surveys.ts
@@ -10,8 +10,8 @@ import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import createEntityReducer from 'app/utils/createEntityReducer';
 import { Survey } from '../actions/ActionTypes';
 import { selectEvents } from './events';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
-import type { ID } from 'app/store/models';
 import type { EventForSurvey, EventType } from 'app/store/models/Event';
 import type {
   DetailedSurvey,
@@ -55,7 +55,7 @@ export const selectSurveys = createSelector(
 
 export const selectSurveyById = createSelector(
   (state: RootState) => selectSurveys(state),
-  (_: RootState, surveyId?: ID) => surveyId,
+  (_: RootState, surveyId?: EntityId) => surveyId,
   (surveys, surveyId) => {
     return surveys.find((survey) => survey.id === Number(surveyId));
   },
@@ -114,16 +114,16 @@ export const useFetchedTemplate = (
 
 export function useFetchedSurvey(
   prepareId: string,
-  surveyId?: ID,
+  surveyId?: EntityId,
   token?: string,
 ): SelectedPublicResultsSurvey | undefined;
 export function useFetchedSurvey(
   prepareId: string,
-  surveyId?: ID,
+  surveyId?: EntityId,
 ): SelectedSurvey | undefined;
 export function useFetchedSurvey(
   prepareId: string,
-  surveyId?: ID,
+  surveyId?: EntityId,
   token?: string,
 ) {
   const dispatch = useAppDispatch();

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -9,7 +9,6 @@ import { User, Event } from '../actions/ActionTypes';
 import type { PhotoConsent } from '../models';
 import type { AnyAction, EntityId } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
-import type { ID } from 'app/store/models';
 
 export type UserEntity = {
   id: number;
@@ -80,7 +79,7 @@ export const selectUserWithGroups = createSelector(
       userId,
     }: {
       username?: string;
-      userId?: ID;
+      userId?: EntityId;
     },
   ) =>
     username

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -14,7 +14,7 @@ import { useAppDispatch } from 'app/store/hooks';
 import { roleOptions, ROLES, type RoleType } from 'app/utils/constants';
 import useQuery from 'app/utils/useQuery';
 import styles from './GroupMembersList.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type Membership from 'app/store/models/Membership';
 import type { ReactNode } from 'react';
 
@@ -59,7 +59,7 @@ const GroupMembersList = ({
     );
   };
 
-  const GroupLinkRender = (abakusGroup: ID): ReactNode => (
+  const GroupLinkRender = (abakusGroup: EntityId): ReactNode => (
     <Link to={`/admin/groups/${abakusGroup}/members?descendants=false`}>
       {groupsById[abakusGroup] && groupsById[abakusGroup].name}
     </Link>

--- a/app/routes/bdb/components/BdbPage.tsx
+++ b/app/routes/bdb/components/BdbPage.tsx
@@ -21,7 +21,7 @@ import sortCompanies from '../SortCompanies';
 import { indexToSemester, ListNavigation } from '../utils';
 import CompanyList from './CompanyList';
 import OptionsBox from './OptionsBox';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { CompanySemesterContactStatus } from 'app/store/models/Company';
 import type { ChangeEvent, KeyboardEvent } from 'react';
 
@@ -71,7 +71,7 @@ const BdbPage = () => {
   };
 
   const editChangedStatuses = (
-    companyId: ID,
+    companyId: EntityId,
     tableIndex: number,
     semesterStatusId: number | null | undefined,
     contactedStatus: CompanySemesterContactStatus[],

--- a/app/routes/bdb/utils.tsx
+++ b/app/routes/bdb/utils.tsx
@@ -8,9 +8,9 @@ import { useAppDispatch } from 'app/store/hooks';
 import { NonEventContactStatus } from 'app/store/models/Company';
 import { EventType } from 'app/store/models/Event';
 import type { ConfigProperties } from '../events/utils';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Semester } from 'app/models';
 import type { CompanySemesterEntity } from 'app/reducers/companySemesters';
-import type { ID } from 'app/store/models';
 import type { CompanySemesterContactStatus } from 'app/store/models/Company';
 import type { ReactNode } from 'react';
 
@@ -198,7 +198,7 @@ export const DetailNavigation = ({
   companyId,
 }: {
   title: ReactNode;
-  companyId: ID;
+  companyId: EntityId;
 }) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();

--- a/app/routes/company/components/CompanyDetail.tsx
+++ b/app/routes/company/components/CompanyDetail.tsx
@@ -30,9 +30,9 @@ import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import createQueryString from 'app/utils/createQueryString';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import styles from './Company.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 
-const queryString = (companyId?: ID) =>
+const queryString = (companyId?: EntityId) =>
   createQueryString({
     company: companyId,
     ordering: '-start_time',

--- a/app/routes/events/components/Admin.tsx
+++ b/app/routes/events/components/Admin.tsx
@@ -7,12 +7,12 @@ import AnnouncementInLine from 'app/components/AnnouncementInLine';
 import { TextInput } from 'app/components/Form';
 import { useAppDispatch } from 'app/store/hooks';
 import styles from './Admin.css';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant } from 'app/models';
-import type { ID } from 'app/store/models';
 import type { AuthUserDetailedEvent } from 'app/store/models/Event';
 
 type ButtonProps = {
-  eventId: ID;
+  eventId: EntityId;
   title: string;
 };
 

--- a/app/routes/events/components/EventAdministrate/Allergies.tsx
+++ b/app/routes/events/components/EventAdministrate/Allergies.tsx
@@ -9,7 +9,7 @@ import { getRegistrationGroups, selectEventById } from 'app/reducers/events';
 import HTTPError from 'app/routes/errors/HTTPError';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { RegistrationPill, getRegistrationInfo } from './RegistrationTables';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { AdministrateEvent } from 'app/store/models/Event';
 import type { CurrentUser } from 'app/store/models/User';
 
@@ -22,7 +22,7 @@ export const canSeeAllergies = (
   }
   return (
     currentUser.id === event.createdBy?.id ||
-    currentUser.abakusGroups?.includes(event.responsibleGroup?.id as ID)
+    currentUser.abakusGroups?.includes(event.responsibleGroup?.id as EntityId)
   );
 };
 

--- a/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
+++ b/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
@@ -15,11 +15,11 @@ import Tooltip from 'app/components/Tooltip';
 import { useAppDispatch } from 'app/store/hooks';
 import { Presence } from 'app/store/models/Registration';
 import styles from './Administrate.css';
+import type { EntityId } from '@reduxjs/toolkit';
 import type {
   EventRegistration,
   EventRegistrationPaymentStatus,
 } from 'app/models';
-import type { ID } from 'app/store/models';
 
 type TooltipIconProps = {
   onClick?: (arg0: React.SyntheticEvent<any>) => unknown;
@@ -31,14 +31,14 @@ type TooltipIconProps = {
 };
 type PresenceProps = {
   presence: Presence;
-  registrationId: ID;
+  registrationId: EntityId;
 };
 type UnregisterProps = {
   fetching: boolean;
   registration: EventRegistration;
 };
 type StripeStatusProps = {
-  registrationId: ID;
+  registrationId: EntityId;
   paymentStatus: EventRegistrationPaymentStatus;
 };
 

--- a/app/routes/forum/components/ThreadList.tsx
+++ b/app/routes/forum/components/ThreadList.tsx
@@ -5,9 +5,9 @@ import { Content, ContentMain } from 'app/components/Content';
 import { selectThreadsByForumId } from 'app/reducers/threads';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import ThreadListEntry from './ThreadListEntry';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 
-const ThreadList = ({ forumId }: { forumId: ID }) => {
+const ThreadList = ({ forumId }: { forumId: EntityId }) => {
   const dispatch = useAppDispatch();
 
   usePreparedEffect(

--- a/app/routes/forum/components/ThreadListEntry.tsx
+++ b/app/routes/forum/components/ThreadListEntry.tsx
@@ -2,7 +2,7 @@ import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { Link } from 'react-router-dom';
 import styles from './ForumList.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { PublicThread } from 'app/store/models/Forum';
 
 const ThreadListEntry = ({
@@ -12,7 +12,7 @@ const ThreadListEntry = ({
 }: {
   thread: PublicThread;
   className: string;
-  forumId: ID;
+  forumId: EntityId;
 }) => {
   return (
     <Flex column className={cx(styles.threadEntry, className)}>

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -36,11 +36,11 @@ import {
 } from 'app/utils/validation';
 import { places, jobTypes, yearValues } from '../constants';
 import styles from './JoblistingEditor.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 
 type SelectInputObject = {
   label: string;
-  value: ID;
+  value: EntityId;
 };
 
 const validate = createValidator({

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -54,7 +54,7 @@ import {
   required,
   timeIsAfter,
 } from 'app/utils/validation';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { AutocompleteGroup } from 'app/store/models/Group';
 import type { DetailedMeeting } from 'app/store/models/Meeting';
 import type { AutocompleteUser } from 'app/store/models/User';
@@ -70,7 +70,7 @@ const time = (hours: number, minutes?: number) =>
     .toISOString();
 
 export type MeetingFormValues = {
-  id?: ID;
+  id?: EntityId;
   title?: string;
   report?: string;
   description?: string;
@@ -79,7 +79,7 @@ export type MeetingFormValues = {
   useMazemap: boolean;
   mazemapPoi?: { value: number; label: string };
   location?: string;
-  reportAuthor?: { value: ID; label: string; id: ID };
+  reportAuthor?: { value: EntityId; label: string; id: EntityId };
   users?: AutocompleteUser[];
   groups?: AutocompleteGroup[];
 };
@@ -124,9 +124,9 @@ const MeetingEditor = () => {
 
   const currentUser = useCurrentUser();
 
-  const [fetchedGroupIds, setFetchedGroupIds] = useState<ID[]>([]);
+  const [fetchedGroupIds, setFetchedGroupIds] = useState<EntityId[]>([]);
   const [invitedGroupMembers, setInvitedGroupMembers] = useState<
-    { value: string; label: string; id: ID; groupId: ID }[]
+    { value: string; label: string; id: EntityId; groupId: EntityId }[]
   >([]);
 
   const dispatch = useAppDispatch();

--- a/app/routes/meetings/components/MeetingList.tsx
+++ b/app/routes/meetings/components/MeetingList.tsx
@@ -19,7 +19,7 @@ import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { EntityType } from 'app/store/models/entities';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import styles from './MeetingList.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ListMeeting } from 'app/store/models/Meeting';
 import type { CurrentUser } from 'app/store/models/User';
 
@@ -28,7 +28,7 @@ function MeetingListItem({
   userId,
 }: {
   meeting: ListMeeting;
-  userId: ID;
+  userId: EntityId;
 }) {
   const isDone = moment(meeting.endTime) < moment();
 

--- a/app/routes/photos/components/GalleryPictureEditModal.tsx
+++ b/app/routes/photos/components/GalleryPictureEditModal.tsx
@@ -24,12 +24,12 @@ import { selectGalleryPictureById } from 'app/reducers/galleryPictures';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import GalleryDetailsRow from './GalleryDetailsRow';
 import styles from './GalleryPictureModal.css';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 
 type FormValues = {
   description: string;
   active: boolean;
-  taggees: { label: string; value: ID }[];
+  taggees: { label: string; value: EntityId }[];
 };
 
 const TypedLegoForm = LegoFinalForm<FormValues>;

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -20,7 +20,7 @@ import Tooltip from 'app/components/Tooltip';
 import { useAppDispatch } from 'app/store/hooks';
 import { createValidator, required } from 'app/utils/validation';
 import styles from './PollEditor.css';
-import type { ID } from 'app/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type Poll from 'app/store/models/Poll';
 import type { ReactNode } from 'react';
 
@@ -98,7 +98,7 @@ const PollEditor = ({
       value: string;
     }>;
     options: Array<{
-      id: ID | null | undefined;
+      id: EntityId | null | undefined;
       name: string;
     }>;
     resultsHidden: boolean;

--- a/app/routes/quotes/components/Quote.tsx
+++ b/app/routes/quotes/components/Quote.tsx
@@ -8,8 +8,8 @@ import Time from 'app/components/Time';
 import { selectEmojis } from 'app/reducers/emojis';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './Quotes.css';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant } from 'app/models';
-import type { ID } from 'app/store/models';
 import type Emoji from 'app/store/models/Emoji';
 import type QuoteType from 'app/store/models/Quote';
 
@@ -32,7 +32,8 @@ const Quote = ({
   const [deleting, setDeleting] = useState(false);
   const dispatch = useAppDispatch();
 
-  let mappedEmojis: (Emoji & { hasReacted: boolean; reactionId: ID })[] = [];
+  let mappedEmojis: (Emoji & { hasReacted: boolean; reactionId: EntityId })[] =
+    [];
 
   if (!fetchingEmojis) {
     mappedEmojis = emojis.map((emoji) => {

--- a/app/routes/quotes/components/QuoteList.tsx
+++ b/app/routes/quotes/components/QuoteList.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Quote from './Quote';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant } from 'app/models';
-import type { ID } from 'app/store/models';
 import type QuoteType from 'app/store/models/Quote';
 
 type Props = {
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const QuoteList = ({ quotes, actionGrant }: Props) => {
-  const [displayAdminId, setDisplayAdminId] = useState<ID>();
+  const [displayAdminId, setDisplayAdminId] = useState<EntityId>();
 
   return (
     <ul>

--- a/app/routes/surveys/components/AddSubmission/SurveySubmissionForm.tsx
+++ b/app/routes/surveys/components/AddSubmission/SurveySubmissionForm.tsx
@@ -10,8 +10,8 @@ import {
 import { SubmitButton } from 'app/components/Form/SubmitButton';
 import styles from 'app/routes/surveys/components/surveys.css';
 import { SurveyQuestionType } from 'app/store/models/SurveyQuestion';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { SelectedSurvey } from 'app/reducers/surveys';
-import type { ID } from 'app/store/models';
 import type { FormSurveyAnswer } from 'app/store/models/SurveyAnswer';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 import type { FormSurveySubmission } from 'app/store/models/SurveySubmission';
@@ -68,7 +68,7 @@ const AnswerField = ({ name, question }: AnswerFieldProps) => {
   const { meta, input } = useField<FormSurveyAnswer>(name);
   const error = meta.touched ? meta.error || meta.submitError : undefined;
 
-  const toggleOption = (optionId: ID, isSingle: boolean) => {
+  const toggleOption = (optionId: EntityId, isSingle: boolean) => {
     let selectedOptions = input.value.selectedOptions;
     if (isSingle) {
       selectedOptions = [optionId];

--- a/app/routes/surveys/components/AdminSideBar.tsx
+++ b/app/routes/surveys/components/AdminSideBar.tsx
@@ -6,8 +6,8 @@ import { ContentSidebar } from 'app/components/Content';
 import { CheckBox } from 'app/components/Form';
 import config from 'app/config';
 import { useAppDispatch } from 'app/store/hooks';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant } from 'app/models';
-import type { ID } from 'app/store/models';
 
 type GeneratedCSV = {
   url: string;
@@ -15,7 +15,7 @@ type GeneratedCSV = {
 };
 
 type Props = {
-  surveyId: ID;
+  surveyId: EntityId;
   actionGrant: ActionGrant;
   token: string | null;
   exportSurvey?: () => Promise<GeneratedCSV>;

--- a/app/routes/surveys/components/Submissions/AveragePill.tsx
+++ b/app/routes/surveys/components/Submissions/AveragePill.tsx
@@ -1,12 +1,12 @@
 import Tag from 'app/components/Tags/Tag';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { TagColors } from 'app/components/Tags/Tag';
 import type { GraphData } from 'app/routes/surveys/components/Submissions/Results';
-import type { ID } from 'app/store/models';
 import type { SurveyQuestionOption } from 'app/store/models/SurveyQuestion';
 
 type Props = {
   options: SurveyQuestionOption[];
-  data: GraphData[ID];
+  data: GraphData[EntityId];
 };
 const AveragePill = ({ options, data }: Props) => {
   const average = getAverage(data);
@@ -32,7 +32,7 @@ const getOptionNumber = (optionText: string) => {
   return Number(optionText.match(/^\d+/)?.[0]);
 };
 
-const getAverage = (data: GraphData[ID]) => {
+const getAverage = (data: GraphData[EntityId]) => {
   const [sum, numberOfAnswers] = data.reduce(
     (accumulator, optionData) => {
       const optionNumber = getOptionNumber(optionData.name);

--- a/app/routes/surveys/components/Submissions/Results.tsx
+++ b/app/routes/surveys/components/Submissions/Results.tsx
@@ -15,13 +15,13 @@ import {
 } from 'app/store/models/SurveyQuestion';
 import { QuestionTypeValue, QuestionTypeOption } from '../../utils';
 import styles from '../surveys.css';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { DistributionDataPoint } from 'app/components/Chart/utils';
 import type { SelectedSurvey } from 'app/reducers/surveys';
-import type { ID } from 'app/store/models';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 
 export type GraphData = {
-  [questionId: ID]: DistributionDataPoint[];
+  [questionId: EntityId]: DistributionDataPoint[];
 };
 type Props = {
   survey: SelectedSurvey;
@@ -101,7 +101,7 @@ const Results = ({
 
   const switchGraph = survey.actionGrant.includes('edit')
     ? (
-        id: ID,
+        id: EntityId,
         selectedType: { value: SurveyQuestionDisplayType; label: string },
       ) => {
         const questionToUpdate = survey.questions.find(

--- a/app/routes/surveys/components/Submissions/SubmissionPublicResultsPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionPublicResultsPage.tsx
@@ -8,7 +8,6 @@ import { TokenNavigation } from '../../utils';
 import Results from './Results';
 import type { GraphData } from './Results';
 import type { EntityId } from '@reduxjs/toolkit';
-import type { ID } from 'app/store/models';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 
 const SubmissionPublicResultsPage = () => {
@@ -37,7 +36,7 @@ const SubmissionPublicResultsPage = () => {
   };
 
   const generateQuestionData = (questionId: EntityId) => {
-    const questionData: GraphData[ID] = [];
+    const questionData: GraphData[EntityId] = [];
     const question = survey.questions.find((q) => q.id === Number(questionId));
     if (!question) {
       return questionData;

--- a/app/routes/surveys/components/Submissions/SubmissionsSummary.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsSummary.tsx
@@ -7,8 +7,8 @@ import { isNotNullish } from 'app/utils';
 import styles from '../surveys.css';
 import Results from './Results';
 import type { GraphData } from './Results';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { SurveysRouteContext } from 'app/routes/surveys';
-import type { ID } from 'app/store/models';
 import type { AdminSurveyAnswer } from 'app/store/models/SurveyAnswer';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 import type { ReactNode } from 'react';
@@ -74,7 +74,7 @@ const SubmissionsSummary = () => {
   };
 
   const generateQuestionData = (question: SurveyQuestion) => {
-    const questionData: GraphData[ID] = [];
+    const questionData: GraphData[EntityId] = [];
     question.options.forEach((option) => {
       const selectedCount = submissions
         .map((submission) =>

--- a/app/routes/surveys/utils.tsx
+++ b/app/routes/surveys/utils.tsx
@@ -5,8 +5,8 @@ import NavigationLink from 'app/components/NavigationTab/NavigationLink';
 import config from 'app/config';
 import { SurveyQuestionType } from 'app/store/models/SurveyQuestion';
 import styles from './components/surveys.css';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant } from 'app/models';
-import type { ID } from 'app/store/models';
 import type { ReactNode } from 'react';
 
 export const questionTypeString: Record<SurveyQuestionType, string> = {
@@ -32,7 +32,7 @@ export const DetailNavigation = ({
   surveyId,
 }: {
   title: string;
-  surveyId?: ID;
+  surveyId?: EntityId;
   actionGrant?: ActionGrant;
 }) => (
   <NavigationTab
@@ -63,7 +63,7 @@ export const TokenNavigation = ({
   actionGrant = [],
 }: {
   title: ReactNode;
-  surveyId: ID;
+  surveyId: EntityId;
   actionGrant?: ActionGrant;
 }) => (
   <NavigationTab title={title}>
@@ -75,7 +75,7 @@ export const TokenNavigation = ({
   </NavigationTab>
 );
 
-export const getCsvUrl = (surveyId: ID) =>
+export const getCsvUrl = (surveyId: EntityId) =>
   `${config.serverUrl}/surveys/${surveyId}/csv/`;
 export const QuestionTypeOption = ({ iconName, option, ...props }: any) => (
   <div

--- a/app/routes/users/components/GroupChange.tsx
+++ b/app/routes/users/components/GroupChange.tsx
@@ -3,7 +3,8 @@ import { useState } from 'react';
 import { changeGrade } from 'app/actions/UserActions';
 import SelectInput from 'app/components/Form/SelectInput';
 import { useAppDispatch } from 'app/store/hooks';
-import type { Group, ID } from 'app/models';
+import type { EntityId } from '@reduxjs/toolkit';
+import type { Group } from 'app/models';
 
 type Props = {
   grades: Array<Group>;
@@ -11,7 +12,7 @@ type Props = {
   username: string;
 };
 type Option = {
-  value: ID;
+  value: EntityId;
   label: string;
 };
 const noLongerStudent = {

--- a/app/routes/users/components/PenaltyForm.tsx
+++ b/app/routes/users/components/PenaltyForm.tsx
@@ -13,8 +13,8 @@ import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { createValidator, isInteger, required } from 'app/utils/validation';
 import styles from './Penalties.css';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { searchMapping } from 'app/reducers/search';
-import type { ID } from 'app/store/models';
 import type { FormApi } from 'final-form';
 
 type FormValues = {
@@ -34,7 +34,7 @@ const validate = createValidator({
 });
 
 type Props = {
-  userId: ID;
+  userId: EntityId;
 };
 
 const PenaltyForm = ({ userId }: Props) => {

--- a/app/routes/users/components/PhotoConsents.tsx
+++ b/app/routes/users/components/PhotoConsents.tsx
@@ -7,8 +7,8 @@ import { PhotoConsentDomain } from 'app/models';
 import { getConsent, toReadableSemester } from 'app/routes/events/utils';
 import { useAppDispatch } from 'app/store/hooks';
 import styles from './PhotoConsents.css';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { PhotoConsent } from 'app/models';
-import type { ID } from 'app/store/models';
 
 const ConsentManager = ({
   consent,
@@ -89,7 +89,7 @@ const PhotoConsents = ({
 }: {
   photoConsents: Array<PhotoConsent>;
   username: string;
-  userId: ID;
+  userId: EntityId;
   isCurrentUser: boolean;
 }) => {
   const semesterOptions = photoConsents

--- a/app/store/models/Announcement.d.ts
+++ b/app/store/models/Announcement.d.ts
@@ -1,12 +1,12 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
-import type { ID } from 'app/store/models';
 import type { ListEvent } from 'app/store/models/Event';
 import type { PublicGroup } from 'app/store/models/Group';
 import type { DetailedMeeting } from 'app/store/models/Meeting';
 import type { PublicUser } from 'app/store/models/User';
 
 interface CompleteAnnouncement {
-  id: ID;
+  id: EntityId;
   message: string;
   fromGroup: null | PublicGroup;
   sent: null | Dateish;

--- a/app/store/models/Article.d.ts
+++ b/app/store/models/Article.d.ts
@@ -1,3 +1,4 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type AllowedPermissionsMixin from 'app/store/models/AllowedPermissionsMixin';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
@@ -5,18 +6,17 @@ import type { PublicGroup } from 'app/store/models/Group';
 import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
 import type { PublicUser } from 'app/store/models/User';
-import type { ID } from 'app/store/models/index';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 interface CompleteArticle {
-  id: ID;
+  id: EntityId;
   title: string;
   slug: string;
   cover: string;
   coverPlaceholder: string;
-  authors: Array<ID>;
+  authors: Array<EntityId>;
   description: string;
-  comments: ID[];
+  comments: EntityId[];
   contentTarget: ContentTarget;
   tags: string[];
   content: string;
@@ -82,7 +82,7 @@ export type UnknownArticle = (
   | AdminDetailedArticle
   | PublicArticle
 ) & {
-  comments?: ID[];
+  comments?: EntityId[];
   reactionsGrouped?: ReactionsGrouped[];
 };
 

--- a/app/store/models/Comment.d.ts
+++ b/app/store/models/Comment.d.ts
@@ -1,18 +1,18 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { PublicUser } from 'app/store/models/User';
-import type { ID } from 'app/store/models/index';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export interface Comment {
-  id: ID;
+  id: EntityId;
   text: string | null;
   author: PublicUser | null;
   contentTarget: ContentTarget;
   createdAt: Dateish;
   updatedAt: Dateish;
-  parent: ID | null;
+  parent: EntityId | null;
 }
 
 export default Comment;
 
-export type ContentAuthors = ID | ID[] | null | undefined;
+export type ContentAuthors = EntityId | EntityId[] | null | undefined;

--- a/app/store/models/Company.ts
+++ b/app/store/models/Company.ts
@@ -1,6 +1,6 @@
 import type { EventType } from './Event';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
-import type { ID } from 'app/store/models/index';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export enum NonEventContactStatus {
@@ -19,8 +19,8 @@ export type CompanySemesterContactStatus =
   | NonEventContactStatus;
 
 interface CompleteSemesterStatus {
-  id: ID;
-  semester: ID;
+  id: EntityId;
+  semester: EntityId;
   contactedStatus: CompanySemesterContactStatus[];
   contract?: string;
   statistics?: string;
@@ -51,7 +51,7 @@ export type DetailedSemesterStatus = Pick<
 export type AnySemesterStatus = SemesterStatus | DetailedSemesterStatus;
 
 export interface CompanyContact {
-  id: ID;
+  id: EntityId;
   name: string;
   role?: string;
   mail?: string;
@@ -60,12 +60,12 @@ export interface CompanyContact {
 }
 
 interface CompanyFile {
-  id: ID;
+  id: EntityId;
   file: string;
 }
 
 interface Company {
-  id: ID;
+  id: EntityId;
   name: string;
   active: boolean;
   description?: string;
@@ -79,10 +79,10 @@ interface Company {
   joblistingCount?: number;
   thumbnail?: string;
   semesterStatuses?: SemesterStatus[];
-  studentContact?: ID | null;
+  studentContact?: EntityId | null;
   adminComment?: string;
   paymentMail: string;
-  comments: ID[];
+  comments: EntityId[];
   contentTarget: ContentTarget;
   files: CompanyFile[];
   companyContacts: CompanyContact[];

--- a/app/store/models/CompanyInterest.d.ts
+++ b/app/store/models/CompanyInterest.d.ts
@@ -1,15 +1,15 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type Company from 'app/store/models/Company';
-import type { ID } from 'app/store/models/index';
 
 interface CompleteCompanyInterest {
-  id: ID;
+  id: EntityId;
   companyName: string;
   company: Company | null;
   contactPerson: string;
   mail: string;
   phone: string;
-  semesters: ID[];
+  semesters: EntityId[];
   createdAt: Dateish;
   officeInTrondheim: string;
   events: string[];

--- a/app/store/models/CompanySemester.d.ts
+++ b/app/store/models/CompanySemester.d.ts
@@ -1,7 +1,8 @@
-import type { ID, Semester } from 'app/store/models/index';
+import type { EntityId } from '@reduxjs/toolkit';
+import type { Semester } from 'app/store/models/index';
 
 export default interface CompanySemester {
-  id: ID;
+  id: EntityId;
   semester: Semester;
   year: number;
   activeInterestForm?: boolean;

--- a/app/store/models/EmailList.d.ts
+++ b/app/store/models/EmailList.d.ts
@@ -1,12 +1,12 @@
-import type { ID } from 'app/store/models/index';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { RoleType } from 'app/utils/constants';
 
 interface CompleteEmailList {
-  id: ID;
+  id: EntityId;
   name: string;
   email: string;
-  users: ID[];
-  groups: ID[];
+  users: EntityId[];
+  groups: EntityId[];
   groupRoles: RoleType[];
   requireInternalAddress: boolean;
   additionalEmails?: string[];

--- a/app/store/models/EmailUser.d.ts
+++ b/app/store/models/EmailUser.d.ts
@@ -1,8 +1,8 @@
-import type { ID } from 'app/store/models/index';
+import type { EntityId } from '@reduxjs/toolkit';
 
 export default interface EmailUser {
-  id: ID;
-  user: ID;
+  id: EntityId;
+  user: EntityId;
   internalEmail: string;
   internalEmailEnabled: boolean;
 }

--- a/app/store/models/Event.ts
+++ b/app/store/models/Event.ts
@@ -1,6 +1,6 @@
 import type { PublicGroup } from './Group';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
-import type { ID } from 'app/store/models';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
 import type { ListCompany } from 'app/store/models/Company';
 import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
@@ -21,7 +21,7 @@ export enum EventType {
 }
 
 interface Event {
-  id: ID;
+  id: EntityId;
   title: string;
   slug: string;
   description: string;
@@ -31,13 +31,13 @@ interface Event {
   eventType: EventType;
   eventStatusType: string;
   location: string;
-  comments: ID[];
+  comments: EntityId[];
   contentTarget: ContentTarget;
   startTime: Dateish;
   endTime: Dateish;
   mergeTime?: Dateish;
   thumbnail: string;
-  pools: ID[];
+  pools: EntityId[];
   totalCapacity: number;
   registrationCloseTime?: Dateish;
   registrationDeadlineHours?: number;
@@ -62,7 +62,7 @@ interface Event {
   createdBy?: PublicUser;
   registrationCount: number;
   legacyRegistrationCount: number;
-  survey?: ID;
+  survey?: EntityId;
   useConsent: boolean;
   youtubeUrl: string;
   mazemapPoi?: number;
@@ -77,12 +77,12 @@ interface Event {
   price: number;
   activationTime: Dateish;
   isAdmitted: boolean;
-  following: false | ID;
+  following: false | EntityId;
   spotsLeft: number;
-  pendingRegistration: ID;
-  photoConsents: ID[];
+  pendingRegistration: EntityId;
+  photoConsents: EntityId[];
 
-  unansweredSurveys: ID[];
+  unansweredSurveys: EntityId[];
 }
 
 export type PublicEvent = Pick<

--- a/app/store/models/Feed.d.ts
+++ b/app/store/models/Feed.d.ts
@@ -6,5 +6,5 @@ export type FeedID = 'notifications' | 'personal' | `user-${EntityId}`;
 export default interface Feed {
   id: EntityId;
   type: FeedType;
-  activities: ID[];
+  activities: EntityId[];
 }

--- a/app/store/models/FetchEntityPayload.d.ts
+++ b/app/store/models/FetchEntityPayload.d.ts
@@ -1,8 +1,8 @@
-import type { ID } from 'app/store/models/index';
+import type { EntityId } from '@reduxjs/toolkit';
 
 export default interface FetchEntityPayload<Entity> {
-  result: ID[];
-  entities: Record<ID, Entity>;
+  result: EntityId[];
+  entities: Record<EntityId, Entity>;
   next: null | string;
   previous: null | string;
 }

--- a/app/store/models/Forum.ts
+++ b/app/store/models/Forum.ts
@@ -1,35 +1,35 @@
 import type { PublicUser } from './User';
 import type { ContentTarget } from '../utils/contentTarget';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant, Dateish } from 'app/models';
-import type { ID } from 'app/store/models';
 
 export interface CreateThread {
   title: string;
   content: string;
-  forum: ID;
+  forum: EntityId;
 }
 
 export interface UpdateThread extends CreateThread {
-  id: ID;
+  id: EntityId;
 }
 
 export interface PublicThread {
-  id: ID;
+  id: EntityId;
   title: string;
   content: string;
   createdAt: Dateish;
-  forum: ID;
+  forum: EntityId;
 }
 
 export interface DetailedThread extends PublicThread {
-  comments?: ID[];
+  comments?: EntityId[];
   createdBy?: PublicUser;
   contentTarget: ContentTarget;
   actionGrant: ActionGrant;
 }
 
 export type UnknownThread = (PublicThread | DetailedThread) & {
-  comments?: ID[];
+  comments?: EntityId[];
 };
 
 export interface CreateForum {
@@ -38,11 +38,11 @@ export interface CreateForum {
 }
 
 export interface UpdateForum extends CreateForum {
-  id: ID;
+  id: EntityId;
 }
 
 export interface PublicForum {
-  id: ID;
+  id: EntityId;
   title: string;
   description: string;
   createdAt: Dateish;

--- a/app/store/models/Gallery.d.ts
+++ b/app/store/models/Gallery.d.ts
@@ -1,13 +1,13 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
 import type { PublicEvent } from 'app/store/models/Event';
 import type { GalleryCoverPicture } from 'app/store/models/GalleryPicture';
 import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
 import type { PublicUser } from 'app/store/models/User';
-import type { ID } from 'app/store/models/index';
 
 interface Gallery {
-  id: ID;
+  id: EntityId;
   title: string;
   description: string;
   cover: GalleryCoverPicture;
@@ -18,7 +18,7 @@ interface Gallery {
   event: PublicEvent;
   photographers: PublicUser[];
   publicMetadata: unknown;
-  pictures: ID[];
+  pictures: EntityId[];
 }
 
 export type ListGallery = Pick<

--- a/app/store/models/GalleryPicture.d.ts
+++ b/app/store/models/GalleryPicture.d.ts
@@ -1,16 +1,16 @@
-import type { ID } from 'app/store/models/index';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 interface GalleryPicture {
-  id: ID;
-  gallery: ID;
+  id: EntityId;
+  gallery: EntityId;
   description: string;
-  taggees: ID[];
+  taggees: EntityId[];
   active: boolean;
   file: string;
   thumbnail: string;
   rawFile: string;
-  comments: ID[];
+  comments: EntityId[];
   contentTarget: ContentTarget;
 }
 

--- a/app/store/models/Joblisting.ts
+++ b/app/store/models/Joblisting.ts
@@ -1,6 +1,6 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { CompanyContact, ListCompany } from 'app/store/models/Company';
-import type { ID } from 'app/store/models/index';
 
 enum JobType {
   FullTime = 'full_time',
@@ -13,12 +13,12 @@ enum JobType {
 type JoblistingYear = 1 | 2 | 3 | 4 | 5;
 
 export interface Workplace {
-  id: ID;
+  id: EntityId;
   town: string;
 }
 
 interface Joblisting {
-  id: ID;
+  id: EntityId;
   title: string;
   slug: string;
   text: string;

--- a/app/store/models/Meeting.d.ts
+++ b/app/store/models/Meeting.d.ts
@@ -1,21 +1,21 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant, Dateish } from 'app/models';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
-import type { ID } from 'app/store/models/index';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 interface Meeting {
-  id: ID;
-  createdBy: ID;
+  id: EntityId;
+  createdBy: EntityId;
   description: string;
   title: string;
   location: string;
   startTime: Dateish;
   endTime: Dateish;
   report: string;
-  reportAuthor?: ID;
-  invitations: ID[];
-  comments: ID[];
+  reportAuthor?: EntityId;
+  invitations: EntityId[];
+  comments: EntityId[];
   contentTarget: ContentTarget;
   mazemapPoi?: number;
   reactionsGrouped?: ReactionsGrouped[];
@@ -67,7 +67,7 @@ export type AutocompleteMeeting = Pick<
 };
 
 export type UnknownMeeting = (DetailedMeeting | ListMeeting) & {
-  comments?: ID[];
+  comments?: EntityId[];
   reactionsGrouped?: ReactionsGrouped[];
 };
 

--- a/app/store/models/MeetingInvitation.ts
+++ b/app/store/models/MeetingInvitation.ts
@@ -1,4 +1,4 @@
-import type { ID } from 'app/store/models/index';
+import type { EntityId } from '@reduxjs/toolkit';
 
 export enum MeetingInvitationStatus {
   NoAnswer = 'NO_ANSWER',
@@ -7,7 +7,7 @@ export enum MeetingInvitationStatus {
 }
 
 export interface MeetingInvitation {
-  user: ID;
+  user: EntityId;
   status: MeetingInvitationStatus;
-  meeting: ID;
+  meeting: EntityId;
 }

--- a/app/store/models/Membership.d.ts
+++ b/app/store/models/Membership.d.ts
@@ -1,12 +1,12 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { PublicUser } from 'app/store/models/User';
-import type { ID } from 'app/store/models/index';
 import type { RoleType } from 'app/utils/constants';
 
 export default interface Membership {
-  id: ID;
+  id: EntityId;
   user: PublicUser;
-  abakusGroup: ID;
+  abakusGroup: EntityId;
   role: RoleType;
   isActive: boolean;
   emailListsEnabled: boolean;

--- a/app/store/models/OAuth2Application.d.ts
+++ b/app/store/models/OAuth2Application.d.ts
@@ -1,8 +1,8 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { PublicUser } from 'app/store/models/User';
-import type { ID } from 'app/store/models/index';
 
 export default interface OAuth2Application {
-  id: ID;
+  id: EntityId;
   name: string;
   description: string;
   redirectUris: string[];

--- a/app/store/models/OAuth2Grant.d.ts
+++ b/app/store/models/OAuth2Grant.d.ts
@@ -1,12 +1,12 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
-import type { ID } from 'app/store/models/index';
 
 export default interface OAuth2Grant {
-  id: ID;
-  user: ID;
+  id: EntityId;
+  user: EntityId;
   token: string;
   application: {
-    id: ID;
+    id: EntityId;
     name: string;
     description: string;
   };

--- a/app/store/models/ObjectPermissionsMixin.d.ts
+++ b/app/store/models/ObjectPermissionsMixin.d.ts
@@ -1,9 +1,9 @@
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 
 interface ObjectPermissionsMixin {
-  canEditUsers: ID[];
-  canViewGroups: ID[];
-  canEditGroups: ID[];
+  canEditUsers: EntityId[];
+  canViewGroups: EntityId[];
+  canEditGroups: EntityId[];
   requireAuth: boolean;
 }
 

--- a/app/store/models/Page.d.ts
+++ b/app/store/models/Page.d.ts
@@ -1,9 +1,9 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
 import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
-import type { ID } from 'app/store/models/index';
 
 interface Page {
-  pk: ID;
+  pk: EntityId;
   title: string;
   slug: string;
   content: string;
@@ -33,7 +33,7 @@ export type SearchPage = Pick<
   Page,
   'title' | 'slug' | 'content' | 'picture' | 'category'
 > & {
-  id: ID;
+  id: EntityId;
 };
 
 export type AutocompletePage = Pick<

--- a/app/store/models/PastMembership.d.ts
+++ b/app/store/models/PastMembership.d.ts
@@ -1,10 +1,10 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type Group from 'app/store/models/Group';
-import type { ID } from 'app/store/models/index';
 import type { RoleType } from 'app/utils/constants';
 
 export default interface PastMembership {
-  id: ID;
+  id: EntityId;
   abakusGroup: Group;
   role: RoleType;
   startDate: Dateish;

--- a/app/store/models/Penalty.d.ts
+++ b/app/store/models/Penalty.d.ts
@@ -1,11 +1,11 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { PublicEvent } from 'app/store/models/Event';
-import type { ID } from 'app/store/models/index';
 
 export interface Penalty {
-  id: ID;
+  id: EntityId;
   createdAt: Dateish;
-  user: ID;
+  user: EntityId;
   reason: string;
   weight: number;
   sourceEvent: PublicEvent;

--- a/app/store/models/Poll.d.ts
+++ b/app/store/models/Poll.d.ts
@@ -1,15 +1,15 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
-import type { ID } from 'app/store/models/index';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 interface PollOption {
-  id: ID;
+  id: EntityId;
   name: string;
   votes: number;
 }
 
 export interface Poll {
-  id: ID;
+  id: EntityId;
   createdAt: Dateish;
   validUntil: Dateish;
   title: string;

--- a/app/store/models/Pool.d.ts
+++ b/app/store/models/Pool.d.ts
@@ -1,15 +1,15 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { PublicGroup } from 'app/store/models/Group';
-import type { ID } from 'app/store/models/index';
 
 interface CompletePool {
-  id: ID;
+  id: EntityId;
   name: string;
   capacity: number;
   activationDate: Dateish;
   permissionGroups: PublicGroup[];
   registrationCount: number;
-  registrations: ID[];
+  registrations: EntityId[];
 }
 
 export type PublicPool = Pick<

--- a/app/store/models/Quote.d.ts
+++ b/app/store/models/Quote.d.ts
@@ -1,10 +1,10 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
-import type { ID } from 'app/store/models/index';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export default interface Quote {
-  id: ID;
+  id: EntityId;
   createdAt: Dateish;
   text: string;
   source: string;

--- a/app/store/models/Reaction.d.ts
+++ b/app/store/models/Reaction.d.ts
@@ -1,9 +1,9 @@
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { PublicUser } from 'app/store/users/User';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export default interface Reaction {
-  reactionId: ID;
+  reactionId: EntityId;
   emoji: string;
   contentTarget: ContentTarget;
 }
@@ -15,6 +15,6 @@ export interface ReactionsGrouped {
   unicodeString: string;
   count: number;
   hasReacted: boolean;
-  reactionId?: ID;
+  reactionId?: EntityId;
   users?: PublicUser[];
 }

--- a/app/store/models/Registration.ts
+++ b/app/store/models/Registration.ts
@@ -1,10 +1,10 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish } from 'app/models';
 import type {
   DetailedUser,
   PhotoConsent,
   PublicUser,
 } from 'app/store/models/User';
-import type { ID } from 'app/store/models/index';
 
 export enum Presence {
   PRESENT = 'PRESENT',
@@ -14,13 +14,13 @@ export enum Presence {
 }
 
 interface Registration {
-  id: ID;
+  id: EntityId;
   user: PublicUser;
   detailedUser: DetailedUser;
-  createdBy: ID;
-  updatedBy: ID;
-  pool: ID;
-  event: ID;
+  createdBy: EntityId;
+  updatedBy: EntityId;
+  pool: EntityId;
+  event: EntityId;
   presence: Presence;
   feedback: string;
   sharedMemberships: unknown;

--- a/app/store/models/RestrictedMail.d.ts
+++ b/app/store/models/RestrictedMail.d.ts
@@ -5,7 +5,7 @@ import type { FieldMeeting } from 'app/store/models/Meeting';
 import type { PublicUser } from 'app/store/models/User';
 
 interface CompleteRestrictedMail {
-  id: ID;
+  id: EntityId;
   fromAddress: string;
   hideSender: boolean;
   used: Dateish;

--- a/app/store/models/Survey.d.ts
+++ b/app/store/models/Survey.d.ts
@@ -1,5 +1,5 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant, Dateish } from 'app/models';
-import type { ID } from 'app/store/models';
 import type { EventType } from 'app/store/models/Event';
 import type {
   SurveyQuestion,
@@ -11,10 +11,10 @@ import type { ValueLabel } from 'app/types';
 import type { Optional, Overwrite } from 'utility-types';
 
 interface Survey {
-  id: ID;
+  id: EntityId;
   title: string;
   activeFrom: Dateish;
-  event: ID;
+  event: EntityId;
   templateType: EventType | null;
   questions: SurveyQuestion[];
   actionGrant: ActionGrant;
@@ -53,7 +53,7 @@ export type PublicResultsSurvey = Omit<
   'actionGrant' | 'token'
 > & {
   results: {
-    [key: ID]: PublicTextQuestionResult | PublicChoiceQuestionResult;
+    [key: EntityId]: PublicTextQuestionResult | PublicChoiceQuestionResult;
   };
   submissionCount: number;
 };

--- a/app/store/models/SurveyAnswer.d.ts
+++ b/app/store/models/SurveyAnswer.d.ts
@@ -1,13 +1,13 @@
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 import type { Overwrite } from 'utility-types';
 
 interface CompleteSurveyAnswer {
-  id: ID;
-  submission: ID;
+  id: EntityId;
+  submission: EntityId;
   question: SurveyQuestion;
   answerText: string;
-  selectedOptions: ID[];
+  selectedOptions: EntityId[];
   hideFromPublic: boolean;
 }
 
@@ -22,6 +22,6 @@ export type AdminSurveyAnswer = Pick<CompleteSurveyAnswer, 'hideFromPublic'> &
 export type FormSurveyAnswer = Overwrite<
   Pick<CompleteSurveyAnswer, 'question' | 'answerText' | 'selectedOptions'>,
   {
-    question: ID;
+    question: EntityId;
   }
 >;

--- a/app/store/models/SurveyQuestion.ts
+++ b/app/store/models/SurveyQuestion.ts
@@ -1,4 +1,4 @@
-import type { ID } from 'app/store/models/index';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { ValueLabel } from 'app/types';
 import type { Optional, Overwrite } from 'utility-types';
 
@@ -13,7 +13,7 @@ export enum SurveyQuestionDisplayType {
 }
 
 export interface SurveyQuestion {
-  id: ID;
+  id: EntityId;
   displayType: SurveyQuestionDisplayType;
   questionType: SurveyQuestionType;
   questionText: string;
@@ -23,7 +23,7 @@ export interface SurveyQuestion {
 }
 
 export interface SurveyQuestionOption {
-  id: ID;
+  id: EntityId;
   optionText: string;
 }
 

--- a/app/store/models/SurveySubmission.d.ts
+++ b/app/store/models/SurveySubmission.d.ts
@@ -1,4 +1,4 @@
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type {
   AdminSurveyAnswer,
   FormSurveyAnswer,
@@ -6,14 +6,14 @@ import type {
 } from 'app/store/models/SurveyAnswer';
 
 export interface SurveySubmission {
-  id: ID;
-  user: ID;
-  survey: ID;
+  id: EntityId;
+  user: EntityId;
+  survey: EntityId;
   answers: (SurveyAnswer | AdminSurveyAnswer)[];
 }
 
 export type FormSurveySubmission = {
-  id?: ID;
-  user: ID;
+  id?: EntityId;
+  user: EntityId;
   answers: FormSurveyAnswer[];
 };

--- a/app/store/models/Tag.d.ts
+++ b/app/store/models/Tag.d.ts
@@ -1,5 +1,5 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
-import type { ID } from 'app/store/models/index';
 
 enum TaggedType {
   Article = 'article',
@@ -23,10 +23,10 @@ export type DetailedTag = Pick<Tag, 'tag' | 'usages' | 'relatedCounts'>;
 
 export type UnknownTag = ListTag | DetailedTag;
 
-export type SearchTag = Pick<Tag, 'tag'> & { id: ID };
+export type SearchTag = Pick<Tag, 'tag'> & { id: EntityId };
 
 export type AutocompleteTag = Pick<Tag, 'tag'> & {
-  id: ID;
+  id: EntityId;
   contentType: AutocompleteContentType.Tag;
   text: 'text';
 };

--- a/app/store/models/User.ts
+++ b/app/store/models/User.ts
@@ -1,10 +1,10 @@
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Dateish, PhotoConsentDomain, Semester } from 'app/models';
 import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
 import type { PublicEmailList } from 'app/store/models/EmailList';
 import type { PublicGroup } from 'app/store/models/Group';
 import type Membership from 'app/store/models/Membership';
 import type PastMembership from 'app/store/models/PastMembership';
-import type { ID } from 'app/store/models/index';
 import type { Required } from 'utility-types';
 
 export interface PhotoConsent {
@@ -22,7 +22,7 @@ export const Gender = {
 } as const;
 
 interface User {
-  id: ID;
+  id: EntityId;
   username: string;
   firstName: string;
   lastName: string;
@@ -39,9 +39,9 @@ interface User {
   isActive: boolean;
   isStudent: boolean;
   abakusEmailLists: PublicEmailList[];
-  penalties: ID[];
+  penalties: EntityId[];
   icalToken: string;
-  abakusGroups: ID[];
+  abakusGroups: EntityId[];
   isAbakusMember: boolean;
   isAbakomMember: boolean;
   pastMemberships: PastMembership[];

--- a/app/store/models/entities.ts
+++ b/app/store/models/entities.ts
@@ -1,4 +1,5 @@
 import type OAuth2Grant from './OAuth2Grant';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { UnknownAnnouncement } from 'app/store/models/Announcement';
 import type { UnknownArticle } from 'app/store/models/Article';
 import type Comment from 'app/store/models/Comment';
@@ -32,7 +33,6 @@ import type { Survey } from 'app/store/models/Survey';
 import type { SurveySubmission } from 'app/store/models/SurveySubmission';
 import type { UnknownTag } from 'app/store/models/Tag';
 import type { UnknownUser } from 'app/store/models/User';
-import type { ID } from 'app/store/models/index';
 
 export enum EntityType {
   Announcements = 'announcements',
@@ -74,50 +74,50 @@ export enum EntityType {
 
 // Most fetch success redux actions are normalized such that payload.entities is a subset of this interface.
 export default interface Entities {
-  [EntityType.Announcements]: Record<ID, UnknownAnnouncement>;
-  [EntityType.Articles]: Record<ID, UnknownArticle>;
-  [EntityType.Comments]: Record<ID, Comment>;
-  [EntityType.Companies]: Record<ID, UnknownCompany>;
-  [EntityType.CompanyInterests]: Record<ID, UnknownCompanyInterest>;
-  [EntityType.CompanySemesters]: Record<ID, CompanySemester>;
-  [EntityType.EmailLists]: Record<ID, UnknownEmailList>;
-  [EntityType.EmailUsers]: Record<ID, EmailUser>;
-  [EntityType.Emojis]: Record<ID, Emoji>;
-  [EntityType.Events]: Record<ID, UnknownEvent>;
-  [EntityType.FeedActivities]: Record<ID, AggregatedFeedActivity>;
-  [EntityType.Feeds]: Record<ID, Feed>;
-  [EntityType.Forums]: Record<ID, UnknownForum>;
-  [EntityType.Galleries]: Record<ID, UnknownGallery>;
-  [EntityType.GalleryPictures]: Record<ID, UnknownGalleryPicture>;
-  [EntityType.Groups]: Record<ID, UnknownGroup>;
-  [EntityType.Joblistings]: Record<ID, UnknownJoblisting>;
-  [EntityType.MeetingInvitations]: Record<ID, MeetingInvitation>;
-  [EntityType.Meetings]: Record<ID, UnknownMeeting>;
-  [EntityType.Memberships]: Record<ID, Membership>;
-  [EntityType.OAuth2Applications]: Record<ID, OAuth2Application>;
-  [EntityType.OAuth2Grants]: Record<ID, OAuth2Grant>;
-  [EntityType.Pages]: Record<ID, UnknownPage>;
-  [EntityType.Penalties]: Record<ID, Penalty>;
-  [EntityType.Polls]: Record<ID, Poll>;
-  [EntityType.Pools]: Record<ID, UnknownPool>;
-  [EntityType.Quotes]: Record<ID, Quote>;
-  [EntityType.Reactions]: Record<ID, Reaction>;
-  [EntityType.Registrations]: Record<ID, UnknownRegistration>;
-  [EntityType.RestrictedMails]: Record<ID, UnknownRestrictedMail>;
-  [EntityType.SurveySubmissions]: Record<ID, SurveySubmission>;
-  [EntityType.Surveys]: Record<ID, Survey>;
-  [EntityType.Tags]: Record<ID, UnknownTag>;
-  [EntityType.Thread]: Record<ID, UnknownThread>;
-  [EntityType.Users]: Record<ID, UnknownUser>;
+  [EntityType.Announcements]: Record<EntityId, UnknownAnnouncement>;
+  [EntityType.Articles]: Record<EntityId, UnknownArticle>;
+  [EntityType.Comments]: Record<EntityId, Comment>;
+  [EntityType.Companies]: Record<EntityId, UnknownCompany>;
+  [EntityType.CompanyInterests]: Record<EntityId, UnknownCompanyInterest>;
+  [EntityType.CompanySemesters]: Record<EntityId, CompanySemester>;
+  [EntityType.EmailLists]: Record<EntityId, UnknownEmailList>;
+  [EntityType.EmailUsers]: Record<EntityId, EmailUser>;
+  [EntityType.Emojis]: Record<EntityId, Emoji>;
+  [EntityType.Events]: Record<EntityId, UnknownEvent>;
+  [EntityType.FeedActivities]: Record<EntityId, AggregatedFeedActivity>;
+  [EntityType.Feeds]: Record<EntityId, Feed>;
+  [EntityType.Forums]: Record<EntityId, UnknownForum>;
+  [EntityType.Galleries]: Record<EntityId, UnknownGallery>;
+  [EntityType.GalleryPictures]: Record<EntityId, UnknownGalleryPicture>;
+  [EntityType.Groups]: Record<EntityId, UnknownGroup>;
+  [EntityType.Joblistings]: Record<EntityId, UnknownJoblisting>;
+  [EntityType.MeetingInvitations]: Record<EntityId, MeetingInvitation>;
+  [EntityType.Meetings]: Record<EntityId, UnknownMeeting>;
+  [EntityType.Memberships]: Record<EntityId, Membership>;
+  [EntityType.OAuth2Applications]: Record<EntityId, OAuth2Application>;
+  [EntityType.OAuth2Grants]: Record<EntityId, OAuth2Grant>;
+  [EntityType.Pages]: Record<EntityId, UnknownPage>;
+  [EntityType.Penalties]: Record<EntityId, Penalty>;
+  [EntityType.Polls]: Record<EntityId, Poll>;
+  [EntityType.Pools]: Record<EntityId, UnknownPool>;
+  [EntityType.Quotes]: Record<EntityId, Quote>;
+  [EntityType.Reactions]: Record<EntityId, Reaction>;
+  [EntityType.Registrations]: Record<EntityId, UnknownRegistration>;
+  [EntityType.RestrictedMails]: Record<EntityId, UnknownRestrictedMail>;
+  [EntityType.SurveySubmissions]: Record<EntityId, SurveySubmission>;
+  [EntityType.Surveys]: Record<EntityId, Survey>;
+  [EntityType.Tags]: Record<EntityId, UnknownTag>;
+  [EntityType.Thread]: Record<EntityId, UnknownThread>;
+  [EntityType.Users]: Record<EntityId, UnknownUser>;
 }
 
 type InferEntityType<T> = {
-  [K in keyof Entities]: T extends Entities[K][ID] ? K : never;
+  [K in keyof Entities]: T extends Entities[K][EntityId] ? K : never;
 }[keyof Entities];
 
 export type NormalizedPayloadEntities<T> = Record<
   InferEntityType<T>,
-  Record<ID, T | undefined>
+  Record<EntityId, T | undefined>
 >;
 
 export interface NormalizedEntityPayload<EntityKeys extends keyof Entities> {

--- a/app/store/models/index.ts
+++ b/app/store/models/index.ts
@@ -1,6 +1,3 @@
-// usually a number, but some entities (f.ex. tags) use the name as id
-export type ID = number | string;
-
 export enum Semester {
   Spring = 'spring',
   Autumn = 'autumn',

--- a/app/store/utils/contentTarget.ts
+++ b/app/store/utils/contentTarget.ts
@@ -1,13 +1,13 @@
 import getEntityType from 'app/utils/getEntityType';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { EntityServerName } from 'app/utils/getEntityType';
 
-export type ContentTarget = `${EntityServerName}-${ID}`;
+export type ContentTarget = `${EntityServerName}-${EntityId}`;
 
 export const parseContentTarget = (contentTarget: ContentTarget) => {
   const [serverTargetType, targetId] = contentTarget.split('-') as [
     EntityServerName,
-    ID,
+    EntityId,
   ];
   const targetType = getEntityType(serverTargetType);
 

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,7 +1,6 @@
 import type { ActionGrant } from './models';
-import type { ID } from './store/models';
 import type { NormalizedPayloadEntities } from './store/models/entities';
-import type { AnyAction, ThunkAction } from '@reduxjs/toolkit';
+import type { AnyAction, EntityId, ThunkAction } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
 import type { JwtPayload } from 'jwt-decode';
 import type { Overwrite } from 'utility-types';
@@ -47,7 +46,7 @@ export type NormalizedApiPayload<T = unknown> = {
   entities: NormalizedPayloadEntities<T extends Array<infer E> ? E : T>;
   next?: string;
   previous?: string;
-  result: T extends Array<unknown> ? ID[] : ID;
+  result: T extends Array<unknown> ? EntityId[] : EntityId;
 };
 
 export type GetState = () => RootState;

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -42,9 +42,9 @@ export const roleOptions = (Object.keys(ROLES) as RoleType[])
   }));
 
 /*
- * Use the production group ID (11) if the ENVIRONMENT environment value is 'production' or 'staging'
+ * Use the production group id (11) if the ENVIRONMENT environment value is 'production' or 'staging'
  * (i.e. abakus.no, webapp-staging.abakus.no) or if it's run locally through yarn start:staging 'local_staging'.
- * Use the local backend group ID (12) if the webapp is running with yarn start.
+ * Use the local backend group id (12) if the webapp is running with yarn start.
  */
 export const WEBKOM_GROUP_ID: number =
   config.environment &&

--- a/app/utils/createEntityReducer.ts
+++ b/app/utils/createEntityReducer.ts
@@ -4,7 +4,7 @@ import { parse } from 'qs';
 import { configWithSSR } from 'app/config';
 import joinReducers from 'app/utils/joinReducers';
 import mergeObjects from 'app/utils/mergeObjects';
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 import type { Reducer, AsyncActionType } from 'app/types';
 import type { StrictReducer } from 'app/utils/joinReducers';
 import type { AnyAction } from 'redux';
@@ -41,7 +41,7 @@ type PaginationCursor = Record<string, string> & { cursor: string };
 
 type PaginationNext = {
   [query: string]: {
-    items: ID[];
+    items: EntityId[];
     hasMore: boolean;
     query: Record<string, string>;
     hasMoreBackwards: boolean;
@@ -55,8 +55,8 @@ export type EntityReducerState<T = any> = {
   actionGrant: string[];
   pagination: Pagination;
   paginationNext: PaginationNext;
-  byId: Record<ID, T>;
-  items: ID[];
+  byId: Record<EntityId, T>;
+  items: EntityId[];
   fetching: boolean;
   hasMore?: boolean;
 };

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -1,4 +1,4 @@
-import type { ID } from 'app/store/models';
+import type { EntityId } from '@reduxjs/toolkit';
 
 type TreeNode<T> = T & {
   children: Tree<T>;
@@ -23,13 +23,13 @@ export type Tree<T> = Array<TreeNode<T>>;
  */
 export function generateTreeStructure<
   T extends {
-    id: ID;
-    parent?: ID | null;
+    id: EntityId;
+    parent?: EntityId | null;
   },
 >(nodes: Array<T>): Tree<T> {
   // Create a map of id -> node for retrievals later:
-  const tree: { [id: ID]: TreeNode<T> } = nodes.reduce(
-    (acc: { [id: ID]: TreeNode<T> }, node: T) => ({
+  const tree: { [id: EntityId]: TreeNode<T> } = nodes.reduce(
+    (acc: { [id: EntityId]: TreeNode<T> }, node: T) => ({
       ...acc,
       [node.id]: { ...node, children: [] },
     }),

--- a/app/utils/legoAdapter/asyncApiActions.ts
+++ b/app/utils/legoAdapter/asyncApiActions.ts
@@ -1,6 +1,5 @@
 // is often expanded with additional properties
-import type { AnyAction } from '@reduxjs/toolkit';
-import type { ID } from 'app/store/models';
+import type { EntityId, AnyAction } from '@reduxjs/toolkit';
 import type Entities from 'app/store/models/entities';
 import type {
   EntityType,
@@ -23,14 +22,14 @@ export interface FetchMeta extends BaseMeta {
   };
 }
 export interface DeleteMeta extends BaseMeta {
-  id: ID;
+  id: EntityId;
 }
 
 type AnyPayload = FetchPayload | [] | null;
 export interface FetchPayload {
   actionGrant?: string[];
   entities: Partial<Entities>;
-  result?: ID[];
+  result?: EntityId[];
   next?: string;
   previous?: string;
 }


### PR DESCRIPTION
# Description

While typing the codebase, we have ended up with three different types for entity ids. This is obviously unnecessary, so I changed them all into `EntityId`. `EntityId` comes from `redux-toolkit` and is meant for use in the `entityAdapter` that `legoAdapter` is built upon. I think it makes sense to use this one for everything, as everything with an id is an object that will be stored in a `legoAdapter`-slice in redux.

# Result

Removed the `ID`-type from "app/store/models/index.ts"
Removed the `ID`-type from "app/models.ts"

# Testing

- [x] I have thoroughly tested my changes.

`yarn lint` finds no issues, and it's only type-changes.