### PR TITLE
Use createSlice and legoAdapter for polls slice

### DIFF
--- a/app/actions/PollActions.ts
+++ b/app/actions/PollActions.ts
@@ -3,30 +3,24 @@ import { Poll } from './ActionTypes';
 import callAPI from './callAPI';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { Tags } from 'app/models';
-import type { OptionEntity } from 'app/reducers/polls';
 import type { Poll as PollType } from 'app/store/models/Poll';
-import type { Thunk } from 'app/types';
 
-export function fetchAll({
+export const fetchAll = ({
   next = false,
 }: {
   next?: boolean;
-} = {}): Thunk<any> {
-  return (dispatch, getState) => {
-    const cursor = next ? getState().polls.pagination.next : {};
-    return dispatch(
-      callAPI({
-        types: Poll.FETCH_ALL,
-        endpoint: '/polls/',
-        schema: [pollSchema],
-        query: cursor,
-        meta: {
-          errorMessage: 'Henting av avstemninger feilet',
-        },
-      }),
-    );
-  };
-}
+} = {}) =>
+  callAPI({
+    types: Poll.FETCH_ALL,
+    endpoint: '/polls/',
+    schema: [pollSchema],
+    pagination: {
+      fetchNext: next,
+    },
+    meta: {
+      errorMessage: 'Henting av avstemninger feilet',
+    },
+  });
 
 export function fetchPoll(pollId: EntityId) {
   return callAPI<PollType>({
@@ -66,12 +60,10 @@ export function editPoll(data: {
   description: string;
   pinned: boolean;
   tags: Tags;
-  options: Array<
-    | OptionEntity
-    | {
-        name: string;
-      }
-  >;
+  options: {
+    id?: EntityId;
+    name: string;
+  }[];
 }) {
   return callAPI<PollType>({
     types: Poll.UPDATE,

--- a/app/reducers/polls.ts
+++ b/app/reducers/polls.ts
@@ -1,48 +1,32 @@
-import { createSelector } from 'reselect';
+import { createSlice } from '@reduxjs/toolkit';
+import moment from 'moment-timezone';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { Poll } from '../actions/ActionTypes';
-import createEntityReducer from '../utils/createEntityReducer';
-import type { EntityId } from '@reduxjs/toolkit';
-import type { Tags } from 'app/models';
 
-export type OptionEntity = {
-  id: number;
-  name: string;
-  votes: number;
-};
-export type PollEntity = {
-  id: EntityId;
-  title: string;
-  description: string;
-  resultsHidden: boolean;
-  pinned: boolean;
-  tags: Tags;
-  hasAnswered: boolean;
-  totalVotes: number;
-  options: Array<OptionEntity>;
-};
-export default createEntityReducer({
-  key: 'polls',
-  types: {
-    fetch: [Poll.FETCH, Poll.FETCH_ALL],
-    mutate: Poll.CREATE,
-    delete: Poll.DELETE,
-  },
+import type { RootState } from 'app/store/createRootReducer';
+
+const legoAdapter = createLegoAdapter(EntityType.Polls, {
+  sortComparer: (a, b) => moment(b.createdAt).diff(a.createdAt),
 });
-export const selectPolls = createSelector(
-  (state) => state.polls.byId,
-  (state) => state.polls.items,
-  (pollsById, pollsIds) => {
-    return pollsIds.map((id) => pollsById[id]);
-  },
-);
-export const selectPollById = createSelector(
-  selectPolls,
-  (state, pollsId) => pollsId,
-  (polls, pollsId) => {
-    if (!polls || !pollsId) return {};
-    return polls.find((polls) => Number(polls.id) === Number(pollsId));
-  },
-);
-export const selectPinnedPolls = createSelector(selectPolls, (polls) =>
-  polls.filter((polls) => polls.pinned),
-);
+
+const pollsSlice = createSlice({
+  name: EntityType.Polls,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [Poll.FETCH, Poll.FETCH_ALL],
+    deleteActions: [Poll.DELETE],
+  }),
+});
+
+export default pollsSlice.reducer;
+
+export const {
+  selectAll: selectAllPolls,
+  selectById: selectPollById,
+  selectByField: selectPollsByField,
+} = legoAdapter.getSelectors((state: RootState) => state.polls);
+
+export const selectPinnedPoll = (state: RootState) =>
+  selectPollsByField('pinned').single(state, true);

--- a/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
+++ b/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
@@ -17,7 +17,7 @@ import {
   addEventType,
   selectPinned,
 } from 'app/reducers/frontpage';
-import { selectPinnedPolls } from 'app/reducers/polls';
+import { selectPinnedPoll } from 'app/reducers/polls';
 import { selectRandomQuote } from 'app/reducers/quotes';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
@@ -251,7 +251,7 @@ const UpcomingRegistrationsSection = () => (
 );
 
 const PollItem = () => {
-  const poll = useAppSelector(selectPinnedPolls)[0];
+  const poll = useAppSelector(selectPinnedPoll);
   const fetching = useAppSelector(
     (state) => state.frontpage.fetching || state.polls.fetching,
   );

--- a/app/routes/polls/components/PollsList.tsx
+++ b/app/routes/polls/components/PollsList.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  Card,
-  Flex,
-  Icon,
-  LoadingIndicator,
-} from '@webkom/lego-bricks';
+import { Button, Card, Flex, Icon } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
@@ -12,15 +6,25 @@ import { fetchAll } from 'app/actions/PollActions';
 import { Content } from 'app/components/Content';
 import NavigationTab from 'app/components/NavigationTab';
 import Paginator from 'app/components/Paginator';
-import { selectPolls } from 'app/reducers/polls';
+import { selectAllPolls } from 'app/reducers/polls';
+import { selectPaginationNext } from 'app/reducers/selectors';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import { EntityType } from 'app/store/models/entities';
 import styles from './PollsList.css';
 
 const PollsList = () => {
-  const polls = useAppSelector(selectPolls);
+  const polls = useAppSelector(selectAllPolls);
   const actionGrant = useAppSelector((state) => state.polls.actionGrant);
   const fetching = useAppSelector((state) => state.polls.fetching);
-  const hasMore = useAppSelector((state) => state.polls.hasMore);
+  const {
+    pagination: { hasMore },
+  } = useAppSelector(
+    selectPaginationNext({
+      endpoint: '/polls/',
+      query: {},
+      entity: EntityType.Polls,
+    }),
+  );
 
   const dispatch = useAppDispatch();
 
@@ -40,7 +44,7 @@ const PollsList = () => {
         }
       />
       <Paginator
-        hasMore={!!hasMore}
+        hasMore={fetching || hasMore} // Paginator only shows loading indicator if hasMore is true
         fetching={fetching}
         fetchNext={() => {
           dispatch(
@@ -52,11 +56,7 @@ const PollsList = () => {
       >
         <section className={styles.pollsList}>
           {polls.map((poll) => (
-            <Link
-              key={poll.id}
-              to={`/polls/${poll.id}`}
-              className={styles.pollItem}
-            >
+            <Link key={poll.id} to={`/polls/${poll.id}`}>
               <Card isHoverable className={styles.pollListItem}>
                 <Flex>
                   <Icon name="stats-chart" size={35} className={styles.icon} />
@@ -94,7 +94,6 @@ const PollsList = () => {
           ))}
         </section>
       </Paginator>
-      <LoadingIndicator loading={fetching} />
     </Content>
   );
 };

--- a/app/store/models/Poll.d.ts
+++ b/app/store/models/Poll.d.ts
@@ -22,6 +22,7 @@ export interface Poll {
   tags: string[];
   hasAnswered: boolean;
   pinned: boolean;
+  actionGrant?: string[];
 }
 
 export default Poll;


### PR DESCRIPTION
# Description

One more slice down. This one is fairly straigtforward, but I did have to change from using old `pagination` to `paginationNext` in poll list.

# Result

I fixed a bug where there would be two loading indicators when fetching more polls in the poll list:
<img width="1143" alt="Screenshot 2024-03-29 at 16 37 54" src="https://github.com/webkom/lego-webapp/assets/8343002/e42a9a5c-18eb-4683-84c9-6b1471440cbb">

# Testing

- [x] I have thoroughly tested my changes.

Have tested poll list, poll detail page, creating a new poll and voting in the poll.

---

ABA-688