### PR TITLE
Add localstorage saving to meeting report

### DIFF
--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -67,6 +67,7 @@ const AccountDropdownItems = ({ onClose }: AccountDropdownItemsProps) => {
         <button
           onClick={() => {
             dispatch(logout());
+            sessionStorage.clear();
             navigate('/');
             onClose();
           }}

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -124,9 +124,11 @@ const MeetingEditor = () => {
       : undefined,
   );
 
+  //For some reason calling the debounce function directly was wack.
+  //Also, we want to check if the new length is greater than the old one or if it doesn't exist already.
   const updateReportValue = useCallback(
     (newReportValue) => {
-      debounce(() => {
+      const debounceFunc = debounce(() => {
         const storedReport = sessionStorage.getItem(
           `meeting-${meetingId}-report`,
         );
@@ -134,11 +136,11 @@ const MeetingEditor = () => {
           setReportValue(newReportValue);
         }
       }, 4500);
+      debounceFunc();
     },
     [meetingId],
   );
 
-  //We only want to override the sessionStorage meeting if we add something, or if it does not exist already
   useEffect(() => {
     if (meeting && meetingId) {
       const storedReport = sessionStorage.getItem(
@@ -502,7 +504,7 @@ const MeetingEditor = () => {
                   sessionStorage.getItem(`meeting-${meeting.id}-report`) !==
                     null && (
                     <ConfirmModal
-                      title="Hente inn referat fra lokal lagring?"
+                      title="Hente inn referat fra sessionStorage?"
                       message={`Fant en lagret backup for dette møtet. Dette vil overskrive det nåværende referatet lokalt.`}
                       onConfirm={() => {
                         loadReportFromLocalStorage(form);

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -7,7 +7,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { debounce, unionBy } from 'lodash';
 import moment from 'moment-timezone';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Field, FormSpy } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { useParams, useNavigate } from 'react-router-dom';
@@ -126,20 +126,20 @@ const MeetingEditor = () => {
 
   //For some reason calling the debounce function directly was wack.
   //Also, we want to check if the new length is greater than the old one or if it doesn't exist already.
-  const updateReportValue = useCallback(
-    (newReportValue) => {
-      const debounceFunc = debounce(() => {
-        const storedReport = sessionStorage.getItem(
-          `meeting-${meetingId}-report`,
-        );
-        if (!storedReport || storedReport.length < newReportValue.length) {
-          setReportValue(newReportValue);
-        }
-      }, 4500);
-      debounceFunc();
-    },
-    [meetingId],
-  );
+  const updateReportValue = useMemo(() => {
+    const debouncedUpdate = debounce((newReportValue) => {
+      const storedReport = sessionStorage.getItem(
+        `meeting-${meetingId}-report`,
+      );
+      if (!storedReport || storedReport.length < newReportValue.length) {
+        setReportValue(newReportValue);
+      }
+    }, 4500);
+
+    return (newReportValue) => {
+      debouncedUpdate(newReportValue);
+    };
+  }, [meetingId]);
 
   useEffect(() => {
     if (meeting && meetingId) {

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -5,9 +5,9 @@ import {
   LoadingIndicator,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { unionBy } from 'lodash';
+import { debounce, unionBy } from 'lodash';
 import moment from 'moment-timezone';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Field, FormSpy } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { useParams, useNavigate } from 'react-router-dom';
@@ -105,6 +105,8 @@ type MeetingEditorParams = {
 };
 const MeetingEditor = () => {
   const { meetingId } = useParams<MeetingEditorParams>();
+  const [formKey, setFormKey] = useState(0);
+  const [reportValue, setReportValue] = useState('');
   const meeting = useAppSelector((state) =>
     meetingId
       ? (selectMeetingById(state, meetingId) as DetailedMeeting)
@@ -121,6 +123,31 @@ const MeetingEditor = () => {
       ? selectUserById(state, meeting?.reportAuthor)
       : undefined,
   );
+
+  const updateReportValue = useCallback(
+    (newReportValue) => {
+      const debouncedFunction = debounce(() => {
+        const storedReport = localStorage.getItem(`meeting-${meetingId}-temp`);
+        if (!storedReport || storedReport.length < newReportValue.length) {
+          setReportValue(newReportValue);
+        }
+      }, 4500);
+
+      debouncedFunction();
+    },
+    [meetingId],
+  );
+
+  useEffect(() => {
+    if (meeting && meetingId) {
+      const storedReport = localStorage.getItem(
+        `meeting-${meeting?.id}-report`,
+      );
+      if (!storedReport || storedReport.length < reportValue.length) {
+        localStorage.setItem(`meeting-${meeting?.id}-report`, reportValue);
+      }
+    }
+  }, [reportValue, meeting, meetingId]);
 
   const currentUser = useCurrentUser();
 
@@ -239,6 +266,14 @@ const MeetingEditor = () => {
 
   const title = isEditPage ? `Redigerer: ${meeting.title}` : 'Nytt møte';
 
+  const loadReportFromLocalStorage = (form) => {
+    const storedReport = localStorage.getItem(`meeting-${meeting.id}-report`);
+    if (storedReport) {
+      form.change('report', storedReport);
+      setFormKey(formKey + 1);
+    }
+  };
+
   return (
     <Content>
       <Helmet title={title} />
@@ -269,7 +304,16 @@ const MeetingEditor = () => {
                 name="report"
                 label="Referat"
                 component={EditorField.Field}
+                key={formKey}
               />
+
+              <FormSpy
+                subscription={{ values: true }}
+                onChange={({ values }) => {
+                  updateReportValue(values.report || '');
+                }}
+              />
+
               <Field
                 name="description"
                 label="Kort beskrivelse"
@@ -452,6 +496,31 @@ const MeetingEditor = () => {
                     )}
                   </ConfirmModal>
                 )}
+                {isEditPage &&
+                  canDelete &&
+                  localStorage.getItem(`meeting-${meeting.id}-report`) !==
+                    null && (
+                    <ConfirmModal
+                      title="Hente inn referat fra localstorage?"
+                      message={`Fant ${
+                        localStorage.getItem(`meeting-${meeting.id}-report`) !==
+                        null
+                          ? 1
+                          : 0
+                      } lagret backup for dette møtet. Dette vil overskrive det nåværende referatet lokalt.`}
+                      onConfirm={() => {
+                        loadReportFromLocalStorage(form);
+                      }}
+                      closeOnConfirm
+                    >
+                      {({ openConfirmModal }) => (
+                        <Button danger onClick={openConfirmModal}>
+                          <Icon name="cloud-download-outline"></Icon>
+                          Hent referat lokalt
+                        </Button>
+                      )}
+                    </ConfirmModal>
+                  )}
               </Flex>
             </Form>
           );


### PR DESCRIPTION
# Description

This adds localstorage saving to meeting reports.
Onchange, if the value is longer than the previous value it will override the localstorage value (or if the localstorage key does not exist).

This was re-opened as we decided at the meeting to go for this approach after consulting the router wiki.

# Result

![image](https://github.com/webkom/lego-webapp/assets/113468143/be63d734-6c37-4763-ab45-6371fddae857)

![image](https://github.com/webkom/lego-webapp/assets/113468143/3467f966-93a7-4d6c-81ed-d2d9c514bce8)


- [ x] Changes look good on both light and dark theme.
- [ x] Changes look good with different viewports (mobile, tablet, etc.).
- [ x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [ x] I have thoroughly tested my changes.

---

Resolves ABA-740
