### PR TITLE
Resolve bug showing active style and add subgroup to email

### DIFF
--- a/app/components/Table/HeadCell.tsx
+++ b/app/components/Table/HeadCell.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Icon } from '@webkom/lego-bricks';
-import cx from 'classnames';
 import { useEffect, useRef } from 'react';
 import Dropdown from 'app/components/Dropdown';
 import { TextInput, RadioButton, CheckBox } from 'app/components/Form';
@@ -106,6 +105,10 @@ const HeadCell: React.FC<HeadCellProps> = ({
         : 'sort-desc'
       : 'sort';
 
+  const iconIsActive =
+    (!!filters[filterIndex] && String(filters[filterIndex])) ||
+    isShown[filterIndex];
+
   return (
     <th key={`${dataIndex}-${index}`}>
       <Flex alignItems="center" justifyContent="center" gap={4.5}>
@@ -124,11 +127,7 @@ const HeadCell: React.FC<HeadCellProps> = ({
               <Icon
                 name="search"
                 size={16}
-                className={cx(
-                  (filters[filterIndex] ?? []).length || isShown[filterIndex]
-                    ? styles.iconActive
-                    : styles.icon,
-                )}
+                className={iconIsActive ? styles.iconActive : styles.icon}
               />
             }
             contentClassName={styles.overlay}
@@ -156,12 +155,7 @@ const HeadCell: React.FC<HeadCellProps> = ({
               <Icon
                 name="funnel"
                 size={16}
-                className={cx(
-                  (filters[filterIndex] ?? []).length > 0 ||
-                    isShown[filterIndex]
-                    ? styles.iconActive
-                    : styles.icon,
-                )}
+                className={iconIsActive ? styles.iconActive : styles.icon}
               />
             }
             contentClassName={styles.checkbox}
@@ -213,11 +207,7 @@ const HeadCell: React.FC<HeadCellProps> = ({
               <Icon
                 name="options"
                 size={16}
-                className={cx(
-                  filters[filterIndex] !== undefined || isShown[filterIndex]
-                    ? styles.iconActive
-                    : styles.icon,
-                )}
+                className={iconIsActive ? styles.iconActive : styles.icon}
               />
             }
             contentClassName={styles.overlay}


### PR DESCRIPTION
# Description

Added subgroups to email-user list view - as some of them have @abakus.no emails as well.

Also fixed a 'lil bug I introduced to the `Table` component way back when I refactored it that made the filter stuff look active even when it wasn't. Now it works the way it's supposed to again, properly tested(:

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
