### PR TITLE
Update and fix search and menu styling

### DIFF
--- a/app/components/Search/Search.css
+++ b/app/components/Search/Search.css
@@ -41,18 +41,22 @@
 }
 
 .searchResultItemIcon {
-  margin-right: 15px;
-  margin-left: 3px;
+  color: var(--lego-font-color);
 }
 
 .resultsContainer {
   display: flex;
   flex-wrap: wrap;
-  max-height: calc(100vh - 120px);
+  max-height: calc(100svh - 120px);
   overflow-y: auto;
   padding: var(--spacing-xl) 3rem 3rem;
   background-color: var(--lego-card-color);
   border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
+
+  @media (--mobile-device) {
+    height: 100svh;
+    padding: var(--spacing-lg) var(--spacing-lg) var(--spacing-lg);
+  }
 }
 
 .sidePanel {
@@ -64,7 +68,7 @@
 
 .quickLinksHeader {
   color: var(--lego-font-color);
-  padding-left: 15px;
+  padding-left: var(--spacing-md);
 }
 
 .quickLinks {
@@ -107,6 +111,10 @@
   border-bottom: 1px solid var(--border-gray);
   padding: var(--spacing-sm);
   height: 4rem;
+
+  &:hover {
+    background-color: var(--additive-background);
+  }
 }
 
 .resultTitle {
@@ -125,7 +133,7 @@
 
 .resultDetail > *:not(:last-child)::after {
   content: '\22C5';
-  padding: 0 5px;
+  padding: 0 var(--spacing-xs);
 }
 
 .truncateTitle {

--- a/app/components/Search/SearchPageResults.css
+++ b/app/components/Search/SearchPageResults.css
@@ -1,23 +1,21 @@
 @import url('~app/styles/variables.css');
 
 .searchResult {
-  padding-left: 20px;
+  padding-left: var(--spacing-md);
   border-left: 4px solid transparent;
-  margin-bottom: 25px;
   display: flex;
   justify-content: space-between;
 }
 
-.searchResultTitle {
-  display: flex;
-  align-items: center;
-  color: var(--lego-color-gray);
-  font-weight: 600;
-  margin: 0;
+.skeleton {
+  height: 80px;
+}
+
+.searchResultTitle * {
+  color: var(--lego-font-color);
 }
 
 .picture {
-  height: 100px;
   flex: 1;
   justify-content: center;
 }
@@ -35,15 +33,10 @@
   }
 }
 
-.searchResultItemIcon {
-  margin-left: 10px;
-  color: initial;
-}
-
 .textbox {
   flex: 4;
   min-width: 260px;
-  margin-right: 15px;
+  margin-right: var(--spacing-md);
 
   @media (--medium-viewport) {
     min-width: 400px;

--- a/app/components/Search/SearchPageResults.tsx
+++ b/app/components/Search/SearchPageResults.tsx
@@ -1,8 +1,10 @@
-import { Flex, Icon } from '@webkom/lego-bricks';
+import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
+import cx from 'classnames';
 import { Link } from 'react-router-dom';
 import EmptyState from 'app/components/EmptyState';
 import { ProfilePicture, Image } from 'app/components/Image';
 import { isUserResult } from 'app/reducers/search';
+import { useAppSelector } from 'app/store/hooks';
 import truncateString from 'app/utils/truncateString';
 import styles from './SearchPageResults.css';
 import type { SearchResult as SearchResultType } from 'app/reducers/search';
@@ -21,12 +23,12 @@ type SearchResultProps = {
   isSelected: boolean;
 };
 
-function SearchResult({ result, onSelect, isSelected }: SearchResultProps) {
+const SearchResult = ({ result, onSelect, isSelected }: SearchResultProps) => {
   return (
     <Flex
       wrap
       style={{
-        backgroundColor: isSelected && 'rgba(255, 0, 0, 0.15)',
+        backgroundColor: isSelected ? 'var(--additive-background)' : undefined,
         borderColor: result.color,
       }}
       className={styles.searchResult}
@@ -39,38 +41,25 @@ function SearchResult({ result, onSelect, isSelected }: SearchResultProps) {
           }}
           to={result.link}
         >
-          <h3 className={styles.searchResultTitle}>
-            <span>
-              {result.label}
-              {isUserResult(result) && <span>({result.username})</span>}
-            </span>
+          <Flex
+            alignItems="center"
+            gap="var(--spacing-sm)"
+            className={styles.searchResultTitle}
+          >
+            <h3>{result.label}</h3>
 
             {isUserResult(result) ? (
-              <ProfilePicture
-                className={styles.searchResultItemIcon}
-                size={24}
-                user={result}
-              />
+              <ProfilePicture size={24} user={result} />
             ) : (
-              <Icon
-                name={result.icon}
-                className={styles.searchResultItemIcon}
-              />
+              <Icon name={result.icon} />
             )}
-          </h3>
+          </Flex>
         </Link>
-        <div>
-          {result.content && (
-            <div>
-              <span>
-                {truncateString(
-                  result.content.replace(/(<([^>]+)>)/gi, ''),
-                  250,
-                )}
-              </span>
-            </div>
-          )}
-        </div>
+        {result.content && (
+          <p>
+            {truncateString(result.content.replace(/(<([^>]+)>)/gi, ''), 140)}
+          </p>
+        )}
       </Flex>
 
       {result.picture && result.picture !== 'cover' && (
@@ -80,10 +69,17 @@ function SearchResult({ result, onSelect, isSelected }: SearchResultProps) {
       )}
     </Flex>
   );
-}
+};
 
-function SearchPageResults({ onSelect, results, selectedIndex, query }: Props) {
-  if (results.length === 0) {
+const SearchPageResults = ({
+  onSelect,
+  results,
+  selectedIndex,
+  query,
+}: Props) => {
+  const searching = useAppSelector((state) => state.search.searching);
+
+  if (results.length === 0 && !searching) {
     return (
       <EmptyState icon="glasses-outline">
         {query ? (
@@ -98,17 +94,24 @@ function SearchPageResults({ onSelect, results, selectedIndex, query }: Props) {
   }
 
   return (
-    <div>
-      {results.map((result, i) => (
-        <SearchResult
-          key={`${result.path}-${result.value}`}
-          onSelect={onSelect}
-          result={result}
-          isSelected={selectedIndex === i}
+    <Flex column gap="var(--spacing-md)">
+      {results.length === 0 ? (
+        <Skeleton
+          array={6}
+          className={cx(styles.searchResult, styles.skeleton)}
         />
-      ))}
-    </div>
+      ) : (
+        results.map((result, i) => (
+          <SearchResult
+            key={`${result.path}-${result.value}`}
+            onSelect={onSelect}
+            result={result}
+            isSelected={selectedIndex === i}
+          />
+        ))
+      )}
+    </Flex>
   );
-}
+};
 
 export default SearchPageResults;

--- a/app/components/Search/SearchResults.tsx
+++ b/app/components/Search/SearchResults.tsx
@@ -33,7 +33,7 @@ const ResultIcon = ({ result }) => {
       if (result.icon) {
         return (
           <Image
-            alt={`${result.title}'s logo`}
+            alt={`${result.title} sin logo`}
             src={result.icon}
             style={{ width: '28px', display: 'block' }}
             className={styles.searchResultItemIcon}
@@ -58,7 +58,10 @@ export const SearchResultItem = ({
   onCloseSearch,
 }: SearchResultItemProps) => (
   <Link to={result.link} onClick={onCloseSearch}>
-    <li className={cx(isSelected && styles.isSelected, styles.resultItem)}>
+    <Flex
+      gap="var(--spacing-sm)"
+      className={cx(isSelected && styles.isSelected, styles.resultItem)}
+    >
       <ResultIcon result={result} />
       <div className={styles.resultTitle}>
         <p className={styles.truncateTitle}>{result.title}</p>
@@ -69,7 +72,7 @@ export const SearchResultItem = ({
           {result.date && <Time time={result.date} wordsAgo />}
         </Flex>
       </div>
-    </li>
+    </Flex>
   </Link>
 );
 

--- a/app/routes/surveys/components/SurveyEditor/SurveyForm.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyForm.tsx
@@ -126,11 +126,7 @@ const SurveyForm = ({
           {spyValues((values: FormSurvey) =>
             // If this is a template
             values.templateType ? (
-              <h2
-                style={{
-                  color: 'var(--lego-color-red)',
-                }}
-              >
+              <h2>
                 Dette er malen for arrangementer av type:{' '}
                 {displayNameForEventType(values.templateType)}
               </h2>


### PR DESCRIPTION
# Description

Use standardized spacing, remove use of non-existing variables and resolve a bug on mobile Safari where links at the bottom were not visible.


# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img height="500" src="https://github.com/webkom/lego-webapp/assets/69514187/91f39a52-ee67-4e6a-b18f-678e9c07d930" />
        </td>
        <td>
            <img height="500" src="https://github.com/webkom/lego-webapp/assets/69514187/0a5251d3-9bca-4e6b-88f8-b3fa28e4f6dc" />
        </td>
    </tr>
    <tr>
        <td>
        	<img width="1428" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/29f8d98a-1ccc-45ad-8310-6ec2d2c27eb4">
        </td>
        <td>
			<img width="1428" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/82aa45f3-d712-43c4-8d29-ee0b461a4a0a">
        </td>
    </tr>
</table>


# Testing

- [x] I have thoroughly tested my changes.

See images above. Tested on my actual iPhone