### PR TITLE
Do not debounce local theme change

### DIFF
--- a/app/components/Header/ToggleTheme.tsx
+++ b/app/components/Header/ToggleTheme.tsx
@@ -23,15 +23,23 @@ const ToggleTheme = ({ className, children, isButton = true }: Props) => {
   const username = useCurrentUser()?.username;
   const icon = useIcon();
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedUpdateUserTheme = useCallback(
+    debounce((username, newTheme) => {
+      dispatch(updateUserTheme(username, newTheme));
+    }, 300),
+    [dispatch],
+  );
+
   const handleThemeChange = useCallback(
     (e: MouseEvent) => {
       e.preventDefault();
       const currentTheme = getTheme();
       const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
       applySelectedTheme(newTheme);
-      loggedIn && username && dispatch(updateUserTheme(username, newTheme));
+      loggedIn && username && debouncedUpdateUserTheme(username, newTheme);
     },
-    [loggedIn, username, dispatch],
+    [loggedIn, username, debouncedUpdateUserTheme],
   );
 
   const Component = isButton ? 'button' : 'div';
@@ -39,7 +47,7 @@ const ToggleTheme = ({ className, children, isButton = true }: Props) => {
     <Component
       name="Endre tema"
       className={className}
-      onClick={debounce(handleThemeChange, 200)}
+      onClick={handleThemeChange}
     >
       {children}
       <Icon


### PR DESCRIPTION
# Description

I hate to have to wait 200ms every time I want to update the theme. Only debouncing the requests to the server should be enough.

This also prevents unnecessary requests and responses, because now if the user spams the switch button, the user will only receive one toast feedback instead of 1000. I increased the debounce time to 300ms since the wait is fine now - could probably do more but meh

I'd say this is a bug fix

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<details>
<summary>Before</summary>

https://github.com/webkom/lego-webapp/assets/69514187/fd2a5bcc-daea-4fbd-85ca-7ce2befd6171


</details>

<details>
<summary>After</summary>

https://github.com/webkom/lego-webapp/assets/69514187/c1e016f2-a35d-4b30-bac6-b29c98e039bf


</details>



# Testing

- [x] I have thoroughly tested my changes.

See videos above.