### PR TITLE
Fix bad height on Textarea

### DIFF
--- a/app/components/Form/TextArea.tsx
+++ b/app/components/Form/TextArea.tsx
@@ -1,3 +1,4 @@
+import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import Textarea from 'react-textarea-autosize';
 import { createField } from './Field';
@@ -10,15 +11,17 @@ type Props = {
   readOnly?: boolean;
 } & ComponentProps<typeof Textarea>;
 
-function TextArea({ className, inputRef, readOnly, ...props }: Props) {
+const TextArea = ({ className, inputRef, readOnly, ...props }: Props) => {
   return (
-    <Textarea
-      ref={inputRef}
-      className={cx(styles.input, readOnly, className)}
-      {...props}
-    />
+    <Flex>
+      <Textarea
+        ref={inputRef}
+        className={cx(styles.input, readOnly, className)}
+        {...props}
+      />
+    </Flex>
   );
-}
+};
 
 TextArea.Field = createField(TextArea);
 export default TextArea;


### PR DESCRIPTION
# Description

All other field components are flexed

Ngl, I have tried to fix this for centuries. I randomly noticed today that it was not flexed like the others 🙃 

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="591" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/311f327a-affe-4c85-b9c1-6a6c45a44c9a">
        </td>
        <td>
            <img width="591" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/52ec7a22-52d3-406a-a022-bc87a6646288">
        </td>
    </tr>
</table>


# Testing

- [x] I have thoroughly tested my changes.

Resizing the textarea still works as expected.