### PR TITLE
Refactor redux penalites

### DIFF
--- a/app/actions/UserActions.ts
+++ b/app/actions/UserActions.ts
@@ -482,7 +482,7 @@ export function deletePenalty(id: EntityId) {
     method: 'DELETE',
     schema: penaltySchema,
     meta: {
-      penaltyId: id,
+      id,
       errorMessage: 'Sletting av prikk feilet',
     },
     body: {},

--- a/app/reducers/penalties.ts
+++ b/app/reducers/penalties.ts
@@ -1,37 +1,23 @@
-import { produce } from 'immer';
-import { without } from 'lodash';
-import { createSelector } from 'reselect';
-import createEntityReducer from 'app/utils/createEntityReducer';
+import { createSlice } from '@reduxjs/toolkit';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { Penalty } from '../actions/ActionTypes';
+import type { RootState } from 'app/store/createRootReducer';
 
-type State = any;
-const mutate = produce((newState: State, action: any): void => {
-  switch (action.type) {
-    case Penalty.DELETE.SUCCESS:
-      newState.items = without(newState.items, action.meta.penaltyId);
-      break;
-  }
+const legoAdapter = createLegoAdapter(EntityType.Penalties);
+
+const penaltiesSlice = createSlice({
+  name: EntityType.Penalties,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [Penalty.FETCH],
+    deleteActions: [Penalty.DELETE],
+  }),
 });
 
-export default createEntityReducer({
-  key: 'penalties',
-  types: {
-    fetch: Penalty.FETCH,
-    mutate: Penalty.CREATE,
-    delete: Penalty.DELETE,
-  },
-  mutate,
-});
+export default penaltiesSlice.reducer;
+export const { selectByField: selectPenaltiesByField } =
+  legoAdapter.getSelectors((state: RootState) => state.penalties);
 
-export const selectPenalties = createSelector(
-  (state) => state.penalties.byId,
-  (state) => state.penalties.items,
-  (penaltiesById, penaltyIds) => penaltyIds.map((id) => penaltiesById[id]),
-);
-
-export const selectPenaltyByUserId = createSelector(
-  selectPenalties,
-  (state, props) => props.userId,
-  (penaltiesById, userId) =>
-    penaltiesById.filter((penalty) => penalty.user === userId),
-);
+export const selectPenaltyByUserId = selectPenaltiesByField('user');

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -142,7 +142,7 @@ const EventDetail = () => {
       selectUserWithGroups(state, { username: currentUser.username }),
   );
   const penalties = useAppSelector((state) =>
-    selectPenaltyByUserId(state, { userId: user?.id }),
+    selectPenaltyByUserId(state, user?.id),
   );
 
   const comments = useAppSelector((state) =>

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -44,7 +44,6 @@ import type {
   AuthUserDetailedEvent,
   UserDetailedEvent,
 } from 'app/store/models/Event';
-import type Penalty from 'app/store/models/Penalty';
 import type { CurrentUser } from 'app/store/models/User';
 
 /**
@@ -195,10 +194,8 @@ const JoinEventForm = ({
   const fetching = useAppSelector((state) => state.events.fetching);
 
   const penalties = useAppSelector((state) =>
-    selectPenaltyByUserId(state, {
-      userId: currentUser?.id,
-    }),
-  ) as Penalty[];
+    selectPenaltyByUserId(state, currentUser?.id),
+  );
   const sumPenalties = sumBy(penalties, 'weight');
 
   const joinTitle = !registration ? 'Meld deg på' : 'Avregistrer';

--- a/app/routes/events/components/__tests__/JoinEventFormCountdownProvider.spec.tsx
+++ b/app/routes/events/components/__tests__/JoinEventFormCountdownProvider.spec.tsx
@@ -68,7 +68,7 @@ const store = configureStore([])({
     fetching: false,
   },
   penalties: {
-    items: [],
+    ids: [],
   },
 });
 

--- a/app/routes/users/components/Penalties.tsx
+++ b/app/routes/users/components/Penalties.tsx
@@ -7,7 +7,6 @@ import { selectPenaltyByUserId } from 'app/reducers/penalties';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './Penalties.css';
 import PenaltyForm from './PenaltyForm';
-import type Penalty from 'app/store/models/Penalty';
 
 type Props = {
   userId: number;
@@ -15,10 +14,8 @@ type Props = {
 
 const Penalties = ({ userId }: Props) => {
   const penalties = useAppSelector((state) =>
-    selectPenaltyByUserId(state, {
-      userId,
-    }),
-  ) as Penalty[];
+    selectPenaltyByUserId(state, userId),
+  );
   const canDeletePenalties = useAppSelector((state) => state.allowed.penalties);
 
   const dispatch = useAppDispatch();


### PR DESCRIPTION
# Description

Simple refactoring PR. Refactored from `createEntityReducer` to `legoAdapter` and `createSlice`. I also removed the need for custom logic when deleting penalties by using correct field-name for `id` in the `DELETE` action.

# Result

No functional or visual changes.

# Testing

- [x] I have thoroughly tested my changes.

I tested creating and deleting penalties.

---

ABA-688