### PR TITLE
Require event content in editor

### DIFF
--- a/app/components/Form/TextEditor.tsx
+++ b/app/components/Form/TextEditor.tsx
@@ -1,3 +1,4 @@
+import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { createField } from './Field';
 import styles from './TextEditor.css';
@@ -15,10 +16,12 @@ type Props = {
  */
 function TextEditor({ className, ...props }: Props) {
   return (
-    <textarea
-      className={cx(styles.input, className)}
-      {...(props as Record<string, any>)}
-    />
+    <Flex>
+      <textarea
+        className={cx(styles.input, className)}
+        {...(props as Record<string, any>)}
+      />
+    </Flex>
   );
 }
 

--- a/app/routes/events/components/EventEditor/EditorSection/Descriptions.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Descriptions.tsx
@@ -28,6 +28,7 @@ const Descriptions: React.FC<Props> = ({ uploadFile, values }) => {
         placeholder="Dette blir tidenes fest ..."
         className={styles.descriptionEditor}
         uploadFile={uploadFile}
+        required
       />
       <Flex className={styles.tagRow}>
         {(values.tags || []).map((tag, i) => (

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -34,6 +34,7 @@ import {
   conditionalValidation,
   createValidator,
   isInteger,
+  legoEditorRequired,
   maxSize,
   mergeTimeAfterAllPoolsActivation,
   minSize,
@@ -62,6 +63,7 @@ const validate = createValidator({
   youtubeUrl: [validYoutubeUrl()],
   title: [required('Tittel er påkrevd')],
   description: [required('Kalenderbeskrivelse er påkrevd')],
+  text: [legoEditorRequired('Innhold er påkrevd')],
   eventType: [required('Arrangementstype er påkrevd')],
   location: [
     requiredIf((allValues) => !allValues.useMazemap, 'Sted er påkrevd'),


### PR DESCRIPTION
# Description

Currently only required on the server - which caused issues for some


# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<img width="355" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/33d76687-9564-4eb5-87fe-62d3234e6393">


# Testing

- [x] I have thoroughly tested my changes.

See image above - it now requires it!