### PR TITLE
Add fetching state to legoAdapter pagination

### DIFF
--- a/app/actions/callAPI.ts
+++ b/app/actions/callAPI.ts
@@ -15,13 +15,13 @@ import type {
   ResolvedPromiseAction,
 } from 'app/store/middleware/promiseMiddleware';
 import type { AsyncActionType, Thunk, NormalizedApiPayload } from 'app/types';
-import type { Query } from 'app/utils/createQueryString';
 import type {
   HttpRequestOptions,
   HttpMethod,
   HttpResponse,
 } from 'app/utils/fetchJSON';
 import type { Schema } from 'normalizr';
+import type { ParsedQs } from 'qs';
 import type { Required } from 'utility-types';
 
 function urlFor(resource: string) {
@@ -73,7 +73,7 @@ type ApiResponse<T> =
 
 type CallAPIMeta<ExtraMeta = Record<string, never>> = ExtraMeta & {
   queryString: string;
-  query?: Record<string, string | number | boolean | undefined>;
+  query?: ParsedQs;
   paginationKey?: string;
   cursor: string;
   optimisticId?: EntityId;
@@ -94,7 +94,7 @@ type CallAPIOptions<Meta extends CallAPIOptionsMeta> = {
   headers?: Record<string, string>;
   schema?: Schema;
   body?: Record<string, unknown> | string;
-  query?: Query;
+  query?: ParsedQs;
   json?: boolean;
   meta?: Meta;
   files?: (string | File)[];
@@ -213,7 +213,7 @@ export default function callAPI<
     const qsWithoutPagination = query
       ? createQueryString(omit(query, 'cursor'))
       : '';
-    let schemaKey = undefined;
+    let schemaKey: string | undefined = undefined;
 
     if (schema) {
       if (isArray(schema)) {
@@ -237,7 +237,7 @@ export default function callAPI<
       paginationForRequest &&
       paginationForRequest.pagination &&
       paginationForRequest.pagination.next
-        ? paginationForRequest.pagination.next.cursor
+        ? (paginationForRequest.pagination.next.cursor as string)
         : '';
 
     const qs =

--- a/app/reducers/pages.ts
+++ b/app/reducers/pages.ts
@@ -175,7 +175,7 @@ export const selectCommitteePage: PageSelector<GroupPage> = createSelector(
       groupId: Number(pageSlug),
       pagination: selectPaginationNext({
         query: {
-          descendants: true,
+          descendants: 'true',
         },
         entity: 'memberships',
         endpoint: `/groups/${pageSlug}/memberships/`,

--- a/app/reducers/selectors.ts
+++ b/app/reducers/selectors.ts
@@ -1,8 +1,9 @@
 import { get, isArray } from 'lodash';
 import createQueryString from 'app/utils/createQueryString';
+import { createInitialPagination } from 'app/utils/legoAdapter/buildPaginationReducer';
 import type { RootState } from 'app/store/createRootReducer';
-import type { Query } from 'app/utils/createQueryString';
 import type { schema, Schema } from 'normalizr';
+import type { ParsedQs } from 'qs';
 
 export const selectPagination =
   (
@@ -23,7 +24,7 @@ export const selectPaginationNext =
     entity,
   }: {
     endpoint: string;
-    query: Query;
+    query: ParsedQs;
     schema?: Schema;
     entity?: string;
   }) =>
@@ -37,13 +38,8 @@ export const selectPaginationNext =
 
     return {
       pagination: state[schemaKey].paginationNext[paginationKey] || {
+        ...createInitialPagination(query),
         hasMore: true,
-        hasMoreBackwards: false,
-        query,
-        next: { ...query, cursor: '' },
-        previous: false,
-        items: [], // TODO: Remove this when all usage of createEntityReducer is removed
-        ids: [],
       },
       paginationKey,
     };

--- a/app/routes/admin/email/components/EmailLists.tsx
+++ b/app/routes/admin/email/components/EmailLists.tsx
@@ -29,7 +29,6 @@ const EmailLists = () => {
   const emailLists = useAppSelector((state) =>
     selectEmailLists(state, { pagination }),
   );
-  const fetching = useAppSelector((state) => state.emailLists.fetching);
 
   const dispatch = useAppDispatch();
 
@@ -118,7 +117,7 @@ const EmailLists = () => {
         filters={query}
         onChange={setQuery}
         hasMore={pagination.hasMore}
-        loading={fetching}
+        loading={pagination.fetching}
         data={emailLists}
       />
     </div>

--- a/app/routes/admin/email/components/EmailUsers.tsx
+++ b/app/routes/admin/email/components/EmailUsers.tsx
@@ -34,7 +34,6 @@ const EmailUsers = () => {
   const emailUsers = useAppSelector((state) =>
     selectTransformedEmailUsers(state, { pagination }),
   );
-  const fetching = useAppSelector((state) => state.emailUsers.fetching);
   const committees = useAppSelector((state) =>
     selectGroupsByType(state, GroupType.Committee),
   );
@@ -213,7 +212,7 @@ const EmailUsers = () => {
         filters={query}
         onChange={setQuery}
         hasMore={pagination.hasMore}
-        loading={fetching}
+        loading={pagination.fetching}
         data={emailUsers}
       />
     </div>

--- a/app/routes/admin/groups/components/GroupMembers.tsx
+++ b/app/routes/admin/groups/components/GroupMembers.tsx
@@ -41,7 +41,6 @@ const GroupMembers = () => {
   );
 
   const groupEntities = useAppSelector(selectGroupEntities);
-  const fetching = useAppSelector((state) => state.memberships.fetching);
   const hasMore = pagination.hasMore;
 
   const dispatch = useAppDispatch();
@@ -79,13 +78,13 @@ const GroupMembers = () => {
         />
       )}
 
-      <LoadingIndicator loading={!memberships && fetching}>
+      <LoadingIndicator loading={!memberships && pagination.fetching}>
         <h3>Brukere</h3>
         <GroupMembersList
           key={Number(groupId) + Number(showDescendants)}
           hasMore={hasMore}
           groupsById={groupEntities}
-          fetching={fetching}
+          fetching={pagination.fetching}
           memberships={memberships}
           fetchMemberships={fetchMemberships}
         />

--- a/app/routes/articles/components/ArticleList.tsx
+++ b/app/routes/articles/components/ArticleList.tsx
@@ -79,13 +79,11 @@ const ArticleList = () => {
       entity: 'articles',
     })(state),
   );
-  const hasMore = pagination.hasMore;
   const articles: PublicArticle[] = useAppSelector((state) =>
     selectArticles(state, {
       pagination,
     }),
   );
-  const fetching = useAppSelector((state) => state.articles.fetching);
   const actionGrant = useAppSelector((state) => state.articles.actionGrant);
   const tags = useAppSelector((state) => selectPopularTags(state));
 
@@ -131,8 +129,8 @@ const ArticleList = () => {
       </Tags>
       <section className={styles.frontpage}>
         <Paginator
-          hasMore={hasMore}
-          fetching={fetching}
+          hasMore={pagination.hasMore}
+          fetching={pagination.fetching}
           fetchNext={() => {
             dispatch(
               fetchAll({

--- a/app/routes/company/components/CompaniesPage.tsx
+++ b/app/routes/company/components/CompaniesPage.tsx
@@ -87,7 +87,6 @@ const CompaniesPage = () => {
   const top = useRef<HTMLHeadingElement>(null);
 
   const companies = useAppSelector((state) => selectActiveCompanies(state));
-  const fetching = useAppSelector((state) => state.companies.fetching);
   const { pagination } = useAppSelector((state) =>
     selectPaginationNext({
       query: {},
@@ -95,7 +94,6 @@ const CompaniesPage = () => {
       endpoint: '/companies/',
     })(state),
   );
-  const hasMore = pagination.hasMore;
 
   const dispatch = useAppDispatch();
 
@@ -168,9 +166,11 @@ const CompaniesPage = () => {
 
       <InfiniteScroll
         element="div"
-        hasMore={hasMore}
+        hasMore={pagination.hasMore}
         loadMore={() =>
-          hasMore && !fetching && dispatch(fetchAll({ fetchMore: true }))
+          pagination.hasMore &&
+          !pagination.fetching &&
+          dispatch(fetchAll({ fetchMore: true }))
         }
         initialLoad={false}
         loader={<LoadingIndicator loading />}

--- a/app/routes/meetings/components/MeetingList.tsx
+++ b/app/routes/meetings/components/MeetingList.tsx
@@ -107,25 +107,21 @@ const MeetingList = () => {
     }),
     [],
   );
-  const fetchMorePagination = useAppSelector((state) =>
+  const { pagination: fetchMorePagination } = useAppSelector(
     selectPaginationNext({
       endpoint: '/meetings/',
       query: fetchUpcomingQuery,
       entity: EntityType.Meetings,
-    })(state),
+    }),
   );
-  const showFetchMore = fetchMorePagination.pagination.hasMore;
-  const fetchOlderPagination = useAppSelector((state) =>
+  const { pagination: fetchOlderPagination } = useAppSelector(
     selectPaginationNext({
       endpoint: '/meetings/',
       query: fetchOlderQuery,
       entity: EntityType.Meetings,
-    })(state),
+    }),
   );
-  const showFetchOlder = fetchOlderPagination.pagination.hasMore;
   const meetingSections = useAppSelector(selectGroupedMeetings);
-  const loading = useAppSelector((state) => state.meetings.fetching);
-
   const currentUser = useCurrentUser();
 
   const dispatch = useAppDispatch();
@@ -164,18 +160,18 @@ const MeetingList = () => {
   useEffect(() => {
     if (
       !initialFetchAttempted &&
-      showFetchOlder &&
+      fetchOlderPagination.hasMore &&
       meetingSections.length === 0 &&
-      !loading
+      !fetchOlderPagination.fetching
     ) {
       fetchOlder();
       setInitialFetchAttempted(true);
     }
   }, [
     initialFetchAttempted,
-    showFetchOlder,
+    fetchOlderPagination.hasMore,
+    fetchOlderPagination.fetching,
     meetingSections.length,
-    loading,
     fetchOlder,
   ]);
 
@@ -190,14 +186,16 @@ const MeetingList = () => {
           </Link>
         }
       />
-      {!meetingSections || !currentUser || loading ? (
-        <LoadingIndicator loading={loading} />
-      ) : (
+      {meetingSections && currentUser && (
         <MeetingListView currentUser={currentUser} sections={meetingSections} />
       )}
-      <LoadingIndicator loading={loading} />
-      {showFetchMore && <Button onClick={fetchMore}>Last inn flere</Button>}
-      {showFetchOlder && (
+      <LoadingIndicator
+        loading={fetchMorePagination.fetching || fetchOlderPagination.fetching}
+      />
+      {fetchMorePagination.hasMore && (
+        <Button onClick={fetchMore}>Last inn flere</Button>
+      )}
+      {fetchOlderPagination.hasMore && (
         <Button flat onClick={fetchOlder}>
           Hent gamle
         </Button>

--- a/app/routes/polls/components/PollsList.tsx
+++ b/app/routes/polls/components/PollsList.tsx
@@ -15,10 +15,7 @@ import styles from './PollsList.css';
 const PollsList = () => {
   const polls = useAppSelector(selectAllPolls);
   const actionGrant = useAppSelector((state) => state.polls.actionGrant);
-  const fetching = useAppSelector((state) => state.polls.fetching);
-  const {
-    pagination: { hasMore },
-  } = useAppSelector(
+  const { pagination } = useAppSelector(
     selectPaginationNext({
       endpoint: '/polls/',
       query: {},
@@ -44,8 +41,8 @@ const PollsList = () => {
         }
       />
       <Paginator
-        hasMore={fetching || hasMore} // Paginator only shows loading indicator if hasMore is true
-        fetching={fetching}
+        hasMore={pagination.fetching || pagination.hasMore} // Paginator only shows loading indicator if hasMore is true
+        fetching={pagination.fetching}
         fetchNext={() => {
           dispatch(
             fetchAll({

--- a/app/routes/quotes/components/QuotePage.tsx
+++ b/app/routes/quotes/components/QuotePage.tsx
@@ -52,7 +52,8 @@ const QuotePage = () => {
 
   const quotes = useAppSelector((state) => {
     if (quoteId) {
-      return [selectQuoteById(state, quoteId)];
+      const quote = selectQuoteById(state, quoteId);
+      return quote ? [quote] : [];
     }
     return selectQuotes(state, { pagination });
   });

--- a/app/routes/surveys/components/SurveyList/SurveyListPage.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyListPage.tsx
@@ -30,7 +30,6 @@ const SurveyListPage = ({ templates }: Props) => {
       : selectAllSurveys(state).filter((survey) => !survey.templateType),
   ) as DetailedSurvey[];
 
-  const fetching = useAppSelector((state) => state.surveys.fetching);
   const { pagination } = useAppSelector(
     selectPaginationNext({
       endpoint: templates ? '/survey-templates/' : '/surveys/',
@@ -46,7 +45,7 @@ const SurveyListPage = ({ templates }: Props) => {
 
       <Paginator
         hasMore={pagination.hasMore}
-        fetching={fetching}
+        fetching={pagination.fetching}
         fetchNext={() => {
           dispatch(
             fetchAll({
@@ -55,7 +54,7 @@ const SurveyListPage = ({ templates }: Props) => {
           );
         }}
       >
-        <SurveyList surveys={surveys} fetching={fetching} />
+        <SurveyList surveys={surveys} fetching={pagination.fetching} />
       </Paginator>
     </Content>
   );

--- a/app/utils/createQueryString.ts
+++ b/app/utils/createQueryString.ts
@@ -1,12 +1,6 @@
-/**
- *
- */
-export type Query = Record<
-  string,
-  string | number | boolean | undefined | null | string[]
->;
+import type { ParsedQs } from 'qs';
 
-export default function createQueryString(query: Query): string {
+export default function createQueryString(query: ParsedQs): string {
   const queryString = Object.keys(query)
     .filter((key) => typeof query[key] === 'number' || !!query[key])
     .map(

--- a/app/utils/legoAdapter/__tests__/buildPaginationReducer.spec.ts
+++ b/app/utils/legoAdapter/__tests__/buildPaginationReducer.spec.ts
@@ -1,4 +1,5 @@
 import { createReducer } from '@reduxjs/toolkit';
+import { produce } from 'immer';
 import { describe, it, expect } from 'vitest';
 import { generateStatuses } from 'app/actions/ActionTypes';
 import buildPaginationReducer from 'app/utils/legoAdapter/buildPaginationReducer';
@@ -11,6 +12,7 @@ describe('buildPaginationReducer', () => {
   const initialPaginationState: Pagination = {
     query: {},
     ids: [],
+    fetching: false,
     hasMore: false,
     hasMoreBackwards: false,
     next: undefined,
@@ -22,6 +24,12 @@ describe('buildPaginationReducer', () => {
       '/fetch/': initialPaginationState,
     },
   };
+  const stateWithFetchingPagination = produce(
+    stateWithInitialPagination,
+    (draft) => {
+      draft.paginationNext['/fetch/'].fetching = true;
+    },
+  );
 
   const reducer = createReducer(initialState, (builder) => {
     buildPaginationReducer(builder, [FETCH]);
@@ -46,7 +54,7 @@ describe('buildPaginationReducer', () => {
         type: FETCH.BEGIN,
         meta: { endpoint: '/fetch', paginationKey: '/fetch/', query: {} },
       }),
-    ).toEqual(stateWithInitialPagination);
+    ).toEqual(stateWithFetchingPagination);
     expect(
       reducer(initialState, {
         type: FETCH.BEGIN,
@@ -59,7 +67,11 @@ describe('buildPaginationReducer', () => {
     ).toEqual({
       ...initialState,
       paginationNext: {
-        '/fetch/': { ...initialPaginationState, query: { title: 'ab' } },
+        '/fetch/': {
+          ...initialPaginationState,
+          fetching: true,
+          query: { title: 'ab' },
+        },
       },
     });
   });
@@ -125,5 +137,24 @@ describe('buildPaginationReducer', () => {
       },
     });
     expect(newState).toEqual(stateWithInitialPagination);
+  });
+  it('should update fetching state on fetch begin', () => {
+    const newState = reducer(stateWithInitialPagination, {
+      type: FETCH.BEGIN,
+      meta: { endpoint: '/fetch', paginationKey: '/fetch/', query: {} },
+    });
+    expect(newState.paginationNext['/fetch/'].fetching).toEqual(true);
+  });
+  it('should update fetching state on fetch failure', () => {
+    stateWithInitialPagination.paginationNext['/fetch/'].fetching = true;
+    const newState = reducer(stateWithFetchingPagination, {
+      type: FETCH.FAILURE,
+      meta: { endpoint: '/fetch', paginationKey: '/fetch/', query: {} },
+    });
+    expect(newState.paginationNext['/fetch/'].fetching).toEqual(false);
+  });
+  it('should update fetching state on fetch success', () => {
+    const newState = reducer(stateWithFetchingPagination, fetchSuccess);
+    expect(newState.paginationNext['/fetch/'].fetching).toEqual(false);
   });
 });

--- a/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
+++ b/app/utils/legoAdapter/__tests__/createLegoAdapter.spec.ts
@@ -171,6 +171,7 @@ describe('createLegoAdapter', () => {
           test: {
             query: {},
             ids: [42],
+            fetching: false,
             hasMore: true,
             hasMoreBackwards: false,
             next: {

--- a/app/utils/legoAdapter/buildPaginationReducer.ts
+++ b/app/utils/legoAdapter/buildPaginationReducer.ts
@@ -13,10 +13,6 @@ import type {
 } from 'app/utils/legoAdapter/asyncApiActions';
 import type { ParsedQs } from 'qs';
 
-interface Query {
-  [key: string]: string;
-}
-
 export type Pagination<Id extends EntityId = EntityId> = {
   query: ParsedQs;
   ids: Id[];
@@ -33,7 +29,9 @@ type StateWithPagination = {
   };
 };
 
-const createInitialPagination = (query: Query) => ({
+export const createInitialPagination = <Id extends EntityId = EntityId>(
+  query: ParsedQs,
+): Pagination<Id> => ({
   query,
   ids: [],
   fetching: false,


### PR DESCRIPTION
# Description

This is a small improvement that might gives us a bit more accurate fetching states. Basically on some pages we might fetch multiple queries for the same entity type simultainiously, f.ex. upcoming and previous meetings. Using the normal `fetching` state we have no idea which one is fetching (and it is sometimes wrong). Instead we can use the pagination system, and save for each separate pagination query if it is fetching or not.

I added this functionality in `legoAdapter`, and changed most paginated pages to use this `fetching`-state instead of the general one for the entity type.

# Result

Currently it should function fairly similarily, but it should be easy to refactor pages to provide more accurate loading indicators if someone wants to do that.

# Testing

- [x] I have thoroughly tested my changes.

I have tested many of the affected pages, and the fetching state seems to be correct

---

Resolves ABA-294
