### PR TITLE
Reduce click-area of mazemap checkbox label

### DIFF
--- a/app/components/Form/CheckBox.css
+++ b/app/components/Form/CheckBox.css
@@ -115,3 +115,7 @@
     transform: scale(1);
   }
 }
+
+.fieldLabel {
+  width: fit-content;
+}

--- a/app/components/Form/CheckBox.tsx
+++ b/app/components/Form/CheckBox.tsx
@@ -64,7 +64,11 @@ const CheckBox = ({
 const RawField = createField(CheckBox, { inlineLabel: true });
 
 const StyledField = ({ fieldClassName, ...props }: FormProps) => (
-  <RawField fieldClassName={fieldClassName} {...props} />
+  <RawField
+    fieldClassName={fieldClassName}
+    labelClassName={styles.fieldLabel}
+    {...props}
+  />
 );
 
 CheckBox.Field = StyledField;

--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -51,6 +51,7 @@ export type FormProps = {
   fieldStyle?: CSSProperties;
   fieldClassName?: string;
   labelClassName?: string;
+  labelContentClassName?: string;
   showErrors?: boolean;
   onChange?: (value: string | ChangeEvent) => void;
   withoutMargin?: boolean;
@@ -87,6 +88,7 @@ export function createField<
       description,
       fieldClassName,
       labelClassName,
+      labelContentClassName,
       onChange,
       showErrors = true,
       className = null,
@@ -107,7 +109,7 @@ export function createField<
               cursor: inlineLabel ? 'pointer' : 'default',
               fontSize: !inlineLabel ? 'var(--font-size-lg)' : 'inherit',
             }}
-            className={labelClassName}
+            className={labelContentClassName}
           >
             {label}
           </div>
@@ -157,7 +159,11 @@ export function createField<
         )}
         style={fieldStyle}
       >
-        {noLabel ? content : <label>{content}</label>}
+        {noLabel ? (
+          content
+        ) : (
+          <label className={labelClassName}>{content}</label>
+        )}
         {hasError && (
           <RenderErrorMessage error={anyError} fieldName={fieldName} />
         )}

--- a/app/components/Form/MultiSelectGroup.tsx
+++ b/app/components/Form/MultiSelectGroup.tsx
@@ -19,7 +19,7 @@ const MultiSelectGroup = ({ name, label, children }: Props) => {
           cloneElement(child, {
             name,
             fieldClassName: styles.radioField,
-            labelClassName: styles.radioLabel,
+            labelContentClassName: styles.radioLabel,
           }),
         )}
       </div>

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -311,6 +311,7 @@ const MeetingEditor = () => {
                 name="useMazemap"
                 type="checkbox"
                 component={CheckBox.Field}
+                withoutMargin
               />
               {spyValues<MeetingFormValues>((values) => {
                 return values?.useMazemap ? (


### PR DESCRIPTION
# Description

Reduce click-area and margin of mazemap checkbox label as reported in https://github.com/webkom/lego/issues/3567.

Also reduces the click area of all checkboxes that are wrapped in the Field component across the webapp.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Reduced size and margin
        </td>
        <td><img width="478" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/32014ee4-f54c-46e0-98eb-de4327867356"></td>
        <td><img width="371" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/6d0d3f66-abbd-406c-9b57-30b8f21f900a">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves https://github.com/webkom/lego/issues/3567
