### PR TITLE
Improve description in error boundary

### DIFF
--- a/app/components/ErrorBoundary/index.tsx
+++ b/app/components/ErrorBoundary/index.tsx
@@ -92,8 +92,23 @@ class ErrorBoundary extends Component<Props, State> {
         onClick={() => !openReportDialog && this.openDialog()}
         className={styles.container}
       >
-        <Card.Header>En feil har oppstått</Card.Header>
+        <Card.Header>
+          <p>En feil har oppstått</p>
+        </Card.Header>
         <p>Webkom har fått beskjed om feilen</p>
+        <br />
+        <p>
+          Hvis du har slitt med problemet en liten stund uten at det har blitt
+          fikset, send gjerne en påminnelse til{' '}
+          <a href="mailto:webkom@abakus.no">webkom@abakus.no</a>
+        </p>
+        <p>
+          Tips: hvis du forklarer hva du gjorde før feilen oppstod og legger ved
+          referansen under (som tekst, ikke skjermbilde) er det mye lettere å
+          identifisere feilen din
+        </p>
+        <br />
+        <p>Referanse: {this.state.lastEventId}</p>
       </Card>
     );
   }


### PR DESCRIPTION
# Description

We get a lot of screenshots of the same component - which really gives us no information at all. And some times it is quite hard to find the error in sentry to get the debugging going.

This should resolve this problem, by encouraging users to report persisting issues that we haven't resolved in an orderly fashion, and requesting them to provide the sentry event id that we can search for to find more details on sentry.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td><img width="837" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/f8345d98-29fb-4a75-b3a8-1a5ad71b06de"></td>
        <td><img width="840" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/2f5bed09-7892-461b-ad5f-f29246b7cf5d"></td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested by running a few errors to view the feedback

---

Resolves ABA-929
