### PR TITLE
Ensure permissions are present to display list

### DIFF
--- a/app/routes/admin/groups/components/AddGroupPermission.tsx
+++ b/app/routes/admin/groups/components/AddGroupPermission.tsx
@@ -6,10 +6,10 @@ import { SubmitButton } from 'app/components/Form/SubmitButton';
 import TextInput from 'app/components/Form/TextInput';
 import { useAppDispatch } from 'app/store/hooks';
 import { createValidator, matchesRegex, required } from 'app/utils/validation';
-import type { DetailedGroup } from 'app/store/models/Group';
+import type { DetailedGroup, UnknownGroup } from 'app/store/models/Group';
 
 type Props = {
-  group: DetailedGroup;
+  group: UnknownGroup;
 };
 
 const validate = createValidator({
@@ -26,10 +26,12 @@ const AddGroupPermission = ({ group }: Props) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
+  const { permissions = [] } = group as DetailedGroup; // Default to [] if the DetailedGroup object has not loaded yet
+
   const handleSubmit = (values, form) => {
     const updatedGroup = {
       ...group,
-      permissions: group.permissions.concat(values.permission),
+      permissions: permissions.concat(values.permission),
     };
     dispatch(editGroup(updatedGroup)).then(() => {
       form.reset();

--- a/app/routes/admin/groups/components/GroupPage.tsx
+++ b/app/routes/admin/groups/components/GroupPage.tsx
@@ -63,6 +63,7 @@ const GroupPageNavigation = ({
 export type GroupPageParams = {
   groupId: string;
 };
+
 const GroupPage = () => {
   const { groupId } = useParams<Optional<GroupPageParams>>(); // optional because of the /admin/groups route with no groupId
   const group = useAppSelector((state) =>


### PR DESCRIPTION
# Description

## Background
In the state, we store all groups in a long list together - more or less like so;
```
groups: {
    entities: [a lot of group objects],
    fetching: false,
    ...
}
```

This is used both for fetching the list of groups that are in the sidepanel of abakus.no/admin/groups and the individual groups. Thus the type of entities is UnknownGroup[] (consisting of DetailedGroup, PublicGroup, +++)

Thus, when you're navigating /admin/groups, the state will contain all the groups, because they are fetched to be in the sidebar. Those groups however are PublicGroup instances (not very detailed, as they're not needed to be for the list.  
That means that they do not have e.g. `permissions` and `parentPermissions`.

When you navigate to another group, it will try to display the group, and as it already exists, it will do so. However, the detailed information has not yet been loaded - so while we're trying to display a DetailedGroup object we only have the PublicGroup so far.

## Current solution

Avoiding casting the group to something that it's not, but rather setting default values for the params that might not be loaded yet.

&nbsp;
**NB** This does make it look as if the group has no permissions when you're navigating from permission to permission, as the `fetching` state is currently not group-specific (and setting it to true for just fetching one group would mess up the places where we display the whole list, like the sidebar) so we have no way of knowing if it's fetching or just empty

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-919
