### PR TITLE
Fix some issues with photo gallery page

### DIFF
--- a/app/reducers/galleries.ts
+++ b/app/reducers/galleries.ts
@@ -1,19 +1,13 @@
 import { createSlice } from '@reduxjs/toolkit';
+import moment from 'moment';
 import { EntityType } from 'app/store/models/entities';
 import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
 import { Gallery } from '../actions/ActionTypes';
 import type { RootState } from 'app/store/createRootReducer';
 
-export type GalleryEntity = {
-  id: number;
-  title: string;
-  description: string;
-  text?: string;
-  comments?: Array<number>;
-  cover?: Record<string, any>;
-};
-
-const legoAdapter = createLegoAdapter(EntityType.Galleries);
+const legoAdapter = createLegoAdapter(EntityType.Galleries, {
+  sortComparer: (a, b) => moment(b.takenAt).diff(a.takenAt),
+});
 const galleriesSlice = createSlice({
   name: EntityType.Galleries,
   initialState: legoAdapter.getInitialState(),

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -128,7 +128,6 @@ const GalleryDetail = () => {
 
     downloadNext(0, [])
       .then((blobs) => {
-        console.log(blobs);
         const names = pictures.map((picture) => picture.file.split('/').pop()!);
         zipFiles(gallery.title, names, blobs).finally(finishDownload);
       })

--- a/app/routes/photos/components/Overview.tsx
+++ b/app/routes/photos/components/Overview.tsx
@@ -16,7 +16,6 @@ import type { ListGallery } from 'app/store/models/Gallery';
 
 const Overview = () => {
   const galleries = useAppSelector(selectAllGalleries<ListGallery>);
-  const fetching = useAppSelector((state) => state.galleries.fetching);
   const { pagination } = useAppSelector(
     selectPaginationNext({
       endpoint: '/galleries/',
@@ -42,8 +41,8 @@ const Overview = () => {
       )}
 
       <Gallery
-        hasMore={pagination.hasMore}
-        fetching={fetching}
+        hasMore={pagination.fetching || pagination.hasMore}
+        fetching={pagination.fetching}
         fetchNext={() =>
           dispatch(
             fetchGalleries({


### PR DESCRIPTION
# Description

There were some small mistakes in #4641, that I have fixed here:)
- Photo album order was reversed (ish). It is now sorted by the `takenAt` attribute.
- The now unused `GalleryEntity` was not removed.
- Loading indicator was not shown on the initial fetch (this was already a problem before #4641)

# Result

No image because of personal data, but it's now sorted the same as in prod.

# Testing

- [x] I have thoroughly tested my changes.

Compared sort order to prod, and tested the loading indicator both on inital fetch and fetching more.

---

ABA-688