### PR TITLE
Use legoAdpater and createSlice for imageGalleryEntries slice

### DIFF
--- a/app/actions/EventActions.ts
+++ b/app/actions/EventActions.ts
@@ -8,11 +8,7 @@ import createQueryString from 'app/utils/createQueryString';
 import { Event } from './ActionTypes';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { AppDispatch } from 'app/store/createStore';
-import type {
-  DetailedEvent,
-  ListEvent,
-  UnknownEvent,
-} from 'app/store/models/Event';
+import type { DetailedEvent, ListEvent } from 'app/store/models/Event';
 import type { Presence } from 'app/store/models/Registration';
 import type { Thunk, Action } from 'app/types';
 
@@ -157,7 +153,7 @@ export function fetchAllergies(eventId: EntityId) {
 }
 
 export function createEvent(event: Record<string, any>) {
-  return callAPI<UnknownEvent>({
+  return callAPI<DetailedEvent>({
     types: Event.CREATE,
     endpoint: '/events/',
     method: 'POST',
@@ -170,7 +166,7 @@ export function createEvent(event: Record<string, any>) {
 }
 
 export function editEvent(event: Record<string, any>) {
-  return callAPI({
+  return callAPI<DetailedEvent>({
     types: Event.EDIT,
     endpoint: `/events/${event.id}/`,
     method: 'PUT',

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -21,7 +21,7 @@ import {
   selectEventByIdOrSlug,
   selectPoolsWithRegistrationsForEvent,
 } from 'app/reducers/events';
-import { selectImageGalleryEntries } from 'app/reducers/imageGallery';
+import { selectAllImageGalleryEntries } from 'app/reducers/imageGallery';
 import {
   transformEvent,
   transformEventStatusType,
@@ -138,7 +138,7 @@ const EventEditor = () => {
   const pools = useAppSelector((state) =>
     selectPoolsWithRegistrationsForEvent(state, { eventId }),
   );
-  const imageGalleryEntries = useAppSelector(selectImageGalleryEntries);
+  const imageGalleryEntries = useAppSelector(selectAllImageGalleryEntries);
   const imageGallery = imageGalleryEntries?.map((image) => ({
     key: image.key,
     cover: image.cover,

--- a/app/store/models/ImageGalleryEntry.d.ts
+++ b/app/store/models/ImageGalleryEntry.d.ts
@@ -1,0 +1,10 @@
+export interface ImageGalleryEntry {
+  cover: string;
+  coverPlaceholder: string;
+  fileType: 'image';
+  key: string;
+  public: boolean;
+  saveForUse: boolean;
+  state: string;
+  token: string;
+}

--- a/app/store/models/entities.ts
+++ b/app/store/models/entities.ts
@@ -16,6 +16,7 @@ import type { UnknownForum, UnknownThread } from 'app/store/models/Forum';
 import type { UnknownGallery } from 'app/store/models/Gallery';
 import type { UnknownGalleryPicture } from 'app/store/models/GalleryPicture';
 import type { UnknownGroup } from 'app/store/models/Group';
+import type { ImageGalleryEntry } from 'app/store/models/ImageGalleryEntry';
 import type { UnknownJoblisting } from 'app/store/models/Joblisting';
 import type { UnknownMeeting } from 'app/store/models/Meeting';
 import type { MeetingInvitation } from 'app/store/models/MeetingInvitation';
@@ -51,6 +52,7 @@ export enum EntityType {
   Galleries = 'galleries',
   GalleryPictures = 'galleryPictures',
   Groups = 'groups',
+  ImageGalleryEntries = 'imageGalleryEntries',
   Joblistings = 'joblistings',
   MeetingInvitations = 'meetingInvitations',
   Meetings = 'meetings',
@@ -91,6 +93,7 @@ export default interface Entities {
   [EntityType.GalleryPictures]: Record<EntityId, UnknownGalleryPicture>;
   [EntityType.Groups]: Record<EntityId, UnknownGroup>;
   [EntityType.Joblistings]: Record<EntityId, UnknownJoblisting>;
+  [EntityType.ImageGalleryEntries]: Record<EntityId, ImageGalleryEntry>;
   [EntityType.MeetingInvitations]: Record<EntityId, MeetingInvitation>;
   [EntityType.Meetings]: Record<EntityId, UnknownMeeting>;
   [EntityType.Memberships]: Record<EntityId, Membership>;


### PR DESCRIPTION
# Description

This is the slice for saved cover images that can be used on new events. The refactoring was fairly straightforward, except for the fact that some types were missing for the redux state.

# Result

More types, less usage of `createEntityReducer`

# Testing

- [x] I have thoroughly tested my changes.

---

ABA-688