### PR TITLE
Match poll validation to backend

### DIFF
--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -41,8 +41,7 @@ const renderOptions = ({ fields }): ReactNode => (
             placeholder={`Valg ${i + 1}`}
             component={TextInput.Field}
             validate={(value) => {
-              if (!value || value.length == 0)
-                return 'Alle valg må ha et navn';
+              if (!value || value.length == 0) return 'Alle valg må ha et navn';
               if (value.length > 30)
                 return 'Valget kan ikke være lengre enn 30 tegn';
               return undefined;

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -40,11 +40,13 @@ const renderOptions = ({ fields }): ReactNode => (
             label={`Valg nr. ${i + 1}`}
             placeholder={`Valg ${i + 1}`}
             component={TextInput.Field}
-            validate={(value) =>
-              value && value.length > 0
-                ? undefined
-                : 'Alle alternativer må ha et navn'
-            }
+            validate={(value) => {
+              if (!value || value.length == 0)
+                return 'Alle valg må ha et navn';
+              if (value.length > 30)
+                return 'Valget kan ikke være lengre enn 30 tegn';
+              return undefined;
+            }}
             required
           />
           <ConfirmModal


### PR DESCRIPTION
# Description

The frontend validation when creating/editing a poll did not check for the length of each, where as in the backend that field can max be 30 characters.

If you tried to create a poll with a option longer than 30 char. you would only get a message that the creation failed, and no reason why. 

# Result


<img width="662" alt="Screenshot 2024-04-19 at 16 29 06" src="https://github.com/webkom/lego-webapp/assets/45620425/a73202e7-22e1-4afa-91f8-7c58528e4767">


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-907
