### PR TITLE
Fix incorrect prop name in timeline acitivity

### DIFF
--- a/app/components/Feed/index.tsx
+++ b/app/components/Feed/index.tsx
@@ -47,10 +47,13 @@ const Feed = ({ feedId }: Props): ReactNode => {
     >
       {feedActivities.length ? (
         feedActivities.map((item) => {
-          const renders = activityRenderers[item.verb];
-          return renders ? (
+          const activityRenderer = activityRenderers[item.verb];
+          return activityRenderer ? (
             <ErrorBoundary hidden key={item.id}>
-              <Activity aggregatedActivity={item} renders={renders} />
+              <Activity
+                aggregatedActivity={item}
+                activityRenderer={activityRenderer}
+              />
             </ErrorBoundary>
           ) : null;
         })


### PR DESCRIPTION
# Description

Timeline page is blank in prod. I think it must have broken during some rebase, it's just a wrong prop name.

# Result

It works now:)

# Testing

- [x] I have thoroughly tested my changes.

Typescript no longer complains, and the page renders in local dev.

---

Resolves https://abakus.sentry.io/issues/5098383302/events/a37e703bacb746e5b9d191ac36f62821/
