### PR TITLE
Fix isNew-bug and add successMessages to mail-list

### DIFF
--- a/app/actions/EmailListActions.ts
+++ b/app/actions/EmailListActions.ts
@@ -27,7 +27,8 @@ export function createEmailList(emailList: CreateEmailList) {
     schema: emailListSchema,
     body: emailList,
     meta: {
-      errorMessage: 'Opprettelse av e-postlisten feilet',
+      successMessage: 'Opprettelse av e-postliste fullført',
+      errorMessage: 'Opprettelse av e-postliste feilet',
     },
   });
 }
@@ -40,6 +41,7 @@ export function editEmailList(emailList: EditEmailList) {
     schema: emailListSchema,
     body: emailList,
     meta: {
+      successMessage: 'Endring av e-postliste fullført',
       errorMessage: 'Endring av e-postliste feilet',
     },
   });

--- a/app/routes/admin/email/components/EmailListEditor.tsx
+++ b/app/routes/admin/email/components/EmailListEditor.tsx
@@ -56,7 +56,7 @@ const validate = createValidator({
 
 const EmailListEditor = () => {
   const { emailListId } = useParams<{ emailListId: string }>();
-  const isNew = emailListId === 'new';
+  const isNew = emailListId === undefined;
   const emailList = useAppSelector((state) =>
     selectEmailListById<DetailedEmailList>(state, emailListId),
   );


### PR DESCRIPTION
# Description

With the changes in routing the param is undefined rather than "new". This fix makes it possible to create email lists again.

Also added some successMessages as the mail-list views suffer from a huge lack of feedback on creation/editing lists.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

Before: no feedback on success

After:

<img width="312" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/a4306688-98e9-47e7-b656-3696863ba0db">


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-933
