### PR TITLE
Fix error when reading plausible analytics data

### DIFF
--- a/app/actions/EventActions.ts
+++ b/app/actions/EventActions.ts
@@ -396,15 +396,15 @@ export function fetchFollowers(eventId: EntityId, currentUserId: EntityId) {
 }
 
 export function fetchAnalytics(eventId: EntityId) {
-  return callAPI<
-    {
+  return callAPI<{
+    results: {
       bounceRate: number | null;
       date: string;
       pageviews: number | null;
       visitDuration: number | null;
       visitors: number | null;
-    }[]
-  >({
+    }[];
+  }>({
     types: Event.FETCH_ANALYTICS,
     endpoint: `/events/${String(eventId)}/statistics/`,
     method: 'GET',

--- a/app/routes/events/components/Analytics.tsx
+++ b/app/routes/events/components/Analytics.tsx
@@ -58,7 +58,7 @@ const Analytics = ({ viewStartTime, viewEndTime }: Props) => {
     () => {
       if (eventId) {
         return dispatch(fetchAnalytics(eventId)).then((response) => {
-          let filteredData = response.payload;
+          let filteredData = response.payload.results;
 
           if (viewStartTime) {
             filteredData = filteredData.filter((item) =>


### PR DESCRIPTION
# Description

It was reading the payload wrong. See diff.

Sentry issue: https://abakus.sentry.io/issues/5086404761/events/bac5f1520a344e3d9b2305e0977fa641/

# Result

The page view analytics on the event statistics page now works again:) 

# Testing

- [x] I have thoroughly tested my changes.

It didn't work, now it does.