### PR TITLE
Add ButtonGroup component

### DIFF
--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Icon, Modal } from '@webkom/lego-bricks';
+import { Button, ButtonGroup, Flex, Icon, Modal } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { Cropper } from 'react-cropper';
@@ -258,7 +258,7 @@ const ImageUpload = ({
               ))}
             </Flex>
           )}
-          <Flex wrap gap="var(--spacing-md)">
+          <ButtonGroup>
             <Button flat onPress={() => closeModal()}>
               Avbryt
             </Button>
@@ -269,7 +269,7 @@ const ImageUpload = ({
             >
               Last opp
             </Button>
-          </Flex>
+          </ButtonGroup>
         </Flex>
       </Modal>
     </>

--- a/app/routes/announcements/components/AnnouncementItem.tsx
+++ b/app/routes/announcements/components/AnnouncementItem.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex } from '@webkom/lego-bricks';
+import { Button, ButtonGroup, Flex } from '@webkom/lego-bricks';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -113,7 +113,7 @@ const AnnouncementItem = ({ announcement, actionGrant }: Props) => {
         </Flex>
       </Flex>
       {!announcement.sent && (
-        <Flex className={styles.wrapperSendButton}>
+        <ButtonGroup className={styles.wrapperSendButton}>
           {actionGrant.includes('delete') && (
             <Button
               danger
@@ -140,7 +140,7 @@ const AnnouncementItem = ({ announcement, actionGrant }: Props) => {
               Send
             </Button>
           )}
-        </Flex>
+        </ButtonGroup>
       )}
     </Flex>
   );

--- a/app/routes/announcements/components/AnnouncementsCreate.tsx
+++ b/app/routes/announcements/components/AnnouncementsCreate.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex } from '@webkom/lego-bricks';
+import { ButtonGroup, Card, Flex } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
@@ -215,7 +215,7 @@ const AnnouncementsCreate = () => {
             />
 
             {spyValues<FormValues>((values) => (
-              <Flex wrap>
+              <ButtonGroup>
                 <SubmitButton
                   onPress={() => {
                     values.send = false;
@@ -230,7 +230,7 @@ const AnnouncementsCreate = () => {
                 >
                   Opprett og send
                 </SubmitButton>
-              </Flex>
+              </ButtonGroup>
             ))}
             <Card severity="info">
               Du kan velge å sende kunngjøringen med en gang, eller lagre den og

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
+  ButtonGroup,
   ConfirmModal,
-  Flex,
   Icon,
   LinkButton,
   LoadingIndicator,
@@ -234,7 +234,7 @@ const ArticleEditor = () => {
               component={EditorField.Field}
             />
 
-            <Flex wrap gap="var(--spacing-md)">
+            <ButtonGroup>
               <LinkButton flat href={`/articles/${isNew ? '' : articleId}`}>
                 Avbryt
               </LinkButton>
@@ -255,7 +255,7 @@ const ArticleEditor = () => {
                   )}
                 </ConfirmModal>
               )}
-            </Flex>
+            </ButtonGroup>
           </Form>
         )}
       </TypedLegoForm>

--- a/app/routes/brand/components/BrandPage.tsx
+++ b/app/routes/brand/components/BrandPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Icon, LinkButton } from '@webkom/lego-bricks';
+import { Flex, Icon, LinkButton } from '@webkom/lego-bricks';
 import logosDonts from 'app/assets/logos-donts.png';
 import logosDos from 'app/assets/logos-dos.png';
 import { Content } from 'app/components/Content';
@@ -26,7 +26,7 @@ const BrandPage = () => (
           identifiserer oss. Vær så snill å ikke modifiser merkene eller bruk
           dem på en forvirrende måte.
         </p>
-        <Flex row>
+        <Flex>
           <Flex column className={styles.colLeft}>
             <h2>Logo</h2>
             <p>
@@ -48,7 +48,7 @@ const BrandPage = () => (
           </Flex>
         </Flex>
 
-        <Flex row>
+        <Flex>
           <Flex column className={styles.colLeft}>
             <b>Vi ber om at du er omtenksom og ikke:</b>
             <ul>
@@ -99,15 +99,13 @@ const BrandPage = () => (
           <p>
             Denne malen skal brukes for presentasjoner som holdes i Abakus-regi
           </p>
-          <a
+          <LinkButton
             href="https://github.com/abakus-ntnu/grafisk-profil/blob/master/maler/Abakus%20-%20Presentasjonsmal.pptx?raw=true"
             download="proposed_file_name"
           >
-            <Button>
-              <Icon name="download-outline" size={19} />
-              Last ned
-            </Button>
-          </a>
+            <Icon name="download-outline" size={19} />
+            Last ned
+          </LinkButton>
         </div>
       </Flex>
     </section>

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -233,9 +233,9 @@ const CompanyInterestList = () => {
         <LinkButton href="/companyInterest/semesters">
           Endre aktive semestre
         </LinkButton>
-        <Link to="/companyInterest/create">
-          <Button>Opprett ny bedriftsinteresse</Button>
-        </Link>
+        <LinkButton href="/companyInterest/create">
+          Opprett ny bedriftsinteresse
+        </LinkButton>
       </Flex>
 
       <Flex
@@ -257,16 +257,17 @@ const CompanyInterestList = () => {
         </Flex>
 
         {generatedCSV ? (
-          <a href={generatedCSV.url} download={generatedCSV.filename}>
-            Last ned
-          </a>
+          <LinkButton
+            success
+            href={generatedCSV.url}
+            download={generatedCSV.filename}
+          >
+            <Icon name="download-outline" size={19} />
+            Last ned CSV
+          </LinkButton>
         ) : (
           <Tooltip
-            style={
-              selectedSemesterFilterOption.year
-                ? { display: 'none' }
-                : undefined
-            }
+            disabled={!!selectedSemesterFilterOption.year}
             content={'Vennligst velg semester'}
           >
             <Button

--- a/app/routes/events/components/Admin.css
+++ b/app/routes/events/components/Admin.css
@@ -1,3 +1,0 @@
-.admin a {
-  width: fit-content;
-}

--- a/app/routes/events/components/Admin.tsx
+++ b/app/routes/events/components/Admin.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
+  ButtonGroup,
   ConfirmModal,
-  Flex,
   Icon,
   LinkButton,
 } from '@webkom/lego-bricks';
@@ -12,7 +12,6 @@ import { deleteEvent } from 'app/actions/EventActions';
 import AnnouncementInLine from 'app/components/AnnouncementInLine';
 import { TextInput } from 'app/components/Form';
 import { useAppDispatch } from 'app/store/hooks';
-import styles from './Admin.css';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant } from 'app/models';
 import type { AuthUserDetailedEvent } from 'app/store/models/Event';
@@ -87,11 +86,11 @@ const Admin = ({ actionGrant, event }: Props) => {
     ) < 1;
 
   return (
-    <Flex column gap="0.5rem" className={styles.admin}>
-      {(canEdit || canDelete) && (
-        <>
-          <h3>Admin</h3>
+    (canEdit || canDelete) && (
+      <>
+        <h3>Admin</h3>
 
+        <ButtonGroup vertical>
           {showRegisterButton && (
             <LinkButton
               success
@@ -136,9 +135,9 @@ const Admin = ({ actionGrant, event }: Props) => {
           </LinkButton>
 
           {canDelete && <DeleteButton eventId={event.id} title={event.title} />}
-        </>
-      )}
-    </Flex>
+        </ButtonGroup>
+      </>
+    )
   );
 };
 

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, LinkButton, LoadingIndicator } from '@webkom/lego-bricks';
+import { ButtonGroup, LinkButton, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import arrayMutators from 'final-form-arrays';
 import { isEmpty } from 'lodash';
@@ -405,7 +405,7 @@ const EventEditor = () => {
               />
             )}
 
-            <Flex wrap gap="var(--spacing-md)">
+            <ButtonGroup>
               {isEditPage && (
                 <LinkButton flat href={`/events/${event.slug}`}>
                   Avbryt
@@ -414,7 +414,7 @@ const EventEditor = () => {
               <SubmitButton>
                 {isEditPage ? 'Lagre endringer' : 'Opprett'}
               </SubmitButton>
-            </Flex>
+            </ButtonGroup>
 
             {isEditPage && <Admin actionGrant={actionGrant} event={values} />}
           </Form>

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -296,7 +296,7 @@ const EventList = () => {
       {pagination.hasMore && field === 'startTime' && (
         <Button
           onPress={fetchMore}
-          pending={!isEmpty(events) && pagination.fetching}
+          isPending={!isEmpty(events) && pagination.fetching}
         >
           Last inn mer
         </Button>

--- a/app/routes/forum/components/ForumEditor.tsx
+++ b/app/routes/forum/components/ForumEditor.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
+  ButtonGroup,
   ConfirmModal,
-  Flex,
   Icon,
   LoadingIndicator,
 } from '@webkom/lego-bricks';
@@ -95,8 +95,7 @@ const ForumEditor = () => {
               component={TextArea.Field}
               id="forum-description"
             />
-            {/* Action buttons */}
-            <Flex wrap gap="var(--spacing-md)">
+            <ButtonGroup>
               <Button
                 flat
                 onPress={() =>
@@ -122,7 +121,7 @@ const ForumEditor = () => {
                   )}
                 </ConfirmModal>
               )}
-            </Flex>
+            </ButtonGroup>
           </Form>
         )}
       </LegoFinalForm>

--- a/app/routes/forum/components/ThreadEditor.tsx
+++ b/app/routes/forum/components/ThreadEditor.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
+  ButtonGroup,
   ConfirmModal,
-  Flex,
   Icon,
   LoadingIndicator,
 } from '@webkom/lego-bricks';
@@ -105,7 +105,7 @@ const ThreadEditor = () => {
               component={EditorField.Field}
             />
 
-            <Flex wrap gap="var(--spacing-md)">
+            <ButtonGroup>
               <Button
                 flat
                 onPress={() =>
@@ -135,7 +135,7 @@ const ThreadEditor = () => {
                   )}
                 </ConfirmModal>
               )}
-            </Flex>
+            </ButtonGroup>
           </Form>
         )}
       </LegoFinalForm>

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonGroup,
   DialogTrigger,
   Flex,
   Icon,
@@ -72,7 +73,7 @@ const ButtonRow = ({ group, memberships }: ButtonRowProps) => {
     : () => dispatch(joinGroup(group.id, currentUser));
 
   return (
-    <Flex>
+    <ButtonGroup>
       <Button
         success={membership === undefined}
         danger={membership !== undefined}
@@ -80,7 +81,7 @@ const ButtonRow = ({ group, memberships }: ButtonRowProps) => {
       >
         {membership ? 'Forlat gruppen' : 'Bli med i gruppen'}
       </Button>
-    </Flex>
+    </ButtonGroup>
   );
 };
 

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonGroup,
   ConfirmModal,
   Flex,
   Icon,
@@ -340,7 +341,7 @@ const JoblistingEditor = () => {
               required
             />
             <SubmissionError />
-            <Flex wrap gap="var(--spacing-md)">
+            <ButtonGroup>
               <LinkButton href={`/joblistings/${isNew ? '' : joblistingId}`}>
                 Avbryt
               </LinkButton>
@@ -361,7 +362,7 @@ const JoblistingEditor = () => {
                   )}
                 </ConfirmModal>
               )}
-            </Flex>
+            </ButtonGroup>
           </Form>
         )}
       </LegoFinalForm>

--- a/app/routes/meetings/components/MeetingDetail.css
+++ b/app/routes/meetings/components/MeetingDetail.css
@@ -7,7 +7,6 @@
 }
 
 .statusButtons {
-  display: flex;
   margin-bottom: 10px;
 }
 

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -1,6 +1,6 @@
 import {
   Button,
-  Flex,
+  ButtonGroup,
   Icon,
   LinkButton,
   LoadingIndicator,
@@ -114,7 +114,7 @@ const MeetingDetails = () => {
   ) =>
     statusMe &&
     moment(startTime) > moment() && (
-      <li className={styles.statusButtons}>
+      <ButtonGroup className={styles.statusButtons}>
         <Button
           success
           onPress={acceptInvitation}
@@ -129,7 +129,7 @@ const MeetingDetails = () => {
         >
           Avslå
         </Button>
-      </li>
+      </ButtonGroup>
     );
 
   if (!meeting || !currentUser) {
@@ -207,9 +207,8 @@ const MeetingDetails = () => {
             )}
           </ul>
 
-          <Flex column gap={7}>
-            <h3>Admin</h3>
-
+          <h3>Admin</h3>
+          <ButtonGroup>
             <AnnouncementInLine meeting={meeting} />
             {canEdit && (
               <LinkButton href={`/meetings/${meeting.id}/edit`}>
@@ -217,7 +216,7 @@ const MeetingDetails = () => {
                 Rediger
               </LinkButton>
             )}
-          </Flex>
+          </ButtonGroup>
         </ContentSidebar>
       </ContentSection>
       <ContentSection>

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -1,4 +1,5 @@
 import {
+  ButtonGroup,
   ConfirmModal,
   Flex,
   Icon,
@@ -427,7 +428,7 @@ const MeetingEditor = () => {
               )}
 
               <SubmissionError />
-              <Flex wrap gap="var(--spacing-md)">
+              <ButtonGroup>
                 <Button
                   flat
                   onPress={() =>
@@ -453,7 +454,7 @@ const MeetingEditor = () => {
                     )}
                   </ConfirmModal>
                 )}
-              </Flex>
+              </ButtonGroup>
             </Form>
           );
         }}

--- a/app/routes/meetings/components/MeetingList.tsx
+++ b/app/routes/meetings/components/MeetingList.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Flex,
   LinkButton,
+  ButtonGroup,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment-timezone';
@@ -193,14 +194,16 @@ const MeetingList = () => {
       <LoadingIndicator
         loading={fetchMorePagination.fetching || fetchOlderPagination.fetching}
       />
-      {fetchMorePagination.hasMore && (
-        <Button onPress={fetchMore}>Last inn flere</Button>
-      )}
-      {fetchOlderPagination.hasMore && (
-        <Button flat onPress={fetchOlder}>
-          Hent gamle
-        </Button>
-      )}
+      <ButtonGroup>
+        {fetchMorePagination.hasMore && (
+          <Button onPress={fetchMore}>Last inn flere</Button>
+        )}
+        {fetchOlderPagination.hasMore && (
+          <Button flat onPress={fetchOlder}>
+            Hent gamle
+          </Button>
+        )}
+      </ButtonGroup>
     </Content>
   );
 };

--- a/app/routes/pages/components/LandingPage.css
+++ b/app/routes/pages/components/LandingPage.css
@@ -97,16 +97,6 @@ div > .locationContainerItem {
   align-items: center;
 }
 
-.socialMediaTypeLinks {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.socialMediaLink {
-  margin-top: var(--spacing-sm);
-}
-
 @media (--mobile-device) {
   .abakusInNumbers {
     display: block;

--- a/app/routes/pages/components/LandingPage.tsx
+++ b/app/routes/pages/components/LandingPage.tsx
@@ -1,4 +1,10 @@
-import { Button, Flex, Icon } from '@webkom/lego-bricks';
+import {
+  Button,
+  ButtonGroup,
+  Flex,
+  Icon,
+  LinkButton,
+} from '@webkom/lego-bricks';
 import cx from 'classnames';
 import moment from 'moment-timezone';
 import { Link } from 'react-router-dom';
@@ -120,49 +126,46 @@ const LandingPage: PageRenderer<null> = () => {
           <Flex wrap gap="var(--spacing-md)">
             <div className={styles.socialMediaType}>
               <Icon name="logo-facebook" size={40} />
-              <div className={styles.socialMediaTypeLinks}>
+              <ButtonGroup vertical centered>
                 {socialMedia.facebook.map((page, index) => (
-                  <a
+                  <LinkButton
+                    flat
                     key={index}
                     href={page.link}
                     className={styles.socialMediaLink}
                   >
                     {page.textInfo}
-                  </a>
+                  </LinkButton>
                 ))}
                 {loggedIn && (
-                  <a
+                  <LinkButton
+                    flat
                     href="https://www.facebook.com/groups/398146436914007/"
-                    className={styles.socialMediaLink}
                   >
                     Medlemsgruppe
-                  </a>
+                  </LinkButton>
                 )}
-              </div>
+              </ButtonGroup>
             </div>
             <div className={styles.socialMediaType}>
               <Icon name="logo-instagram" size={40} />
-              <div className={styles.socialMediaTypeLinks}>
+              <ButtonGroup vertical centered>
                 {socialMedia.instagram.map((page, index) => (
-                  <a
-                    key={index}
-                    href={page.link}
-                    className={styles.socialMediaLink}
-                  >
+                  <LinkButton flat key={index} href={page.link}>
                     {page.textInfo}
-                  </a>
+                  </LinkButton>
                 ))}
-              </div>
+              </ButtonGroup>
             </div>
             <div className={styles.socialMediaType}>
               <Icon name="logo-snapchat" size={40} />
-              <div className={styles.socialMediaTypeLinks}>
+              <ButtonGroup vertical centered>
                 {socialMedia.snapchat.map((page, index) => (
-                  <Button flat key={index} className={styles.socialMediaLink}>
+                  <Button flat key={index}>
                     {page.name}
                   </Button>
                 ))}
-              </div>
+              </ButtonGroup>
             </div>
           </Flex>
         </div>

--- a/app/routes/pages/components/PageEditor.tsx
+++ b/app/routes/pages/components/PageEditor.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonGroup,
   ConfirmModal,
   Flex,
   Icon,
@@ -193,7 +194,7 @@ const PageEditor = () => {
               uploadFile={uploadFile}
             />
 
-            <Flex wrap gap="var(--spacing-md)">
+            <ButtonGroup>
               {!isNew && (
                 <ConfirmModal
                   title="Slett side"
@@ -210,7 +211,7 @@ const PageEditor = () => {
               )}
 
               <SubmitButton>{isNew ? 'Opprett' : 'Lagre'}</SubmitButton>
-            </Flex>
+            </ButtonGroup>
           </Form>
         )}
       </TypedLegoForm>

--- a/app/routes/photos/components/GalleryEditor.tsx
+++ b/app/routes/photos/components/GalleryEditor.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonGroup,
   Card,
   ConfirmModal,
   Flex,
@@ -344,7 +345,7 @@ const GalleryEditor = () => {
               component={ObjectPermissions}
             />
 
-            <Flex className={styles.buttonRow} wrap gap="var(--spacing-md)">
+            <ButtonGroup className={styles.buttonRow}>
               <LinkButton flat href={`/photos/${gallery?.id ?? ''}`}>
                 Avbryt
               </LinkButton>
@@ -363,7 +364,7 @@ const GalleryEditor = () => {
                   )}
                 </ConfirmModal>
               )}
-            </Flex>
+            </ButtonGroup>
           </Form>
         )}
       </TypedLegoForm>

--- a/app/routes/photos/components/GalleryEditorActions.tsx
+++ b/app/routes/photos/components/GalleryEditorActions.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Flex } from '@webkom/lego-bricks';
+import { Button, ButtonGroup, Card, Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import styles from './GalleryEditorActions.css';
 
@@ -25,7 +25,7 @@ const GalleryEditorActions = ({
         <span>
           <b>{selectedCount}</b> valgt
         </span>
-        <Flex wrap gap="var(--spacing-md)">
+        <ButtonGroup>
           <Button flat onPress={onDeselect}>
             Avbryt
           </Button>
@@ -44,7 +44,7 @@ const GalleryEditorActions = ({
           <Button danger onPress={onDeletePictures}>
             Slett {selectedCount > 1 ? 'valgte' : 'valgt'}
           </Button>
-        </Flex>
+        </ButtonGroup>
       </Card>
     </Flex>
   );

--- a/app/routes/photos/components/GalleryPictureEditModal.tsx
+++ b/app/routes/photos/components/GalleryPictureEditModal.tsx
@@ -1,4 +1,10 @@
-import { Button, Flex, LoadingIndicator, Modal } from '@webkom/lego-bricks';
+import {
+  Button,
+  ButtonGroup,
+  Flex,
+  LoadingIndicator,
+  Modal,
+} from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Field } from 'react-final-form';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -151,7 +157,7 @@ const GalleryPictureEditModal = () => {
                 component={SelectInput.AutocompleteField}
                 isMulti
               />
-              <Flex wrap gap="var(--spacing-md)">
+              <ButtonGroup>
                 <Button
                   flat
                   onPress={() => {
@@ -171,7 +177,7 @@ const GalleryPictureEditModal = () => {
                 >
                   Slett
                 </Button>
-              </Flex>
+              </ButtonGroup>
             </Form>
           )}
         </TypedLegoForm>

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -109,21 +109,6 @@ const Taggees = ({ taggees }: { taggees: PublicUser[] }) => {
   }
 };
 
-const RenderGalleryPicture = ({
-  id,
-  handleDelete,
-  clickedDeletePicture,
-}: {
-  id: number;
-  handleDelete: (arg0: number) => void;
-  clickedDeletePicture: number;
-}) => (
-  <button onClick={() => handleDelete(id)}>
-    {clickedDeletePicture === id ? 'Er du sikker?' : 'Slett'}
-    <Icon name="trash-outline" />
-  </button>
-);
-
 const Swipeable = (props: {
   onSwiping: (arg0: { dir: string }) => void;
   children: ReactNode;
@@ -368,11 +353,12 @@ const GalleryPictureModal = () => {
                         e.stopPropagation();
                       }}
                     >
-                      <RenderGalleryPicture
-                        handleDelete={handleDelete}
-                        id={pictureId}
-                        clickedDeletePicture={clickedDeletePicture}
-                      />
+                      <button onClick={() => handleDelete(Number(pictureId))}>
+                        {clickedDeletePicture === Number(pictureId)
+                          ? 'Er du sikker?'
+                          : 'Slett'}
+                        <Icon name="trash-outline" />
+                      </button>
                     </Dropdown.ListItem>,
                   ]}
               </Dropdown.List>
@@ -415,7 +401,6 @@ const GalleryPictureModal = () => {
           )}
           {picture.contentTarget && (
             <CommentView
-              formEnabled
               contentTarget={picture.contentTarget}
               comments={comments}
             />

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -1,4 +1,4 @@
-import { Button, ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
+import { Button, ButtonGroup, ConfirmModal, Icon } from '@webkom/lego-bricks';
 import arrayMutators from 'final-form-arrays';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
@@ -189,7 +189,7 @@ const PollEditor = ({
             />
 
             <SubmissionError />
-            <Flex className={styles.actionButtons} wrap gap="var(--spacing-md)">
+            <ButtonGroup className={styles.actionButtons}>
               <SubmitButton>
                 {editing ? 'Lagre endringer' : 'Lag ny avstemning'}
               </SubmitButton>
@@ -212,7 +212,7 @@ const PollEditor = ({
                   )}
                 </ConfirmModal>
               )}
-            </Flex>
+            </ButtonGroup>
           </form>
         )}
       </LegoFinalForm>

--- a/app/routes/surveys/components/AdminSideBar.tsx
+++ b/app/routes/surveys/components/AdminSideBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, LinkButton } from '@webkom/lego-bricks';
+import { Button, ButtonGroup, Icon, LinkButton } from '@webkom/lego-bricks';
 import { useCallback, useState } from 'react';
 import { hideSurvey, shareSurvey } from 'app/actions/SurveyActions';
 import { ContentSidebar } from 'app/components/Content';
@@ -56,19 +56,21 @@ const AdminSideBar = ({
       <ContentSidebar>
         <h3>Admin</h3>
 
-        <LinkButton href="/surveys/add">
-          <Icon name="add" size={19} />
-          Ny undersøkelse
-        </LinkButton>
+        <ButtonGroup vertical>
+          <LinkButton href="/surveys/add">
+            <Icon name="add" size={19} />
+            Ny undersøkelse
+          </LinkButton>
 
-        <LinkButton href={`/surveys/${surveyId}/edit`}>
-          <Icon name="create-outline" size={19} />
-          Rediger
-        </LinkButton>
+          <LinkButton href={`/surveys/${surveyId}/edit`}>
+            <Icon name="create-outline" size={19} />
+            Rediger
+          </LinkButton>
 
-        {actionGrant && actionGrant.includes('csv') && exportSurvey && (
-          <div>
-            {generatedCSV ? (
+          {actionGrant &&
+            actionGrant.includes('csv') &&
+            exportSurvey &&
+            (generatedCSV ? (
               <LinkButton
                 success
                 href={generatedCSV.url}
@@ -84,9 +86,8 @@ const AdminSideBar = ({
                 <Icon name="download-outline" size={19} />
                 Eksporter til CSV
               </Button>
-            )}
-          </div>
-        )}
+            ))}
+        </ButtonGroup>
 
         {actionGrant && actionGrant.includes('edit') && (
           <CheckBox

--- a/app/routes/users/components/PhotoConsents.css
+++ b/app/routes/users/components/PhotoConsents.css
@@ -1,11 +1,3 @@
-.consentBtn {
-  height: 2.9rem;
-}
-
-.consentBtnContainer {
-  display: flex;
-}
-
 .categoryTitle {
   margin-top: var(--spacing-xl);
 }

--- a/app/routes/users/components/PhotoConsents.tsx
+++ b/app/routes/users/components/PhotoConsents.tsx
@@ -1,4 +1,4 @@
-import { Button, ConfirmModal, Flex } from '@webkom/lego-bricks';
+import { Button, ButtonGroup, ConfirmModal, Flex } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { updatePhotoConsent } from 'app/actions/UserActions';
@@ -48,7 +48,7 @@ const ConsentManager = ({
           ''
         )}
       </div>
-      <div className={styles.consentBtnContainer}>
+      <ButtonGroup>
         <ConfirmModal
           closeOnConfirm={true}
           title={`Trekke bildesamtykke på ${presentableDomain}`}
@@ -62,7 +62,6 @@ const ConsentManager = ({
               onPress={openConfirmModal}
               dark
               disabled={!isCurrentUser || consent.isConsenting === false}
-              className={styles.consentBtn}
             >
               Trekk samtykke
             </Button>
@@ -72,11 +71,10 @@ const ConsentManager = ({
           success
           disabled={!isCurrentUser || consent.isConsenting === true}
           onPress={() => updateConsent({ ...consent, isConsenting: true })}
-          className={styles.consentBtn}
         >
           Behold samtykke
         </Button>
-      </div>
+      </ButtonGroup>
     </>
   );
 };

--- a/app/routes/users/components/RemovePicture.tsx
+++ b/app/routes/users/components/RemovePicture.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Icon } from '@webkom/lego-bricks';
+import { Button, ButtonGroup, Icon } from '@webkom/lego-bricks';
 import { useState } from 'react';
 import { removePicture } from 'app/actions/UserActions';
 import { useAppDispatch } from 'app/store/hooks';
@@ -22,7 +22,7 @@ const RemovePicture = (props: Props) => {
   const toggleSelected = () => setSelected(!selected);
 
   return (
-    <Flex wrap gap="var(--spacing-md)">
+    <ButtonGroup>
       {selected ? (
         <Button onPress={toggleSelected}>Avbryt</Button>
       ) : (
@@ -36,7 +36,7 @@ const RemovePicture = (props: Props) => {
           Bekreft
         </Button>
       )}
-    </Flex>
+    </ButtonGroup>
   );
 };
 

--- a/app/routes/users/components/StudentConfirmation.tsx
+++ b/app/routes/users/components/StudentConfirmation.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex, Modal } from '@webkom/lego-bricks';
+import { ButtonGroup, Card, Modal } from '@webkom/lego-bricks';
 import qs from 'qs';
 import { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
@@ -201,14 +201,14 @@ const StudentConfirmation = () => {
           </p>
         </div>
 
-        <Flex>
+        <ButtonGroup>
           <Button dark onPress={() => setAbakusMember(false)}>
             Jeg vil ikke bli medlem
           </Button>
           <Button success onPress={() => setAbakusMember(true)}>
             Jeg vil bli medlem
           </Button>
-        </Flex>
+        </ButtonGroup>
       </Modal>
     </>
   );

--- a/app/routes/users/components/UserConfirmation.tsx
+++ b/app/routes/users/components/UserConfirmation.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex, LinkButton } from '@webkom/lego-bricks';
+import { ButtonGroup, Card, LinkButton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { normalize } from 'normalizr';
 import qs from 'qs';
@@ -99,12 +99,12 @@ const UserConfirmationForm = () => {
               at du er student.
             </span>
           </Card>
-          <Flex gap="var(--spacing-md)">
+          <ButtonGroup>
             <LinkButton success href="/users/me/settings/student-confirmation/">
               Verifiser studentstatus
             </LinkButton>
             <LinkButton href="/">Eller gå til hovedsiden</LinkButton>
-          </Flex>
+          </ButtonGroup>
         </Content>
       </>
     );

--- a/packages/lego-bricks/src/components/Button/ButtonGroup.stories.tsx
+++ b/packages/lego-bricks/src/components/Button/ButtonGroup.stories.tsx
@@ -1,0 +1,85 @@
+import { Danger, Primary, PrimaryDisabled, Secondary } from './Button.stories';
+import { ButtonGroup } from './ButtonGroup';
+import { Button } from '.';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof ButtonGroup> = {
+  title: 'Interaction/ButtonGroup',
+  component: ButtonGroup,
+  subcomponents: {
+    Button,
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonGroup>;
+
+export const Default: Story = {
+  args: {},
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <Button {...Primary.args} />
+      <Button {...Secondary.args} />
+    </ButtonGroup>
+  ),
+};
+
+export const Vertical: Story = {
+  args: {
+    vertical: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Using the `vertical` prop will stack the buttons vertically instead of horizontally. By default they are left-aligned, but they can be centered using `center`',
+      },
+    },
+  },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <Button {...Primary.args} />
+      <Button {...Secondary.args} />
+    </ButtonGroup>
+  ),
+};
+
+export const HorizontalWrapping: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When width is constrained (like in the box below), buttons will wrap to the next line.',
+      },
+    },
+  },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <Button {...Danger.args} />
+      <Button {...Primary.args} />
+      <Button {...PrimaryDisabled.args} />
+      <Button {...Primary.args} />
+      <Button {...Secondary.args} />
+    </ButtonGroup>
+  ),
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: 400,
+          height: 300,
+          border: '1px solid black',
+          resize: 'horizontal',
+          overflow: 'auto',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/packages/lego-bricks/src/components/Button/ButtonGroup.tsx
+++ b/packages/lego-bricks/src/components/Button/ButtonGroup.tsx
@@ -1,0 +1,29 @@
+import { Flex } from '../Layout';
+import type { ReactNode } from 'react';
+
+type Props = {
+  vertical?: boolean;
+  centered?: boolean;
+  className?: string;
+  children: ReactNode;
+};
+
+export const ButtonGroup = ({
+  vertical = false,
+  centered = false,
+  className,
+  children,
+}: Props) => (
+  <Flex
+    wrap
+    alignItems={centered ? 'center' : 'flex-start'}
+    style={{
+      columnGap: 'var(--spacing-md)',
+      rowGap: 'var(--spacing-sm)',
+    }}
+    column={vertical}
+    className={className}
+  >
+    {children}
+  </Flex>
+);

--- a/packages/lego-bricks/src/components/Modal/ConfirmModal.tsx
+++ b/packages/lego-bricks/src/components/Modal/ConfirmModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Button } from '../Button';
+import { ButtonGroup } from '../Button/ButtonGroup';
 import { Icon } from '../Icon';
 import { Flex } from '../Layout';
 import styles from './ConfirmModal.module.css';
@@ -35,14 +36,14 @@ const ConfirmModalContent = ({
       <h2 className={danger ? styles.dangerTitle : undefined}>{title}</h2>
     </Flex>
     <span>{message}</span>
-    <Flex wrap gap="var(--spacing-sm)">
+    <ButtonGroup>
       <Button flat disabled={disabled} onPress={onCancel}>
         {cancelText}
       </Button>
       <Button danger={danger} disabled={disabled} onPress={onConfirm}>
         {confirmText}
       </Button>
-    </Flex>
+    </ButtonGroup>
     {errorMessage && <p className={styles.errorMessage}>{errorMessage} </p>}
   </Flex>
 );

--- a/packages/lego-bricks/src/index.ts
+++ b/packages/lego-bricks/src/index.ts
@@ -6,6 +6,7 @@ export type { PressEvent } from 'react-aria-components';
 export { RouterProvider, DialogTrigger } from 'react-aria-components';
 
 export { Button, LinkButton } from './components/Button';
+export { ButtonGroup } from './components/Button/ButtonGroup';
 export { Container, Flex } from './components/Layout';
 export { Card } from './components/Card';
 export { Icon } from './components/Icon';


### PR DESCRIPTION
# Description

I figured we should have a component to ensure consistent spacing in groups of buttons. 

# Result

Not much has changed, as I used the same spacing that was normally used already. But I changed a few things I was annoyed by, see the table below.

I also re-added this https://github.com/webkom/lego-webapp/pull/4156 fix which seems to have been lost during `react-router` refactoring.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
Changed the SoMe links in "Om Abakus" to all be link-buttons instead of a mix of normal links and link-buttons.
        </td>
        <td>
<img width="779" alt="Screenshot 2024-05-14 at 00 40 56" src="https://github.com/webkom/lego-webapp/assets/8343002/1640b777-715d-44bc-852a-fba5ebd2a08f">
        </td>
        <td>
<img width="779" alt="Screenshot 2024-05-14 at 00 42 18" src="https://github.com/webkom/lego-webapp/assets/8343002/cd30c686-db8f-4017-8102-064e455a72f8">
        </td>
    </tr>
    <tr>
        <td>
Changed layout of photo-consent buttons.
        </td>
        <td>
<img width="323" alt="Screenshot 2024-05-14 at 00 44 47" src="https://github.com/webkom/lego-webapp/assets/8343002/5127fa7a-d754-45b3-8a7a-3425894c0c46">
        </td>
        <td>
<img width="310" alt="Screenshot 2024-05-14 at 00 43 19" src="https://github.com/webkom/lego-webapp/assets/8343002/99956429-00ed-43a7-90ad-d3fe772ec869">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

I looked at them.
