### PR TITLE
Cache theme in localStorage

### DIFF
--- a/app/utils/themeUtils.tsx
+++ b/app/utils/themeUtils.tsx
@@ -9,6 +9,7 @@ export const applySelectedTheme = (theme) => {
       theme === 'auto' ? getOSTheme() : theme,
     );
     global.dispatchEvent(new Event('themeChange'));
+    localStorage.setItem('theme', theme);
   }
 };
 
@@ -23,9 +24,16 @@ export const ThemeContextListener = () => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
+    // Configure listener to synchronize state
     const handleThemeChange = () => dispatch(setTheme(getTheme()));
     handleThemeChange();
     window.addEventListener('themeChange', handleThemeChange);
+
+    // Optimistically upadte theme from localStorage
+    const cachedTheme =
+      localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
+    applySelectedTheme(cachedTheme);
+
     return () => window.removeEventListener('themeChange', handleThemeChange);
   }, [dispatch]);
 


### PR DESCRIPTION
# Description

Allow the site to set the previously selected theme before it is overridden by the backend

# Result

Werks

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.



# Testing

- [x] I have thoroughly tested my changes.

Run some reloads and hard reloads in dark mode and it seems to work as expected

---

Resolves ABA-788
