### PR TITLE
Resolve readme container missing height on public frontpage

### DIFF
--- a/app/components/Image/Image.tsx
+++ b/app/components/Image/Image.tsx
@@ -32,12 +32,13 @@ const ImageComponent = (props: Props) => {
     alt = 'image',
     style,
     darkModeSource,
+    darkThemeSource,
     ...rest
   } = props;
 
   const theme = useTheme();
   const themedSource =
-    props.darkThemeSource && theme === 'dark' ? props.darkThemeSource : src;
+    darkThemeSource && theme === 'dark' ? darkThemeSource : src;
 
   const isProgressive = !!props.placeholder;
   useEffect(() => {

--- a/app/routes/frontpage/components/AuthenticatedFrontpage.css
+++ b/app/routes/frontpage/components/AuthenticatedFrontpage.css
@@ -30,6 +30,7 @@
 
   h3 {
     margin-top: 0;
+    margin-left: 0;
   }
 }
 

--- a/app/routes/frontpage/components/LatestReadme.tsx
+++ b/app/routes/frontpage/components/LatestReadme.tsx
@@ -25,6 +25,8 @@ const LatestReadme = ({
   const ref = useRef<HTMLDivElement>(null);
 
   const [expanded, setExpanded] = useState(expandedInitially);
+  const [containerHeight, setContainerHeight] = useState(0);
+  const updateHeight = () => setContainerHeight(ref.current?.clientHeight ?? 0);
 
   useEffect(() => {
     setExpanded(expandedInitially);
@@ -35,7 +37,10 @@ const LatestReadme = ({
       {collapsible ? (
         <div
           className={cx(styles.heading, styles.pointer)}
-          onClick={() => setExpanded(!expanded)}
+          onClick={() => {
+            setExpanded(!expanded);
+            updateHeight();
+          }}
         >
           <Flex justifyContent="space-between" alignItems="center">
             {readmeIfy('readme')}
@@ -53,13 +58,17 @@ const LatestReadme = ({
       <div
         className={styles.thumbnailWrapper}
         style={{
-          height: expanded ? ref.current?.clientHeight ?? 0 : 0,
+          height: expanded ? containerHeight : 0,
         }}
       >
         <div className={styles.thumbnailContainer} ref={ref}>
           {readmes.slice(0, displayCount).map(({ image, pdf, title }) => (
             <a key={title} href={pdf} className={styles.thumb}>
-              <Image src={image} alt={`Cover of ${title}`} />
+              <Image
+                src={image}
+                alt={`Cover of ${title}`}
+                onLoad={() => updateHeight()}
+              />
             </a>
           ))}
         </div>

--- a/app/routes/frontpage/components/Pinned.css
+++ b/app/routes/frontpage/components/Pinned.css
@@ -8,6 +8,10 @@
 .body {
   padding: 0;
   min-height: 260px;
+
+  @media (--mobile-device) {
+    min-height: 180px;
+  }
 }
 
 .innerLinks {

--- a/app/routes/frontpage/components/PublicFrontpage.css
+++ b/app/routes/frontpage/components/PublicFrontpage.css
@@ -2,25 +2,38 @@
 
 .container {
   display: grid;
-  grid-gap: 40px;
+  grid-gap: var(--spacing-xl);
   grid-template-columns: 1fr 1fr 1fr;
   grid-auto-rows: auto;
   grid-template-areas: 'welcome welcome login' 'events events hsp' 'article article readme' 'links links links';
+  padding: 0 var(--lego-default-padding);
 
   @media (--mobile-device) {
-    grid-gap: 20px;
     grid-template-columns: 1fr;
     grid-template-areas: 'welcome' 'login' 'events' 'hsp' 'article' 'readme' 'links';
+    padding: 0 var(--spacing-md);
   }
+
+  h1 {
+    margin-top: 0;
+  }
+
+  h3 {
+    margin-top: 0;
+    margin-left: 0;
+  }
+}
+
+.welcome i {
+  display: inline;
 }
 
 .login {
   height: fit-content;
 }
 
-.welcome,
 .links {
-  padding: 0 10px 10px;
+  padding: 0 var(--lego-default-padding) var(--lego-default-padding);
 }
 
 .hsp {

--- a/app/routes/frontpage/components/PublicFrontpage.tsx
+++ b/app/routes/frontpage/components/PublicFrontpage.tsx
@@ -1,5 +1,6 @@
 import { Button, Card, Container, Flex, LinkButton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import moment from 'moment-timezone';
 import { fetchData, fetchReadmes } from 'app/actions/FrontpageActions';
 import buddyWeekGraphic from 'app/assets/frontpage-graphic-buddyweek.png';
 import dataGraphic from 'app/assets/frontpage-graphic-data.png';
@@ -105,7 +106,7 @@ const HspInfo = () => (
 
 const usefulLinksConf = [
   {
-    title: 'Fadderperioden 2023',
+    title: `Fadderperioden ${moment().year()}`,
     image: buddyWeekGraphic,
     description:
       'Abakus arrangerer fadderperioden for alle nye studenter, og her kan du lese mer om den og finne annen nyttig informasjon til studiestart.',
@@ -155,7 +156,7 @@ const UsefulLinks = () => (
   <div className={styles.links}>
     <h3 className="u-ui-heading">Nyttige lenker</h3>
 
-    <Flex wrap justifyContent="center" gap={40}>
+    <Flex wrap justifyContent="center" gap={'var(--spacing-lg)'}>
       {usefulLinksConf.map((item) => (
         <a
           href={item.link}


### PR DESCRIPTION
# Description

As our beloved prod-testers have reported through the proper channels, the readmes do not display properly on the public frontpage.

Turns out that the ref used to get the proper size of the container does not update the component state (which makes sense), and the only reason this works locally and when authenticated is that the component is always re-rendered after the images are fully loaded (either locally from being slow or when logged in by toggling the component).

Also added some long-awaited padding and styling to the public frontpage to match the authenticated one.

Minor changes
* Update fp-2023->2024
* Minor styling of the public frontpage

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td><b>Public</b><br>
            - Reduce top padding<br>- Add side margins<br>- Make cybdat inline to allow linebreaks
        </td>
        <td><img width="350" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/d2d32310-a9ab-4583-9ba1-1fe9a2b7793e">
        </td>
        <td><img width="349" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/699ade80-4eba-4ad2-96d7-25c40a031ed3">
        </td>
    </tr>
    <tr>
        <td><b>Authenticated:</b><br>Remove padding from title</td>
        <td><img width="349" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/abd7f50b-92e2-41f5-a739-f7ea22370aa4">
</td>
        <td><img width="350" alt="image" src="https://github.com/webkom/lego-webapp/assets/13599770/ae580377-d7eb-429c-8283-17b4eb37dc6d">
</td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves snapchat-complaints
