### PR TITLE
Show payment-form if event was attended

### DIFF
--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -25,6 +25,7 @@ import Tooltip from 'app/components/Tooltip';
 import { useCurrentUser } from 'app/reducers/auth';
 import { selectPenaltyByUserId } from 'app/reducers/penalties';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import { Presence } from 'app/store/models/Registration';
 import { spyValues } from 'app/utils/formSpyUtils';
 import { createValidator, requiredIf } from 'app/utils/validation';
 import {
@@ -218,7 +219,7 @@ const JoinEventForm = ({
     event.isPriced &&
     event.price > 0 &&
     registration &&
-    registration.pool &&
+    (registration.pool || registration.presence === Presence.PRESENT) &&
     ![paymentManual, paymentSuccess].includes(registration.paymentStatus);
   const [registrationPendingDelayed, setRegistrationPendingDelayed] =
     useState(false);


### PR DESCRIPTION
# Description

When people are getting off the waitlist on a paid event the payment form is not visible, even though the person has to pay. Currently this forces the money-people to setup manual payments and manually keep track of whether those payments have been received outside the system.

# Result

This change enables waitlisted attendees to pay as soon as they are marked as present. In this way, payments will show up in the overview along all the other payments and no manual workarounds should be needed to receive the payment.

This could also allow the hosting groups to receive the payment at the start of the event instead of having to hunt them down later on.

# Testing

- [x] I have thoroughly tested my changes.

The payment-form is now presented if you're on the waitlist and attended.

---

Resolves ABA-943
