### PR TITLE
Prevent endless skeleton for interest groups with < 10 members

### DIFF
--- a/app/components/UserGrid/index.tsx
+++ b/app/components/UserGrid/index.tsx
@@ -12,7 +12,7 @@ const UserGrid = ({
   maxRows = 2,
   minRows = 0,
   padding = 3,
-  skeleton,
+  skeleton = false,
 }: {
   users?: PublicUser[];
   size?: number /* profile picture size */;

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -39,13 +39,15 @@ import type { PublicDetailedGroup } from 'app/store/models/Group';
 type MembersProps = {
   memberships: TransformedMembership[];
   group: PublicDetailedGroup;
+  fetching: boolean;
 };
 
-const Members = ({ group, memberships }: MembersProps) => (
+const Members = ({ group, memberships, fetching }: MembersProps) => (
   <Flex column>
     <h4>{group.numberOfUsers} medlemmer</h4>
     <UserGrid
       users={memberships && memberships.slice(0, 14).map((reg) => reg.user)}
+      skeleton={fetching}
       maxRows={2}
       minRows={2}
     />
@@ -183,7 +185,11 @@ const InterestGroupDetail = () => {
           )}
           {memberships.length > 0 && (
             <>
-              <Members group={group} memberships={memberships} />
+              <Members
+                group={group}
+                memberships={memberships}
+                fetching={fetching}
+              />
               <Contact memberships={memberships} />
             </>
           )}


### PR DESCRIPTION
# Description

im back

See linear issue for context

# Result

It works, but I don't want to show members here. Check out http://localhost:3000/interest-groups/201 if you don't believe me 😝 

# Testing

- [x] I have thoroughly tested my changes.

Hard refresh, and no skeleton. Added a default value of false to prevent any other similar bugs