### PR TITLE
Make icon on latest readme comp "act" as a button

### DIFF
--- a/app/routes/frontpage/components/LatestReadme.tsx
+++ b/app/routes/frontpage/components/LatestReadme.tsx
@@ -35,6 +35,7 @@ const LatestReadme = ({
               {readmeIfy('readme')}
               {!disabled && (
                 <Icon
+                  onClick={onClick}
                   name="chevron-forward-outline"
                   className={rotateClassName}
                 />


### PR DESCRIPTION
# Description

Although you can click on the entire component to expand it, I think it's good for the icon to "act" (or, look) as a button since the user may assume (s)he should click on it.

Also, this lets the user "tab" to and use the component. So I suppose that's a "yay" for universal design

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/webkom/lego-webapp/assets/69514187/462ee059-ce03-439b-b6a5-72f6540db8f4

# Testing

- [x] I have thoroughly tested my changes.

See video above