### PR TITLE
Fix overflow issues on meeting details

### DIFF
--- a/app/components/UserAttendance/AttendanceModalContent.css
+++ b/app/components/UserAttendance/AttendanceModalContent.css
@@ -69,12 +69,13 @@
 .row > img {
   width: 50px;
   height: 50px;
-  margin: 0 10px;
+  margin: 0 var(--spacing-md);
 }
 
 .nav {
-  margin: 5px auto;
-  height: 40px;
+  margin: var(--spacing-sm) auto;
+  min-height: 40px;
+  height: fit-content;
   border: 1px solid var(--border-gray);
   border-radius: var(--border-radius-md);
   font-size: var(--font-size-sm);
@@ -84,7 +85,7 @@
   height: 100%;
   border-radius: inherit;
   text-align: center;
-  padding: 5px 15px;
+  padding: var(--spacing-sm) var(--spacing-md);
   font-weight: 500;
 }
 

--- a/app/components/UserAttendance/AttendanceStatus.css
+++ b/app/components/UserAttendance/AttendanceStatus.css
@@ -6,7 +6,7 @@
   min-height: 72px;
   text-align: center;
   border-radius: var(--border-radius-md);
-  margin: 10px 0;
+  margin: var(--spacing-sm) 0;
   overflow: hidden;
 }
 
@@ -15,6 +15,6 @@
   min-width: 25%;
   flex-direction: column;
   align-items: center;
-  padding: 7px 0;
+  padding: var(--spacing-sm);
   background-color: var(--additive-background);
 }


### PR DESCRIPTION
# Description

Technically, this also applies to event details, but the pool names there are rarely named something with multiple words.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img src="https://github.com/webkom/lego-webapp/assets/69514187/623d93b1-68cb-4a3c-87e7-fc5dfcf0ca2b" />
        </td>
        <td>
            <img src="https://github.com/webkom/lego-webapp/assets/69514187/7e8cfc13-4a2a-4160-b124-8fdb71c4928c" />
        </td>
    </tr>
    <tr>
        <td>
            <img src="https://github.com/webkom/lego-webapp/assets/69514187/813a092f-2785-4daf-9fdd-8e7becb3f234" />
        </td>
        <td>
            <img src="https://github.com/webkom/lego-webapp/assets/69514187/208d2a90-b912-4431-9b7e-ee1053b07e75" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See image above. Tested with ssr as well due to css cascading behaving a bit weird here