### PR TITLE
Reword header on company interest editor

### DIFF
--- a/app/routes/bdb/utils.tsx
+++ b/app/routes/bdb/utils.tsx
@@ -187,7 +187,7 @@ export const getContactStatuses = (
 
 export const BdbTabs = () => (
   <>
-    <NavigationTab href="/companyInterest">Interesseskjema</NavigationTab>
+    <NavigationTab href="/company-interest">Interesseskjema</NavigationTab>
     <NavigationTab href="/bdb">BDB</NavigationTab>
   </>
 );

--- a/app/routes/companyInterest/components/CompanyInterest.css
+++ b/app/routes/companyInterest/components/CompanyInterest.css
@@ -15,11 +15,6 @@
   margin-left: 20px;
 }
 
-.guiWrapper {
-  margin-right: 30px;
-  flex-wrap: wrap;
-}
-
 .guiBoxes {
   justify-content: flex-end;
   margin: 10px 0;

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -143,7 +143,7 @@ const CompanyInterestList = () => {
       title: 'Bedriftsnavn',
       dataIndex: 'companyName',
       render: (companyName: string, companyInterest: Record<string, any>) => (
-        <Link to={`/companyInterest/${companyInterest.id}/edit`}>
+        <Link to={`/company-interest/${companyInterest.id}/edit`}>
           {companyInterest.company ? companyInterest.company.name : companyName}
         </Link>
       ),
@@ -209,7 +209,7 @@ const CompanyInterestList = () => {
     <Page
       title="Bedriftsinteresser"
       actionButtons={
-        <LinkButton href="/companyInterest/create">
+        <LinkButton href="/company-interest/create">
           Ny bedriftsinteresse
         </LinkButton>
       }
@@ -231,7 +231,7 @@ const CompanyInterestList = () => {
               isClearable={false}
             />
           </Flex>
-          <LinkButton href="/companyInterest/semesters">
+          <LinkButton href="/company-interest/semesters">
             Endre aktive semestre
           </LinkButton>
         </Flex>

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -461,7 +461,7 @@ const CompanyInterestPage = () => {
         : createCompanyInterest(newData, isEnglish),
     ).then(() => {
       navigate(
-        allowedBdb ? '/companyInterest/' : '/pages/bedrifter/for-bedrifter',
+        allowedBdb ? '/company-interest' : '/pages/bedrifter/for-bedrifter',
       );
     });
   };
@@ -525,13 +525,14 @@ const CompanyInterestPage = () => {
     },
   ];
 
-  const title = edit
-    ? 'Redigerer bedriftsinteresse'
-    : FORM_LABELS.mainHeading[language];
+  const title = edit ? 'Bedriftsinteresse' : FORM_LABELS.mainHeading[language];
 
   return (
     <Page
       title={title}
+      back={{
+        href: '/company-interest',
+      }}
       actionButtons={
         !edit && (
           <Link to={isEnglish ? '/interesse' : '/register-interest'}>

--- a/app/routes/companyInterest/components/CompanySemesterGUI.tsx
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.tsx
@@ -40,14 +40,9 @@ const validate = createValidator({
 
 const CompanySemesterGUI = () => {
   return (
-    <Page title="Endre aktive semestre" back={{ href: '/companyInterest/' }}>
-      <Flex className={styles.guiWrapper}>
-        <Flex
-          column
-          style={{
-            marginRight: '50px',
-          }}
-        >
+    <Page title="Endre aktive semestre" back={{ href: '/company-interest' }}>
+      <Flex wrap gap="var(--spacing-xl)">
+        <Flex column>
           <AddSemesterForm />
         </Flex>
         <Flex column>


### PR DESCRIPTION
# Description

The "editor" is also used when you just want to view the submitted form, so I believe saying you're "editing it" may sound scary and is in most cases "wrong". Does that make sense?

Also add a back button, and change all urls to point to `company-interest` instead of `companyInterest` (both are supported) since urls should be kebab-case.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img src="https://github.com/webkom/lego-webapp/assets/69514187/77338a33-595a-4243-b257-8ff6331b3b7f" />
        </td>
        <td>
            <img src="https://github.com/webkom/lego-webapp/assets/69514187/c68dfd63-e5fd-40d2-abed-8db5ceecc210" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above.

I removed some unnecessary css, but that was tested. Urls were also tested 