### PR TITLE
Change ts compiler option "module" to `preserve`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "jsx": "react-jsx",
-    "module": "commonjs",
+    "module": "preserve",
     "moduleResolution": "bundler",
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
# Description

`commonjs` is not an allowed module when `moduleResolution` is set to `bundler`. Read more about this here https://www.typescriptlang.org/tsconfig/#module

@eikhr you'll have to verify this since you recently changed it

# Testing

- [x] I have thoroughly tested my changes.

`yarn tsc` now works, and everything seems to bundle and work fine?