### PR TITLE
Fix crash on statistics page

### DIFF
--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -178,7 +178,7 @@ const createAttendeeDataPoints = (
 
     addGenericDataPoint(
       attendeeStatistics.genderDistribution,
-      Gender[registration.user.gender],
+      registration.user.gender ? Gender[registration.user.gender] : 'Ukjent',
     );
 
     addGroupDataPoint(

--- a/app/store/models/User.ts
+++ b/app/store/models/User.ts
@@ -27,7 +27,7 @@ interface User {
   firstName: string;
   lastName: string;
   fullName: string;
-  gender: keyof typeof Gender;
+  gender?: keyof typeof Gender;
   email: string;
   emailAddress: string;
   emailListsEnabled: boolean;


### PR DESCRIPTION
Gender is not required in the backend. The statistics page assumed it was, causing a crash whenever a user had `gender=undefined`.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Behaiviour of statistics page
        </td>
        <td>
            Crash
        </td>
        <td>
            Works
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

In the testing fixtures, one user has gender `undefined`. It now works with the testing fixtures.

---