### PR TITLE
Update various spacings

### DIFF
--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -172,11 +172,9 @@ const EventItem = ({
           style={{ borderColor: colorForEventType(event.eventType) }}
           className={styles.eventItemCompact}
         >
-          <Flex width="100%">
-            <Link to={`/events/${event.slug}`}>
-              <h3 className={styles.eventItemTitle}>{event.title}</h3>
-            </Link>
-          </Flex>
+          <Link to={`/events/${event.slug}`}>
+            <h3 className={styles.eventItemTitle}>{event.title}</h3>
+          </Link>
           <Flex width="100%" justifyContent="space-between">
             <Flex width="72%">
               <Flex className={styles.companyLogoCompact}>

--- a/app/components/EventItem/styles.css
+++ b/app/components/EventItem/styles.css
@@ -5,6 +5,7 @@
   margin-bottom: var(--spacing-md);
   display: flex;
   justify-content: space-between;
+  line-height: 1.3;
 }
 
 .eventItemCompact {
@@ -22,6 +23,7 @@
   color: var(--lego-font-color);
   margin: 0;
   word-break: break-word;
+  margin-bottom: var(--spacing-sm);
 }
 
 .eventTime {

--- a/app/components/Form/CheckBox.css
+++ b/app/components/Form/CheckBox.css
@@ -19,6 +19,7 @@
 
 .label {
   user-select: none;
+  line-height: 1.3;
 
   &:not:disabled {
     cursor: pointer;

--- a/app/components/Form/CheckBox.tsx
+++ b/app/components/Form/CheckBox.tsx
@@ -38,7 +38,7 @@ const CheckBox = ({
   };
 
   return (
-    <Flex wrap alignItems="center" gap={7}>
+    <Flex wrap alignItems="center" gap="var(--spacing-sm)">
       <div className={cx(styles.checkbox, styles.bounce, className)}>
         <input
           {...props}

--- a/app/components/Form/Field.css
+++ b/app/components/Form/Field.css
@@ -25,12 +25,12 @@
   border-radius: var(--border-radius-md);
 }
 
-.label {
-  font-size: var(--font-size-lg);
+.labelContent {
+  line-height: 1.8;
 }
 
 .description {
-  margin-left: 7px;
+  margin-left: var(--spacing-sm);
 }
 
 .required {

--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -84,7 +84,7 @@ export function createField<T, ExtraProps extends object>(
               cursor: inlineLabel ? 'pointer' : 'default',
               fontSize: !inlineLabel ? 'var(--font-size-lg)' : 'inherit',
             }}
-            className={labelContentClassName}
+            className={cx(labelContentClassName, styles.labelContent)}
           >
             {label}
           </div>
@@ -114,7 +114,7 @@ export function createField<T, ExtraProps extends object>(
     );
 
     const content = inlineLabel ? (
-      <Flex gap={7}>
+      <Flex gap="var(--spacing-sm)">
         {component}
         {labelComponent}
       </Flex>

--- a/app/components/Form/MultiSelectGroup.css
+++ b/app/components/Form/MultiSelectGroup.css
@@ -7,10 +7,6 @@
   font-size: var(--font-size-lg);
 }
 
-.radioField {
-  margin-bottom: 10px;
-}
-
 .radioLabel {
   display: flex;
   flex-direction: row;

--- a/app/components/Form/RadioButton.css
+++ b/app/components/Form/RadioButton.css
@@ -17,6 +17,7 @@
 
 .label {
   user-select: none;
+  line-height: 1.3;
 
   &:not:disabled {
     cursor: pointer;

--- a/app/components/Form/RadioButton.tsx
+++ b/app/components/Form/RadioButton.tsx
@@ -29,7 +29,7 @@ function RadioButton({
   };
 
   return (
-    <Flex wrap alignItems="center" gap={7}>
+    <Flex wrap alignItems="center" gap="var(--spacing-sm)">
       <div className={cx(styles.radioButton, styles.bounce, className)}>
         <input
           {...props}

--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -16,7 +16,8 @@
 }
 
 .themeChange {
-  padding: 10px 15px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  line-height: 1.3;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -110,7 +111,7 @@
 
 .dropdown {
   width: 355px;
-  padding: 15px;
+  padding: var(--spacing-md);
 
   @media (--small-viewport) {
     width: 100%;

--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -22,7 +22,8 @@
   text-align: center;
   background-color: var(--lego-red-color);
   color: var(--color-white);
-  padding: 0 var(--spacing-sm) var(--spacing-sm);
+  line-height: 1.3;
+  padding: var(--spacing-sm) 0 var(--spacing-md);
   box-shadow: 0 2px 2px rgba(0, 0, 0, 20%);
 }
 

--- a/app/components/Upload/UploadImage.css
+++ b/app/components/Upload/UploadImage.css
@@ -29,12 +29,9 @@
   position: absolute;
   background: rgba(var(--rgb-max), var(--rgb-max), var(--rgb-max), 50%);
   font-weight: 500;
-  padding: 10px 40px;
+  padding: var(--spacing-sm) 40px;
+  line-height: 1.3;
   text-align: center;
-
-  @media (--small-viewport) {
-    line-height: 1.3;
-  }
 }
 
 .inModalUpload .placeholderContainer {

--- a/app/routes/app/AppRoute.tsx
+++ b/app/routes/app/AppRoute.tsx
@@ -79,8 +79,9 @@ const App = () => {
             style={{
               backgroundColor: 'var(--danger-color)',
               color: 'white',
-              fontWeight: 'bold',
+              fontWeight: '500',
               padding: 'var(--spacing-sm)',
+              lineHeight: '1.3',
             }}
           >
             This is a development version of lego-webapp.

--- a/app/routes/events/components/Calendar.css
+++ b/app/routes/events/components/Calendar.css
@@ -56,15 +56,15 @@
 
 .dayNumber {
   position: absolute;
-  top: 2px;
-  right: 5px;
+  top: var(--spacing-xs);
+  right: var(--spacing-sm);
   font-size: var(--font-size-sm);
+  line-height: var(--spacing-lg);
 }
 
 .currentDay {
-  font-size: var(--font-size-sm);
-  width: 25px;
-  height: 25px;
+  width: var(--spacing-lg);
+  height: var(--spacing-lg);
   border-radius: 50%;
   color: var(--color-absolute-white);
   text-align: center;
@@ -72,10 +72,8 @@
 }
 
 .popoverEventTitle {
-  font-size: 22px;
   display: inline-block;
   line-height: 1.3;
-  padding-bottom: 10px;
 }
 
 .popoverEventTitleText {

--- a/app/routes/forum/components/ForumEditor.tsx
+++ b/app/routes/forum/components/ForumEditor.tsx
@@ -84,7 +84,7 @@ const ForumEditor = () => {
         {({ handleSubmit }) => (
           <Form onSubmit={handleSubmit}>
             <Field
-              placeholder="Title"
+              placeholder="Tips til utveksling, hvordan velge veileder eller er indøk virkelig homo?"
               name="title"
               label="Tittel"
               component={TextInput.Field}

--- a/app/routes/pages/components/subcomponents/Statistic/Statistic.css
+++ b/app/routes/pages/components/subcomponents/Statistic/Statistic.css
@@ -1,11 +1,8 @@
 @import url('~app/styles/variables.css');
 
 .container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   margin: 0 var(--spacing-md) var(--spacing-md);
+  line-height: 1.3;
 }
 
 .statistic {

--- a/app/routes/pages/components/subcomponents/Statistic/index.tsx
+++ b/app/routes/pages/components/subcomponents/Statistic/index.tsx
@@ -1,3 +1,4 @@
+import { Flex } from '@webkom/lego-bricks';
 import styles from './Statistic.css';
 
 type Props = {
@@ -8,11 +9,17 @@ type Props = {
 
 const Statistic = ({ statistic, label, topLabel }: Props) => {
   return (
-    <div className={styles.container}>
+    <Flex
+      column
+      justifyContent="center"
+      alignItems="center"
+      gap="var(--spacing-sm)"
+      className={styles.container}
+    >
       {topLabel && <div className={styles.topLabel}>{topLabel}</div>}
       <div className={styles.statistic}>{statistic}</div>
       <div className={styles.label}>{label}</div>
-    </div>
+    </Flex>
   );
 };
 

--- a/app/routes/users/components/UserSettings.css
+++ b/app/routes/users/components/UserSettings.css
@@ -7,10 +7,10 @@
 }
 
 .changePassword {
-  margin-top: 30px;
+  margin-top: var(--spacing-md);
 }
 
 .deleteUser {
-  margin-top: 30px;
+  margin-top: var(--spacing-md);
   color: var(--danger-color);
 }

--- a/packages/lego-bricks/src/components/Layout/Page/filterSidebar.tsx
+++ b/packages/lego-bricks/src/components/Layout/Page/filterSidebar.tsx
@@ -33,6 +33,8 @@ type SectionProps = {
 export const FilterSection = ({ title, children }: SectionProps) => (
   <Flex column gap="var(--spacing-sm)">
     <h4>{title}</h4>
-    <Flex column>{children}</Flex>
+    <Flex column gap="var(--spacing-sm)">
+      {children}
+    </Flex>
   </Flex>
 );


### PR DESCRIPTION
# Description

There's some buggy behaviour where our webapp inherits the `line-height` from the `lego-editor` of `1.8`. I've tried to update most places that are affected by this if we ever update `lego-editor` with the latest `lego-bricks` variables ..

# Result

Most changes are barely noticeable.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="218" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/4f14c0bf-1012-434a-a271-57a64d2be04a">
        </td>
        <td>
			<img width="218" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/34f2e7a8-1f2a-4c54-94b3-fe915a0833da">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

All changes were tested. That's why there's not that many ...