### PR TITLE
"Blackify" parts of the webapp

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -64,15 +64,6 @@
   outline: none;
 }
 
-.searchIcon {
-  color: var(--lego-link-color);
-
-  &:hover,
-  &.activeItem {
-    color: var(--lego-red-color-hover);
-  }
-}
-
 .hideOnMobile {
   @media (--mobile-device) {
     display: none;
@@ -101,11 +92,6 @@
 .menu {
   display: flex;
   flex-direction: row;
-}
-
-.toggleButton {
-  color: var(--lego-link-color);
-  font-size: var(--font-size-sm);
 }
 
 .dropdown {

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -221,7 +221,7 @@ const Header = () => {
             <AccountDropdown />
 
             <button onClick={() => dispatch(toggleSearch())}>
-              <Icon name="menu" className={styles.searchIcon} />
+              <Icon name="menu" data-test-id="search-menu-icon" />
             </button>
           </div>
         </div>

--- a/app/components/UserAttendance/Attendance.tsx
+++ b/app/components/UserAttendance/Attendance.tsx
@@ -43,7 +43,7 @@ const Attendance = ({
 
   return (
     <>
-      {!isMeeting && registrations && (
+      {!isMeeting && (
         <UserGrid
           minRows={minUserGridRows}
           maxRows={maxUserGridRows}
@@ -51,7 +51,7 @@ const Attendance = ({
           skeleton={skeleton}
         />
       )}
-      {!isMeeting && registrations && (
+      {!isMeeting && (
         <RegisteredSummary
           registrations={loggedIn ? registrations : undefined}
           currentRegistration={currentRegistration}

--- a/app/routes/bdb/components/OptionsBox.tsx
+++ b/app/routes/bdb/components/OptionsBox.tsx
@@ -99,8 +99,6 @@ const OptionsBox = ({ updateFilters, removeFilters }: Props) => {
               name="studentContact"
               filter={[AutocompleteContentType.User]}
               onChange={(user: AutocompleteUser) => {
-                console.log(studentContactValue);
-                console.log(user);
                 if (user) {
                   updateFilters('studentContact', user.id);
                   setStudentContactValue(user);

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -39,11 +39,6 @@
   height: 1px;
 }
 
-.simulateLink {
-  color: var(--lego-link-color);
-  cursor: pointer;
-}
-
 .infoList tr {
   & td {
     width: unset;

--- a/app/routes/events/components/Registrations.css
+++ b/app/routes/events/components/Registrations.css
@@ -11,10 +11,9 @@
 }
 
 .registrationList {
-  color: var(--lego-link-color);
+  cursor: pointer;
 
   &:hover {
     text-decoration: underline;
-    cursor: pointer;
   }
 }

--- a/cypress/e2e/router_spec.js
+++ b/cypress/e2e/router_spec.js
@@ -9,7 +9,7 @@ describe('Navigate throughout app', () => {
   // Open the hamburgermenu and select by name, then assert by path
   const openMenuAndSelect = (name, path) => {
     cy.get(`${c('Header__menu')} ${c('buttonGroup')}`).within(() => {
-      cy.get(c('searchIcon')).click();
+      cy.get(t('search-menu-icon')).click();
     });
     cy.get(c('Search__quickLinks-'))
       .first()
@@ -136,7 +136,7 @@ describe('Navigate throughout app', () => {
 
     // Go to the extended menu
     cy.get(c('buttonGroup')).within(() => {
-      cy.get(c('searchIcon')).click();
+      cy.get(t('search-menu-icon')).click();
     });
     cy.url().should('contain', '/');
     cy.contains('Sider');

--- a/packages/lego-bricks/src/components/Icon/Icon.module.css
+++ b/packages/lego-bricks/src/components/Icon/Icon.module.css
@@ -6,7 +6,7 @@
   top: -10px;
   right: -7px;
   background-color: var(--lego-red-color);
-  color: var(--color-white);
+  color: var(--color-absolute-white);
   border: 1.5px solid var(--lego-background-color);
   border-radius: 50%;
   width: 22px;

--- a/packages/lego-bricks/src/components/Layout/Page/Page.module.css
+++ b/packages/lego-bricks/src/components/Layout/Page/Page.module.css
@@ -6,9 +6,24 @@
     padding: 1rem;
   }
 
-  .backButton {
-    margin: calc(-1 * var(--spacing-md)) 0 0 calc(-1 * var(--spacing-md));
-    color: var(--lego-red-color);
+  .back {
+    display: flex;
+    align-items: center;
+    width: fit-content;
+    margin-bottom: var(--spacing-sm);
+  }
+
+  span.backLabel {
+    font-weight: 500;
+    margin-left: var(--spacing-xs);
+  }
+
+  .backIcon {
+    transition: transform var(--easing-medium);
+  }
+
+  .back:hover > .backIcon {
+    transform: translateX(calc(-1 * var(--spacing-xs)));
   }
 }
 

--- a/packages/lego-bricks/src/components/Layout/Page/Page.tsx
+++ b/packages/lego-bricks/src/components/Layout/Page/Page.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { LinkButton } from '../../Button';
+import { NavLink } from 'react-router-dom';
 import { ButtonGroup } from '../../Button/ButtonGroup';
 import { Icon } from '../../Icon';
 import { Skeleton } from '../../Skeleton';
@@ -52,10 +52,10 @@ const Page = ({
   >
     <Flex column className={cx(styles.content, classNames?.content)}>
       {back && (
-        <LinkButton flat href={back.href} className={styles.backButton}>
-          <Icon name="arrow-back" size={19} />
-          {back.label ?? 'Tilbake'}
-        </LinkButton>
+        <NavLink to={back.href} className={styles.back}>
+          <Icon name="arrow-back" size={18} className={styles.backIcon} />
+          <span className={styles.backLabel}>{back.label ?? 'Tilbake'}</span>
+        </NavLink>
       )}
       <Flex
         wrap


### PR DESCRIPTION
# Description

I don't believe these things should be "red". Also, re-implement the
transition on the back link on pages hehe :see-no-evil:

---

Also fix a unrelated minor bug; [Show skeleton user cells when fetching registrations](https://github.com/webkom/lego-webapp/commit/25384b1e6469219e94453795b1171023332dd23a)

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
		<td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
		<td>Back link, notification badge and hamburger icon</td>
        <td>
            <img width="1022" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/949acf28-864d-4302-b406-d7232e90ca90">
        </td>
        <td>
            <img width="1022" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/592daeee-5fed-4bef-8204-aa5398945151">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Looked at the changes - and they looked alright 👍🏼 