### PR TITLE
Prevent text overflow on error boundary

### DIFF
--- a/app/components/ErrorBoundary/ErrorBoundary.css
+++ b/app/components/ErrorBoundary/ErrorBoundary.css
@@ -3,6 +3,10 @@
 .container {
   width: 40%;
   margin: 0 auto;
+  line-height: 1.3;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: break-word;
 
   @media (--mobile-device) {
     width: 60%;

--- a/app/components/ErrorBoundary/index.tsx
+++ b/app/components/ErrorBoundary/index.tsx
@@ -92,11 +92,8 @@ class ErrorBoundary extends Component<Props, State> {
         onClick={() => !openReportDialog && this.openDialog()}
         className={styles.container}
       >
-        <Card.Header>
-          <p>En feil har oppstått</p>
-        </Card.Header>
+        <Card.Header>En feil har oppstått</Card.Header>
         <p>Webkom har fått beskjed om feilen</p>
-        <br />
         <p>
           Hvis du har slitt med problemet en liten stund uten at det har blitt
           fikset, send gjerne en påminnelse til{' '}
@@ -107,7 +104,6 @@ class ErrorBoundary extends Component<Props, State> {
           referansen under (som tekst, ikke skjermbilde) er det mye lettere å
           identifisere feilen din
         </p>
-        <br />
         <p>Referanse: {this.state.lastEventId}</p>
       </Card>
     );

--- a/packages/lego-bricks/src/components/Card/Card.module.css
+++ b/packages/lego-bricks/src/components/Card/Card.module.css
@@ -4,10 +4,19 @@
   border-radius: var(--border-radius-lg);
 }
 
+.withIcon {
+  gap: var(--spacing-md);
+
+  @media (max-width: 992px) {
+    flex-direction: column;
+    gap: var(--spacing-sm);
+  }
+}
+
 .header {
   font-weight: 600;
   font-size: var(--font-size-lg);
-  line-height: 1.3;
+  margin-bottom: var(--spacing-sm);
 }
 
 .shadow {

--- a/packages/lego-bricks/src/components/Card/index.tsx
+++ b/packages/lego-bricks/src/components/Card/index.tsx
@@ -44,7 +44,7 @@ const CardContent = ({ children, severity }: CardContentProps) => {
   }
 
   return icon !== undefined ? (
-    <Flex gap={20}>
+    <Flex className={styles.withIcon}>
       {icon}
       <Flex column>{children}</Flex>
     </Flex>


### PR DESCRIPTION
# Description

This bug still confuses me .. I'm still not sure why the overflow actually happens

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="13%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            iPhone 12 Pro (390x844)
        </td>
        <td>
            <img width="409" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/221f4d8e-2475-401f-8c27-d9744f361b9f">
        </td>
        <td>
            <img width="409" alt="image" src="https://github.com/webkom/lego-webapp/assets/69514187/8bb82e14-dd6c-4e4e-8d83-e7bbde512485">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested on larger viewports as well hehe