### PR TITLE
Slight improvements to the announcements page

### DIFF
--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -81,7 +81,7 @@ export function createField<T, ExtraProps extends object>(
         {label && (
           <div
             style={{
-              cursor: inlineLabel ? 'pointer' : 'default',
+              cursor: inlineLabel && !props.disabled ? 'pointer' : 'default',
               fontSize: !inlineLabel ? 'var(--font-size-lg)' : 'inherit',
             }}
             className={cx(labelContentClassName, styles.labelContent)}

--- a/app/routes/announcements/components/AnnouncementItem.tsx
+++ b/app/routes/announcements/components/AnnouncementItem.tsx
@@ -24,7 +24,7 @@ const AnnouncementItem = ({ announcement, actionGrant }: Props) => {
 
   return (
     <Flex className={styles.item}>
-      <Flex column>
+      <Flex column gap="var(--spacing-sm)">
         <Flex className={styles.date}>
           {announcement.sent ? (
             <Time time={announcement.sent} format="ll HH:mm" />
@@ -45,7 +45,7 @@ const AnnouncementItem = ({ announcement, actionGrant }: Props) => {
           </Flex>
         )}
         <Flex column>
-          <b className={styles.recHeader}>Mottakere</b>
+          <b>Mottakere</b>
           <Flex alignItems="center" gap="var(--spacing-sm)" wrap>
             {announcement.events.length > 0 && (
               <span>

--- a/app/routes/announcements/components/AnnouncementsCreate.tsx
+++ b/app/routes/announcements/components/AnnouncementsCreate.tsx
@@ -1,6 +1,6 @@
 import { ButtonGroup, Card, Flex } from '@webkom/lego-bricks';
+import { isEmpty } from 'lodash';
 import { Field } from 'react-final-form';
-import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
 import {
   createAnnouncement,
@@ -13,6 +13,7 @@ import {
   TextArea,
 } from 'app/components/Form';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
+import Tooltip from 'app/components/Tooltip';
 import { statusesText } from 'app/reducers/meetingInvitations';
 import { selectAutocomplete } from 'app/reducers/search';
 import { useAppDispatch } from 'app/store/hooks';
@@ -130,8 +131,7 @@ const AnnouncementsCreate = () => {
   };
 
   return (
-    <>
-      <Helmet title="Kunngjøringer" />
+    <div>
       <h2>Ny kunngjøring</h2>
       <TypedLegoForm
         validate={validate}
@@ -147,14 +147,13 @@ const AnnouncementsCreate = () => {
               name="message"
               component={TextArea.Field}
               placeholder="Skriv din melding her ..."
-              label="Kunngjøring"
+              label="Melding"
               required
             />
             <span className={styles.formHeaders}>Mottakere</span>
-            <Flex column gap="var(--spacing-sm)">
+            <Flex column>
               <Flex className={styles.rowRec}>
                 <Field
-                  className={styles.recField}
                   name="users"
                   placeholder="Brukere"
                   filter={['users.user']}
@@ -171,20 +170,32 @@ const AnnouncementsCreate = () => {
               </Flex>
               <Flex alignItems="center" className={styles.rowRec}>
                 <Field
-                  className={styles.recField}
                   name="events"
                   placeholder="Arrangementer"
                   filter={['events.event']}
                   isMulti
                   component={SelectInput.AutocompleteField}
                 />
-                <Field
-                  name="excludeWaitingList"
-                  label="Ekskluder venteliste"
-                  component={CheckBox.Field}
-                />
+                {spyValues<FormValues>((values) => {
+                  const disabled = isEmpty(values.events);
+                  return (
+                    <Flex width="100%">
+                      <Tooltip
+                        content="Velg minst ett arrangement"
+                        disabled={!disabled}
+                      >
+                        <Field
+                          name="excludeWaitingList"
+                          label="Ekskluder venteliste"
+                          component={CheckBox.Field}
+                          disabled={disabled}
+                        />
+                      </Tooltip>
+                    </Flex>
+                  );
+                })}
               </Flex>
-              <Flex className={styles.rowRec}>
+              <Flex className={styles.rowRec} justifyContent="center">
                 <Field
                   name="meetings"
                   placeholder="Møter"
@@ -194,7 +205,7 @@ const AnnouncementsCreate = () => {
                 />
                 <Field
                   name="meetingInvitationStatus"
-                  placeholder="Filtrer på deltagelsesstatus"
+                  placeholder="Filtrer på deltagelsesstatus til møtet"
                   component={SelectInput.Field}
                   options={Object.values(MeetingInvitationStatus).map(
                     (status) => ({
@@ -207,12 +218,17 @@ const AnnouncementsCreate = () => {
             </Flex>
             <Field
               name="fromGroup"
-              placeholder="Fra gruppe"
+              placeholder="Velg gruppe"
               filter={['users.abakusgroup']}
               component={SelectInput.AutocompleteField}
-              label="Send på vegne av"
+              label="Send på vegne av gruppe"
               isClearable
             />
+
+            <Card severity="info">
+              Du kan velge å opprette og sende kunngjøringen med en gang, eller
+              kun opprette og heller sende den senere fra listen nedenfor.
+            </Card>
 
             {spyValues<FormValues>((values) => (
               <ButtonGroup>
@@ -232,14 +248,10 @@ const AnnouncementsCreate = () => {
                 </SubmitButton>
               </ButtonGroup>
             ))}
-            <Card severity="info">
-              Du kan velge å sende kunngjøringen med en gang, eller lagre den og
-              sende den senere fra listen nedenfor.
-            </Card>
           </form>
         )}
       </TypedLegoForm>
-    </>
+    </div>
   );
 };
 

--- a/app/routes/announcements/components/AnnouncementsList.css
+++ b/app/routes/announcements/components/AnnouncementsList.css
@@ -1,10 +1,5 @@
 @import url('~app/styles/variables.css');
 
-.item {
-  padding: 10px 0;
-  justify-content: space-between;
-}
-
 .form {
   width: 100%;
   padding: 10px;
@@ -15,15 +10,11 @@
   font-size: var(--font-size-lg);
 }
 
-.recField {
-  margin-right: 4px;
-}
-
 .rowRec {
   gap: var(--spacing-md);
 
   @media (--mobile-device) {
-    gap: var(--spacing-sm);
+    gap: 0;
     flex-direction: column;
   }
 }
@@ -32,18 +23,29 @@
   flex-direction: column-reverse;
 }
 
+.item {
+  max-width: calc(var(--lego-max-width) / 2);
+  padding: var(--spacing-md);
+  margin-left: calc(-1 * var(--spacing-md));
+  justify-content: space-between;
+  line-height: 1.3;
+
+  @media (--mobile-device) {
+    max-width: 100%;
+  }
+}
+
+.item:nth-child(even) {
+  background-color: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 2%);
+  border-radius: var(--border-radius-md);
+}
+
 .date {
   font-weight: bold;
   text-decoration: underline;
-  margin-top: 5px;
-}
-
-.recHeader {
-  margin-top: 8px;
 }
 
 .wrapperSendButton {
-  justify-content: space-around;
   align-items: center;
 }
 

--- a/app/routes/announcements/components/AnnouncementsList.tsx
+++ b/app/routes/announcements/components/AnnouncementsList.tsx
@@ -1,5 +1,6 @@
-import { Flex, LoadingIndicator, Page } from '@webkom/lego-bricks';
+import { Flex, LoadingPage, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Helmet } from 'react-helmet-async';
 import { fetchAll } from 'app/actions/AnnouncementsActions';
 import EmptyState from 'app/components/EmptyState';
 import { selectAnnouncements } from 'app/reducers/announcements';
@@ -19,18 +20,25 @@ const AnnouncementsList = () => {
     (state) => state.announcements.actionGrant,
   );
 
+  if (fetching) {
+    return <LoadingPage loading />;
+  }
+
+  const title = 'Kunngjøringer';
+
   return (
-    <Page title="Send kunngjøringer">
-      <LoadingIndicator loading={fetching}>
+    <Page title={title}>
+      <Helmet title={title} />
+      <Flex column gap="var(--spacing-md)">
         {actionGrant.includes('create') && <AnnouncementsCreate />}
 
         {actionGrant.includes('list') && actionGrant.includes('delete') && (
-          <>
+          <div>
             <h2>Dine kunngjøringer</h2>
             {announcements.length === 0 ? (
               <EmptyState>Du har ingen tidligere kunngjøringer</EmptyState>
             ) : (
-              <Flex column className={styles.list}>
+              <Flex column gap="var(--spacing-sm)" className={styles.list}>
                 {announcements.map((a, i) => (
                   <AnnouncementItem
                     key={i}
@@ -40,9 +48,9 @@ const AnnouncementsList = () => {
                 ))}
               </Flex>
             )}
-          </>
+          </div>
         )}
-      </LoadingIndicator>
+      </Flex>
     </Page>
   );
 };

--- a/packages/lego-bricks/src/components/Card/Card.module.css
+++ b/packages/lego-bricks/src/components/Card/Card.module.css
@@ -2,6 +2,7 @@
   background: var(--lego-card-color);
   padding: var(--spacing-lg);
   border-radius: var(--border-radius-lg);
+  line-height: 1.3;
 }
 
 .withIcon {


### PR DESCRIPTION
# Description

Improved ux, with a slightly updated list design

* Title is changed, and helmet moved
* Some sub headers and placeholders are also updated
* Exclude waiting list checkbox is disabled (with a tooltip) when no event has been chosen
* Info card is moved and rephrased to avoid any confusion
* Announcement list is retouched
* General spacing improvements

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="767" alt="image" src="https://github.com/user-attachments/assets/53b64659-9884-4a7d-9f99-bbc3c2a5a0ab">
        </td>
        <td>
            <img width="767" alt="image" src="https://github.com/user-attachments/assets/5ccba271-86aa-4e44-a699-490fc52d2256">
        </td>
    </tr>
</table>

I think it's worth noting that it's pretty rare for people to have sent many announcements

# Testing

- [x] I have thoroughly tested my changes.

See images above. Minor changes to the field and card components were tested with other use cases.