### PR TITLE
Add toggle for password visibility in field

### DIFF
--- a/app/components/Form/TextInput.css
+++ b/app/components/Form/TextInput.css
@@ -23,7 +23,7 @@
 
 .prefix,
 .spacing:not(.centered) input {
-  padding-left: 10px;
+  padding-left: var(--spacing-sm);
 }
 
 /* stylelint-disable no-descending-specificity */
@@ -64,7 +64,7 @@ span.suffix {
   width: fit-content;
   height: inherit;
   margin-left: auto;
-  padding: 0 10px;
+  padding: 0 var(--spacing-sm);
   color: var(--placeholder-color);
   text-align: center;
   background-color: var(--additive-background);
@@ -80,4 +80,8 @@ span.suffix {
 
 .phoneNumberInput {
   padding: var(--spacing-sm);
+}
+
+.togglePasswordVisibility {
+  padding-right: var(--spacing-sm);
 }

--- a/app/components/Form/TextInput.tsx
+++ b/app/components/Form/TextInput.tsx
@@ -1,6 +1,6 @@
 import { Flex, Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { createField } from './Field';
 import styles from './TextInput.css';
 import type { RefObject, InputHTMLAttributes } from 'react';
@@ -42,6 +42,12 @@ const TextInput = ({
   // Force use of inputRef from props if set, as newInputRef does not update the inputRef and parent components thus loose access
   const ref = useMemo(() => inputRef ?? newInputRef, [inputRef, newInputRef]);
 
+  const [showPassword, setShowPassword] = useState(false);
+  const isPasswordField = type === 'password';
+  const togglePasswordVisibility = () => {
+    setShowPassword((prev) => !prev);
+  };
+
   return (
     <Flex
       alignItems="center"
@@ -66,12 +72,20 @@ const TextInput = ({
       )}
       <input
         ref={ref}
-        type={type}
+        type={isPasswordField && showPassword ? 'text' : type}
         placeholder={placeholder}
         disabled={disabled}
         readOnly={!!readOnly}
         {...props}
       />
+      {isPasswordField && (
+        <Icon
+          onClick={togglePasswordVisibility}
+          name={showPassword ? 'eye-off' : 'eye'}
+          size={16}
+          className={styles.togglePasswordVisibility}
+        />
+      )}
       {suffix && <span className={styles.suffix}>{suffix}</span>}
     </Flex>
   );


### PR DESCRIPTION
# Description

Applies to all fields of type `password`

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<video src="https://github.com/user-attachments/assets/ebb486d3-d809-4b53-b775-574f35cfc6e5" />

# Testing

- [x] I have thoroughly tested my changes.

Logging in still works fine 😎 

---

Resolves ABA-966
