### PR TITLE
Remove `es6-promise-pool` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "cookie-parser": "^1.4.6",
     "core-js": "^3.37.1",
     "crypto-browserify": "^3.12.0",
-    "es6-promise-pool": "^2.5.0",
     "file-saver": "^2.0.5",
     "final-form": "^4.20.10",
     "final-form-arrays": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8293,11 +8293,6 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es6-promise-pool@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz#147c612b36b47f105027f9d2bf54a598a99d9ccb"
-  integrity sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA==
-
 esbuild-register@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/esbuild-register/-/esbuild-register-3.5.0.tgz#449613fb29ab94325c722f560f800dd946dc8ea8"


### PR DESCRIPTION
# Description

It was only used one place, so I figured it could be removed. We still have a ton of outdated and pretty much unused deps we should remove.

# Testing

- [x] I have thoroughly tested my changes.

Images are still uploaded in sequential batches.