### PR TITLE
Improve empty state message on joblisting list

### DIFF
--- a/app/components/Content/ContentSidebar.tsx
+++ b/app/components/Content/ContentSidebar.tsx
@@ -17,7 +17,7 @@ function ContentSidebar({ children, className }: Props) {
   return (
     <Flex
       column
-      gap="var(--spacing-sm)"
+      gap="var(--spacing-md)"
       className={cx(styles.sidebar, className)}
     >
       {children}

--- a/app/components/Form/CheckBox.css
+++ b/app/components/Form/CheckBox.css
@@ -21,7 +21,7 @@
   user-select: none;
   line-height: 1.3;
 
-  &:not:disabled {
+  &:not(.disabled) {
     cursor: pointer;
   }
 }

--- a/app/components/Form/CheckBox.tsx
+++ b/app/components/Form/CheckBox.tsx
@@ -54,7 +54,10 @@ const CheckBox = ({
         </svg>
       </div>
       {label && (
-        <label htmlFor={id} className={styles.label}>
+        <label
+          htmlFor={id}
+          className={cx(styles.label, props.disabled && styles.disabled)}
+        >
           {label}
         </label>
       )}

--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -89,6 +89,7 @@ export function createField<T, ExtraProps extends object>(
             {label}
           </div>
         )}
+        {required && <span className={styles.required}>*</span>}
         {description && (
           <Flex className={styles.description}>
             <Tooltip content={description}>
@@ -96,7 +97,6 @@ export function createField<T, ExtraProps extends object>(
             </Tooltip>
           </Flex>
         )}
-        {required && <span className={styles.required}>*</span>}
       </Flex>
     );
 

--- a/app/components/Form/RadioButton.css
+++ b/app/components/Form/RadioButton.css
@@ -19,7 +19,7 @@
   user-select: none;
   line-height: 1.3;
 
-  &:not:disabled {
+  &:not(.disabled) {
     cursor: pointer;
   }
 }

--- a/app/components/Form/RadioButton.tsx
+++ b/app/components/Form/RadioButton.tsx
@@ -44,7 +44,10 @@ function RadioButton({
         </svg>
       </div>
       {label && (
-        <label htmlFor={id} className={styles.label}>
+        <label
+          htmlFor={id}
+          className={cx(styles.label, props.disabled && styles.disabled)}
+        >
           {label}
         </label>
       )}

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -56,6 +56,8 @@ const propertyGenerator: PropertyGenerator<{
   ];
 };
 
+const NotGiven = () => <span className="secondaryFontColor">Ikke oppgitt</span>;
+
 const JoblistingDetail = () => {
   const { joblistingIdOrSlug } = useParams();
   const joblisting = useAppSelector((state) =>
@@ -112,47 +114,50 @@ const JoblistingDetail = () => {
           <DisplayContent content={joblisting.text} />
         </ContentMain>
         <ContentSidebar>
-          <h3>Generell info</h3>
-          <InfoList
-            items={[
-              {
-                key: 'Type',
-                value: jobType(joblisting.jobType),
-              },
-              {
-                key: 'Bedrift',
-                value: (
-                  <Link to={`/companies/${joblisting.company.id}`}>
-                    {joblisting.company.name}
-                  </Link>
-                ),
-              },
-              {
-                key: 'Klassetrinn',
-                value: <Year joblisting={joblisting} />,
-              },
-              joblisting.workplaces.length && {
-                key: 'Sted',
-                value: <Workplaces places={joblisting.workplaces} />,
-              },
-              {
-                key: 'Søknadsfrist',
-                value: (
-                  <strong>
-                    <Time time={joblisting.deadline} format="ll HH:mm" />
-                  </strong>
-                ),
-              },
-              {
-                key: 'Publisert',
-                value: (
-                  <strong>
-                    <Time time={joblisting.createdAt} format="ll HH:mm" />
-                  </strong>
-                ),
-              },
-            ].filter(isTruthy)}
-          />
+          <div>
+            <h3>Generell info</h3>
+            <InfoList
+              items={[
+                {
+                  key: 'Type',
+                  value: jobType(joblisting.jobType),
+                },
+                {
+                  key: 'Bedrift',
+                  value: (
+                    <Link to={`/companies/${joblisting.company.id}`}>
+                      {joblisting.company.name}
+                    </Link>
+                  ),
+                },
+                {
+                  key: 'Klassetrinn',
+                  value: <Year joblisting={joblisting} />,
+                },
+                joblisting.workplaces.length && {
+                  key: 'Sted',
+                  value: <Workplaces places={joblisting.workplaces} />,
+                },
+                {
+                  key: 'Søknadsfrist',
+                  value: (
+                    <strong>
+                      <Time time={joblisting.deadline} format="ll HH:mm" />
+                    </strong>
+                  ),
+                },
+                {
+                  key: 'Publisert',
+                  value: (
+                    <strong>
+                      <Time time={joblisting.createdAt} format="ll HH:mm" />
+                    </strong>
+                  ),
+                },
+              ].filter(isTruthy)}
+            />
+          </div>
+
           {joblisting.applicationUrl && (
             <LinkButton
               success
@@ -163,15 +168,12 @@ const JoblistingDetail = () => {
               Søk her
             </LinkButton>
           )}
+
           {(joblisting.responsible || joblisting.contactMail) && (
-            <div
-              style={{
-                marginTop: '10px',
-              }}
-            >
+            <div>
               <h3>Kontaktinfo</h3>
-              {joblisting.contactMail && (
-                <div>
+              <Flex column gap="var(--spacing-sm)">
+                {joblisting.contactMail && (
                   <InfoList
                     items={[
                       {
@@ -180,51 +182,46 @@ const JoblistingDetail = () => {
                       },
                     ]}
                   />
-                  {joblisting.responsible && (
-                    <div
-                      style={{
-                        marginTop: '10px',
-                      }}
-                    >
-                      <strong>Kontaktperson</strong>
-                    </div>
-                  )}
-                </div>
-              )}
-              {joblisting.responsible && (
-                <div
-                  style={{
-                    marginTop: '0px',
-                  }}
-                >
-                  <InfoList
-                    items={[
-                      {
-                        key: 'Navn',
-                        value: joblisting.responsible.name || 'Ikke oppgitt.',
-                      },
-                      {
-                        key: 'E-post',
-                        value: joblisting.responsible.mail || 'Ikke oppgitt.',
-                      },
-                      {
-                        key: 'Telefon',
-                        value: joblisting.responsible.phone || 'Ikke oppgitt.',
-                      },
-                    ]}
-                  />
-                </div>
-              )}
+                )}
+                {joblisting.responsible && (
+                  <div>
+                    <h4>Kontaktperson</h4>
+                    <InfoList
+                      items={[
+                        {
+                          key: 'Navn',
+                          value: joblisting.responsible.name || <NotGiven />,
+                        },
+                        {
+                          key: 'E-post',
+                          value: joblisting.responsible.mail ? (
+                            <a href={`mailto:${joblisting.responsible.mail}`}>
+                              {joblisting.responsible.mail}
+                            </a>
+                          ) : (
+                            <NotGiven />
+                          ),
+                        },
+                        {
+                          key: 'Telefon',
+                          value: joblisting.responsible.phone ? (
+                            <a href={`tel:${joblisting.responsible.phone}`}>
+                              {joblisting.responsible.phone}
+                            </a>
+                          ) : (
+                            <NotGiven />
+                          ),
+                        },
+                      ]}
+                    />
+                  </div>
+                )}
+              </Flex>
             </div>
           )}
 
           {(canEdit || canDelete) && (
-            <Flex
-              column
-              style={{
-                marginTop: '10px',
-              }}
-            >
+            <div>
               <h3>Admin</h3>
               {canEdit && (
                 <LinkButton href={`/joblistings/${joblisting.id}/edit`}>
@@ -232,7 +229,7 @@ const JoblistingDetail = () => {
                   Rediger
                 </LinkButton>
               )}
-            </Flex>
+            </div>
           )}
         </ContentSidebar>
       </ContentSection>

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -336,7 +336,7 @@ const JoblistingEditor = () => {
               name="text"
               className={styles.textField}
               placeholder="Søknadstekst"
-              label="Søknadstekst:"
+              label="Søknadstekst"
               component={EditorField.Field}
               initialized
               required

--- a/app/routes/joblistings/components/JoblistingList.css
+++ b/app/routes/joblistings/components/JoblistingList.css
@@ -1,21 +1,12 @@
 @import url('~app/styles/variables.css');
 
-.heading {
-  margin-bottom: var(--spacing-md);
-}
-
-.headingDeadline {
-  margin-right: var(--spacing-md);
-
-  @media (--mobile-device) {
-    display: none;
-  }
-}
-
-.joblistingList {
-  flex: 3;
+.emptyState {
+  max-width: 280px;
+  text-align: center;
+  margin: 0 auto;
+  margin-top: var(--spacing-xl);
 
   @media (--mobile-device) {
-    margin: 0 var(--spacing-sm);
+    margin-top: var(--spacing-md);
   }
 }

--- a/app/routes/joblistings/components/JoblistingList.css
+++ b/app/routes/joblistings/components/JoblistingList.css
@@ -5,6 +5,7 @@
   text-align: center;
   margin: 0 auto;
   margin-top: var(--spacing-xl);
+  line-height: 1.3;
 
   @media (--mobile-device) {
     margin-top: var(--spacing-md);

--- a/app/routes/joblistings/components/JoblistingList.tsx
+++ b/app/routes/joblistings/components/JoblistingList.tsx
@@ -1,4 +1,6 @@
-import { Flex, Skeleton } from '@webkom/lego-bricks';
+import { Button, Flex, Icon, Skeleton } from '@webkom/lego-bricks';
+import { FilterX } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import EmptyState from 'app/components/EmptyState';
 import JoblistingItem from 'app/components/JoblistingItem';
 import sharedStyles from 'app/components/JoblistingItem/JoblistingItem.css';
@@ -14,12 +16,24 @@ type JobListingsListProps = {
 const JoblistingsList = ({ joblistings, totalCount }: JobListingsListProps) => {
   const fetching = useAppSelector((state) => state.joblistings.fetching);
 
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const clearQueryParams = () => {
+    navigate(pathname);
+  };
+
   if (joblistings.length === 0 && !fetching) {
     return (
       <EmptyState icon="folder-open-outline" className={styles.emptyState}>
         <b>Her var det tomt ...</b>
-        Ingen jobbannonser {totalCount > 0 && 'som matcher filter'} ligger
+        Ingen jobbannonser {totalCount > 0 && 'som matcher ditt filter'} ligger
         {totalCount === 0 && ' for øyeblikket'} ute
+        {totalCount > 0 && (
+          <Button flat onPress={clearQueryParams}>
+            <Icon iconNode={<FilterX />} size={22} />
+            Tøm filter
+          </Button>
+        )}
       </EmptyState>
     );
   }

--- a/app/routes/joblistings/components/JoblistingList.tsx
+++ b/app/routes/joblistings/components/JoblistingList.tsx
@@ -8,31 +8,32 @@ import type { ListJoblisting } from 'app/store/models/Joblisting';
 
 type JobListingsListProps = {
   joblistings: ListJoblisting[];
+  totalCount: number;
 };
 
-const JoblistingsList = ({ joblistings }: JobListingsListProps) => {
+const JoblistingsList = ({ joblistings, totalCount }: JobListingsListProps) => {
   const fetching = useAppSelector((state) => state.joblistings.fetching);
 
   if (joblistings.length === 0 && !fetching) {
     return (
-      <EmptyState icon="folder-open-outline">
-        Ingen jobbannonser ligger ute
+      <EmptyState icon="folder-open-outline" className={styles.emptyState}>
+        <b>Her var det tomt ...</b>
+        Ingen jobbannonser {totalCount > 0 && 'som matcher filter'} ligger
+        {totalCount === 0 && ' for øyeblikket'} ute
       </EmptyState>
     );
   }
 
   return (
-    <div className={styles.joblistingList}>
-      <Flex column gap="var(--spacing-sm)">
-        {fetching && !joblistings.length ? (
-          <Skeleton array={5} className={sharedStyles.joblistingItem} />
-        ) : (
-          joblistings.map((joblisting) => (
-            <JoblistingItem key={joblisting.id} joblisting={joblisting} />
-          ))
-        )}
-      </Flex>
-    </div>
+    <Flex column gap="var(--spacing-sm)">
+      {fetching && !joblistings.length ? (
+        <Skeleton array={5} className={sharedStyles.joblistingItem} />
+      ) : (
+        joblistings.map((joblisting) => (
+          <JoblistingItem key={joblisting.id} joblisting={joblisting} />
+        ))
+      )}
+    </Flex>
   );
 };
 

--- a/app/routes/joblistings/components/JoblistingPage.tsx
+++ b/app/routes/joblistings/components/JoblistingPage.tsx
@@ -122,7 +122,10 @@ const JoblistingsPage = () => {
       }
     >
       <Helmet title="Karriere" />
-      <JoblistingsList joblistings={joblistings} />
+      <JoblistingsList
+        joblistings={joblistings}
+        totalCount={unsortedJoblistings.length}
+      />
     </Page>
   );
 };


### PR DESCRIPTION
# Description

Saying there are no joblistings out at all is wrong when the user has only filtered out all, imo.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

The improved spacing on the detailed joblisting page is very subtle, but it's there

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="1123" alt="image" src="https://github.com/user-attachments/assets/7620149d-863d-4e7a-b777-7372def67999">
        </td>
        <td>
            <img width="1123" alt="image" src="https://github.com/user-attachments/assets/392a2f0b-2f46-4c0f-84c0-2bb7112f9ba3">
        </td>
    </tr>
    <tr>
        <td>
            <img width="420" alt="image" src="https://github.com/user-attachments/assets/cfe7b200-1b90-4a37-8e39-7750be06a475">
        </td>
        <td>    
			<img width="420" alt="image" src="https://github.com/user-attachments/assets/9b282c52-fc42-4ffa-9ad0-b867dc59418a">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Looks good on mobile as well.