### PR TITLE
Slightly refactor and retouch poll styling

### DIFF
--- a/app/components/Poll/Poll.css
+++ b/app/components/Poll/Poll.css
@@ -8,7 +8,8 @@
   min-height: 120px;
   margin: 0 auto;
   overflow-y: hidden;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--border-radius-lg);
+  line-height: 1.3;
 }
 
 .topBar {
@@ -21,10 +22,9 @@
   width: 100%;
   text-align: center;
   background-color: var(--lego-red-color);
-  color: var(--color-white);
-  line-height: 1.3;
-  padding: var(--spacing-sm) 0 var(--spacing-md);
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 20%);
+  color: var(--color-absolute-white);
+  padding: var(--spacing-sm) 0 var(--spacing-lg);
+  overflow: hidden;
 }
 
 .titleLink {
@@ -36,15 +36,14 @@
   border-radius: var(--border-radius-lg);
   color: var(--lego-font-color);
   background-color: var(--lego-card-color);
-  box-shadow: 0 3px 3px rgba(0, 0, 0, 20%);
+  box-shadow: var(--shadow-md);
   z-index: 3;
 }
 
 .title {
-  padding: var(--spacing-sm);
+  padding: var(--spacing-md);
   font-weight: 500;
   text-align: center;
-  line-height: 1.5;
 }
 
 .contentWrapper {
@@ -73,7 +72,7 @@
 .voteButton + .voteButton {
   font-weight: 500;
   width: 90%;
-  padding: 5px;
+  padding: var(--sapcing-xs);
   margin: 2px;
   border-radius: var(--border-radius-md);
 }
@@ -87,39 +86,32 @@
 
 .pollTable td {
   border: 0;
-  padding: 5px;
+  padding: var(--spacing-xs);
 }
 
 .pollTable .textColumn {
-  border-right: 1px solid var(--border-gray);
+  border-right: 1.5px solid var(--border-gray);
   text-align: right;
-  padding-right: 13px;
-  line-height: 16px;
+  padding-right: var(--spacing-md);
 }
 
 .pollTable .graphColumn {
   width: auto;
   min-width: 200px;
-  padding-left: 13px;
+  padding-left: var(--spacing-md);
 }
 
 .pollGraph {
   animation: graph var(--easing-fast);
   background-color: var(--lego-red-color);
-  padding: 5px;
-  border-radius: 0 var(--border-radius-sm) var(--border-radius-sm) 0;
+  padding: var(--spacing-xs);
+  border-radius: 0 var(--border-radius-md) var(--border-radius-md) 0;
   color: var(--color-absolute-white);
   height: 30px;
 }
 
 .fullGraph {
   background-color: var(--additive-background);
-  width: 100%;
-  display: flex;
-}
-
-.pollGraph span {
-  vertical-align: middle;
 }
 
 @keyframes graph {
@@ -132,8 +124,8 @@
   }
 }
 
-.resultsHiddenInfo {
-  color: var(--secondary-font-color);
+.ratioOutsideBar {
+  margin: var(--spacing-xs);
 }
 
 .totalVotes {
@@ -152,7 +144,7 @@
   position: relative;
   background-color: var(--lego-red-color);
   width: 100%;
-  padding: 6.25rem 0 var(--spacing-sm);
+  padding: 6.25rem 0 var(--spacing-md);
   top: -4.75rem;
   margin-bottom: -5.25rem;
   transition:
@@ -164,11 +156,10 @@
 
 .bottomBar.expanded {
   top: 0;
-  padding-top: var(--spacing-sm);
+  padding-top: var(--spacing-md);
   margin-bottom: 0;
 }
 
 .arrowIcon {
-  color: var(--color-white);
-  text-shadow: 0 2px 2px rgba(0, 0, 0, 20%);
+  color: var(--color-absolute-white);
 }

--- a/app/components/Poll/index.tsx
+++ b/app/components/Poll/index.tsx
@@ -1,6 +1,13 @@
 import { Accordion, Button, Flex, Icon, Skeleton } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { sortBy } from 'lodash';
+import {
+  ChartNoAxesColumn,
+  ChevronDown,
+  ChevronUp,
+  CircleCheck,
+  Info,
+} from 'lucide-react';
 import moment from 'moment-timezone';
 import { Link } from 'react-router-dom';
 import { votePoll } from 'app/actions/PollActions';
@@ -8,6 +15,7 @@ import EmptyState from 'app/components/EmptyState';
 import Tooltip from 'app/components/Tooltip';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './Poll.css';
+
 import type PollType from 'app/store/models/Poll';
 
 type PollOptionRatio = PollType['options'][0] & {
@@ -86,16 +94,12 @@ const Poll = ({
   return (
     <Flex alignItems="center" className={styles.poll} column>
       <Flex
-        alignItems="center"
-        className={styles.topBar}
         column
+        alignItems="center"
         justifyContent="center"
+        className={styles.topBar}
       >
-        <Icon
-          name={hasAnswered ? 'stats-chart' : 'help'}
-          size={28}
-          className={styles.pollIcon}
-        />
+        <Icon iconNode={<ChartNoAxesColumn />} className={styles.pollIcon} />
         <Link to={`/polls/${pollId}`} className={styles.titleLink}>
           <Flex
             alignItems="center"
@@ -126,8 +130,7 @@ const Poll = ({
             {!alwaysOpen && (
               <Icon
                 className={styles.arrowIcon}
-                size={26}
-                name={open ? 'chevron-up' : 'chevron-down'}
+                iconNode={open ? <ChevronUp /> : <ChevronDown />}
               />
             )}
           </Flex>
@@ -154,13 +157,13 @@ const Poll = ({
           gap="var(--spacing-sm)"
           className={styles.registrationCount}
         >
-          <Tooltip content="Avstemningen er anonym.">
-            <Icon name="information-circle-outline" size={17} />
-          </Tooltip>
           <span>
             <span className={styles.totalVotes}>{totalVotes}</span>{' '}
             {totalVotes === 1 ? 'stemme' : 'stemmer'}
           </span>
+          <Tooltip content="Avstemningen er anonym">
+            <Icon iconNode={<Info />} size={17} />
+          </Tooltip>
         </Flex>
       </Accordion>
     </Flex>
@@ -220,27 +223,22 @@ const VoteResults = ({
                 {votes === 0 ? (
                   <EmptyState>Ingen stemmer</EmptyState>
                 ) : (
-                  <div className={styles.fullGraph}>
+                  <Flex alignItems="center" className={styles.fullGraph}>
                     <div
                       style={{
                         width: `${ratio}%`,
                       }}
                     >
-                      <div className={styles.pollGraph}>
+                      <Flex alignItems="center" className={styles.pollGraph}>
                         {ratio >= 18 && <span>{`${ratio}%`}</span>}
-                      </div>
+                      </Flex>
                     </div>
                     {ratio < 18 && (
-                      <span
-                        style={{
-                          padding: '5px',
-                          marginLeft: '2px',
-                        }}
-                      >
+                      <span className={styles.ratioOutsideBar}>
                         {`${ratio}%`}
                       </span>
                     )}
-                  </div>
+                  </Flex>
                 )}
               </td>
             </tr>
@@ -249,7 +247,7 @@ const VoteResults = ({
       </tbody>
     </table>
     {resultsHidden && (
-      <div className={styles.resultsHiddenInfo}>
+      <div className="secondaryFontColor">
         Resultatet er skjult for vanlige brukere
       </div>
     )}
@@ -264,14 +262,10 @@ type VoteHiddenProps = {
 const VoteHidden = ({ details, poll }: VoteHiddenProps) => (
   <Flex column alignItems="center" className={styles.voteOptions}>
     {details && <p className={styles.description}>{poll.description}</p>}
-    <Flex justifyContent="center" alignItems="center" gap={5}>
+    <Flex justifyContent="center" alignItems="center" gap="var(--spacing-sm)">
       Du har svart
-      <Icon
-        name="checkmark-circle-outline"
-        size={20}
-        className={styles.success}
-      />
+      <Icon iconNode={<CircleCheck />} size={20} className={styles.success} />
     </Flex>
-    <div className={styles.resultsHiddenInfo}>Resultatet er skjult</div>
+    <div className="secondaryFontColor">Resultatet er skjult</div>
   </Flex>
 );

--- a/app/components/Search/utils.tsx
+++ b/app/components/Search/utils.tsx
@@ -1,24 +1,25 @@
 import { Flex } from '@webkom/lego-bricks';
 import { sample } from 'lodash';
 import {
-  BadgeInfo,
   Banana,
-  BarChart3,
   BookImage,
   BookOpenText,
   BriefcaseBusiness,
   CalendarRange,
   CircleUser,
+  ChartNoAxesColumn,
   Database,
   ExternalLink,
   FilePieChart,
   Gamepad,
   Group,
+  Info,
   MailSearch,
   MailWarning,
   MessageCircleHeart,
   MessageCircleWarning,
   MessageCircleQuestion,
+  MessageCircleX,
   MessagesSquare,
   MountainSnow,
   Newspaper,
@@ -85,7 +86,7 @@ const LINKS: Array<Link> = [
   {
     key: 'aboutUs',
     title: 'Om Abakus',
-    icon: <BadgeInfo />,
+    icon: <Info />,
     url: '/pages/info-om-abakus',
   },
   {
@@ -122,6 +123,7 @@ const LINKS: Array<Link> = [
       <MessageCircleWarning key="1" />,
       <MessageCircleHeart key="2" />,
       <MessageCircleQuestion key="3" />,
+      <MessageCircleX key="4" />,
     ]),
     url: '/quotes/',
   },
@@ -146,7 +148,7 @@ const LINKS: Array<Link> = [
   {
     key: 'polls',
     title: 'Avstemninger',
-    icon: <BarChart3 />,
+    icon: <ChartNoAxesColumn />,
     url: '/polls',
   },
   {

--- a/app/routes/polls/components/PollsList.css
+++ b/app/routes/polls/components/PollsList.css
@@ -4,7 +4,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: auto;
-  grid-gap: 20px;
+  grid-gap: var(--spacing-md);
 
   @media (--mobile-device) {
     grid-template-columns: 1fr;
@@ -15,14 +15,10 @@
   color: var(--lego-font-color);
 }
 
-.icon {
-  color: var(--lego-red-color);
-}
-
-.heading {
-  margin-left: 15px;
-}
-
 .success {
   color: var(--success-color);
+}
+
+.danger {
+  color: var(--danger-color);
 }

--- a/app/routes/polls/components/PollsList.tsx
+++ b/app/routes/polls/components/PollsList.tsx
@@ -1,5 +1,6 @@
 import { Card, Flex, Icon, LinkButton, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { CircleCheck, CircleX } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import { fetchAll } from 'app/actions/PollActions';
@@ -50,20 +51,17 @@ const PollsList = () => {
           {polls.map((poll) => (
             <Link key={poll.id} to={`/polls/${poll.id}`}>
               <Card isHoverable className={styles.pollListItem}>
-                <Flex>
-                  <Icon name="stats-chart" size={35} className={styles.icon} />
-                  <h3 className={styles.heading}>{poll.title}</h3>
-                </Flex>
+                <Card.Header>{poll.title}</Card.Header>
 
-                <Flex wrap justifyContent="space-between">
-                  <span>{`Antall stemmer: ${poll.totalVotes}`}</span>
-                  <Flex alignItems="center" gap={5}>
+                <Flex wrap justifyContent="space-between" alignItems="center">
+                  <span>{`${poll.totalVotes} ${poll.totalVotes === 1 ? 'stemme' : 'stemmer'}`}</span>
+                  <Flex alignItems="center" gap="var(--spacing-sm)">
                     {poll.hasAnswered ? (
                       <>
                         Svart
                         <Icon
-                          name="checkmark-circle-outline"
-                          size={20}
+                          iconNode={<CircleCheck />}
+                          size={21}
                           className={styles.success}
                         />
                       </>
@@ -71,11 +69,9 @@ const PollsList = () => {
                       <>
                         Ikke svart
                         <Icon
-                          name="close-circle-outline"
-                          size={20}
-                          style={{
-                            color: 'var(--danger-color)',
-                          }}
+                          iconNode={<CircleX />}
+                          size={21}
+                          className={styles.danger}
                         />
                       </>
                     )}

--- a/cypress/e2e/poll_spec.js
+++ b/cypress/e2e/poll_spec.js
@@ -129,7 +129,7 @@ describe('Polls', () => {
     cy.visit('/polls');
     cy.get(c('PollsList__pollListItem')).should('have.length', 2);
 
-    cy.get(c('PollsList__heading')).first().click();
+    cy.get(c('PollsList__pollListItem')).first().click();
 
     cy.contains('button', 'Rediger').click();
     cy.contains('button', 'Slett avstemning').click();


### PR DESCRIPTION
# Description

Minor clean ups here and there, better alignments and less "custom" css. It still feels a bit out-of-place, but I think it's improved (especially the items in the poll list).

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

It has annoyed me for a long time that the border radius did not match the rest on the front page.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="366" alt="image" src="https://github.com/user-attachments/assets/26c81279-7c68-46f6-9280-0c5a1192d941">
        </td>
        <td>
            <img width="366" alt="image" src="https://github.com/user-attachments/assets/85c6ad5f-e44d-4fcd-a793-85103ac3181b">
        </td>
    </tr>
    <tr>
        <td>
            <img width="1120" alt="image" src="https://github.com/user-attachments/assets/a317e011-b9fc-4c7b-b123-68689c3b4784">
        </td>
        <td>
            <img width="1120" alt="image" src="https://github.com/user-attachments/assets/c1440ff8-b923-4a16-9801-ad627ec450f7">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Works on mobile. Border radius does still not work on Safari though ..
