### PR TITLE
Fix bad spacing between article tags

### DIFF
--- a/app/components/Tags/Tag.css
+++ b/app/components/Tags/Tag.css
@@ -1,12 +1,5 @@
 /* stylelint-disable indentation */
 
-.tags {
-  margin: 20px 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-}
-
 .linkSpacing {
   display: inline-flex;
 }

--- a/app/components/Tags/Tag.tsx
+++ b/app/components/Tags/Tag.tsx
@@ -55,7 +55,7 @@ const Tag = ({
       </Link>
     ) : (
       <Flex
-        gap={5}
+        gap="var(--spacing-xs)"
         alignItems="center"
         className={cx(styles.tag, styles[color], className)}
       >

--- a/app/components/Tags/index.tsx
+++ b/app/components/Tags/index.tsx
@@ -1,4 +1,4 @@
-import styles from './Tag.css';
+import { Flex } from '@webkom/lego-bricks';
 import type { ReactNode } from 'react';
 
 type Props = {
@@ -10,7 +10,11 @@ type Props = {
  * A basic tag component for displaying tags
  */
 const Tags = ({ children, className }: Props) => {
-  return <div className={className ? className : styles.tags}>{children}</div>;
+  return (
+    <Flex wrap gap="var(--spacing-sm)" className={className}>
+      {children}
+    </Flex>
+  );
 };
 
 export default Tags;

--- a/app/routes/articles/articles.css
+++ b/app/routes/articles/articles.css
@@ -9,10 +9,9 @@
 }
 
 .tagline {
-  margin: 10px 0 0;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  display: inline-flex;
+  margin: 0;
+  margin-left: var(--spacing-sm);
 }
 
 .overviewAuthor::after {

--- a/app/routes/articles/components/ArticleList.tsx
+++ b/app/routes/articles/components/ArticleList.tsx
@@ -52,11 +52,13 @@ export const ArticleListItem = ({ article }: { article: PublicArticle }) => {
 
         <Time time={article.createdAt} format="DD.MM.YYYY HH:mm" />
 
-        <Tags className={styles.tagline}>
-          {article.tags.map((tag) => (
-            <Tag tag={tag} key={tag} />
-          ))}
-        </Tags>
+        {article.tags?.length > 0 && (
+          <Tags className={styles.tagline}>
+            {article.tags.map((tag) => (
+              <Tag tag={tag} key={tag} />
+            ))}
+          </Tags>
+        )}
       </span>
 
       <p className={styles.itemDescription}>{article.description}</p>

--- a/app/routes/frontpage/components/AuthenticatedFrontpage.css
+++ b/app/routes/frontpage/components/AuthenticatedFrontpage.css
@@ -76,10 +76,3 @@
   color: var(--secondary-font-color);
   line-height: 1.3;
 }
-
-.tagline {
-  margin: 0;
-  margin-left: var(--spacing-sm);
-  display: inline-flex;
-  gap: 7px;
-}

--- a/app/routes/frontpage/components/utils.tsx
+++ b/app/routes/frontpage/components/utils.tsx
@@ -48,7 +48,7 @@ export const renderMeta = (item?: ArticleWithType | EventWithType) => {
       </span>
 
       {item.tags?.length > 0 && (
-        <Tags className={styles.tagline}>
+        <Tags>
           {item.tags.slice(0, 3).map((tag) => (
             <Tag tag={tag} key={tag} />
           ))}


### PR DESCRIPTION
# Description

Made some general clean ups as well

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="421" alt="image" src="https://github.com/user-attachments/assets/ed96702e-8e75-426c-a509-6962ef8d6d9a">
        </td>
       <td>
            <img width="421" alt="image" src="https://github.com/user-attachments/assets/bf8af1de-6f67-49d1-ae1d-8fb3b3477866">
        </td>
    </tr>
    <tr>
        <td>
            <img width="363" alt="image" src="https://github.com/user-attachments/assets/e81229ba-eb41-4434-a5ef-2ccfd085da06">
        </td>
       <td>
            <img width="363" alt="image" src="https://github.com/user-attachments/assets/b3d78091-492e-4616-a516-49426f852ef0">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested wrap on mobile.

Tested various tag lines; on front page, articles list, comments (author tag).