### PR TITLE
Replace a bunch of ionicon icons with lucide icons

### DIFF
--- a/app/components/AnnouncementInLine/index.tsx
+++ b/app/components/AnnouncementInLine/index.tsx
@@ -1,4 +1,5 @@
 import { Icon, LinkButton } from '@webkom/lego-bricks';
+import { Send } from 'lucide-react';
 import { useAppSelector } from 'app/store/hooks';
 import type { AnnouncementCreateLocationState } from 'app/routes/announcements/components/AnnouncementsCreate';
 import type { UnknownEvent } from 'app/store/models/Event';
@@ -29,7 +30,7 @@ const AnnouncementInLine = ({ event, meeting, group }: Props) => {
         } as AnnouncementCreateLocationState
       }
     >
-      <Icon name="send-outline" size={18} />
+      <Icon iconNode={<Send />} size={18} />
       Send kunngjøring
     </LinkButton>
   );

--- a/app/components/Comments/Comment.css
+++ b/app/components/Comments/Comment.css
@@ -29,7 +29,7 @@
 }
 
 .text {
-  margin: var(--spacing-md) 0;
+  margin: var(--spacing-sm) 0;
 }
 
 .anonymousProfilePicture {

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -1,4 +1,5 @@
 import { Button, Flex, Icon } from '@webkom/lego-bricks';
+import { Reply, Trash2 } from 'lucide-react';
 import moment from 'moment';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -81,11 +82,12 @@ const Comment = ({
                 <Tooltip content="Slett kommentar">
                   <Icon
                     danger
-                    name="trash"
+                    iconNode={<Trash2 />}
                     size={20}
                     onClick={() =>
                       dispatch(deleteComment(comment.id, contentTarget))
                     }
+                    data-test-id="delete-comment-button"
                   />
                 </Tooltip>
               </Flex>
@@ -116,13 +118,14 @@ const Comment = ({
             contentTarget: comment.contentTargetSelf,
           }}
         />
+
         {author && (
           <Button flat onPress={() => setReplyOpen(!replyOpen)}>
             {replyOpen ? (
               'Avbryt'
             ) : (
               <>
-                <Icon name="return-up-back" size={20} />
+                <Icon iconNode={<Reply />} size={20} />
                 Svar
               </>
             )}

--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -95,20 +95,6 @@
   flex-direction: row;
 }
 
-.dropdown {
-  width: 355px;
-  padding: var(--spacing-md);
-
-  @media (--small-viewport) {
-    width: 100%;
-
-    &::before,
-    &::after {
-      display: none;
-    }
-  }
-}
-
 .logoLightMode,
 .logoDarkMode {
   display: none;

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -108,7 +108,7 @@ const UpcomingMeetingButton = () => {
         navigate(`/meetings/${upcomingMeetingId}`);
       }}
     >
-      <Icon name="people" />
+      <Icon iconNode={<Users />} />
     </button>
   );
 };
@@ -145,14 +145,10 @@ const AccountDropdown = () => {
       show={accountOpen}
       toggle={() => setAccountOpen(!accountOpen)}
       triggerComponent={
-        currentUser && (
-          <ProfilePicture
-            size={24}
-            user={currentUser}
-            style={{
-              verticalAlign: 'middle',
-            }}
-          />
+        currentUser ? (
+          <ProfilePicture size={24} user={currentUser} />
+        ) : (
+          <Icon iconNode={<CircleUser />} />
         )
       }
     >
@@ -162,7 +158,6 @@ const AccountDropdown = () => {
     <Dropdown
       show={accountOpen}
       toggle={() => setAccountOpen(!accountOpen)}
-      contentClassName={styles.dropdown}
       triggerComponent={<Icon iconNode={<CircleUser />} />}
     >
       <AuthSection />

--- a/app/components/PhotoUploadStatus/index.tsx
+++ b/app/components/PhotoUploadStatus/index.tsx
@@ -1,4 +1,5 @@
 import { Card, Flex, Icon, Image } from '@webkom/lego-bricks';
+import { X } from 'lucide-react';
 import { connect } from 'react-redux';
 import Tooltip from 'app/components/Tooltip';
 import {
@@ -37,7 +38,11 @@ const UploadStatusCard = ({
       severity={!uploadDone ? 'info' : hasFailedUploads ? 'danger' : 'success'}
       className={styles.photoUploadStatus}
     >
-      <Icon className={styles.close} onClick={hideUploadStatus} name="close" />
+      <Icon
+        className={styles.close}
+        onClick={hideUploadStatus}
+        iconNode={<X />}
+      />
 
       {uploadDone ? (
         <Card.Header className={styles.header}>

--- a/app/components/Search/SearchBar.tsx
+++ b/app/components/Search/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { Flex, Icon } from '@webkom/lego-bricks';
+import { Search, X } from 'lucide-react';
 import styles from './Search.css';
 import type { Dispatch, KeyboardEventHandler, SetStateAction } from 'react';
 
@@ -33,7 +34,7 @@ const SearchBar = ({
       alignItems="center"
     >
       <div className={styles.searchIcon}>
-        <Icon name="search" size={30} />
+        <Icon iconNode={<Search />} size={30} />
       </div>
       {searchFields.map((k) => (
         <input
@@ -42,7 +43,6 @@ const SearchBar = ({
           className={k.className}
           onChange={(e) => onQueryChanged(e.target.value)}
           value={query}
-          type="search"
           size={1}
           placeholder="Hva leter du etter?"
           ref={(input) => input && k.autoFocus && input.focus()}
@@ -51,7 +51,7 @@ const SearchBar = ({
 
       <Icon
         onClick={onCloseSearch}
-        name={'close'}
+        iconNode={<X />}
         size={30}
         data-test-id="closeButton"
       />

--- a/app/components/Search/utils.tsx
+++ b/app/components/Search/utils.tsx
@@ -2,6 +2,7 @@ import { Flex } from '@webkom/lego-bricks';
 import { sample } from 'lodash';
 import {
   BadgeInfo,
+  Banana,
   BarChart3,
   BookImage,
   BookOpenText,
@@ -11,6 +12,7 @@ import {
   Database,
   ExternalLink,
   FilePieChart,
+  Gamepad,
   Group,
   MailSearch,
   MailWarning,
@@ -18,13 +20,13 @@ import {
   MessageCircleWarning,
   MessageCircleQuestion,
   MessagesSquare,
+  MountainSnow,
   Newspaper,
   Phone,
   ReceiptText,
   ScrollText,
   Send,
   Tags,
-  Telescope,
   Users,
 } from 'lucide-react';
 import ReadmeLogo from 'app/components/ReadmeLogo';
@@ -94,7 +96,11 @@ const LINKS: Array<Link> = [
   {
     key: 'interest-groups',
     title: 'Interessegrupper',
-    icon: <Telescope />,
+    icon: sample([
+      <Banana key="1" />,
+      <Gamepad key="2" />,
+      <MountainSnow key="3" />,
+    ]),
     url: '/interest-groups',
   },
   {

--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -7,6 +7,7 @@ import {
   Image,
 } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { Trash2 } from 'lucide-react';
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { Cropper } from 'react-cropper';
 import { type Accept, useDropzone } from 'react-dropzone';
@@ -66,7 +67,7 @@ const FilePreview = ({ file, onRemove }: FilePreviewProps) => {
         src={previewUrl}
       />
       <div className={styles.fileName}>{file.name}</div>
-      <Icon onClick={onRemove} name="trash" danger />
+      <Icon onClick={onRemove} iconNode={<Trash2 />} danger />
     </Flex>
   );
 };

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -1,4 +1,5 @@
 import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
+import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { removeMember, addMember } from 'app/actions/GroupActions';
@@ -124,7 +125,12 @@ const GroupMembersList = ({
           onConfirm={() => dispatch(removeMember(membership))}
         >
           {({ openConfirmModal }) => (
-            <Icon onClick={openConfirmModal} name="trash" size={20} danger />
+            <Icon
+              onClick={openConfirmModal}
+              iconNode={<Trash2 />}
+              size={20}
+              danger
+            />
           )}
         </ConfirmModal>
       </Flex>

--- a/app/routes/admin/groups/components/GroupPermissions.tsx
+++ b/app/routes/admin/groups/components/GroupPermissions.tsx
@@ -1,5 +1,6 @@
 import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
 import { sortBy } from 'lodash';
+import { Trash2 } from 'lucide-react';
 import { Fragment } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { editGroup } from 'app/actions/GroupActions';
@@ -97,7 +98,11 @@ const PermissionList = ({ group }: PermissionListProps) => {
                   }
                 >
                   {({ openConfirmModal }) => (
-                    <Icon onClick={openConfirmModal} name="trash" danger />
+                    <Icon
+                      onClick={openConfirmModal}
+                      iconNode={<Trash2 />}
+                      danger
+                    />
                   )}
                 </ConfirmModal>
                 {permission}

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -8,6 +8,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -248,7 +249,7 @@ const ArticleEditor = () => {
                 >
                   {({ openConfirmModal }) => (
                     <Button onPress={openConfirmModal} danger>
-                      <Icon name="trash" size={19} />
+                      <Icon iconNode={<Trash2 />} size={19} />
                       Slett artikkel
                     </Button>
                   )}

--- a/app/routes/bdb/components/BdbDetail.tsx
+++ b/app/routes/bdb/components/BdbDetail.tsx
@@ -12,6 +12,7 @@ import {
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
+import { Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -237,7 +238,7 @@ const BdbDetail = () => {
                 {({ openConfirmModal }) => (
                   <Icon
                     onClick={openConfirmModal}
-                    name="trash"
+                    iconNode={<Trash2 />}
                     danger
                     size={20}
                   />

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -6,6 +6,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -156,7 +157,7 @@ const CompanyEditor = () => {
           >
             {({ openConfirmModal }) => (
               <Button onPress={openConfirmModal} danger>
-                <Icon name="trash" size={19} />
+                <Icon iconNode={<Trash2 />} size={19} />
                 Slett bedrift
               </Button>
             )}

--- a/app/routes/bdb/components/SemesterStatusDetail.tsx
+++ b/app/routes/bdb/components/SemesterStatusDetail.tsx
@@ -4,6 +4,7 @@ import {
   Flex,
   LoadingIndicator,
 } from '@webkom/lego-bricks';
+import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { deleteSemesterStatus } from 'app/actions/CompanyActions';
 import FileUpload from 'app/components/Upload/FileUpload';
@@ -117,7 +118,12 @@ const SemesterStatusDetail = (props: Props) => {
             closeOnConfirm
           >
             {({ openConfirmModal }) => (
-              <Icon onClick={openConfirmModal} name="trash" danger size={20} />
+              <Icon
+                onClick={openConfirmModal}
+                iconNode={<Trash2 />}
+                danger
+                size={20}
+              />
             )}
           </ConfirmModal>
         </Flex>
@@ -166,7 +172,7 @@ const RenderFile = (props: RenderFileProps) => {
           closeOnConfirm
         >
           {({ openConfirmModal }) => (
-            <Icon onClick={openConfirmModal} name="trash" danger />
+            <Icon onClick={openConfirmModal} iconNode={<Trash2 />} danger />
           )}
         </ConfirmModal>
       </span>

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -7,6 +7,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchSemesters } from 'app/actions/CompanyActions';
@@ -165,12 +166,14 @@ const CompanyInterestList = () => {
         <Flex justifyContent="center">
           <ConfirmModal
             title="Bekreft fjerning av interesse"
-            message={'Er du sikker på at du vil fjerne?'}
+            message="Er du sikker på at du vil fjerne?"
             closeOnConfirm
-            onConfirm={() => dispatch(deleteCompanyInterest(id))}
+            onConfirm={() => {
+              dispatch(deleteCompanyInterest(id));
+            }}
           >
             {({ openConfirmModal }) => (
-              <Icon onClick={openConfirmModal} name="trash" danger />
+              <Icon onClick={openConfirmModal} iconNode={<Trash2 />} danger />
             )}
           </ConfirmModal>
         </Flex>

--- a/app/routes/events/components/Admin.tsx
+++ b/app/routes/events/components/Admin.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   LinkButton,
 } from '@webkom/lego-bricks';
+import { Pencil, Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -32,7 +33,7 @@ const DeleteButton = ({ eventId, title }: ButtonProps) => {
     <>
       {!show ? (
         <Button danger onPress={() => setShow(true)}>
-          <Icon name="trash" size={19} />
+          <Icon iconNode={<Trash2 />} size={19} />
           Slett arrangement
         </Button>
       ) : (
@@ -60,7 +61,7 @@ const DeleteButton = ({ eventId, title }: ButtonProps) => {
             >
               {({ openConfirmModal }) => (
                 <Button onPress={openConfirmModal} danger>
-                  <Icon name="trash" size={19} />
+                  <Icon iconNode={<Trash2 />} size={19} />
                   Slett
                 </Button>
               )}
@@ -110,7 +111,7 @@ const Admin = ({ actionGrant, event }: Props) => {
 
           {canEdit && (
             <LinkButton href={`/events/${event.slug}/edit`}>
-              <Icon name="create-outline" size={19} />
+              <Icon iconNode={<Pencil />} size={19} />
               Rediger
             </LinkButton>
           )}

--- a/app/routes/events/components/EventEditor/EditorSection/Header.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Header.tsx
@@ -6,6 +6,7 @@ import {
   Modal,
   Image,
 } from '@webkom/lego-bricks';
+import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { setSaveForUse } from 'app/actions/FileActions';
 import EmptyState from 'app/components/EmptyState';
@@ -111,14 +112,16 @@ const Header = ({
                       />
                       <ConfirmModal
                         title="Fjern fra galleri"
-                        message={`Er du sikker på at du vil fjerne bildet fra bildegalleriet? Bildet blir ikke slettet fra databasen.`}
+                        message="Er du sikker på at du vil fjerne bildet fra bildegalleriet? Bildet blir ikke slettet fra databasen."
                         closeOnConfirm
-                        onConfirm={() => setSaveForUse(e.key, e.token, false)}
+                        onConfirm={() => {
+                          setSaveForUse(e.key, e.token, false);
+                        }}
                       >
                         {({ openConfirmModal }) => (
                           <Icon
                             onClick={openConfirmModal}
-                            name="trash"
+                            iconNode={<Trash2 />}
                             danger
                           />
                         )}

--- a/app/routes/events/components/EventsTabs.tsx
+++ b/app/routes/events/components/EventsTabs.tsx
@@ -2,7 +2,7 @@ import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 
 const EventsTabs = () => (
   <>
-    <NavigationTab href="/events">Liste</NavigationTab>
+    <NavigationTab href="/events">Oversikt</NavigationTab>
     <NavigationTab href="/events/calendar" matchSubpages>
       Kalender
     </NavigationTab>

--- a/app/routes/forum/components/ForumEditor.tsx
+++ b/app/routes/forum/components/ForumEditor.tsx
@@ -7,6 +7,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -117,7 +118,7 @@ const ForumEditor = () => {
                 >
                   {({ openConfirmModal }) => (
                     <Button onPress={openConfirmModal} danger>
-                      <Icon name="trash" size={19} />
+                      <Icon iconNode={<Trash2 />} size={19} />
                       Slett forum
                     </Button>
                   )}

--- a/app/routes/forum/components/ThreadEditor.tsx
+++ b/app/routes/forum/components/ThreadEditor.tsx
@@ -7,6 +7,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -135,7 +136,7 @@ const ThreadEditor = () => {
                 >
                   {({ openConfirmModal }) => (
                     <Button onPress={openConfirmModal} danger>
-                      <Icon name="trash" size={19} />
+                      <Icon iconNode={<Trash2 />} size={19} />
                       Slett tråd
                     </Button>
                   )}

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -10,6 +10,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Pencil } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import {
@@ -190,7 +191,7 @@ const InterestGroupDetail = () => {
             <>
               <h3>Admin</h3>
               <LinkButton href={`/interest-groups/${group.id}/edit`}>
-                <Icon name="create-outline" size={19} />
+                <Icon iconNode={<Pencil />} size={19} />
                 Rediger
               </LinkButton>
             </>

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -1,5 +1,6 @@
 import { Flex, Icon, LinkButton, LoadingPage, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Pencil } from 'lucide-react';
 import { useEffect } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { fetchJoblisting } from 'app/actions/JoblistingActions';
@@ -228,7 +229,7 @@ const JoblistingDetail = () => {
               <h3>Admin</h3>
               {canEdit && (
                 <LinkButton href={`/joblistings/${joblisting.id}/edit`}>
-                  <Icon name="create-outline" size={19} />
+                  <Icon iconNode={<Pencil />} size={19} />
                   Rediger
                 </LinkButton>
               )}

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -8,6 +8,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Trash2 } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
@@ -357,7 +358,7 @@ const JoblistingEditor = () => {
                 >
                   {({ openConfirmModal }) => (
                     <Button onPress={openConfirmModal} danger>
-                      <Icon name="trash" size={19} />
+                      <Icon iconNode={<Trash2 />} size={19} />
                       Slett jobbannonse
                     </Button>
                   )}

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -7,6 +7,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { isEmpty } from 'lodash';
+import { Pencil } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
 import { Link, useParams } from 'react-router-dom';
@@ -200,7 +201,7 @@ const MeetingDetails = () => {
             <AnnouncementInLine meeting={meeting} />
             {canEdit && (
               <LinkButton href={`/meetings/${meeting.id}/edit`}>
-                <Icon name="create-outline" size={19} />
+                <Icon iconNode={<Pencil />} size={19} />
                 Rediger
               </LinkButton>
             )}

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -8,6 +8,7 @@ import {
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { unionBy } from 'lodash';
+import { Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Field, FormSpy } from 'react-final-form';
@@ -441,7 +442,7 @@ const MeetingEditor = () => {
                   >
                     {({ openConfirmModal }) => (
                       <Button onPress={openConfirmModal} danger>
-                        <Icon name="trash" size={19} />
+                        <Icon iconNode={<Trash2 />} size={19} />
                         Slett møtet
                       </Button>
                     )}

--- a/app/routes/pages/components/PageEditor.tsx
+++ b/app/routes/pages/components/PageEditor.tsx
@@ -8,6 +8,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
@@ -198,7 +199,7 @@ const PageEditor = () => {
                 >
                   {({ openConfirmModal }) => (
                     <Button onPress={openConfirmModal} danger>
-                      <Icon name="trash" size={19} />
+                      <Icon iconNode={<Trash2 />} size={19} />
                       Slett
                     </Button>
                   )}

--- a/app/routes/photos/components/GalleryEditor.tsx
+++ b/app/routes/photos/components/GalleryEditor.tsx
@@ -12,6 +12,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
 import { without } from 'lodash';
+import { Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
@@ -357,7 +358,7 @@ const GalleryEditor = () => {
                 >
                   {({ openConfirmModal }) => (
                     <Button danger onPress={openConfirmModal}>
-                      <Icon name="trash" size={19} />
+                      <Icon iconNode={<Trash2 />} size={19} />
                       Slett album
                     </Button>
                   )}

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -1,6 +1,7 @@
 import { Flex, Icon, Modal, Image, LoadingPage } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import throttle from 'lodash/throttle';
+import { Pencil } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useSwipeable, RIGHT, LEFT } from 'react-swipeable';
@@ -325,7 +326,7 @@ const GalleryPictureModal = () => {
                         className={styles.dropdownLink}
                       >
                         Rediger
-                        <Icon name="create-outline" size={24} />
+                        <Icon iconNode={<Pencil />} size={24} />
                       </Link>
                     </Dropdown.ListItem>,
                     <Dropdown.ListItem key="cover">

--- a/app/routes/polls/components/PollDetail.tsx
+++ b/app/routes/polls/components/PollDetail.tsx
@@ -1,5 +1,6 @@
 import { Button, Icon, LoadingPage, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
@@ -46,7 +47,7 @@ const PollDetail = () => {
               'Avbryt'
             ) : (
               <>
-                <Icon name="create-outline" size={19} />
+                <Icon iconNode={<Pencil />} size={19} />
                 Rediger
               </>
             )}

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -6,6 +6,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import arrayMutators from 'final-form-arrays';
+import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
@@ -60,7 +61,7 @@ const renderOptions = ({ fields }): ReactNode => (
           >
             {({ openConfirmModal }) => (
               <Tooltip className="deleteOption" content="Fjern">
-                <Icon onClick={openConfirmModal} name="trash" danger />
+                <Icon onClick={openConfirmModal} iconNode={<Trash2 />} danger />
               </Tooltip>
             )}
           </ConfirmModal>
@@ -210,7 +211,7 @@ const PollEditor = ({
                 >
                   {({ openConfirmModal }) => (
                     <Button onPress={openConfirmModal} danger>
-                      <Icon name="trash" size={19} />
+                      <Icon iconNode={<Trash2 />} size={19} />
                       Slett avstemning
                     </Button>
                   )}

--- a/app/routes/surveys/components/AdminSideBar.tsx
+++ b/app/routes/surveys/components/AdminSideBar.tsx
@@ -1,4 +1,5 @@
 import { Button, ButtonGroup, Icon, LinkButton } from '@webkom/lego-bricks';
+import { Pencil } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { hideSurvey, shareSurvey } from 'app/actions/SurveyActions';
 import { ContentSidebar } from 'app/components/Content';
@@ -63,7 +64,7 @@ const AdminSideBar = ({
           </LinkButton>
 
           <LinkButton href={`/surveys/${surveyId}/edit`}>
-            <Icon name="create-outline" size={19} />
+            <Icon iconNode={<Pencil />} size={19} />
             Rediger
           </LinkButton>
 

--- a/app/routes/surveys/components/SurveyEditor/Option.tsx
+++ b/app/routes/surveys/components/SurveyEditor/Option.tsx
@@ -1,4 +1,5 @@
 import { Flex, Icon } from '@webkom/lego-bricks';
+import { X } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { RadioButton, TextInput, CheckBox } from 'app/components/Form';
 import { SurveyQuestionType } from 'app/store/models/SurveyQuestion';
@@ -13,7 +14,7 @@ type Props = {
 };
 
 const RemoveButton = ({ remove }: { remove?: () => void }) =>
-  remove ? <Icon name="close" onClick={remove} /> : null;
+  remove ? <Icon iconNode={<X />} onClick={remove} /> : null;
 
 const Option = (props: Props) => {
   return props.questionType === SurveyQuestionType.SingleChoice ? (

--- a/app/routes/surveys/components/SurveyEditor/Question.tsx
+++ b/app/routes/surveys/components/SurveyEditor/Question.tsx
@@ -1,4 +1,5 @@
 import { Card, ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
+import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import {
@@ -159,7 +160,7 @@ const Question = ({
             closeOnConfirm
           >
             {({ openConfirmModal }) => (
-              <Icon onClick={openConfirmModal} name="trash" danger />
+              <Icon onClick={openConfirmModal} iconNode={<Trash2 />} danger />
             )}
           </ConfirmModal>
         </Flex>

--- a/app/routes/users/components/RemovePicture.tsx
+++ b/app/routes/users/components/RemovePicture.tsx
@@ -1,4 +1,5 @@
 import { Button, ButtonGroup, Icon } from '@webkom/lego-bricks';
+import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { removePicture } from 'app/actions/UserActions';
 import { useAppDispatch } from 'app/store/hooks';
@@ -27,7 +28,7 @@ const RemovePicture = (props: Props) => {
         <Button onPress={toggleSelected}>Avbryt</Button>
       ) : (
         <Button danger onPress={toggleSelected}>
-          <Icon name="trash" size={19} />
+          <Icon iconNode={<Trash2 />} size={19} />
           Slett profilbildet
         </Button>
       )}

--- a/app/routes/users/components/UserSettingsOAuth2.tsx
+++ b/app/routes/users/components/UserSettingsOAuth2.tsx
@@ -7,6 +7,7 @@ import {
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import keys from 'lodash/keys';
+import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -141,7 +142,7 @@ const UserSettingsOAuth2 = () => {
               <Flex justifyContent="center">
                 <Icon
                   onClick={openConfirmModal}
-                  name="trash"
+                  iconNode={<Trash2 />}
                   size={19}
                   danger
                 />

--- a/cypress/e2e/event_visit_spec.js
+++ b/cypress/e2e/event_visit_spec.js
@@ -62,12 +62,12 @@ describe('View event', () => {
       .within(() => {
         cy.contains('This event will be awesome');
         cy.contains('button', 'Svar').should('exist').and('not.be.disabled');
-        cy.get('ion-icon[name=trash]')
+        cy.get(t('delete-comment-button'))
           .should('exist')
           .and('not.be.disabled')
           .click();
         cy.contains('Kommentar slettet');
-        cy.contains('button', 'svar').should('not.exist');
+        cy.contains('button', 'Svar').should('not.exist');
       });
 
     cy.get(c('CommentForm')).find('input').last().click();

--- a/cypress/e2e/router_spec.js
+++ b/cypress/e2e/router_spec.js
@@ -26,7 +26,7 @@ describe('Navigate throughout app', () => {
     });
     cy.url().should('contain', '/events');
     cy.contains('Denne uken');
-    cy.contains('Liste');
+    cy.contains('Oversikt');
   });
 
   it('should be able to navigate to joblistings', () => {
@@ -155,7 +155,7 @@ describe('Navigate throughout app', () => {
 
     // Events
     openMenuAndSelect('Arrangementer', '/events');
-    cy.contains('Liste');
+    cy.contains('Oversikt');
 
     // Articles
     openMenuAndSelect('Artikler', '/articles');

--- a/packages/lego-bricks/src/components/Card/index.tsx
+++ b/packages/lego-bricks/src/components/Card/index.tsx
@@ -1,4 +1,5 @@
 import cx from 'classnames';
+import { CircleAlert, CircleCheck, Info, TriangleAlert } from 'lucide-react';
 import { Icon } from '../Icon';
 import Flex from '../Layout/Flex';
 import { Skeleton } from '../Skeleton';
@@ -26,20 +27,18 @@ const CardContent = ({ children, severity }: CardContentProps) => {
 
   switch (severity) {
     case 'danger':
-      icon = <Icon name="alert-circle-outline" className={styles.dangerIcon} />;
+      icon = <Icon iconNode={<CircleAlert />} className={styles.dangerIcon} />;
       break;
     case 'info':
-      icon = (
-        <Icon name="information-circle-outline" className={styles.infoIcon} />
-      );
+      icon = <Icon iconNode={<Info />} className={styles.infoIcon} />;
       break;
     case 'success':
-      icon = (
-        <Icon name="checkmark-circle-outline" className={styles.successIcon} />
-      );
+      icon = <Icon iconNode={<CircleCheck />} className={styles.successIcon} />;
       break;
     case 'warning':
-      icon = <Icon name="warning-outline" className={styles.warningIcon} />;
+      icon = (
+        <Icon iconNode={<TriangleAlert />} className={styles.warningIcon} />
+      );
       break;
   }
 

--- a/packages/lego-bricks/src/components/Layout/Page/Sidebar.tsx
+++ b/packages/lego-bricks/src/components/Layout/Page/Sidebar.tsx
@@ -1,4 +1,5 @@
 import cx from 'classnames';
+import { X } from 'lucide-react';
 import { createContext, useContext } from 'react';
 import { Button } from '../../Button';
 import { Icon } from '../../Icon';
@@ -16,7 +17,9 @@ type Props = {
 
 export const Sidebar = ({ title, close, className, children }: Props) => (
   <Flex className={cx(styles.sidebar, className)} column>
-    {close && <Icon name="close" className={styles.close} onClick={close} />}
+    {close && (
+      <Icon iconNode={<X />} className={styles.close} onClick={close} />
+    )}
     {title && <h2 className={styles.title}>{title}</h2>}
     {children}
   </Flex>

--- a/packages/lego-bricks/src/components/Modal/Modal.tsx
+++ b/packages/lego-bricks/src/components/Modal/Modal.tsx
@@ -1,4 +1,5 @@
 import cx from 'classnames';
+import { X } from 'lucide-react';
 import {
   Dialog,
   Heading,
@@ -76,7 +77,7 @@ const Modal = ({
                 </Heading>
               )}
               <Icon
-                name="close"
+                iconNode={<X />}
                 onClick={close}
                 className={styles.closeButton}
                 data-test-id="Modal__closeButton"


### PR DESCRIPTION
# Description

Slowly getting there

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

Not really any major changes

<table>
    <tr>
		<td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
		<td />
        <td>
            <img width="170" alt="image" src="https://github.com/user-attachments/assets/ebf41b67-5959-496a-8c2f-56a1bc8561f6">
        </td>
        <td>
            <img width="170" alt="image" src="https://github.com/user-attachments/assets/7faf5bfa-403c-499d-82f7-636a68f4cddc"> 
		</td>
    </tr>
    <tr>
		<td>Removed ui glitch for when loggedIn is true, but currentUser is undefined (for a split second)</td>
        <td>
            <img width="226" alt="image" src="https://github.com/user-attachments/assets/98041a3d-787d-4426-b475-cae2ac051637">
        </td>
        <td>
            <img width="226" alt="image" src="https://github.com/user-attachments/assets/1716f1c4-eab8-4832-81d5-5ac5fb86b2fd">
		</td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

They work