### PR TITLE
Fix bad spacing on event details

### DIFF
--- a/app/components/UserAttendance/Attendance.tsx
+++ b/app/components/UserAttendance/Attendance.tsx
@@ -44,20 +44,20 @@ const Attendance = ({
   return (
     <>
       {!isMeeting && (
-        <UserGrid
-          minRows={minUserGridRows}
-          maxRows={maxUserGridRows}
-          users={registrations?.slice(0, 14).map((reg) => reg.user)}
-          skeleton={skeleton}
-        />
-      )}
-      {!isMeeting && (
-        <RegisteredSummary
-          registrations={loggedIn ? registrations : undefined}
-          currentRegistration={currentRegistration}
-          skeleton={skeleton}
-          openModalTab={openModalTab}
-        />
+        <>
+          <UserGrid
+            minRows={minUserGridRows}
+            maxRows={maxUserGridRows}
+            users={registrations?.slice(0, 14).map((reg) => reg.user)}
+            skeleton={skeleton}
+          />
+          <RegisteredSummary
+            registrations={loggedIn ? registrations : undefined}
+            currentRegistration={currentRegistration}
+            skeleton={skeleton}
+            openModalTab={openModalTab}
+          />
+        </>
       )}
       <AttendanceStatus
         pools={pools}

--- a/app/routes/events/components/EventDetail/EventDetail.css
+++ b/app/routes/events/components/EventDetail/EventDetail.css
@@ -32,7 +32,7 @@
 }
 
 .line {
-  margin: 18px 0;
+  margin: var(--spacing-sm) 0;
   background-color: var(--border-gray);
   height: 1px;
 }

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -531,35 +531,39 @@ const EventDetail = () => {
           {['OPEN', 'TBA'].includes(event.eventStatusType) ? (
             <JoinEventForm event={event} />
           ) : (
-            <Flex column>
-              <h3>Påmeldte</h3>
+            <>
+              <Flex column>
+                <h3>Påmeldte</h3>
 
-              <Attendance
-                pools={pools}
-                registrations={registrations}
-                currentRegistration={currentRegistration}
-                minUserGridRows={minUserGridRows}
-                maxUserGridRows={MAX_USER_GRID_ROWS}
-                legacyRegistrationCount={event.legacyRegistrationCount}
-                skeleton={fetching && !registrations}
-              />
-
-              {loggedIn && (
-                <RegistrationMeta
-                  useConsent={event.useConsent}
-                  hasOpened={moment(event.activationTime).isBefore(
-                    currentMoment,
-                  )}
-                  photoConsents={event.photoConsents}
-                  eventSemester={getEventSemesterFromStartTime(event.startTime)}
-                  hasEnded={moment(event.endTime).isBefore(currentMoment)}
-                  registration={currentRegistration}
-                  isPriced={event.isPriced}
-                  registrationIndex={currentRegistrationIndex}
-                  hasSimpleWaitingList={hasSimpleWaitingList}
-                  skeleton={showSkeleton}
+                <Attendance
+                  pools={pools}
+                  registrations={registrations}
+                  currentRegistration={currentRegistration}
+                  minUserGridRows={minUserGridRows}
+                  maxUserGridRows={MAX_USER_GRID_ROWS}
+                  legacyRegistrationCount={event.legacyRegistrationCount}
+                  skeleton={fetching && !registrations}
                 />
-              )}
+
+                {loggedIn && (
+                  <RegistrationMeta
+                    useConsent={event.useConsent}
+                    hasOpened={moment(event.activationTime).isBefore(
+                      currentMoment,
+                    )}
+                    photoConsents={event.photoConsents}
+                    eventSemester={getEventSemesterFromStartTime(
+                      event.startTime,
+                    )}
+                    hasEnded={moment(event.endTime).isBefore(currentMoment)}
+                    registration={currentRegistration}
+                    isPriced={event.isPriced}
+                    registrationIndex={currentRegistrationIndex}
+                    hasSimpleWaitingList={hasSimpleWaitingList}
+                    skeleton={showSkeleton}
+                  />
+                )}
+              </Flex>
 
               {'unansweredSurveys' in event &&
               event.unansweredSurveys?.length > 0 &&
@@ -589,7 +593,7 @@ const EventDetail = () => {
                   />
                 )
               )}
-            </Flex>
+            </>
           )}
 
           {showSkeleton ? (

--- a/app/routes/events/components/Registrations.css
+++ b/app/routes/events/components/Registrations.css
@@ -3,7 +3,7 @@
 .summary {
   white-space: pre;
   color: var(--secondary-font-color);
-  margin-top: 10px;
+  margin-top: var(--spacing-sm);
 
   > * {
     min-height: var(--spacing-lg);


### PR DESCRIPTION
# Description

kind of subtle, but annoying

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="303" alt="image" src="https://github.com/user-attachments/assets/5d088b10-afeb-4f09-9072-3d7016279a37">
        </td>
        <td>
            <img width="303" alt="image" src="https://github.com/user-attachments/assets/8e1859d3-ce42-45ba-8d86-aac74c244d54">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See image above.