### PR TITLE
Improve contact info on joblistings

### DIFF
--- a/app/components/Header/Navbar/ItemList.tsx
+++ b/app/components/Header/Navbar/ItemList.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 const ItemList = ({ items }: Props) => {
   return (
-    <Flex column={true}>
+    <Flex column>
       {items.map((item) => (
         <Item
           key={item.title}

--- a/app/components/InfoList/styles.css
+++ b/app/components/InfoList/styles.css
@@ -1,4 +1,8 @@
 .value {
-  font-weight: 600;
+  font-weight: 500;
   text-align: right;
+  max-width: 66%;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: break-word;
 }

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -57,6 +57,13 @@ const propertyGenerator: PropertyGenerator<{
   ];
 };
 
+const MailWrapper = ({ mail }: { mail: string }) => (
+  <a href={`mailto:${mail}`}>
+    {mail.split('@')[0]}
+    <wbr />@{mail.split('@')[1]}
+  </a>
+);
+
 const NotGiven = () => <span className="secondaryFontColor">Ikke oppgitt</span>;
 
 const JoblistingDetail = () => {
@@ -183,7 +190,7 @@ const JoblistingDetail = () => {
                     items={[
                       {
                         key: 'E-post',
-                        value: joblisting.contactMail,
+                        value: <MailWrapper mail={joblisting.contactMail} />,
                       },
                     ]}
                   />
@@ -200,9 +207,7 @@ const JoblistingDetail = () => {
                         {
                           key: 'E-post',
                           value: joblisting.responsible.mail ? (
-                            <a href={`mailto:${joblisting.responsible.mail}`}>
-                              {joblisting.responsible.mail}
-                            </a>
+                            <MailWrapper mail={joblisting.responsible.mail} />
                           ) : (
                             <NotGiven />
                           ),

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -89,6 +89,10 @@ const JoblistingDetail = () => {
   const canEdit = actionGrant.includes('edit');
   const canDelete = actionGrant.includes('delete');
 
+  const showContactMail =
+    joblisting.contactMail &&
+    joblisting.contactMail !== joblisting.responsible?.mail;
+
   return (
     <Page
       cover={
@@ -174,7 +178,7 @@ const JoblistingDetail = () => {
             <div>
               <h3>Kontaktinfo</h3>
               <Flex column gap="var(--spacing-sm)">
-                {joblisting.contactMail && (
+                {showContactMail && (
                   <InfoList
                     items={[
                       {
@@ -186,7 +190,7 @@ const JoblistingDetail = () => {
                 )}
                 {joblisting.responsible && (
                   <div>
-                    <h4>Kontaktperson</h4>
+                    {showContactMail && <h4>Kontaktperson</h4>}
                     <InfoList
                       items={[
                         {

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   ButtonGroup,
   ConfirmModal,
-  Flex,
   Icon,
   LinkButton,
   Page,
@@ -302,12 +301,14 @@ const JoblistingEditor = () => {
               label="Søknadslenke"
               name="applicationUrl"
               component={TextInput.Field}
+              parse={(value) => value}
             />
             <Field
               name="contactMail"
               placeholder="E-post"
-              label="Søknadsmail eller kontaktmail"
+              label="Søknads- eller kontakt-e-post"
               component={TextInput.Field}
+              parse={(value) => value}
             />
             <Field
               name="responsible"
@@ -315,15 +316,15 @@ const JoblistingEditor = () => {
               label="Kontaktperson"
               options={responsibleOptions}
               component={SelectInput.Field}
+              isClearable
             />
-            <Flex>
-              <Field
-                name="youtubeUrl"
-                label="YouTube-video som cover"
-                placeholder="https://www.youtube.com/watch?v=bLHL75H_VEM&t=5"
-                component={TextInput.Field}
-              />
-            </Flex>
+            <Field
+              name="youtubeUrl"
+              label="YouTube-video som cover"
+              placeholder="https://www.youtube.com/watch?v=bLHL75H_VEM&t=5"
+              component={TextInput.Field}
+              parse={(value) => value}
+            />
             <Field
               name="description"
               className={styles.descriptionField}


### PR DESCRIPTION
# Description

* Check for duplicate mails
* Turn contact mail into an anchor element
* Wrap mails on @ for readability
* Only show "Kontaktperson" sub header if needed
* Better widths, wrappings and look
* Let editor fields be clearable

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
		<td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
		<td>Duplicate mails</td>
        <td>
            <img width="376" alt="image" src="https://github.com/user-attachments/assets/c8a462f0-d13c-4104-bc53-a96c8530b546">
        </td>
        <td>
            <img width="370" alt="image" src="https://github.com/user-attachments/assets/5b187f82-8cf5-4d25-b36e-ddf9c1f577b6">
        </td>
    </tr>
    <tr>
		<td>
				<p>Different mails</p>
				<div>Notice that the first contact mail is not wrapping on "@", since it's not needed
		</td>
        <td>
            <img width="376" alt="image" src="https://github.com/user-attachments/assets/20d00d8f-544e-4787-a560-cc940c28b52e">
        </td>
        <td>
            <img width="376" alt="image" src="https://github.com/user-attachments/assets/bb8b8270-e479-4981-86f6-27228fdedbf5">
        </td>
    </tr>
</table>


# Testing

- [x] I have thoroughly tested my changes.

See images above