### PR TITLE
Fix bad field widths

### DIFF
--- a/app/components/Form/Field.css
+++ b/app/components/Form/Field.css
@@ -1,5 +1,9 @@
 @import url('~app/styles/variables.css');
 
+.field {
+  width: 100%;
+}
+
 .field:not(.withoutMargin) {
   margin-bottom: var(--spacing-md);
 }

--- a/app/routes/admin/groups/components/GroupForm/index.css
+++ b/app/routes/admin/groups/components/GroupForm/index.css
@@ -1,6 +1,0 @@
-.logo {
-  width: 400px;
-  height: 400px;
-  min-width: 200px;
-  min-height: 200px;
-}

--- a/app/routes/admin/groups/components/GroupForm/index.tsx
+++ b/app/routes/admin/groups/components/GroupForm/index.tsx
@@ -17,7 +17,6 @@ import { selectGroupById } from 'app/reducers/groups';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { EDITOR_EMPTY } from 'app/utils/constants';
 import { createValidator, required } from 'app/utils/validation';
-import styles from './index.css';
 import type { GroupPageParams } from 'app/routes/admin/groups/components/GroupPage';
 import type { DetailedGroup } from 'app/store/models/Group';
 
@@ -133,7 +132,6 @@ const GroupForm = ({ isInterestGroup }: Props) => {
             label="Gruppelogo"
             aspectRatio={1}
             img={group && group.logo}
-            className={styles.logo}
             required={isInterestGroup}
           />
 


### PR DESCRIPTION
# Description

Two seperat fixes

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="1093" alt="image" src="https://github.com/user-attachments/assets/54ad6f67-41c9-429e-817f-51ec0bf8e207">
        </td>
        <td>
            <img width="1093" alt="image" src="https://github.com/user-attachments/assets/744689ce-3389-4452-a511-46e929e631b1">
        </td>
    </tr>
    <tr>
        <td>
            <img width="1163" alt="image" src="https://github.com/user-attachments/assets/e7b9b6a3-1934-4a2d-b60f-6f5d80e31516">
        </td>
        <td>
			<img width="1163" alt="image" src="https://github.com/user-attachments/assets/8e8d543d-17b9-4ea1-875f-059813ce42b7">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above. Tested with ssr

---

Resolves ABA-1010
