### PR TITLE
Fix z-index issue on registration warning

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -93,6 +93,7 @@
 
 .dropdown {
   width: 355px;
+  z-index: 10;
   padding: var(--spacing-md);
 
   @media (--small-viewport) {


### PR DESCRIPTION
# Description

oops

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="446" alt="image" src="https://github.com/user-attachments/assets/ca0a36c7-7ded-432e-ab97-1fe7f721c509">
        </td>
        <td>
            <img width="446" alt="image" src="https://github.com/user-attachments/assets/19336358-3a15-4810-8015-fe3edc8544c7">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above.