### PR TITLE
Fix bug in table filtering breaking group member list

### DIFF
--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -150,7 +150,7 @@ const Table = <T extends { id: EntityId }>({
         filterIndex,
       } = columns.find(
         (column) => column.filterIndex === key || column.dataIndex === key,
-      ) || {};
+      ) || { inlineFiltering: false };
 
       if (!inlineFiltering) return true;
 

--- a/app/routes/admin/groups/components/GroupMembers.tsx
+++ b/app/routes/admin/groups/components/GroupMembers.tsx
@@ -3,14 +3,16 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { fetchMembershipsPagination } from 'app/actions/GroupActions';
-import { selectGroupEntities } from 'app/reducers/groups';
+import { selectGroupById } from 'app/reducers/groups';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
 import { selectPaginationNext } from 'app/reducers/selectors';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import { EntityType } from 'app/store/models/entities';
 import useQuery from 'app/utils/useQuery';
 import AddGroupMember from './AddGroupMember';
 import GroupMembersList from './GroupMembersList';
 import type { GroupPageParams } from 'app/routes/admin/groups/components/GroupPage';
+import type { DetailedGroup } from 'app/store/models/Group';
 
 export const defaultGroupMembersQuery = {
   descendants: 'false' as 'false' | 'true',
@@ -27,7 +29,7 @@ const GroupMembers = () => {
   const { pagination } = useAppSelector((state) =>
     selectPaginationNext({
       endpoint: `/groups/${groupId}/memberships/`,
-      entity: 'memberships',
+      entity: EntityType.Memberships,
       query,
     })(state),
   );
@@ -40,7 +42,9 @@ const GroupMembers = () => {
     }),
   );
 
-  const groupEntities = useAppSelector(selectGroupEntities);
+  const group = useAppSelector((state) =>
+    selectGroupById<DetailedGroup>(state, groupId),
+  );
   const hasMore = pagination.hasMore;
 
   const dispatch = useAppDispatch();
@@ -66,10 +70,7 @@ const GroupMembers = () => {
 
   return (
     <>
-      <>
-        Antall medlemmer (inkl. undergrupper):{' '}
-        {groupEntities[groupId?.toString()]?.numberOfUsers}
-      </>
+      <>Antall medlemmer (inkl. undergrupper): {group?.numberOfUsers}</>
 
       {showDescendants || (
         <AddGroupMember
@@ -83,7 +84,6 @@ const GroupMembers = () => {
         <GroupMembersList
           key={Number(groupId) + Number(showDescendants)}
           hasMore={hasMore}
-          groupsById={groupEntities}
           fetching={pagination.fetching}
           memberships={memberships}
           fetchMemberships={fetchMemberships}


### PR DESCRIPTION
# Description

The problem was that the Table-component was filtering on all the things that were passed in through the `filters`-prop. This may sound correct, but I think we only want it to filter on the ones that are also defined as columns in the table. These are the ones with filters in the table UI.

I think this is the best way to do it, as we often pass all query parameters to the table filters even though not all of them should directly filter the table contents.

# Result

Group members now appear.

# Testing

- [x] I have thoroughly tested my changes.

The filters on group member list page now works as intended, and I also tested some filtering in BDB to ensure I didn't break that.

---

Resolves ABA-1008
