### PR TITLE
Replace a bunch of ionicons with lucide

### DIFF
--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -93,7 +93,6 @@ const TimeStartAndRegistration = ({ event }: TimeStampProps) => {
       {!!event.activationTime && (
         <Flex alignItems="center" gap="var(--spacing-sm)">
           <Tooltip content="Påmelding åpner">
-            <Icon name="alarm-outline" size={20} />
             <Icon iconNode={<AlarmClock />} size={18} />
           </Tooltip>
           <Time time={event.activationTime} format="ll HH:mm" />

--- a/app/components/TextWithIcon/TextWithIcon.css
+++ b/app/components/TextWithIcon/TextWithIcon.css
@@ -1,6 +1,6 @@
 .infoIcon {
   justify-content: center;
-  padding-right: 0.2em;
+  margin-right: var(--spacing-xs);
 }
 
 .textContainer {

--- a/app/components/TextWithIcon/index.tsx
+++ b/app/components/TextWithIcon/index.tsx
@@ -11,7 +11,7 @@ export type TextWithIconProps = {
   tooltipContentIcon?: ReactElement;
   iconRight?: boolean;
   size?: number;
-  gap?: number;
+  gap?: number | string;
 };
 
 const TextWithIcon = ({
@@ -22,7 +22,7 @@ const TextWithIcon = ({
   tooltipContentIcon,
   iconRight = false,
   size,
-  gap = 5,
+  gap = 'var(--spacing-sm)',
 }: TextWithIconProps) => {
   const icon = (
     <Icon

--- a/app/components/UserValidator/Validator.css
+++ b/app/components/UserValidator/Validator.css
@@ -7,9 +7,3 @@
 .scannerButton {
   margin-bottom: var(--spacing-md);
 }
-
-.qrIcon {
-  display: flex;
-  align-items: center;
-  margin-right: 0.2rem;
-}

--- a/app/components/UserValidator/index.tsx
+++ b/app/components/UserValidator/index.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex, Icon, Modal } from '@webkom/lego-bricks';
 import { get, debounce } from 'lodash';
+import { ScanQrCode } from 'lucide-react';
 import { useCallback, useRef, useState, type ComponentProps } from 'react';
 import { QrReader } from 'react-qr-reader';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -226,7 +227,7 @@ const Validator = ({ handleSelect, validateAbakusGroup }: Props) => {
         className={styles.scannerButton}
         onPress={() => setShowScanner(true)}
       >
-        <Icon className={styles.qrIcon} name="scan-outline" size={18} />
+        <Icon iconNode={<ScanQrCode />} size={19} />
         Åpne scanner
       </Button>
       <SearchPage<UserSearchResult>

--- a/app/routes/admin/email/components/RestrictedMailEditor.tsx
+++ b/app/routes/admin/email/components/RestrictedMailEditor.tsx
@@ -1,5 +1,6 @@
 import { Icon, LinkButton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { Download } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -225,7 +226,7 @@ const RestrictedMailEditor = () => {
               href={`${config.serverUrl}/restricted-mail/${restrictedMailId}/token?auth=${restrictedMail.tokenQueryParam}`}
               download
             >
-              <Icon name="download-outline" size={19} />
+              <Icon iconNode={<Download />} size={19} />
               Last ned e-post token
             </LinkButton>
           )}

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -146,6 +146,7 @@ const ArticleEditor = () => {
   return (
     <Page
       title={title}
+      skeleton={fetching}
       back={{
         href: `/articles/${isNew ? '' : articleId}`,
       }}

--- a/app/routes/bdb/components/CompanyContactEditor.tsx
+++ b/app/routes/bdb/components/CompanyContactEditor.tsx
@@ -83,7 +83,11 @@ const CompanyContactEditor = () => {
     : `Redigerer: Bedriftskontakt for ${company.name}`;
 
   return (
-    <Page title={title} back={{ href: `/bdb/${company.id}` }}>
+    <Page
+      title={title}
+      skeleton={fetching}
+      back={{ href: `/bdb/${company.id}` }}
+    >
       <TypedLegoForm
         onSubmit={onSubmit}
         initialValues={initialValues}

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -142,6 +142,7 @@ const CompanyEditor = () => {
   return (
     <Page
       title={title}
+      skeleton={fetching}
       back={{ href: backUrl }}
       actionButtons={
         !isNew && (

--- a/app/routes/bdb/components/SemesterStatusContent.tsx
+++ b/app/routes/bdb/components/SemesterStatusContent.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@webkom/lego-bricks';
+import { Check } from 'lucide-react';
 import { useState } from 'react';
 import Circle from 'app/components/Circle';
 import Dropdown from 'app/components/Dropdown';
@@ -69,7 +70,7 @@ const SemesterStatusContent = ({
                 >
                   {getStatusDisplayName(status)}
                   {active ? (
-                    <Icon name="checkmark" />
+                    <Icon iconNode={<Check />} />
                   ) : (
                     <Circle color={getStatusColor(status)} size={20} />
                   )}

--- a/app/routes/brand/components/BrandPage.tsx
+++ b/app/routes/brand/components/BrandPage.tsx
@@ -1,4 +1,5 @@
 import { Flex, Icon, LinkButton, Image, Page } from '@webkom/lego-bricks';
+import { Download } from 'lucide-react';
 import logosDonts from 'app/assets/logos-donts.png';
 import logosDos from 'app/assets/logos-dos.png';
 import styles from './BrandPage.css';
@@ -87,7 +88,7 @@ const BrandPage = () => (
             href="https://github.com/abakus-ntnu/grafisk-profil/archive/master.zip"
             download="proposed_file_name"
           >
-            <Icon name="download-outline" size={19} />
+            <Icon iconNode={<Download />} size={19} />
             Last ned
           </LinkButton>
           <h2 className={styles.h2Padding}>Abakusfarger</h2>
@@ -107,7 +108,7 @@ const BrandPage = () => (
             href="https://github.com/abakus-ntnu/grafisk-profil/blob/master/maler/Abakus%20-%20Presentasjonsmal.pptx?raw=true"
             download="proposed_file_name"
           >
-            <Icon name="download-outline" size={19} />
+            <Icon iconNode={<Download />} size={19} />
             Last ned
           </LinkButton>
         </div>

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -7,7 +7,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Trash2 } from 'lucide-react';
+import { FileDown, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchSemesters } from 'app/actions/CompanyActions';
@@ -258,7 +258,7 @@ const CompanyInterestList = () => {
               href={generatedCSV.url}
               download={generatedCSV.filename}
             >
-              <Icon name="download-outline" size={19} />
+              <Icon iconNode={<FileDown />} size={19} />
               Last ned CSV
             </LinkButton>
           ) : (

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -1,6 +1,7 @@
 import { Card, Flex, Icon, LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import arrayMutators from 'final-form-arrays';
+import { Info } from 'lucide-react';
 import { Field, FormSpy } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
@@ -624,7 +625,7 @@ const CompanyInterestPage = () => {
                         </span>
                       }
                     >
-                      <Icon name="information-circle-outline" size={20} />
+                      <Icon iconNode={<Info />} size={20} />
                     </Tooltip>
                   </Flex>
                 </label>

--- a/app/routes/events/components/Admin.tsx
+++ b/app/routes/events/components/Admin.tsx
@@ -5,7 +5,14 @@ import {
   Icon,
   LinkButton,
 } from '@webkom/lego-bricks';
-import { Pencil, Trash2 } from 'lucide-react';
+import {
+  Copy,
+  UserCog,
+  FilePieChart,
+  Pencil,
+  Trash2,
+  Contact,
+} from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -88,7 +95,7 @@ const Admin = ({ actionGrant, event }: Props) => {
 
   return (
     (canEdit || canDelete) && (
-      <>
+      <div>
         <h3>Admin</h3>
 
         <ButtonGroup vertical>
@@ -97,15 +104,15 @@ const Admin = ({ actionGrant, event }: Props) => {
               success
               href={`/events/${event.id}/administrate/abacard`}
             >
-              <Icon name="id-card" size={19} />
+              <Icon iconNode={<Contact />} size={19} />
               Registrer oppmøte
             </LinkButton>
           )}
 
           {canEdit && (
             <LinkButton href={`/events/${event.id}/administrate/attendees`}>
-              <Icon name="people-outline" size={19} />
-              Se påmeldinger
+              <Icon iconNode={<UserCog />} size={19} />
+              Administrer
             </LinkButton>
           )}
 
@@ -120,24 +127,24 @@ const Admin = ({ actionGrant, event }: Props) => {
 
           {event.survey ? (
             <LinkButton href={`/surveys/${event.survey}`}>
-              <Icon name="clipboard-outline" size={19} />
+              <Icon iconNode={<FilePieChart />} size={19} />
               Gå til spørreundersøkelse
             </LinkButton>
           ) : (
             <LinkButton href={`/surveys/add/?event=${event.id}`}>
-              <Icon name="clipboard-outline" size={19} />
+              <Icon iconNode={<FilePieChart />} size={19} />
               Lag spørreundersøkelse
             </LinkButton>
           )}
 
           <LinkButton href="/events/create" state={{ id: event.id }}>
-            <Icon name="copy-outline" size={19} />
+            <Icon iconNode={<Copy />} size={19} />
             Lag kopi av arrangement
           </LinkButton>
 
           {canDelete && <DeleteButton eventId={event.id} title={event.title} />}
         </ButtonGroup>
-      </>
+      </div>
     )
   );
 };

--- a/app/routes/events/components/EventAdministrate/Allergies.tsx
+++ b/app/routes/events/components/EventAdministrate/Allergies.tsx
@@ -1,6 +1,7 @@
 import { Flex, Icon, LinkButton, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty } from 'lodash';
+import { FileDown } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
 import { fetchAllergies } from 'app/actions/EventActions';
 import EmptyState from 'app/components/EmptyState';
@@ -30,7 +31,7 @@ export const canSeeAllergies = (
 const Allergies = () => {
   const { eventId } = useParams<{ eventId: string }>();
   const event = useAppSelector((state) =>
-    selectEventById(state, { eventId }),
+    eventId ? selectEventById(state, { eventId }) : undefined,
   ) as AdministrateEvent;
   const { registered } = useAppSelector((state) =>
     getRegistrationGroups(state, {
@@ -124,7 +125,15 @@ const Allergies = () => {
 
   return (
     <>
-      <Flex column>
+      <Flex column gap="var(--spacing-md)">
+        <LinkButton
+          href={allergiesTXT}
+          download={'allergier_' + event.title.replaceAll(' ', '_') + '.txt'}
+        >
+          <Icon iconNode={<FileDown />} size={19} />
+          Last ned allergier som tekstfil
+        </LinkButton>
+
         {registeredAllergies.length === 0 && !fetching ? (
           <EmptyState body="Ingen påmeldte med allergier" />
         ) : (
@@ -135,15 +144,6 @@ const Allergies = () => {
             data={registeredAllergies}
           />
         )}
-      </Flex>
-      <br></br>
-      <Flex justifyContent="space-between">
-        <LinkButton
-          href={allergiesTXT}
-          download={'allergier_' + event.title.replaceAll(' ', '_') + '.txt'}
-        >
-          <Icon name="download-outline" /> Last ned allergier som tekstfil
-        </LinkButton>
       </Flex>
     </>
   );

--- a/app/routes/events/components/EventAdministrate/index.tsx
+++ b/app/routes/events/components/EventAdministrate/index.tsx
@@ -12,6 +12,7 @@ import { canSeeAllergies } from 'app/routes/events/components/EventAdministrate/
 import pageNotFound from 'app/routes/pageNotFound';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
+import type { AdministrateEvent } from 'app/store/models/Event';
 
 const Statistics = loadable(() => import('./Statistics'));
 const Attendees = loadable(() => import('./Attendees'));
@@ -21,7 +22,9 @@ const Abacard = loadable(() => import('./Abacard'));
 
 const EventAdministrateIndex = () => {
   const { eventId } = useParams<{ eventId: string }>();
-  const event = useAppSelector((state) => selectEventById(state, { eventId }));
+  const event = useAppSelector((state) =>
+    eventId ? selectEventById(state, { eventId }) : undefined,
+  ) as AdministrateEvent | undefined;
   const fetching = useAppSelector((state) => state.events.fetching);
   const currentUser = useCurrentUser();
 
@@ -35,9 +38,11 @@ const EventAdministrateIndex = () => {
 
   const base = `/events/${eventId}/administrate`;
 
+  const title = event?.title ? `Administrerer: ${event.title}` : 'Administrer';
+
   return (
     <Page
-      title={`Administrerer: ${event.title}`}
+      title={title}
       back={
         event?.slug && {
           label: 'Tilbake til arrangement',
@@ -67,7 +72,7 @@ const EventAdministrateIndex = () => {
       }
       skeleton={fetching}
     >
-      <Helmet title={`Administrer: ${event.title}`} />
+      <Helmet title={title} />
       <Outlet />
     </Page>
   );

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -1,7 +1,16 @@
 import { Button, Card, Flex, Icon, Page, Skeleton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty } from 'lodash';
-import { FilePenLine, Star } from 'lucide-react';
+import {
+  BriefcaseBusiness,
+  CircleHelp,
+  Clock,
+  Coins,
+  FilePenLine,
+  Languages,
+  MapPin,
+  Star,
+} from 'lucide-react';
 import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
@@ -276,7 +285,7 @@ const EventDetail = () => {
           key: 'Frist for prikk',
           keyNode: (
             <TextWithIcon
-              iconName="help-circle-outline"
+              iconNode={<CircleHelp />}
               content="Frist for prikk"
               tooltipContentIcon={
                 <>
@@ -288,7 +297,7 @@ const EventDetail = () => {
                 </>
               }
               iconRight
-              size={16}
+              size={14}
             />
           ),
           value: (
@@ -304,7 +313,7 @@ const EventDetail = () => {
           key: 'Frist for av/påmelding',
           keyNode: (
             <TextWithIcon
-              iconName="help-circle-outline"
+              iconNode={<CircleHelp />}
               content={
                 currentMoment.isBefore(registrationCloseTimeMoment)
                   ? 'Påmelding stenger'
@@ -317,7 +326,7 @@ const EventDetail = () => {
                 </>
               }
               iconRight
-              size={16}
+              size={14}
             />
           ),
           value: (
@@ -468,7 +477,8 @@ const EventDetail = () => {
             <Flex column gap="var(--spacing-sm)">
               {event.company && (
                 <TextWithIcon
-                  iconName="briefcase-outline"
+                  iconNode={<BriefcaseBusiness />}
+                  size={20}
                   content={
                     <Link to={`/companies/${event.company.id}`}>
                       {event.company.name}
@@ -479,7 +489,8 @@ const EventDetail = () => {
               )}
 
               <TextWithIcon
-                iconName="time-outline"
+                iconNode={<Clock />}
+                size={20}
                 content={
                   <FromToTime from={event.startTime} to={event.endTime} />
                 }
@@ -488,14 +499,16 @@ const EventDetail = () => {
 
               {event.isForeignLanguage !== null && event.isForeignLanguage && (
                 <TextWithIcon
-                  iconName="language-outline"
+                  iconNode={<Languages />}
+                  size={20}
                   content="English"
                   className={styles.sidebarInfo}
                 />
               )}
 
               <TextWithIcon
-                iconName="location-outline"
+                iconNode={<MapPin />}
+                size={20}
                 content={event.location}
                 className={styles.sidebarInfo}
               />
@@ -516,7 +529,8 @@ const EventDetail = () => {
 
               {event.isPriced && (
                 <TextWithIcon
-                  iconName="cash-outline"
+                  iconNode={<Coins />}
+                  size={20}
                   content={event.priceMember / 100 + ',-'}
                   className={styles.sidebarInfo}
                 />

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -315,6 +315,7 @@ const EventEditor = () => {
   return (
     <Page
       title={title}
+      skeleton={fetching}
       back={{
         href: isEditPage ? `/events/${event.slug}` : '/events',
       }}

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -8,6 +8,7 @@ import {
   ProgressBar,
 } from '@webkom/lego-bricks';
 import { sumBy } from 'lodash';
+import { Info, UserMinus } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useEffect } from 'react';
 import { Field } from 'react-final-form';
@@ -88,7 +89,7 @@ const SubmitButton = ({
     >
       {({ openConfirmModal }) => (
         <Button danger onPress={openConfirmModal} disabled={disabled}>
-          <Icon name="person-remove" size={19} />
+          <Icon iconNode={<UserMinus />} size={19} />
           {title}
         </Button>
       )}
@@ -131,7 +132,7 @@ const RegistrationPending = ({
           </span>
         }
       >
-        <Icon name="information-circle-outline" size={20} />
+        <Icon iconNode={<Info />} size={20} />
       </Tooltip>
     </p>
     <ProgressBar />

--- a/app/routes/forum/components/ForumEditor.tsx
+++ b/app/routes/forum/components/ForumEditor.tsx
@@ -43,6 +43,7 @@ const ForumEditor = () => {
   const forum = useAppSelector((state) =>
     isNew ? undefined : (selectForumById(state, forumId) as DetailedForum),
   );
+  const fetching = useAppSelector((state) => state.forums.fetching);
 
   const dispatch = useAppDispatch();
 
@@ -79,6 +80,7 @@ const ForumEditor = () => {
   return (
     <Page
       title={isNew ? 'Nytt forum' : `Redigerer: ${forum?.title}`}
+      skeleton={fetching}
       back={{ href: forum ? `/forum/${forum.id}/threads` : '/forum' }}
     >
       <LegoFinalForm onSubmit={onSubmit} initialValues={initialValues}>

--- a/app/routes/forum/components/ThreadEditor.tsx
+++ b/app/routes/forum/components/ThreadEditor.tsx
@@ -49,6 +49,7 @@ const ThreadEditor = () => {
   const thread = useAppSelector((state) =>
     isNew ? undefined : (selectThreadById(state, threadId) as DetailedThread),
   );
+  const fetching = useAppSelector((state) => state.threads.fetching);
 
   const dispatch = useAppDispatch();
 
@@ -89,6 +90,7 @@ const ThreadEditor = () => {
   return (
     <Page
       title={isNew ? 'Ny tråd' : `Redigerer: ${thread?.title}`}
+      skeleton={fetching}
       back={{
         href: thread
           ? `/forum/${forumId}/threads/${thread.id}`

--- a/app/routes/frontpage/components/UpcomingRegistrations.tsx
+++ b/app/routes/frontpage/components/UpcomingRegistrations.tsx
@@ -1,5 +1,5 @@
 import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
-import { Leaf } from 'lucide-react';
+import { AlarmClock, Leaf } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -60,7 +60,7 @@ const UpcomingRegistration = ({ event }: Props) => {
           gap="var(--spacing-sm)"
           className={styles.info}
         >
-          <Icon name="alarm-outline" size={20} />
+          <Icon iconNode={<AlarmClock />} size={20} />
           <div>
             <span>
               Påmelding

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -87,6 +87,7 @@ const JoblistingEditor = () => {
   const joblisting = useAppSelector((state) =>
     selectJoblistingById<DetailedJoblisting>(state, joblistingId),
   );
+  const fetching = useAppSelector((state) => state.joblistings.fetching);
 
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -210,6 +211,7 @@ const JoblistingEditor = () => {
   return (
     <Page
       title={title}
+      skeleton={fetching}
       back={{
         href: !isNew ? `/joblistings/${joblisting?.slug}` : '/joblistings',
       }}

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -122,6 +122,7 @@ const MeetingEditor = () => {
       ? selectUserById(state, meeting?.reportAuthor)
       : undefined,
   );
+  const fetching = useAppSelector((state) => state.meetings.fetching);
 
   const currentUser = useCurrentUser();
 
@@ -239,6 +240,7 @@ const MeetingEditor = () => {
   return (
     <Page
       title={title}
+      skeleton={fetching}
       back={{
         label: `${isEditPage ? 'Tilbake' : 'Dine møter'}`,
         href: `/meetings/${isEditPage ? meetingId : ''}`,

--- a/app/routes/pages/components/PageEditor.tsx
+++ b/app/routes/pages/components/PageEditor.tsx
@@ -61,6 +61,7 @@ const PageEditor = () => {
   const page = useAppSelector((state) =>
     selectPageById<AuthDetailedPage>(state, pageSlug),
   );
+  const fetching = useAppSelector((state) => state.pages.fetching);
 
   const isNew = pageSlug === undefined;
 
@@ -144,7 +145,7 @@ const PageEditor = () => {
   const title = isNew ? 'Ny side' : `Redigerer: ${page?.title}`;
 
   return (
-    <Page title={title} back={{ href: backUrl }}>
+    <Page title={title} skeleton={fetching} back={{ href: backUrl }}>
       <Helmet title={title} />
       <TypedLegoForm onSubmit={onSubmit} initialValues={initialValues}>
         {({ handleSubmit }) => (

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -6,7 +6,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Images } from 'lucide-react';
+import { ImageDown, ImagePlus, Images, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { fetchGallery, fetchGalleryMetadata } from 'app/actions/GalleryActions';
@@ -178,11 +178,13 @@ const GalleryDetail = () => {
               href={`/photos/${gallery.id}/?upload=true`}
               onPress={() => toggleUpload()}
             >
+              <Icon iconNode={<ImagePlus />} size={19} />
               Last opp bilder
             </LinkButton>
           ),
           actionGrant?.includes('edit') && (
             <LinkButton key="edit" href={`/photos/${gallery.id}/edit`}>
+              <Icon iconNode={<Pencil />} size={19} />
               Rediger
             </LinkButton>
           ),
@@ -191,7 +193,7 @@ const GalleryDetail = () => {
             onPress={downloadGallery}
             isPending={downloading}
           >
-            <Icon name="download-outline" size={19} />
+            <Icon iconNode={<ImageDown />} size={19} />
             Last ned album
           </Button>,
         ]}

--- a/app/routes/photos/components/GalleryEditor.tsx
+++ b/app/routes/photos/components/GalleryEditor.tsx
@@ -267,6 +267,7 @@ const GalleryEditor = () => {
   return (
     <Page
       title={title}
+      skeleton={fetching}
       back={{
         href: `/photos/${gallery?.id ?? ''}`,
       }}

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -1,7 +1,7 @@
 import { Flex, Icon, Modal, Image, LoadingPage } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import throttle from 'lodash/throttle';
-import { Pencil } from 'lucide-react';
+import { Download, Pencil } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useSwipeable, RIGHT, LEFT } from 'react-swipeable';
@@ -312,7 +312,7 @@ const GalleryPictureModal = () => {
                     className={styles.dropdownLink}
                   >
                     Last ned
-                    <Icon name="download-outline" size={24} />
+                    <Icon iconNode={<Download />} size={24} />
                   </a>
                 </Dropdown.ListItem>
                 {actionGrant &&

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -6,7 +6,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import arrayMutators from 'final-form-arrays';
-import { Trash2 } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
@@ -70,7 +70,7 @@ const renderOptions = ({ fields }): ReactNode => (
     </ul>
 
     <Button onPress={() => fields.push({})}>
-      <Icon name="add" size={25} />
+      <Icon iconNode={<Plus />} size={25} />
       Legg til alternativ
     </Button>
   </>

--- a/app/routes/surveys/components/AdminSideBar.tsx
+++ b/app/routes/surveys/components/AdminSideBar.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonGroup, Icon, LinkButton } from '@webkom/lego-bricks';
-import { Pencil } from 'lucide-react';
+import { Check, Copy, FileDown, FileUp, Pencil, Plus } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { hideSurvey, shareSurvey } from 'app/actions/SurveyActions';
 import { ContentSidebar } from 'app/components/Content';
@@ -59,7 +59,7 @@ const AdminSideBar = ({
 
         <ButtonGroup vertical>
           <LinkButton href="/surveys/add">
-            <Icon name="add" size={19} />
+            <Icon iconNode={<Plus />} size={19} />
             Ny undersøkelse
           </LinkButton>
 
@@ -77,14 +77,14 @@ const AdminSideBar = ({
                 href={generatedCSV.url}
                 download={generatedCSV.filename}
               >
-                <Icon name="download-outline" size={19} />
+                <Icon iconNode={<FileDown />} size={19} />
                 Last ned CSV
               </LinkButton>
             ) : (
               <Button
                 onPress={async () => setGeneratedCSV(await exportSurvey())}
               >
-                <Icon name="download-outline" size={19} />
+                <Icon iconNode={<FileUp />} size={19} />
                 Eksporter til CSV
               </Button>
             ))}
@@ -105,7 +105,7 @@ const AdminSideBar = ({
 
         {token && (
           <Button onPress={handleCopyButtonClick} success={copied}>
-            <Icon name={copied ? 'checkmark' : 'copy-outline'} />
+            <Icon iconNode={copied ? <Check /> : <Copy />} size={19} />
             {copied ? 'Kopiert!' : 'Kopier delbar link'}
           </Button>
         )}

--- a/app/routes/surveys/components/SurveyEditor/EditSurveyPage.tsx
+++ b/app/routes/surveys/components/SurveyEditor/EditSurveyPage.tsx
@@ -4,7 +4,7 @@ import { editSurvey } from 'app/actions/SurveyActions';
 import { useFetchedSurvey, useFetchedTemplate } from 'app/reducers/surveys';
 import SurveyForm from 'app/routes/surveys/components/SurveyEditor/SurveyForm';
 import { questionTypeString } from 'app/routes/surveys/utils';
-import { useAppDispatch } from 'app/store/hooks';
+import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import useQuery from 'app/utils/useQuery';
 import type { EventType } from 'app/store/models/Event';
 import type { FormSubmitSurvey, FormSurvey } from 'app/store/models/Survey';
@@ -23,6 +23,7 @@ const EditSurveyPage = () => {
   const { survey, event } = useFetchedSurvey('editSurvey', surveyId);
   const { templateType } = query;
   const template = useFetchedTemplate('addSurvey', templateType);
+  const fetching = useAppSelector((state) => state.surveys.fetching);
 
   const navigate = useNavigate();
   const onSubmit = (surveyData: FormSubmitSurvey): Promise<void> =>
@@ -50,6 +51,7 @@ const EditSurveyPage = () => {
   return (
     <Page
       title={`Redigerer: ${survey.title}`}
+      skeleton={fetching}
       back={{ href: `/surveys/${surveyId}` }}
     >
       <SurveyForm

--- a/app/routes/surveys/components/SurveyEditor/SurveyForm.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyForm.tsx
@@ -1,5 +1,6 @@
 import { Button, Card, ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
 import arrayMutators from 'final-form-arrays';
+import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
@@ -227,7 +228,7 @@ const Questions = ({ fields }: QuestionsProps) => (
     </ul>
 
     <Icon
-      name="add"
+      iconNode={<Plus />}
       size={30}
       onClick={() => {
         fields.push(initialQuestion);

--- a/app/routes/users/components/UserProfile.css
+++ b/app/routes/users/components/UserProfile.css
@@ -19,12 +19,6 @@
   margin-top: var(--spacing-sm);
 }
 
-.qrIcon {
-  display: flex;
-  align-items: center;
-  margin-right: 0.2rem;
-}
-
 .frameMargin {
   margin-top: var(--spacing-xl);
 }

--- a/app/routes/users/components/UserProfile.tsx
+++ b/app/routes/users/components/UserProfile.tsx
@@ -13,7 +13,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
 import { sortBy, uniqBy, groupBy, orderBy } from 'lodash';
-import { Settings } from 'lucide-react';
+import { Settings, QrCode } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
 import { QRCode } from 'react-qrcode-logo';
@@ -456,7 +456,7 @@ const UserProfile = () => {
                   hasFrame && styles.frameMargin,
                 )}
               >
-                <Icon className={styles.qrIcon} name="qr-code" size={18} />
+                <Icon iconNode={<QrCode />} size={19} />
                 Vis ABA-ID
               </Button>
               <Modal title="ABA-ID">

--- a/app/routes/users/components/UserSettingsOAuth2.tsx
+++ b/app/routes/users/components/UserSettingsOAuth2.tsx
@@ -7,7 +7,7 @@ import {
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import keys from 'lodash/keys';
-import { Trash2 } from 'lucide-react';
+import { Copy, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -92,7 +92,11 @@ const UserSettingsOAuth2 = () => {
             {application.clientId}
             <Tooltip content={copied ? 'Kopiert!' : 'Kopier client ID'}>
               <Icon
-                name={copied ? 'copy' : 'copy-outline'}
+                iconNode={
+                  <Copy
+                    fill={copied ? 'var(--success-color)' : 'transparent'}
+                  />
+                }
                 size={20}
                 success={copied}
                 className={styles.copyIcon}

--- a/packages/lego-bricks/src/components/Layout/Page/Page.tsx
+++ b/packages/lego-bricks/src/components/Layout/Page/Page.tsx
@@ -63,7 +63,9 @@ const Page = ({
         className={title ? styles.title : undefined}
       >
         {sidebar?.side === 'left' && <SidebarTrigger />}
-        {skeleton && !title ? (
+        {skeleton &&
+        (!title ||
+          (typeof title === 'string' && title.includes('undefined'))) ? (
           <Skeleton height={39} width="50%" />
         ) : (
           title && <h1>{title}</h1>

--- a/packages/lego-bricks/src/components/Layout/Page/Page.tsx
+++ b/packages/lego-bricks/src/components/Layout/Page/Page.tsx
@@ -63,7 +63,7 @@ const Page = ({
         className={title ? styles.title : undefined}
       >
         {sidebar?.side === 'left' && <SidebarTrigger />}
-        {skeleton ? (
+        {skeleton && !title ? (
           <Skeleton height={39} width="50%" />
         ) : (
           title && <h1>{title}</h1>


### PR DESCRIPTION
# Description

yes there's more

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

For example

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="364" alt="image" src="https://github.com/user-attachments/assets/84f68b4a-ccb7-47a2-9135-d16ca66c4350">
        </td>
        <td>
            <img width="364" alt="image" src="https://github.com/user-attachments/assets/d02ab3ad-e136-4ee5-8025-e7aef0c2079c">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested most of them hehe

---

Resolves ABA-1009