### PR TITLE
Bump lego-bricks version

### DIFF
--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -19,6 +19,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/lego-bricks.js",
       "require": "./dist/lego-bricks.umd.cjs"
     },

--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/lego-bricks",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "description": "Component library for lego and other Abakus projects",
   "author": "webkom",
   "license": "MIT",


### PR DESCRIPTION
# Description

npm version was far behind

PROBLEMS:

It doesn't work without `react-router-dom`. Seems a bit complicated to fix...