### PR TITLE
Minor improvements to joblisting items

### DIFF
--- a/app/components/JoblistingItem/Items.tsx
+++ b/app/components/JoblistingItem/Items.tsx
@@ -1,4 +1,5 @@
 import joinValues from 'app/utils/joinValues';
+import type { TagColors } from 'app/components/Tags/Tag';
 import type { ListJoblisting, Workplace } from 'app/store/models/Joblisting';
 
 export const Year = ({ joblisting }: { joblisting: ListJoblisting }) => (
@@ -25,4 +26,21 @@ export type JobType = keyof typeof jobTypes;
 
 export const jobType = (status: JobType) => {
   return jobTypes[status];
+};
+
+export const jobTypeColor = (status: JobType): TagColors => {
+  switch (status) {
+    case 'full_time':
+      return 'red';
+    case 'part_time':
+      return 'blue';
+    case 'summer_job':
+      return 'orange';
+    case 'master_thesis':
+      return 'purple';
+    case 'other':
+      return 'cyan';
+    default:
+      return 'gray';
+  }
 };

--- a/app/components/JoblistingItem/index.tsx
+++ b/app/components/JoblistingItem/index.tsx
@@ -1,7 +1,12 @@
 import { Flex, Image } from '@webkom/lego-bricks';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
-import { jobType, Year, Workplaces } from 'app/components/JoblistingItem/Items';
+import {
+  jobType,
+  Year,
+  Workplaces,
+  jobTypeColor,
+} from 'app/components/JoblistingItem/Items';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';
 import styles from './JoblistingItem.css';
@@ -29,7 +34,7 @@ const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
         <Flex
           wrap
           alignItems="center"
-          gap="var(--spacing-sm)"
+          gap="var(--spacing-xs)"
           className={styles.joblistingItemTitle}
         >
           {moment(joblisting.createdAt).isAfter(
@@ -42,7 +47,10 @@ const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
           {joblisting.jobType && (
             <>
               <span> • </span>
-              {jobType(joblisting.jobType)}
+              <Tag
+                tag={jobType(joblisting.jobType)}
+                color={jobTypeColor(joblisting.jobType)}
+              />
             </>
           )}
         </div>

--- a/app/components/JoblistingItem/index.tsx
+++ b/app/components/JoblistingItem/index.tsx
@@ -66,7 +66,7 @@ const JoblistingItem = ({ joblisting }: JobListingItemProps) => (
       </div>
       <Time
         time={joblisting.deadline}
-        format="ll HH:mm"
+        format={`ll ${moment(joblisting.deadline).format('HH:mm') !== '23:59' ? 'HH:mm' : ''}`}
         className={styles.deadLine}
       />
     </div>


### PR DESCRIPTION
# Description

Two minor improvements to joblisting items. The tags make the list much easier to quickly go through. Not entirely sure about the colors

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="1201" alt="image" src="https://github.com/user-attachments/assets/f6464c5e-33b3-4026-a527-a9a3b70a5b48">
        </td>
        <td>
           <img width="1201" alt="image" src="https://github.com/user-attachments/assets/ca1ce4e3-9e09-40d9-9013-1af7fb00a0eb">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above. Only 23:59 is filtered out (see second item)
