### PR TITLE
Resolve reload bug on page edit

### DIFF
--- a/app/routes/pages/components/PageEditor.tsx
+++ b/app/routes/pages/components/PageEditor.tsx
@@ -62,7 +62,7 @@ const PageEditor = () => {
     selectPageById<AuthDetailedPage>(state, pageSlug),
   );
 
-  const isNew = page === undefined;
+  const isNew = pageSlug === undefined;
 
   const [form, setForm] = useState<{
     picture?: string;


### PR DESCRIPTION
# Description

Resolves a bug where when you go directly into the edit-page it won't fetch anything - as the `page` object is only populated on fetch - and the fetch call was not executed as page was undefined.

# Result

Werks

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

