### PR TITLE
Fix spacing glitch for tooltips

### DIFF
--- a/app/components/Tooltip/Tooltip.css
+++ b/app/components/Tooltip/Tooltip.css
@@ -1,5 +1,6 @@
 :root {
   --tooltip-background: var(--lego-font-color);
+  --shadow-md: 0 12px 20px 6px rgba(104, 112, 118, 8%);
 }
 
 .tooltip {
@@ -9,10 +10,17 @@
   background: var(--tooltip-background);
   color: var(--inverted-font-color);
   border-radius: var(--border-radius-md);
-  box-shadow: var(--shadow-md);
   z-index: 1;
   font-size: var(--font-size-md);
   font-weight: normal;
+
+  /* A small "border" added to the box-shadow 
+  in case of sub-pixels rendering in the browser
+  or rounding errors when positioning the arrow
+  causing a small space between content and arrow */
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 0.5px var(--tooltip-background);
 }
 
 @keyframes fade-in {


### PR DESCRIPTION
# Description

In case of sub-pixels rendering in the browser or rounding errors when positioning the arrow, a small space between content and arrow might appear. This fixes this glitch by adding a small border.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="328" alt="image" src="https://github.com/user-attachments/assets/5cd2dcec-66c9-405f-acf7-d3f6e7b5bfea">
        </td>
        <td>
            <img width="328" alt="image" src="https://github.com/user-attachments/assets/f5fa112d-0986-494a-b06a-5b01dc23b516">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Try zooming in the browser, and the glitch will likely appear. Sometimes difficult to reproduce hehe.
