### PR TITLE
Wrap comments to prevent buggy shifted pages

### DIFF
--- a/app/components/Comments/Comment.css
+++ b/app/components/Comments/Comment.css
@@ -2,13 +2,6 @@
 
 .comment {
   padding: var(--spacing-md);
-
-  :global {
-    /* stylelint-disable-next-line selector-class-pattern */
-    .md-RichEditor-editor .public-DraftEditor-content {
-      min-height: 0;
-    }
-  }
 }
 
 .username a {
@@ -30,6 +23,10 @@
 
 .text {
   margin: var(--spacing-sm) 0;
+  max-width: 90%;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .anonymousProfilePicture {


### PR DESCRIPTION
# Description

Happened in a recent meeting with a long url

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="1156" alt="image" src="https://github.com/user-attachments/assets/cce3025d-2f09-4072-bd16-c9ef1b683a81">
        </td>
        <td>
            <img width="1156" alt="image" src="https://github.com/user-attachments/assets/b6a3c605-251d-4670-83c6-9fb0dda1287a">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above. Removed some old lego-editor specific css, but that was also tested, in the sense that I double-checked we don't have any left-over lego-editor stuff in comments