### PR TITLE
Fix types and overflow issue in user settings

### DIFF
--- a/app/components/Upload/ImageUpload.tsx
+++ b/app/components/Upload/ImageUpload.tsx
@@ -21,10 +21,8 @@ export interface DropFile extends File {
 type BaseProps = {
   crop?: boolean;
   inModal?: boolean;
-  multiple?: boolean;
   img?: string;
   aspectRatio?: number;
-  onSubmit: (arg0: File | Array<DropFile>) => void;
   onDrop?: () => void;
   onClose?: () => void;
 };
@@ -32,7 +30,7 @@ type BaseProps = {
 type Props = BaseProps &
   (
     | { multiple: true; onSubmit: (files: Array<DropFile>) => void }
-    | { multiple: false; onSubmit: (file: File) => void }
+    | { multiple?: false; onSubmit: (file: File) => void }
   );
 
 type FilePreviewProps = {
@@ -149,7 +147,6 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
 const ImageUpload = ({
   crop = true,
   inModal = false,
-  multiple = false,
   aspectRatio,
   ...props
 }: Props) => {
@@ -177,13 +174,13 @@ const ImageUpload = ({
       setCropOpen(true);
     }
 
-    if (multiple && !crop) {
+    if (props.multiple && !crop) {
       setFiles((files) => files.concat(droppedFiles));
     }
   };
 
   const onSubmit = () => {
-    if (crop && !multiple && file) {
+    if (crop && !props.multiple && file) {
       const { name } = file;
       if (cropper.current) {
         cropper.current.getCroppedCanvas().toBlob((image) => {
@@ -196,7 +193,7 @@ const ImageUpload = ({
       }
     }
 
-    if (multiple && files.length) {
+    if (props.multiple && files.length) {
       props.onSubmit(files);
     }
 
@@ -211,7 +208,7 @@ const ImageUpload = ({
   };
 
   const onRemove = (index: number) => {
-    if (multiple) {
+    if (props.multiple) {
       setFiles((files) => files.filter((_file, i) => index !== i));
     }
   };
@@ -225,7 +222,7 @@ const ImageUpload = ({
       {!inModal && (
         <UploadArea
           onDrop={onDrop}
-          multiple={multiple}
+          multiple={props.multiple}
           image={img}
           accept={accept}
         />
@@ -233,14 +230,14 @@ const ImageUpload = ({
       <Modal
         isOpen={cropOpen}
         onOpenChange={(open) => !open && closeModal()}
-        title={`Last opp bilde${multiple ? 'r' : ''}`}
+        title={`Last opp bilde${props.multiple ? 'r' : ''}`}
       >
         <Flex column alignItems="center" gap="var(--spacing-md)">
           {inModal && !preview && (
             <div className={styles.inModalUpload}>
               <UploadArea
                 onDrop={onDrop}
-                multiple={multiple}
+                multiple={props.multiple}
                 image={img}
                 accept={accept}
               />
@@ -258,7 +255,7 @@ const ImageUpload = ({
               autoCropArea={1}
             />
           )}
-          {multiple && !crop && (
+          {props.multiple && !crop && (
             <Flex wrap column gap="var(--spacing-sm)">
               {files.map((file, index) => (
                 <FilePreview

--- a/app/routes/users/components/UserImage.tsx
+++ b/app/routes/users/components/UserImage.tsx
@@ -1,10 +1,10 @@
 import { updatePicture } from 'app/actions/UserActions';
 import ImageUpload from 'app/components/Upload/ImageUpload';
 import { useAppDispatch } from 'app/store/hooks';
-import type { User } from 'app/models';
+import type { PublicUser } from 'app/store/models/User';
 
 type Props = {
-  user: User;
+  user: Pick<PublicUser, 'username' | 'profilePicture'>;
 };
 
 const UploadPage = ({ user }: Props) => {

--- a/app/routes/users/components/UserResetPassword.tsx
+++ b/app/routes/users/components/UserResetPassword.tsx
@@ -1,26 +1,32 @@
 import { Card, Page } from '@webkom/lego-bricks';
-import qs from 'qs';
 import { Field } from 'react-final-form';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { resetPassword } from 'app/actions/UserActions';
 import { TextInput } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';
+import useQuery from 'app/utils/useQuery';
 import { createValidator, required, sameAs } from 'app/utils/validation';
 import { validPassword } from '../utils';
 import PasswordField from './PasswordField';
 
+type FormValues = {
+  password: string;
+  retypeNewPassword: string;
+};
+
+const TypedLegoForm = LegoFinalForm<FormValues>;
+
 const UserResetPasswordForm = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const { search } = useLocation();
-  const { token } = qs.parse(search, {
-    ignoreQueryPrefix: true,
-  });
+  const {
+    query: { token },
+  } = useQuery({ token: '' });
 
-  const onSubmit = (props) =>
+  const onSubmit = (props: FormValues) =>
     dispatch(
       resetPassword({
         token,
@@ -40,7 +46,7 @@ const UserResetPasswordForm = () => {
   return (
     <Page title="Tilbakestill passord">
       {token ? (
-        <LegoFinalForm onSubmit={onSubmit} validate={validate}>
+        <TypedLegoForm onSubmit={onSubmit} validate={validate}>
           {({ handleSubmit }) => (
             <form onSubmit={handleSubmit}>
               <PasswordField label="Nytt passord" user={user} />
@@ -55,7 +61,7 @@ const UserResetPasswordForm = () => {
               <SubmitButton danger>Tilbakestill passord</SubmitButton>
             </form>
           )}
-        </LegoFinalForm>
+        </TypedLegoForm>
       ) : (
         <Card severity="danger">
           <Card.Header>Ingen token ...</Card.Header>

--- a/app/routes/users/components/UserSettings.css
+++ b/app/routes/users/components/UserSettings.css
@@ -1,3 +1,5 @@
+@import url('~app/styles/variables.css');
+
 .right {
   flex: 1;
 }
@@ -13,4 +15,10 @@
 .deleteUser {
   margin-top: var(--spacing-md);
   color: var(--danger-color);
+}
+
+@media (--mobile-device) {
+  .mobileColumn {
+    flex-direction: column;
+  }
 }

--- a/app/routes/users/components/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings.tsx
@@ -115,7 +115,7 @@ const UserSettings = () => {
       >
         {({ handleSubmit }) => (
           <form onSubmit={handleSubmit}>
-            <Flex gap="var(--spacing-xl)">
+            <Flex gap="var(--spacing-xl)" className={styles.mobileColumn}>
               <Flex
                 column
                 justifyContent="center"

--- a/app/routes/users/components/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings.tsx
@@ -33,12 +33,7 @@ import AllergiesOrPreferencesField from '../AllergiesOrPreferencesField';
 import ChangePassword from './ChangePassword';
 import UserImage from './UserImage';
 import styles from './UserSettings.css';
-
-export type PasswordPayload = {
-  newPassword: string;
-  password: string;
-  retype_new_password: string;
-};
+import type { CurrentUser } from 'app/store/models/User';
 
 type GenderKey = keyof typeof Gender;
 
@@ -49,11 +44,11 @@ type FormValues = {
   gender: { label: (typeof Gender)[GenderKey]; value: GenderKey };
   allergies: string;
   email: string;
-  phoneNumber: string;
+  phoneNumber?: string;
   selectedTheme: string;
   isAbakusMember: boolean;
-  githubUsername: string;
-  linkedinId: string;
+  githubUsername?: string;
+  linkedinId?: string;
 };
 
 const TypedLegoForm = LegoFinalForm<FormValues>;
@@ -74,8 +69,8 @@ const UserSettings = () => {
   const currentUser = useCurrentUser();
   const isCurrentUser = useIsCurrentUser(params.username);
   const username = isCurrentUser ? currentUser?.username : params.username;
-  const user = useAppSelector(
-    (state) => username && selectUserByUsername(state, username),
+  const user = useAppSelector((state) =>
+    selectUserByUsername<CurrentUser>(state, username),
   );
 
   const dispatch = useAppDispatch();
@@ -108,7 +103,6 @@ const UserSettings = () => {
   const initialValues: FormValues = {
     ...user,
     gender: { label: Gender[user.gender], value: user.gender },
-    isAbakusMember: user?.isAbakusMember.toString(),
   };
 
   return (

--- a/app/store/models/User.ts
+++ b/app/store/models/User.ts
@@ -27,7 +27,7 @@ interface User {
   firstName: string;
   lastName: string;
   fullName: string;
-  gender?: keyof typeof Gender;
+  gender: keyof typeof Gender;
   email: string;
   emailAddress: string;
   emailListsEnabled: boolean;


### PR DESCRIPTION
# Description

User settings page overflowed on mobile as the name fields did not fit to the right of the profile picture. I also fixed some types.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.
Oops

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
User settings page
        </td>
        <td>
<img width="376" alt="Screenshot 2024-08-27 at 20 23 19" src="https://github.com/user-attachments/assets/a961e1a3-5382-4a70-ae89-192f281532bb">
        </td>
        <td>
<img width="376" alt="Screenshot 2024-08-27 at 20 22 51" src="https://github.com/user-attachments/assets/5deaae2a-e685-407b-a2c6-e09e4be7b83f">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-1000
