### PR TITLE
Rename KiD to NEXUS

### DIFF
--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -199,7 +199,7 @@ const EventList = () => {
         return showSocial;
 
       case 'other':
-      case 'kid_event':
+      case 'nexus_event':
         return showOther;
 
       default:

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -62,9 +62,9 @@ export const EventTypeConfig: Record<EventType, ConfigProperties> = {
     textColor: '#FFF',
   },
   [EventType.KiD_EVENT]: {
-    displayName: 'KiD-arrangement',
-    color: 'var(--color-event-black)',
-    textColor: 'var(--color-white)',
+    displayName: 'NEXUS-arrangement',
+    color: '#00509E',
+    textColor: '#FFF',
   },
   [EventType.OTHER]: {
     displayName: 'Annet',

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -61,10 +61,10 @@ export const EventTypeConfig: Record<EventType, ConfigProperties> = {
     color: '#8A2BE2',
     textColor: '#FFF',
   },
-  [EventType.KiD_EVENT]: {
+  [EventType.NEXUS_EVENT]: {
     displayName: 'NEXUS-arrangement',
     color: '#00509E',
-    textColor: '#FFF',
+    textColor: 'var(--color-absolute-white)',
   },
   [EventType.OTHER]: {
     displayName: 'Annet',

--- a/app/routes/frontpage/components/CompactEvents.tsx
+++ b/app/routes/frontpage/components/CompactEvents.tsx
@@ -73,7 +73,7 @@ const CompactEvents = ({ className, style }: Props) => {
     EventType.ALTERNATIVE_PRESENTATION,
     EventType.COURSE,
     EventType.BREAKFAST_TALK,
-    EventType.KiD_EVENT,
+    EventType.NEXUS_EVENT,
   ]);
   const leftEvents =
     presentations.length > 0 ? presentations : ['Ingen presentasjoner'];

--- a/app/store/models/Event.ts
+++ b/app/store/models/Event.ts
@@ -13,7 +13,7 @@ export enum EventType {
   COMPANY_PRESENTATION = 'company_presentation',
   COURSE = 'course',
   EVENT = 'event',
-  KiD_EVENT = 'kid_event',
+  NEXUS_EVENT = 'nexus_event',
   LUNCH_PRESENTATION = 'lunch_presentation',
   OTHER = 'other',
   PARTY = 'party',


### PR DESCRIPTION
# Description

Renames KiD to NEXUS and updates colors to match the company logo.

[Backend PR](https://github.com/webkom/lego/pull/3629)

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.



<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Calendar
        </td>
        <td>
  
![Screenshot from 2024-08-27 21-48-38](https://github.com/user-attachments/assets/8e0ef2f4-17db-41b6-8f56-5e41439c8cf5)
        </td>
        <td>
            
![Screenshot from 2024-08-27 21-45-18](https://github.com/user-attachments/assets/f80a114e-1c1c-4a17-b3b8-d1e47f0e5f3e)
<tr>
<td>
Event details
</td>
<td> <img src="https://github.com/user-attachments/assets/9420e911-0eba-43ba-a929-1a8be361ea7c"/> </td>
<td> <img src="https://github.com/user-attachments/assets/44181f08-b9d4-4a9b-8ea1-3571aa112caa"/>

</td>
</tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.


Resolves [ABA-1027](https://linear.app/abakus-webkom/issue/ABA-1027/update-name-from-kid-nexus)
