### PR TITLE
Fix sizing of attendance modal

### DIFF
--- a/app/components/UserAttendance/AttendanceModalContent.css
+++ b/app/components/UserAttendance/AttendanceModalContent.css
@@ -1,16 +1,34 @@
-.modal {
-  height: calc(100vh - 100px - 70px);
+@import url('~app/styles/variables.css');
+
+.modalContent {
+  /* 
+   * Kinda hacky solution, but with the current flexibility of modal sizing it's the only way I could think of for now
+   * 
+   * 100vh - 100px          = height of the modal from @lego-bricks/src/components/Modal/Modal.module.css
+   * 2 * var(--spacing-xl)  = the padding of the modal
+   * 2rem                   = the height of the title
+   * var(--spacing-md)      = the margin-bottom of the title
+  */
+  --attendance-modal-content-height: calc(
+    (100vh - 100px) - (2 * var(--spacing-xl)) - (2rem) - var(--spacing-md)
+  );
+
+  height: var(--attendance-modal-content-height);
 
   @media (--tall-viewport) {
-    max-height: calc(100vh - 300px - 70px);
+    height: calc(var(--attendance-modal-content-height) - 100px);
   }
+}
+
+.searchInput {
+  flex-shrink: 0;
 }
 
 .list {
   position: relative;
   width: 100%;
   min-height: 100px;
-  height: 80%;
+  flex-grow: 1;
   overflow-y: auto;
   /* stylelint-disable indentation */
   background:

--- a/app/components/UserAttendance/AttendanceModalContent.tsx
+++ b/app/components/UserAttendance/AttendanceModalContent.tsx
@@ -81,12 +81,13 @@ const AttendanceModalContent = ({
   );
 
   return (
-    <Flex column gap="var(--spacing-md)" className={styles.modal}>
+    <Flex column gap="var(--spacing-md)" className={styles.modalContent}>
       <TextInput
         type="text"
         prefix="search"
         placeholder="Søk etter navn"
         onChange={(e) => setFilter(e.target.value)}
+        className={styles.searchInput}
       />
 
       <ul className={styles.list}>

--- a/cypress/e2e/joblistings_specs.js
+++ b/cypress/e2e/joblistings_specs.js
@@ -37,8 +37,17 @@ describe('Create joblisting', () => {
 
     // TODO sometimes there is an issue in the joblisting editor where you have to click
     // the top editor twice. Not a breaking bug.
-    selectEditor('description').type('A joblisting description');
-    selectEditor('text').type('Joblisting text');
+    const description = 'A joblisting description';
+    const text = 'Joblisting text';
+    selectEditor('description').type(description);
+    selectEditor('text').type(text);
+
+    // Wait for editor debounce
+    selectEditor('description', { timeout: 2000 }).should(
+      'contain',
+      description,
+    );
+    selectEditor('text', { timeout: 2000 }).should('contain', text);
 
     cy.contains('button', 'Opprett').should('not.be.disabled');
 
@@ -47,8 +56,6 @@ describe('Create joblisting', () => {
     //.first()
     //.clear();
     //cy.contains('button', 'Lagre endringer').should('be.disabled');
-
-    cy.wait(100); // wait for editor debounce
 
     cy.contains('button', 'Opprett').should('not.be.disabled').click();
     //TODO: check new url

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -45,10 +45,13 @@ export const fieldError = (name) => cy.get(`[data-error-field-name="${name}"`);
 
 export const button = (buttonText) => cy.contains('button', buttonText);
 
-export const selectEditor = (name) =>
+export const selectEditor = (name, options = {}) =>
   name
-    ? cy.get(`[name="${name}"] div[data-slate-editor="true"]`).click().click()
-    : cy.get('div[data-slate-editor="true"]').click().click();
+    ? cy
+        .get(`[name="${name}"] div[data-slate-editor="true"]`, options)
+        .click()
+        .click()
+    : cy.get('div[data-slate-editor="true"]', options).click().click();
 
 const selectDatePickerHours = () =>
   cy.get(c('TimePicker__timePickerInput')).first().find('input');


### PR DESCRIPTION
# Description

The sizing of the Modal component was changed without updating the sizing of AttendanceModal.

This solution is still kinda hacky - but with the current flexibility of the Modal components size it's kinda tricky to flex the sizing of this one properly, and at least now the calculations are explained better..

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

# Testing

- [x] I have thoroughly tested my changes.

Works fine in Chrome and Safari


Resolves ABA-957
