### PR TITLE
Changed 'Melding til Arrangør' to 'Kommentar' at request from ArrKom

### DIFF
--- a/app/routes/events/components/EventAdministrate/AdminRegister.tsx
+++ b/app/routes/events/components/EventAdministrate/AdminRegister.tsx
@@ -95,7 +95,7 @@ const AdminRegister = () => {
             />
             <Field
               placeholder="Tilbakemelding"
-              label="Melding til arrangør"
+              label="Kommentar"
               name="feedback"
               component={TextEditor.Field}
             />

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -459,7 +459,7 @@ const JoinEventForm = ({
                             {spyValues((values) => (
                               <Field
                                 id={feedbackName}
-                                placeholder="Melding til arrangør"
+                                placeholder="Kommentar"
                                 name={feedbackName}
                                 component={TextInput.Field}
                                 className={styles.feedbackText}
@@ -528,7 +528,7 @@ function getFeedbackName(event: UserDetailedEvent) {
 }
 
 function getFeedbackLabel(event: UserDetailedEvent) {
-  return event.feedbackDescription || 'Melding til arrangør';
+  return event.feedbackDescription || 'Kommentar';
 }
 
 export default withCountdown(JoinEventForm);


### PR DESCRIPTION
# Description

ArrKom requested that the tag for "Melding til arrangør" be changes to "Kommentar" to better reflects its purpose, as it does not send the message to the Host, but rather to ArrKom who also gets no notfication. 

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

Event page visible to normal users before:
![image](https://github.com/user-attachments/assets/f3fc7e8f-8975-4c4c-b1b8-c647d255491c)

Event page visible to normal users after:
![image](https://github.com/user-attachments/assets/f6426dec-d4fe-4c5c-814a-3b47d5987dce)

Admin registration page before:
![image](https://github.com/user-attachments/assets/5a9cc614-d2eb-4412-981c-cc7e06634530)

Admin registration page after:
![image](https://github.com/user-attachments/assets/eb58ef1b-56e6-4b30-a991-b3bf820765d7)

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1040
