### PR TITLE
Bump mazemap to v2.2.1

### DIFF
--- a/config/webpack.dll.js
+++ b/config/webpack.dll.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const pullAll = require('lodash/pullAll');
 const webpack = require('webpack');
+const publicPath = require('./webpack.client');
 
 const root = path.resolve(__dirname, '..');
 const packageJson = require(path.join(root, 'package.json'));
@@ -20,6 +21,7 @@ module.exports = () => ({
     filename: '[name].dll.js',
     path: outputPath,
     library: '[name]',
+    publicPath,
   },
   plugins: [
     new webpack.DllPlugin({

--- a/mazemap/package.json
+++ b/mazemap/package.json
@@ -1,12 +1,12 @@
 {
   "name": "mazemap",
-  "version": "2.0.96",
+  "version": "2.2.1",
   "main": "mazemap.min.js",
   "license": "",
   "author": "Dag Jomar Mersland <dagjomar@mazemap.com>",
   "dependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "sh install.sh 2.0.96"
+    "install": "sh install.sh 2.2.1"
   }
 }


### PR DESCRIPTION
# Description

Bumps mazemap to v2.2.1

# Result

Changes to webpack caused by internal changes from mazemap, hopefully nothing breaks 👉👈

# Testing

- [x] I have thoroughly tested my changes.

Map looks the same

---
