### PR TITLE
Set input font size to be 16px on mobile

### DIFF
--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -110,6 +110,12 @@ th:last-child {
   border-radius: 0 2em 2em 0;
 }
 
+input {
+  @media (--mobile-device) {
+    font-size: var(--font-size-md);
+  }
+}
+
 label {
   display: block;
 }


### PR DESCRIPTION
# Description

For some dumb reason, any inputs with a smaller font size than `16px` will cause the browser on mobile (I think only Safari) to "zoom" in on the field when focusing on it. On the event registration modal, this causes annoying bugs when trying to search for attendees.

[Read more here.](https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone)

# Testing

- [x] I have thoroughly tested my changes.

Not actually tested, other than that I have confirmed that the font-size is `16px` on mobile viewports.

---

Resolves ABA-1068
