### PR TITLE
Display correct registrationDeadline in event editor

### DIFF
--- a/app/routes/events/components/EventEditor/EditorSection/Registration.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Registration.tsx
@@ -13,6 +13,7 @@ import Attendance from 'app/components/UserAttendance/Attendance';
 import {
   containsAllergier,
   eventStatusTypes,
+  registrationCloseTime,
   tooLow,
 } from 'app/routes/events/utils';
 import { spyValues } from 'app/utils/formSpyUtils';
@@ -153,7 +154,7 @@ const NormalOrInfiniteStatusType: React.FC<NormalOrInfiniteStatusTypeProps> = ({
             className={styles.formField}
           />
           <p className={styles.registrationDeadlineHours}>
-            Stenger <FormatTime time={moment(values.registrationDeadline)} />
+            Stenger <FormatTime time={registrationCloseTime(values)} />
           </p>
         </Flex>
         <Flex column className={styles.editorSectionColumn}>


### PR DESCRIPTION
# Description

The little text in the editor was using a variable that was not set - and therefore always showed the current time.

Now it uses the same function as is used when it is displayed, and works better.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<img width="491" alt="image" src="https://github.com/user-attachments/assets/37c0df8e-efa3-4dae-b634-8a359d0205b6">


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
