### PR TITLE
Fix lego-bricks not working without react-router

### DIFF
--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/lego-bricks",
-  "version": "1.2.1",
+  "version": "1.3.3",
   "description": "Component library for lego and other Abakus projects",
   "author": "webkom",
   "license": "MIT",

--- a/packages/lego-bricks/src/components/Layout/Page/Page.tsx
+++ b/packages/lego-bricks/src/components/Layout/Page/Page.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { NavLink } from 'react-router-dom';
+import { Link } from 'react-aria-components';
 import { ButtonGroup } from '../../Button/ButtonGroup';
 import { Icon } from '../../Icon';
 import { Skeleton } from '../../Skeleton';
@@ -52,10 +52,10 @@ const Page = ({
   >
     <Flex column className={cx(styles.content, classNames?.content)}>
       {back && (
-        <NavLink to={back.href} className={styles.back}>
+        <Link href={back.href} className={styles.back}>
           <Icon name="arrow-back" size={18} className={styles.backIcon} />
           <span className={styles.backLabel}>{back.label ?? 'Tilbake'}</span>
-        </NavLink>
+        </Link>
       )}
       <Flex
         wrap


### PR DESCRIPTION
# Description

Fixes `lego-bricks` breaking when used in a project without `react-router`. 

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

Tested on the `lego-editor` project
---

Resolves [ABA-1025](https://linear.app/abakus-webkom/issue/ABA-1025/lego-bricks-doesnt-work-without-react-router-dom)
