### PR TITLE
Fix button styling in bricks

### DIFF
--- a/app/components/Header/Header.css
+++ b/app/components/Header/Header.css
@@ -50,6 +50,7 @@
 
 .buttonGroup button,
 .buttonGroup img {
+  background-color: transparent;
   border: 0;
   color: var(--lego-font-color);
   cursor: pointer;

--- a/app/components/Header/Navbar/Navbar.css
+++ b/app/components/Header/Navbar/Navbar.css
@@ -32,6 +32,11 @@
   }
 }
 
+.navigation button {
+  background-color: transparent;
+  border: none;
+}
+
 .navbarDropdown {
   width: auto;
   padding: var(--spacing-sm) var(--spacing-md);

--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/lego-bricks",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Component library for lego and other Abakus projects",
   "author": "webkom",
   "license": "MIT",

--- a/packages/lego-bricks/src/components/Button/Button.module.css
+++ b/packages/lego-bricks/src/components/Button/Button.module.css
@@ -26,6 +26,7 @@
 }
 
 .button {
+  border: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/packages/lego-bricks/src/components/Icon/Icon.module.css
+++ b/packages/lego-bricks/src/components/Icon/Icon.module.css
@@ -16,6 +16,8 @@
 }
 
 .clickable {
+  background-color: transparent;
+  border: none;
   display: flex;
   width: fit-content;
   height: fit-content;

--- a/packages/lego-bricks/src/global.css
+++ b/packages/lego-bricks/src/global.css
@@ -1,1 +1,6 @@
 @import '../../../app/styles/variables.css';
+
+button {
+    background-color: transparent;
+    border: none;
+}

--- a/packages/lego-bricks/src/global.css
+++ b/packages/lego-bricks/src/global.css
@@ -1,6 +1,6 @@
 @import '../../../app/styles/variables.css';
 
 button {
-    background-color: transparent;
-    border: none;
+  background-color: transparent;
+  border: none;
 }

--- a/packages/lego-bricks/src/global.css
+++ b/packages/lego-bricks/src/global.css
@@ -1,6 +1,1 @@
 @import '../../../app/styles/variables.css';
-
-button {
-  background-color: transparent;
-  border: none;
-}


### PR DESCRIPTION
# Description

The latest version of `lego-bricks` incorrectly styles buttons, adding a gray background and border. This is likely caused by the recent removal of the global css import from `lego-webapp`. This PR fixes the styling.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

| Before | After |
| -- | -- |
| ![Screenshot from 2024-09-22 17-17-49](https://github.com/user-attachments/assets/4246bad7-4b59-49a4-a553-0bd7aaf49a09) | ![Screenshot from 2024-09-22 17-17-58](https://github.com/user-attachments/assets/a38140d8-cab0-4308-8da5-0ff76eb10b89) |
| ![Screenshot from 2024-09-22 17-27-25](https://github.com/user-attachments/assets/b32aafbc-3d8c-431e-9808-acc3388eebb1) | ![Screenshot from 2024-09-22 17-27-33](https://github.com/user-attachments/assets/fe12cdb3-c9b3-4a8e-822d-325bf4150749) |


# Testing

- [x] I have thoroughly tested my changes.

Navigate through the application and ensure all buttons, icon buttons and link buttons have the correct styling.
