### PR TITLE
Remove horizontal table scroll

### DIFF
--- a/app/components/Table/Table.css
+++ b/app/components/Table/Table.css
@@ -1,7 +1,7 @@
 @import url('~app/styles/variables.css');
 
 .wrapper {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .wrapper table {


### PR DESCRIPTION
# Description

This has annoyed me for quite a while, especially when working on the updated BDB. This PR hides the horizontal scroll bar in the `Table` component when it's not needed. The bar will still appear if the content becomes scrollable.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

| Before | After
| -- | -- | 
| ![Screenshot from 2024-09-22 22-15-08](https://github.com/user-attachments/assets/3c62c9e8-1f92-445a-821f-57e30a92ca8c) | ![Screenshot from 2024-09-22 22-15-28](https://github.com/user-attachments/assets/1bcdcd89-5ece-4a54-a510-1215fdc5ff67) |


# Testing

- [x] I have thoroughly tested my changes.

Verify that the horizontal scroll bar is hidden in all tables when the content is not horizontally scrollable. 
