### PR TITLE
Show waiting list position even if there are multiple pools

### DIFF
--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -32,6 +32,7 @@ import type {
   AdministrateUser,
   AdministrateUserWithGrade,
   PublicUser,
+  PublicUserWithAbakusGroups,
 } from 'app/store/models/User';
 import type { AnyAction } from 'redux';
 import type { Optional, Overwrite } from 'utility-types';
@@ -174,12 +175,14 @@ export const selectEventByIdOrSlug = createSelector(
 
 export type PoolRegistrationWithUser = Overwrite<
   ReadRegistration,
-  { user: PublicUser }
+  { user: PublicUserWithAbakusGroups }
 >;
 export type PoolWithRegistrations = Overwrite<
   Optional<AuthPool, 'activationDate'>,
   { registrations: PoolRegistrationWithUser[] }
->;
+> & {
+  isWaitingList?: boolean;
+};
 export const selectPoolsForEvent = createSelector(
   selectEventById<DetailedEvent>,
   selectPoolEntities,
@@ -243,7 +246,7 @@ export const selectMergedPool = createSelector(selectPoolsForEvent, (pools) => {
 export const selectMergedPoolWithRegistrations = createSelector(
   selectPoolsForEvent,
   selectRegistrationEntities<ReadRegistration>,
-  selectUserEntities<PublicUser>,
+  selectUserEntities<PublicUserWithAbakusGroups>,
   (pools, registrationEntities, userEntities) => {
     if (pools.length === 0) return [];
     return [

--- a/app/routes/events/components/EventDetail/AttendeeSection.tsx
+++ b/app/routes/events/components/EventDetail/AttendeeSection.tsx
@@ -1,8 +1,10 @@
 import { Flex } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
+import { useMemo } from 'react';
 import Attendance from 'app/components/UserAttendance/Attendance';
 import { useIsLoggedIn } from 'app/reducers/auth';
 import { selectRegistrationsFromPools } from 'app/reducers/events';
+import { getWaitingListPosition } from 'app/routes/events/components/EventDetail/getWaitingListPosition';
 import RegistrationMeta, {
   RegistrationMetaSkeleton,
 } from 'app/routes/events/components/RegistrationMeta';
@@ -39,11 +41,10 @@ export const AttendeeSection = ({
   );
 
   const currentMoment = moment();
-  const hasSimpleWaitingList =
-    pools.filter((p) => p.name != 'Venteliste').length <= 1;
-  const waitingListIndex =
-    currentRegistration &&
-    currentPool?.registrations.indexOf(currentRegistration);
+  const waitingListPosition = useMemo(
+    () => getWaitingListPosition(currentRegistration, currentPool, pools),
+    [currentRegistration, currentPool, pools],
+  );
 
   // The UserGrid is expanded when there's less than 5 minutes till activation
   const minUserGridRows =
@@ -78,8 +79,7 @@ export const AttendeeSection = ({
             hasEnded={moment(event.endTime).isBefore(currentMoment)}
             registration={currentRegistration}
             isPriced={event.isPriced}
-            registrationIndex={waitingListIndex ?? 0}
-            hasSimpleWaitingList={hasSimpleWaitingList}
+            waitingListPosition={waitingListPosition}
             skeleton={showSkeleton}
           />
         ))}

--- a/app/routes/events/components/EventDetail/getWaitingListPosition.ts
+++ b/app/routes/events/components/EventDetail/getWaitingListPosition.ts
@@ -1,0 +1,45 @@
+import type {
+  PoolRegistrationWithUser,
+  PoolWithRegistrations,
+} from 'app/reducers/events';
+import type { PublicUserWithAbakusGroups } from 'app/store/models/User';
+
+const isPermittedInPool = (
+  user: PublicUserWithAbakusGroups,
+  pool: PoolWithRegistrations,
+) => {
+  return pool.permissionGroups.some((permissionGroup) =>
+    user.allAbakusGroupIds.some(
+      (userGroup) => userGroup === permissionGroup.id,
+    ),
+  );
+};
+
+export const getWaitingListPosition = (
+  currentRegistration?: PoolRegistrationWithUser,
+  waitingList?: PoolWithRegistrations,
+  pools?: PoolWithRegistrations[],
+) => {
+  if (!currentRegistration || !waitingList || !pools) return undefined;
+
+  const nonWaitingListPools = pools.filter((pool) => !pool.isWaitingList);
+
+  const applicablePools = nonWaitingListPools.filter((pool) =>
+    isPermittedInPool(currentRegistration.user, pool),
+  );
+
+  if (applicablePools.length === 0) return undefined;
+  if (nonWaitingListPools.length === 1) {
+    return waitingList.registrations.indexOf(currentRegistration) + 1;
+  }
+  return applicablePools.map((pool) => {
+    const applicableWaitingListRegistrations = waitingList.registrations.filter(
+      (r) => isPermittedInPool(r.user, pool),
+    );
+    return {
+      poolName: pool.name,
+      position:
+        applicableWaitingListRegistrations.indexOf(currentRegistration) + 1,
+    };
+  });
+};

--- a/app/routes/events/components/EventDetail/usePools.ts
+++ b/app/routes/events/components/EventDetail/usePools.ts
@@ -44,6 +44,7 @@ export function usePools(
             registrations: waitingRegistrations,
             registrationCount: waitingRegistrations.length,
             permissionGroups: [],
+            isWaitingList: true,
           },
         ]
       : pools;
@@ -55,6 +56,7 @@ export function usePools(
             name: 'Venteliste',
             registrationCount: event.waitingRegistrationCount,
             permissionGroups: [],
+            isWaitingList: true,
           },
         ]
       : pools;

--- a/app/routes/events/components/RegistrationMeta.tsx
+++ b/app/routes/events/components/RegistrationMeta.tsx
@@ -23,11 +23,17 @@ import type {
 import type { PoolRegistrationWithUser } from 'app/reducers/events';
 import type { Presence } from 'app/store/models/Registration';
 
+type WaitingListPosition =
+  | number
+  | {
+      poolName: string;
+      position: number;
+    }[];
+
 type Props = {
   registration?: PoolRegistrationWithUser;
   isPriced: boolean;
-  registrationIndex: number;
-  hasSimpleWaitingList: boolean;
+  waitingListPosition?: WaitingListPosition;
   useConsent: boolean;
   hasOpened: boolean;
   hasEnded: boolean;
@@ -246,8 +252,7 @@ const RegistrationMeta = ({
   hasEnded,
   useConsent,
   isPriced,
-  registrationIndex,
-  hasSimpleWaitingList,
+  waitingListPosition,
   photoConsents,
   eventSemester,
   skeleton,
@@ -282,20 +287,39 @@ const RegistrationMeta = ({
                 />
               )}
             </>
-          ) : hasSimpleWaitingList ? (
-            <TextWithIconWrapper
-              iconName="pause-circle-outline"
-              content={
-                <>
-                  Din plass i ventelisten er{' '}
-                  <strong>{registrationIndex + 1}</strong>
-                </>
-              }
-            />
           ) : (
             <TextWithIconWrapper
               iconName="pause-circle-outline"
-              content={`Du ${hasEnded ? 'stod' : 'står'} på venteliste`}
+              content={
+                waitingListPosition === undefined ? (
+                  <>Du {hasEnded ? 'stod' : 'står'} på venteliste</>
+                ) : typeof waitingListPosition === 'number' ? (
+                  <>
+                    Din plass i ventelisten er{' '}
+                    <strong>{waitingListPosition}</strong>
+                  </>
+                ) : waitingListPosition.length === 1 ? (
+                  <>
+                    Din plass i ventelisten for{' '}
+                    {waitingListPosition[0].poolName} er{' '}
+                    <strong>{waitingListPosition[0].position}</strong>
+                  </>
+                ) : (
+                  <>
+                    Dine plasser i ventelistene er{' '}
+                    {waitingListPosition.map(
+                      ({ poolName, position }, index) => (
+                        <>
+                          <strong>{position}</strong> for {poolName}
+                          {index < waitingListPosition.length - 2
+                            ? ', '
+                            : index < waitingListPosition.length - 1 && ' og '}
+                        </>
+                      ),
+                    )}
+                  </>
+                )
+              }
             />
           )}
           <PresenceStatus

--- a/app/store/models/User.ts
+++ b/app/store/models/User.ts
@@ -42,6 +42,7 @@ interface User {
   penalties: EntityId[];
   icalToken: string;
   abakusGroups: EntityId[];
+  allAbakusGroupIds: EntityId[];
   isAbakusMember: boolean;
   isAbakomMember: boolean;
   pastMemberships: PastMembership[];
@@ -131,14 +132,17 @@ export type PublicUser = Pick<
   | 'linkedinId'
 >;
 
-export type PublicUserWithAbakusGroups = Pick<User, 'abakusGroups'> &
+export type PublicUserWithAbakusGroups = Pick<
+  User,
+  'abakusGroups' | 'allAbakusGroupIds'
+> &
   PublicUser;
 
 export type PublicUserWithGroups = Pick<
   User,
-  'abakusGroups' | 'pastMemberships' | 'memberships'
+  'pastMemberships' | 'memberships'
 > &
-  PublicUser;
+  PublicUserWithAbakusGroups;
 
 export type AdministrateUser = Pick<User, 'abakusGroups'> & PublicUser;
 


### PR DESCRIPTION
DEPENDS ON BACKEND PR: https://github.com/webkom/lego/pull/3642 (that is why cypress fails)

# Description

Show waiting list position for each applicable pool if there are multiple pools in the event.

The waitlist position is calculated for each pool by looping through the waiting list and counting how many people before you are applicable for the given pool. This depends on a backend change, that includes the ids of all groups (including inherited) for each registration on the waiting list. https://github.com/webkom/lego/pull/3642

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

**Before:**
![Screenshot 2024-09-23 at 16 16 38](https://github.com/user-attachments/assets/c3fac255-6da1-4038-9d42-602259b475c4)

**After:**
This user is first on the waiting list and has access to only the "Abakus" pool:
<img width="344" alt="Screenshot 2024-09-24 at 17 33 44" src="https://github.com/user-attachments/assets/b3f6af5b-da30-4cfc-8e7c-7eda2f54291d">

This user is second on the waiting list, but is the only one with access to the "Webkom" pool:
<img width="344" alt="Screenshot 2024-09-24 at 17 32 47" src="https://github.com/user-attachments/assets/c7a0f2b8-8988-4bac-a9d3-1cb0c0695459">

Event with only one pool/merged pools:
<img width="344" alt="Screenshot 2024-09-24 at 21 22 20" src="https://github.com/user-attachments/assets/67b75203-dfcf-4384-bfeb-159cf30a8843">

# Testing


- [x] I have thoroughly tested my changes.

I have created a few different events with different conditions, and it has calculated and shown the correct positions in all my tests:)

---

Resolves ABA-1070