### PR TITLE
Support anonymized survey submissions

### DIFF
--- a/app/reducers/surveySubmissions.ts
+++ b/app/reducers/surveySubmissions.ts
@@ -36,12 +36,11 @@ const { selectByField: selectSurveySubmissionsByField } =
 export const selectSurveySubmissionsBySurveyId =
   selectSurveySubmissionsByField('survey');
 
-export const selectSurveySubmissionForUser = createSelector(
+export const selectOwnSurveySubmission = createSelector(
   (state: RootState, props: { surveyId: EntityId }) =>
     selectSurveySubmissionsBySurveyId(state, props.surveyId),
-  (_: RootState, props: { currentUserId: EntityId }) => props.currentUserId,
-  (submissions, userId) =>
-    submissions.find((surveySubmission) => surveySubmission.user === userId),
+  (submissions) =>
+    submissions.find((surveySubmission) => surveySubmission.isOwner),
 );
 
 export const useFetchedSurveySubmissions = (

--- a/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
+++ b/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
@@ -9,7 +9,7 @@ import {
 } from 'app/actions/SurveySubmissionActions';
 import Time from 'app/components/Time';
 import { useCurrentUser } from 'app/reducers/auth';
-import { selectSurveySubmissionForUser } from 'app/reducers/surveySubmissions';
+import { selectOwnSurveySubmission } from 'app/reducers/surveySubmissions';
 import { useFetchedSurvey } from 'app/reducers/surveys';
 import AlreadyAnswered from 'app/routes/surveys/components/AddSubmission/AlreadyAnswered';
 import SurveySubmissionForm from 'app/routes/surveys/components/AddSubmission/SurveySubmissionForm';
@@ -27,13 +27,10 @@ const AddSubmissionPage = () => {
     useParams<AddSubmissionPageParams>() as AddSubmissionPageParams;
   const currentUser = useCurrentUser();
   const { survey, event } = useFetchedSurvey('addSubmission', surveyId);
-  const submission = useAppSelector(
-    (state) =>
-      currentUser &&
-      selectSurveySubmissionForUser(state, {
-        surveyId: Number(surveyId),
-        currentUserId: currentUser.id,
-      }),
+  const submission = useAppSelector((state) =>
+    selectOwnSurveySubmission(state, {
+      surveyId: Number(surveyId),
+    }),
   );
 
   const fetchingSubmission = useAppSelector(

--- a/app/store/models/SurveySubmission.d.ts
+++ b/app/store/models/SurveySubmission.d.ts
@@ -7,7 +7,7 @@ import type {
 
 export interface SurveySubmission {
   id: EntityId;
-  user: EntityId;
+  isOwner: boolean;
   survey: EntityId;
   answers: (SurveyAnswer | AdminSurveyAnswer)[];
 }


### PR DESCRIPTION
# Description

Currently we send the user object with every survey submission, which is not ideal because we tell users they are anonymous. This makes changes to frontend to support the changes to the API endpoint removing the user field from the submissions.

Backend PR: https://github.com/webkom/lego/pull/3529

# Result

No visual or functional changes.

# Testing

- [ ] I have thoroughly tested my changes.

Needs more testing with non-admin users

---

Resolves ABA-273