### PR TITLE
Add warning to pin to frontpage

### DIFF
--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   ButtonGroup,
+  Card,
   ConfirmModal,
   Icon,
   LinkButton,
@@ -158,7 +159,7 @@ const ArticleEditor = () => {
         validate={validate}
         initialValues={initialValues}
       >
-        {({ handleSubmit }) => (
+        {({ handleSubmit, values }) => (
           <Form onSubmit={handleSubmit}>
             <Field
               name="cover"
@@ -179,6 +180,15 @@ const ArticleEditor = () => {
               type="checkbox"
               component={CheckBox.Field}
             />
+            {values.pinned && (
+              <Card style={{ marginTop: 0 }} severity="warning">
+                <span>
+                  OBS! Du må ha godkjenning fra ledelsen for å feste til
+                  forsiden.
+                </span>
+              </Card>
+            )}
+
             <Field
               placeholder="Title"
               name="title"

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -181,11 +181,11 @@ const ArticleEditor = () => {
               component={CheckBox.Field}
             />
             {values.pinned && (
-              <Card style={{ marginTop: 0 }} severity="warning">
-                <span>
-                  OBS! Du må ha godkjenning fra ledelsen for å feste til
-                  forsiden.
-                </span>
+              <Card severity="warning">
+                <Card.Header>Obs!</Card.Header>
+                <p>
+                  Du må ha godkjenning fra ledelsen for å feste til forsiden.
+                </p>
               </Card>
             )}
 

--- a/app/routes/events/components/EventEditor/EditorSection/Header.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Header.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   Modal,
   Image,
+  Card,
 } from '@webkom/lego-bricks';
 import { FolderOpen, Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
@@ -64,6 +65,14 @@ const Header = ({
         fieldClassName={styles.metaField}
         className={styles.formField}
       />
+
+      {values.pinned && (
+        <Card style={{ marginTop: 0 }} severity="warning">
+          <span>
+            OBS! Du må ha godkjenning fra ledelsen for å feste til forsiden.
+          </span>
+        </Card>
+      )}
 
       <Field
         label="Cover"

--- a/app/routes/events/components/EventEditor/EditorSection/Header.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Header.tsx
@@ -67,10 +67,9 @@ const Header = ({
       />
 
       {values.pinned && (
-        <Card style={{ marginTop: 0 }} severity="warning">
-          <span>
-            OBS! Du må ha godkjenning fra ledelsen for å feste til forsiden.
-          </span>
+        <Card severity="warning">
+          <Card.Header>Obs!</Card.Header>
+          <p>Du må ha godkjenning fra ledelsen for å feste til forsiden.</p>
         </Card>
       )}
 


### PR DESCRIPTION
# Description
Add warning under "fest til forsiden" to make i clear you need permission to pin.
Applies to article- and event-editing.
# Result
If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.
<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
<img width="936" alt="image" src="https://github.com/user-attachments/assets/e4ac030a-f179-4aaa-8d23-3cb4b80f0d97">
        </td>
        <td>
<img width="945" alt="image" src="https://github.com/user-attachments/assets/683a6923-609f-47e9-968f-eeebecd97fb6">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves: ABA-1077
