### PR TITLE
Fix error when entering event detail page after /administrate

### DIFF
--- a/app/routes/events/components/EventDetail/getWaitingListPosition.ts
+++ b/app/routes/events/components/EventDetail/getWaitingListPosition.ts
@@ -9,7 +9,7 @@ const isPermittedInPool = (
   pool: PoolWithRegistrations,
 ) => {
   return pool.permissionGroups.some((permissionGroup) =>
-    user.allAbakusGroupIds.some(
+    user.allAbakusGroupIds?.some(
       (userGroup) => userGroup === permissionGroup.id,
     ),
   );
@@ -21,6 +21,8 @@ export const getWaitingListPosition = (
   pools?: PoolWithRegistrations[],
 ) => {
   if (!currentRegistration || !waitingList || !pools) return undefined;
+  if (!waitingList.registrations.includes(currentRegistration))
+    return undefined;
 
   const nonWaitingListPools = pools.filter((pool) => !pool.isWaitingList);
 


### PR DESCRIPTION
# Description

Doing this loads the event with the "Administrate"-serializer, which is without the "allAbakusGroupIds"-field in users. Everything gets loaded once the page is entered, but we need to avoid a crash in the meantime.

Fixes [LEGO-WEBAPP-25G](https://abakus.sentry.io/issues/5920611469/)

# Result

No more crash:)

# Testing

- [x] I have thoroughly tested my changes.