### PR TITLE
Only show one semester at a time on BDB

### DIFF
--- a/app/actions/CompanyActions.ts
+++ b/app/actions/CompanyActions.ts
@@ -35,10 +35,10 @@ export const fetchAll = ({ fetchMore }: { fetchMore: boolean }) => {
   });
 };
 
-export function fetchAllAdmin() {
+export function fetchAllAdmin(semesterId: EntityId) {
   return callAPI<AdminListCompany[]>({
     types: Company.FETCH,
-    endpoint: '/bdb/',
+    endpoint: `/bdb/?semester_id=${semesterId}`,
     schema: [companySchema],
     meta: {
       errorMessage: 'Henting av bedrifter feilet',
@@ -271,13 +271,8 @@ export function fetchSemestersForInterestform() {
   });
 }
 
-export function fetchSemesters(
-  queries: Record<
-    string,
-    (string | null | undefined) | (number | null | undefined)
-  > = {},
-) {
-  return callAPI<DetailedSemesterStatus[]>({
+export function fetchSemesters(queries: Record<string, string> = {}) {
+  return callAPI<CompanySemester[]>({
     types: Company.FETCH_SEMESTERS,
     endpoint: `/company-semesters/${createQueryString(queries)}`,
     schema: [companySemesterSchema],

--- a/app/routes/bdb/components/BdbPage.tsx
+++ b/app/routes/bdb/components/BdbPage.tsx
@@ -1,158 +1,77 @@
-import { Card, Flex, Icon, LinkButton, Page } from '@webkom/lego-bricks';
+import { Card, LinkButton, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { MoveLeft, MoveRight } from 'lucide-react';
-import moment from 'moment-timezone';
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Link, useNavigate } from 'react-router-dom';
-import {
-  fetchAllAdmin,
-  addSemesterStatus,
-  editSemesterStatus,
-  fetchSemesters,
-  addSemester,
-} from 'app/actions/CompanyActions';
+import { Link } from 'react-router-dom';
+import { fetchAllAdmin, fetchSemesters } from 'app/actions/CompanyActions';
 import Table from 'app/components/Table';
 import { selectTransformedAdminCompanies } from 'app/reducers/companies';
 import { selectAllCompanySemesters } from 'app/reducers/companySemesters';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
-import { Semester } from 'app/store/models';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import useQuery from 'app/utils/useQuery';
 import {
-  indexToCompanySemester,
-  indexToYearAndSemester,
   BdbTabs,
-  selectMostProminentStatus,
-  contactStatuses,
+  getClosestCompanySemester,
+  getCompanySemesterBySlug,
+  getSemesterStatus,
 } from '../utils';
 import SemesterStatus from './SemesterStatus';
-import styles from './bdb.css';
-import type { EntityId } from '@reduxjs/toolkit';
 import type { ColumnProps } from 'app/components/Table';
-import type { TransformedAdminCompany } from 'app/reducers/companies';
-import type { CompanySemesterContactStatus } from 'app/store/models/Company';
+import type CompanySemester from 'app/store/models/CompanySemester';
 import type { UnknownUser } from 'app/store/models/User';
 
 const companiesDefaultQuery = {
   active: '' as '' | 'true' | 'false',
   name: '',
   studentContact: '',
+  semester: undefined,
 };
-
-const NUMBER_OF_SEMESTERS = 3;
 
 const BdbPage = () => {
   const { query, setQuery } = useQuery(companiesDefaultQuery);
-
-  const [startYear, setStartYear] = useState(moment().year());
-  const [startSemester, setStartSemester] = useState(
-    moment().month() > 6 ? 1 : 0,
-  );
 
   const companies = useAppSelector(selectTransformedAdminCompanies);
   const companySemesters = useAppSelector(selectAllCompanySemesters);
   const fetching = useAppSelector((state) => state.companies.fetching);
 
-  const dispatch = useAppDispatch();
+  const resolveCurrentSemester = (
+    slug: string | undefined,
+    companySemesters: CompanySemester[],
+  ) => {
+    if (slug) {
+      const companySemester = getCompanySemesterBySlug(slug, companySemesters);
+      if (companySemester) return companySemester;
+    }
 
-  usePreparedEffect(
-    'fetchBdb',
-    () => dispatch(fetchSemesters()).then(() => dispatch(fetchAllAdmin())),
-    [],
+    return getClosestCompanySemester(companySemesters);
+  };
+
+  const currentCompanySemester = useMemo(
+    () => resolveCurrentSemester(query.semester, companySemesters),
+    [companySemesters, query.semester],
   );
 
-  const navigateThroughTime = (options: {
-    direction: 'forward' | 'backward';
-  }) => {
-    let newYear: number;
-    if (options.direction === 'forward') {
-      newYear = startSemester === 0 ? startYear : startYear + 1;
-    } else {
-      newYear = startSemester === 1 ? startYear : startYear - 1;
-    }
-    setStartYear(newYear);
+  const dispatch = useAppDispatch();
+  usePreparedEffect(
+    'fetchBdb',
+    () =>
+      dispatch(fetchSemesters()).then((action) => {
+        const companySemesterEntities =
+          action.payload.entities.companySemesters;
+        const companySemesters = Object.values(companySemesterEntities).filter(
+          (companySemester) => companySemester !== undefined,
+        );
 
-    const newSemester = (startSemester + 1) % (NUMBER_OF_SEMESTERS - 1);
-    setStartSemester(newSemester);
-  };
+        const semester = resolveCurrentSemester(
+          query.semester,
+          companySemesters,
+        );
 
-  const navigate = useNavigate();
-
-  const editChangedStatuses = async (
-    companyId: EntityId,
-    tableIndex: number,
-    semesterStatusId: EntityId | undefined,
-    contactedStatus: CompanySemesterContactStatus[],
-  ) => {
-    // Update state whenever a semesterStatus is graphically changed by the user
-    const companySemester = indexToCompanySemester(
-      tableIndex,
-      startYear,
-      startSemester,
-      companySemesters,
-    );
-
-    let companySemesterId: EntityId;
-
-    if (!companySemester) {
-      const newCompanySemester = indexToYearAndSemester(
-        tableIndex,
-        startYear,
-        startSemester,
-      );
-      const response = await dispatch(addSemester(newCompanySemester));
-      companySemesterId = response.payload.result;
-    } else {
-      companySemesterId = companySemester.id;
-    }
-
-    const semesterStatus = {
-      companyId,
-      contactedStatus,
-      semester: companySemesterId,
-    };
-    return semesterStatusId
-      ? dispatch(editSemesterStatus({ ...semesterStatus, semesterStatusId }))
-      : dispatch(addSemesterStatus(semesterStatus)).then(() => {
-          navigate('/bdb');
-        });
-  };
-
-  const semesterTitle = (index: number) => {
-    const result = indexToYearAndSemester(index, startYear, startSemester);
-    const semester = result.semester === Semester.Spring ? 'Vår' : 'Høst';
-
-    return (
-      <Flex alignItems="center" gap="var(--spacing-sm)">
-        {index === 0 && (
-          <Icon
-            onClick={() => navigateThroughTime({ direction: 'backward' })}
-            iconNode={<MoveLeft />}
-            className={styles.navigateThroughTime}
-          />
-        )}
-        <span>
-          {semester} {result.year}
-        </span>
-        {index === NUMBER_OF_SEMESTERS - 1 && (
-          <Icon
-            onClick={() => navigateThroughTime({ direction: 'forward' })}
-            iconNode={<MoveRight />}
-            className={styles.navigateThroughTime}
-          />
-        )}
-      </Flex>
-    );
-  };
-
-  const semesterElement = (index: number, company: TransformedAdminCompany) => {
-    const result = indexToYearAndSemester(index, startYear, startSemester);
-    return (company.semesterStatuses || []).find(
-      (status) =>
-        status.year === result.year && status.semester === result.semester,
-    );
-  };
+        return dispatch(fetchAllAdmin(semester!.id));
+      }),
+    [],
+  );
 
   const columns: ColumnProps<(typeof companies)[number]>[] = [
     {
@@ -165,42 +84,26 @@ const BdbPage = () => {
         <Link to={`/bdb/${company.id}`}>{company.name}</Link>
       ),
     },
-    ...Array.from({ length: NUMBER_OF_SEMESTERS }, (_, index) => ({
-      title: semesterTitle(index),
-      dataIndex: `semester-${index}`,
-      sorter: (a, b) => {
-        const { year, semester } = indexToYearAndSemester(
-          index,
-          startYear,
-          startSemester,
-        );
-        const semesterA = a.semesterStatuses?.find(
-          (obj) => obj.year === year && obj.semester === semester,
-        );
-        const statusA = selectMostProminentStatus(semesterA?.contactedStatus);
-        const semesterB = b.semesterStatuses?.find(
-          (obj) => obj.year === year && obj.semester === semester,
-        );
-        const statusB = selectMostProminentStatus(semesterB?.contactedStatus);
-
-        if (statusA === statusB) {
-          return a.name.localeCompare(b.name);
-        }
-
-        return (
-          contactStatuses.indexOf(statusA) - contactStatuses.indexOf(statusB)
-        );
-      },
+    {
+      title: 'Status',
+      dataIndex: `status`,
       padding: 0,
       render: (_, company) => (
         <SemesterStatus
-          semIndex={index}
-          semesterStatus={semesterElement(index, company)}
-          editChangedStatuses={editChangedStatuses}
-          companyId={company.id}
+          semesterStatus={
+            currentCompanySemester &&
+            getSemesterStatus(company, currentCompanySemester)
+          }
+          semester={
+            currentCompanySemester && {
+              semester: currentCompanySemester?.semester,
+              year: currentCompanySemester.year,
+            }
+          }
+          company={company}
         />
       ),
-    })),
+    },
     {
       title: 'Studentkontakt',
       dataIndex: 'studentContact',
@@ -209,15 +112,6 @@ const BdbPage = () => {
       filterMapping: (studentContact: UnknownUser) => {
         if (studentContact && typeof studentContact === 'object') {
           return studentContact.fullName;
-        }
-      },
-      render: (_, { studentContact }) => {
-        if (studentContact && typeof studentContact === 'object') {
-          return (
-            <Link to={`/users/${studentContact.username}`}>
-              {studentContact.fullName}
-            </Link>
-          );
         }
       },
     },

--- a/app/routes/bdb/components/SemesterStatus.tsx
+++ b/app/routes/bdb/components/SemesterStatus.tsx
@@ -1,36 +1,74 @@
 import { Flex } from '@webkom/lego-bricks';
+import { useMemo } from 'react';
+import {
+  addSemesterStatus,
+  editSemesterStatus,
+} from 'app/actions/CompanyActions';
+import { selectAllCompanySemesters } from 'app/reducers/companySemesters';
+import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { NonEventContactStatus } from 'app/store/models/Company';
 import {
   getStatusColor,
   getContactStatuses,
   selectMostProminentStatus,
+  getSemesterStatus,
 } from '../utils';
 import styles from './SemesterStatus.css';
 import SemesterStatusContent from './SemesterStatusContent';
-import type { EntityId } from '@reduxjs/toolkit';
-import type { TransformedSemesterStatus } from 'app/reducers/companies';
-import type { CompanySemesterContactStatus } from 'app/store/models/Company';
+import type { Semester } from 'app/models';
+import type {
+  TransformedAdminCompany,
+  TransformedSemesterStatus,
+} from 'app/reducers/companies';
+import type {
+  AdminDetailCompany,
+  AdminListCompany,
+  CompanySemesterContactStatus,
+} from 'app/store/models/Company';
 
 type Props = {
   semesterStatus: TransformedSemesterStatus | undefined;
-  editChangedStatuses: (
-    companyId: EntityId,
-    tableIndex: number,
-    semesterStatusId: EntityId | undefined,
-    contactedStatus: CompanySemesterContactStatus[],
-  ) => Promise<unknown>;
-  companyId: EntityId;
-  semIndex: number;
+  semester: { semester: Semester; year: number } | undefined;
+  company: TransformedAdminCompany;
 };
-const SemesterStatus = ({
-  semesterStatus,
-  companyId,
-  semIndex,
-  editChangedStatuses,
-}: Props) => {
+const SemesterStatus = ({ semesterStatus, semester, company }: Props) => {
   const contactedStatuses = semesterStatus?.contactedStatus ?? [
     NonEventContactStatus.NOT_CONTACTED,
   ];
+
+  const companySemesters = useAppSelector(selectAllCompanySemesters);
+  const companySemester = useMemo(
+    () =>
+      companySemesters.find(
+        (companySemester) =>
+          companySemester.semester === semester?.semester &&
+          companySemester.year === semester?.year,
+      ),
+    [semester?.semester, semester?.year, companySemesters],
+  );
+
+  const dispatch = useAppDispatch();
+  const editChangedStatuses = async (
+    company: TransformedAdminCompany<AdminListCompany | AdminDetailCompany>,
+    contactedStatus: CompanySemesterContactStatus[],
+  ) => {
+    if (!companySemester) {
+      return;
+    }
+
+    const semesterStatus = {
+      companyId: company.id,
+      contactedStatus,
+      semester: companySemester.id,
+    };
+
+    const semesterStatusId = getSemesterStatus(company, companySemester)?.id;
+
+    return semesterStatusId
+      ? dispatch(editSemesterStatus({ ...semesterStatus, semesterStatusId }))
+      : dispatch(addSemesterStatus(semesterStatus));
+  };
+
   return (
     <Flex
       alignItems="center"
@@ -45,9 +83,7 @@ const SemesterStatus = ({
         contactedStatus={contactedStatuses}
         editFunction={(status) =>
           editChangedStatuses(
-            companyId,
-            semIndex,
-            semesterStatus?.id,
+            company,
             getContactStatuses(contactedStatuses, status),
           )
         }


### PR DESCRIPTION
# Description

[Related backend PR](https://github.com/webkom/lego/pull/3645)

- Update to refactored backend bdb endpoint
- Only show one semester at a time
- (Coming soon: student contacts for a company should be distinct for each semester. Waiting for other PRs first)

TODO:
- The viewed semester can be changed by the `semester` query in the URL. We should probably add a dropdown for this at some point

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
  - BDB looks trash on mobile
- [X] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
        <img src="https://github.com/user-attachments/assets/f98cdf18-c3af-43b6-88d0-a5e77289f7ab">
        </td>
        <td>
        <img src="https://github.com/user-attachments/assets/1a7e89b0-8587-413c-b5eb-4f03efc915e2">
        </td>
    </tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.

Changing semester statues still work
The detailed bdb route still works

---

Resolves ABA-1049, ABA-1051
