### PR TITLE
Fix attendance modal overflowing when searching on mobile

### DIFF
--- a/app/components/UserAttendance/AttendanceModalContent.css
+++ b/app/components/UserAttendance/AttendanceModalContent.css
@@ -4,13 +4,14 @@
   /* 
    * Kinda hacky solution, but with the current flexibility of modal sizing it's the only way I could think of for now
    * 
-   * 100vh - 100px          = height of the modal from @lego-bricks/src/components/Modal/Modal.module.css
+   * var(--visual-viewport-height) - 100px          = height of the modal from @lego-bricks/src/components/Modal/Modal.module.css
    * 2 * var(--spacing-xl)  = the padding of the modal
    * 2rem                   = the height of the title
    * var(--spacing-md)      = the margin-bottom of the title
   */
   --attendance-modal-content-height: calc(
-    (100vh - 100px) - (2 * var(--spacing-xl)) - (2rem) - var(--spacing-md)
+    (var(--visual-viewport-height) - 100px) - (2 * var(--spacing-xl)) - (2rem) -
+      var(--spacing-md)
   );
 
   height: var(--attendance-modal-content-height);

--- a/packages/lego-bricks/src/components/Modal/Modal.module.css
+++ b/packages/lego-bricks/src/components/Modal/Modal.module.css
@@ -49,7 +49,13 @@ html[data-theme='dark'] .overlay {
   position: fixed;
   width: 475px;
   max-width: 100%;
-  max-height: calc(100vh - 100px);
+  /**
+   * max-height must be smaller than the height of .overlay
+   * This is because we use align-items: center to vertically center, 
+   * which moves the modal content out of the top of the screen if it 
+   * is too tall
+  */
+  max-height: calc(var(--visual-viewport-height) - 100px);
   padding: var(--spacing-xl);
   background: var(--color-white);
   outline: none;


### PR DESCRIPTION
# Description

The previously used `100vh` became bigger than the `var(--visual-viewport-height)` that was introduced to the overlay 5 months ago, which caused the page to overflow when visual-viewport-height shrinked when users opened their keyboards to search (on mobile).

# Result

This is now fixed, so the div does not move when you search for attendants.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
