### PR TITLE
Improve event items on frontpage

### DIFF
--- a/app/routes/frontpage/components/CompactEvents.css
+++ b/app/routes/frontpage/components/CompactEvents.css
@@ -8,7 +8,7 @@
   text-align: left;
   gap: var(--spacing-xl);
 
-  @media (--small-viewport) {
+  @media (--medium-viewport) {
     flex-direction: column;
   }
 }
@@ -24,29 +24,20 @@
   flex: 1;
 }
 
-.compactEvents li {
-  display: flex;
-  align-items: center;
-}
-
 .eventItem {
-  height: 26px;
-}
-
-.compactEvents a {
+  height: 28.8px; /* Used for the skeleton component */
   color: var(--lego-font-color);
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin-left: calc(-1 * var(--spacing-sm));
+  transition: background-color var(--easing-blazingly-fast);
+
+  &:hover {
+    background-color: var(--additive-background);
+  }
 }
 
-.compactEvents li > a {
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  width: 0;
-  flex-grow: 1;
-  padding-right: 10px;
-}
-
-.compactEvents a:hover {
+.pinned {
+  transform: rotate(-20deg);
   color: var(--lego-link-color);
 }

--- a/app/routes/frontpage/components/CompactEvents.tsx
+++ b/app/routes/frontpage/components/CompactEvents.tsx
@@ -1,6 +1,8 @@
-import { Flex, Skeleton } from '@webkom/lego-bricks';
+import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
+import { Pin } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Link } from 'react-router-dom';
+import Circle from 'app/components/Circle';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';
 import { selectAllEvents } from 'app/reducers/events';
@@ -8,6 +10,7 @@ import { eventListDefaultQuery } from 'app/routes/events/components/EventList';
 import { colorForEventType } from 'app/routes/events/utils';
 import { useAppSelector } from 'app/store/hooks';
 import { EventType } from 'app/store/models/Event';
+import truncateString from 'app/utils/truncateString';
 import { stringifyQuery } from 'app/utils/useQuery';
 import styles from './CompactEvents.css';
 import type { FrontpageEvent } from 'app/store/models/Event';
@@ -32,38 +35,37 @@ const CompactEvents = ({ className, style }: Props) => {
       .filter((event) => eventTypes.includes(event.eventType))
       .slice(0, EVENT_COLUMN_LIMIT)
       .map((event, key) => (
-        <li key={key} className={styles.eventItem}>
-          <span
-            style={{
-              color: colorForEventType(event.eventType),
-              fontSize: '15px',
-              lineHeight: '0',
-              marginRight: '10px',
-            }}
+        <Link
+          key={key}
+          to={`/events/${event.slug}`}
+          className={styles.eventItem}
+        >
+          <Flex
+            alignItems="center"
+            justifyContent="space-between"
+            gap="var(--spacing-md)"
           >
-            <i className="fa fa-circle" />
-          </span>
-          <Link to={`/events/${event.slug}`}>{event.title}</Link>
-          {event.pinned && (
-            <Tooltip content="Dette arrangementet er festet til forsiden">
-              <i
-                className="fa fa-thumb-tack"
-                style={{
-                  transform: 'rotate(-20deg)',
-                  marginRight: '4px',
-                  color: 'var(--lego-red-color)',
-                }}
+            <Flex alignItems="center" gap="var(--spacing-sm)">
+              <Circle
+                size="var(--font-size-xs)"
+                color={colorForEventType(event.eventType)}
               />
-            </Tooltip>
-          )}
-          <Time
-            format="dd D.MM"
-            time={event.startTime}
-            style={{
-              flex: '0 1 0',
-            }}
-          />
-        </li>
+              <span>{truncateString(event.title, 27)}</span>
+            </Flex>
+            <Flex alignItems="center" gap="var(--spacing-xs)">
+              {event.pinned && (
+                <Tooltip content="Dette arrangementet er festet til forsiden">
+                  <Icon
+                    iconNode={<Pin />}
+                    size={16}
+                    className={styles.pinned}
+                  />
+                </Tooltip>
+              )}
+              <Time format="dd D. MMM" time={event.startTime} />
+            </Flex>
+          </Flex>
+        </Link>
       ));
   };
 
@@ -95,7 +97,7 @@ const CompactEvents = ({ className, style }: Props) => {
 
   return (
     <Flex column className={className} style={style}>
-      <Flex wrap className={styles.compactEvents}>
+      <Flex className={styles.compactEvents}>
         <Flex column className={styles.compactLeft}>
           <Link
             to={{
@@ -110,7 +112,7 @@ const CompactEvents = ({ className, style }: Props) => {
           >
             <h3 className="u-ui-heading">Bedpres og kurs</h3>
           </Link>
-          <Flex column gap="5px">
+          <Flex column gap="var(--spacing-xs)">
             {fetching && !presentations.length ? skeleton : leftEvents}
           </Flex>
         </Flex>
@@ -128,7 +130,7 @@ const CompactEvents = ({ className, style }: Props) => {
           >
             <h3 className="u-ui-heading">Arrangementer</h3>
           </Link>
-          <Flex column gap="5px">
+          <Flex column gap="var(--spacing-xs)">
             {fetching && !other.length ? skeleton : rightEvents}
           </Flex>
         </Flex>

--- a/cypress/e2e/home_page_spec.js
+++ b/cypress/e2e/home_page_spec.js
@@ -10,10 +10,10 @@ describe('The Home Page and Login', () => {
     cy.contains('a', 'Om Abakus');
 
     cy.contains('h3', 'Bedpres og kurs');
-    cy.contains('li', 'DIPS');
+    cy.contains(c('CompactEvents__eventItem'), 'DIPS');
 
     cy.contains('h3', 'Arrangementer');
-    cy.contains('li', 'Sikkerhet og Sårbarhet');
+    cy.contains(c('CompactEvents__eventItem'), 'Sikkerhet og Sårbarhet');
 
     cy.contains('h3', 'Oppslag');
     cy.contains('span', 'readme');
@@ -45,10 +45,10 @@ describe('The Home Page and Login', () => {
     cy.visit('/');
 
     cy.contains('h3', 'Bedpres og kurs');
-    cy.contains('li', 'Deloitte AS');
+    cy.contains(c('CompactEvents__eventItem'), 'Deloitte AS');
 
     cy.contains('h3', 'Arrangementer');
-    cy.contains('li', 'Sikkerhet og Sårbarhet');
+    cy.contains(c('CompactEvents__eventItem'), 'Sikkerhet og Sårbarhet');
 
     cy.contains('h3', 'Påmeldinger');
 


### PR DESCRIPTION
# Description

Better spacing, look and the entire thing is now clickable!

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
			<video src="https://github.com/user-attachments/assets/b7cd367a-9ab4-4623-bce6-fb8ea5e09522" />
        </td>
        <td>
			<video src="https://github.com/user-attachments/assets/5a7a8de6-39a4-4ec7-8814-aab25adb32f1" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Checked different viewports and themes (and with skeleton components on slower connections).