### PR TITLE
Fix  1 other attendees

### DIFF
--- a/app/routes/events/components/RegisteredSummary.tsx
+++ b/app/routes/events/components/RegisteredSummary.tsx
@@ -40,8 +40,8 @@ const renderNameList = (registrations) => {
       {registrationsList.map((reg) => (
         <Flex key={reg.id}>{reg.user.fullName}</Flex>
       ))}
-      {registrations.length > 11 && (
-        <Flex>{`og ${registrations.length - 11} ${registrations.length - 11 === 1 ? 'annen' : 'andre'}`}</Flex>
+      {registrations.length > 14 && (
+        <Flex>{`og ${registrations.length - 14} ${registrations.length - 14 === 1 ? 'annen' : 'andre'}`}</Flex>
       )}
     </Flex>
   );

--- a/app/routes/events/components/RegisteredSummary.tsx
+++ b/app/routes/events/components/RegisteredSummary.tsx
@@ -40,8 +40,8 @@ const renderNameList = (registrations) => {
       {registrationsList.map((reg) => (
         <Flex key={reg.id}>{reg.user.fullName}</Flex>
       ))}
-      {registrations.length > 10 && (
-        <Flex>{`og ${registrations.length - 12} andre`}</Flex>
+      {registrations.length > 11 && (
+        <Flex>{`og ${registrations.length - 11} ${registrations.length - 11 === 1 ? 'annen' : 'andre'}`}</Flex>
       )}
     </Flex>
   );


### PR DESCRIPTION
# Description
Correct the display of the attendee count when hovering over "andre" in the UI. This change ensures that users see the accurate number of additional attendees, and no longer see -1/0 others. The indexing was also wrong, it said two more others than it should. 

# Result


- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
<tr>
        <td width="25%">Changed indexing and removed -1</td>
        <td>

![Screenshot 2024-10-09 at 20 50 04](https://github.com/user-attachments/assets/5869c64c-ff0c-4815-9612-606f167073d0)

![Screenshot 2024-10-09 at 20 55 45](https://github.com/user-attachments/assets/e2e1d736-3854-4804-8249-8fd1b4d5d978)

![Screenshot 2024-10-09 at 21 40 57](https://github.com/user-attachments/assets/39cc2319-3a39-414c-99fe-5bc613a2672c)




</td>
        <td>       


![Screenshot 2024-10-09 at 20 49 19](https://github.com/user-attachments/assets/9121446f-fc30-4c95-9bed-c54ea5eb3394)

![Screenshot 2024-10-09 at 20 55 38](https://github.com/user-attachments/assets/873d5c37-1c66-4a50-8566-a210bec197a9)

![Screenshot 2024-10-09 at 21 40 46](https://github.com/user-attachments/assets/37d92790-29cf-413a-b86d-8a1d70045b5a)

![Screenshot 2024-10-09 at 22 14 59](https://github.com/user-attachments/assets/3502410a-a35a-4320-9cfd-44e6a7775fed)



</td>
</tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Tested the "critical number" of attendees, 13-17 where the error occured. 
---
Resolves: 
ABA-1114

