### PR TITLE
Fix bug where empty email info field is shown

### DIFF
--- a/app/models.ts
+++ b/app/models.ts
@@ -4,7 +4,7 @@ import type { EntityId } from '@reduxjs/toolkit';
 import type Comment from 'app/store/models/Comment';
 import type { ListCompany } from 'app/store/models/Company';
 import type { ReactionsGrouped } from 'app/store/models/Reaction';
-import type { DetailedUser, PublicUser } from 'app/store/models/User';
+import type { PublicUser } from 'app/store/models/User';
 import type { RoleType } from 'app/utils/constants';
 import type { Moment } from 'moment';
 // TODO: Id handling could be opaque
@@ -285,7 +285,7 @@ export type TransformEvent = EventBase & {
   mazemapPoi: Record<string, any>;
   useMazemap: boolean;
   hasFeedbackQuestion: boolean;
-  responsibleUsers: DetailedUser[];
+  responsibleUsers: PublicUser[];
   isForeignLanguage: boolean;
 };
 

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -58,7 +58,6 @@ import type { UploadArgs } from 'app/actions/FileActions';
 import type { ActionGrant } from 'app/models';
 import type { EditingEvent } from 'app/routes/events/utils';
 import type { AdministrateEvent } from 'app/store/models/Event';
-import type { DetailedUser } from 'app/store/models/User';
 
 const TypedLegoForm = LegoFinalForm<EditingEvent>;
 
@@ -241,7 +240,7 @@ const EventEditor = () => {
         },
         responsibleUsers:
           event.responsibleUsers &&
-          event.responsibleUsers.map((user: DetailedUser) => ({
+          event.responsibleUsers.map((user) => ({
             label: user.fullName,
             value: user.id,
           })),

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -13,7 +13,7 @@ import type {
 } from 'app/models';
 import type { CompleteEvent } from 'app/store/models/Event';
 import type Penalty from 'app/store/models/Penalty';
-import type { DetailedUser } from 'app/store/models/User';
+import type { PublicUser } from 'app/store/models/User';
 
 export type ConfigProperties = {
   displayName: string;
@@ -109,7 +109,7 @@ export type EditingEvent = Event & {
   hasFeedbackQuestion: boolean;
   isClarified: boolean;
   authors: Option[];
-  responsibleUsers: DetailedUser[];
+  responsibleUsers: PublicUser[];
   saveToImageGallery: boolean;
 };
 

--- a/app/routes/users/components/UserProfile/UserInfo.tsx
+++ b/app/routes/users/components/UserProfile/UserInfo.tsx
@@ -6,7 +6,7 @@ import {
   ProfileSection,
 } from 'app/routes/users/components/UserProfile/ProfileSection';
 import styles from 'app/routes/users/components/UserProfile/UserProfile.css';
-import type { CurrentUser, DetailedUser } from 'app/store/models/User';
+import type { CurrentUser, PublicUserWithGroups } from 'app/store/models/User';
 
 const GithubField = ({ githubUsername }: { githubUsername: string }) => (
   <a href={`https://github.com/${githubUsername}`}>
@@ -32,7 +32,7 @@ const LinkedInField = ({
 );
 
 interface Props {
-  user: DetailedUser | CurrentUser;
+  user: PublicUserWithGroups | CurrentUser;
 }
 
 export const UserInfo = ({ user }: Props) => (
@@ -40,7 +40,7 @@ export const UserInfo = ({ user }: Props) => (
     <Flex column gap="var(--spacing-sm)">
       <InfoField name="Brukernavn">{user.username}</InfoField>
       <InfoField name="Navn">{user.fullName}</InfoField>
-      <EmailInfoField name="E-post" email={user.email} />
+      {'email' in user && <EmailInfoField name="E-post" email={user.email} />}
       {'internalEmailAddress' in user && user.internalEmailAddress && (
         <EmailInfoField
           name="Abakus e-post"

--- a/app/routes/users/components/UserProfile/index.tsx
+++ b/app/routes/users/components/UserProfile/index.tsx
@@ -45,7 +45,7 @@ import PhotoConsents from './PhotoConsents';
 import styles from './UserProfile.css';
 import type { ListEventWithUserRegistration } from 'app/store/models/Event';
 import type { PublicGroup } from 'app/store/models/Group';
-import type { CurrentUser, DetailedUser } from 'app/store/models/User';
+import type { CurrentUser, PublicUserWithGroups } from 'app/store/models/User';
 import type { ExclusifyUnion } from 'app/types';
 
 const UserProfile = () => {
@@ -55,7 +55,7 @@ const UserProfile = () => {
   const username = isCurrentUser ? currentUser?.username : params.username;
   const fetching = useAppSelector((state) => state.users.fetching);
   const user = useAppSelector((state) =>
-    selectUserByUsername<ExclusifyUnion<CurrentUser | DetailedUser>>(
+    selectUserByUsername<ExclusifyUnion<CurrentUser | PublicUserWithGroups>>(
       state,
       username,
     ),
@@ -245,9 +245,11 @@ const UserProfile = () => {
             <Permissions allAbakusGroupsWithPerms={allAbakusGroupsWithPerms} />
           )}
 
-          {isCurrentUser && user.email !== user.emailAddress && (
-            <GSuiteInfo emailAddress={user.emailAddress} />
-          )}
+          {isCurrentUser &&
+            user.emailAddress &&
+            user.email !== user.emailAddress && (
+              <GSuiteInfo emailAddress={user.emailAddress} />
+            )}
         </div>
         <div className={styles.rightContent}>
           {isCurrentUser && (

--- a/app/store/models/Event.ts
+++ b/app/store/models/Event.ts
@@ -5,11 +5,7 @@ import type { AutocompleteContentType } from 'app/store/models/Autocomplete';
 import type { ListCompany } from 'app/store/models/Company';
 import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
 import type { ReadRegistration } from 'app/store/models/Registration';
-import type {
-  DetailedUser,
-  PhotoConsent,
-  PublicUser,
-} from 'app/store/models/User';
+import type { PhotoConsent, PublicUser } from 'app/store/models/User';
 import type { ContentTarget } from 'app/store/utils/contentTarget';
 
 export enum EventType {
@@ -80,7 +76,7 @@ export interface CompleteEvent {
   youtubeUrl: string;
   mazemapPoi?: number;
   pinned: boolean;
-  responsibleUsers: DetailedUser[];
+  responsibleUsers: PublicUser[];
   isForeignLanguage: boolean;
   unregistered: EntityId[];
 

--- a/app/store/models/User.ts
+++ b/app/store/models/User.ts
@@ -69,6 +69,7 @@ interface User {
   actionGrant?: ActionGrant;
 }
 
+// Used if the user tries to get themselves or has the EDIT permission.
 export type CurrentUser = Pick<
   User,
   | 'id'
@@ -98,30 +99,6 @@ export type CurrentUser = Pick<
   | 'selectedTheme'
   | 'permissionsPerGroup'
   | 'photoConsents'
-  | 'githubUsername'
-  | 'linkedinId'
-  | 'actionGrant'
->;
-
-export type DetailedUser = Pick<
-  User,
-  | 'id'
-  | 'username'
-  | 'firstName'
-  | 'lastName'
-  | 'fullName'
-  | 'gender'
-  | 'email'
-  | 'emailAddress'
-  | 'emailListsEnabled'
-  | 'profilePicture'
-  | 'profilePicturePlaceholder'
-  | 'allergies'
-  | 'isActive'
-  | 'penalties'
-  | 'abakusGroups'
-  | 'pastMemberships'
-  | 'permissionsPerGroup'
   | 'githubUsername'
   | 'linkedinId'
   | 'actionGrant'
@@ -214,7 +191,6 @@ Some user object, unknown serializer
  */
 export type UnknownUser =
   | CurrentUser
-  | DetailedUser
   | PublicUser
   | PublicUserWithAbakusGroups
   | PublicUserWithGroups


### PR DESCRIPTION
# Description

For users without access to other users email, an empty field was shown. This bug was because I used the wrong user-type in the ProfilePage. Type is fixed and an added check ensured the entire field is hidden when the user doesn't have access to see the email.

Also I removed the `DetailedUser` type. It is (almost) never actually used, and with my upcoming backend PR it will be removed completely.

# Result

This no longer happens:

<img width="245" alt="Screenshot 2024-10-11 at 12 46 35" src="https://github.com/user-attachments/assets/009efb29-3dc7-47ce-a8ba-ec595206abcf">

# Testing

- [x] I have thoroughly tested my changes.

It is still shown when I am logged in as an admin, and not shown when I am logged in as a normal user.