### PR TITLE
Clean up bdb company details

### DIFF
--- a/app/routes/bdb/components/BdbDetail.tsx
+++ b/app/routes/bdb/components/BdbDetail.tsx
@@ -275,7 +275,9 @@ const BdbDetail = () => {
       link: false,
     },
     {
-      text: studentContact?.fullName || '-',
+      text: studentContact?.fullName || (
+        <span className="secondaryFontColor">Ingen studentkontakt</span>
+      ),
       icon: 'person-outline',
       link: studentContact
         ? `abakus.no/users/${studentContact.username}`
@@ -389,6 +391,7 @@ const BdbDetail = () => {
     {
       title: 'Status',
       dataIndex: 'contactedStatus',
+      padding: 0,
       render: (_, semesterStatus: TransformedSemesterStatus) => (
         <SemesterStatus
           semesterStatus={semesterStatus}
@@ -466,64 +469,74 @@ const BdbDetail = () => {
 
       <ContentSection>
         <ContentMain className={styles.mainContent}>
-          <CollapsibleDisplayContent
-            content={company.description}
-            skeleton={showSkeleton}
-          />
-
-          <Flex justifyContent="space-between" alignItems="center">
-            <h3>Bedriftskontakter</h3>
-            <LinkButton href={`/bdb/${company.id}/company-contacts/add`}>
-              Legg til bedriftskontakt
-            </LinkButton>
-          </Flex>
-          {company.companyContacts?.length > 0 ? (
-            <Table
-              columns={contactsColumns}
-              data={company.companyContacts}
-              hasMore={false}
-              loading={showSkeleton}
+          {company.description && (
+            <CollapsibleDisplayContent
+              content={company.description}
+              skeleton={showSkeleton}
             />
-          ) : (
-            <EmptyState body="Ingen bedriftskontakter registrert" />
           )}
 
-          <h3>Semesterstatuser</h3>
-          {company.semesterStatuses?.length > 0 ? (
-            <Table
-              columns={semesterColumns}
-              data={company.semesterStatuses}
-              hasMore={false}
-              loading={showSkeleton}
-            />
-          ) : (
-            <EmptyState body="Ingen semesterstatuser registrert" />
-          )}
-
-          <h3>Bedriftens arrangementer</h3>
-          {companyEvents.length > 0 ? (
-            <Table
-              columns={eventColumns}
-              data={companyEvents}
-              hasMore={showFetchMoreEvents}
-              loading={fetchingCompany}
-            />
-          ) : (
-            <EmptyState body="Ingen arrangementer registrert" />
-          )}
-
-          <h3>Bedriftens jobbannonser</h3>
-          {fetchingJoblistings && !joblistings.length ? (
-            <Skeleton className={sharedStyles.joblistingItem} />
-          ) : joblistings.length > 0 ? (
-            <Flex column gap="var(--spacing-sm)">
-              {joblistings.map((joblisting) => (
-                <JoblistingItem key={joblisting.id} joblisting={joblisting} />
-              ))}
+          <div>
+            <Flex justifyContent="space-between" alignItems="center">
+              <h3>Bedriftskontakter</h3>
+              <LinkButton href={`/bdb/${company.id}/company-contacts/add`}>
+                Legg til bedriftskontakt
+              </LinkButton>
             </Flex>
-          ) : (
-            <EmptyState body="Ingen tidligere jobbannonser" />
-          )}
+            {company.companyContacts?.length > 0 ? (
+              <Table
+                columns={contactsColumns}
+                data={company.companyContacts}
+                hasMore={false}
+                loading={showSkeleton}
+              />
+            ) : (
+              <EmptyState body="Ingen bedriftskontakter registrert" />
+            )}
+          </div>
+
+          <div>
+            <h3>Semesterstatuser</h3>
+            {company.semesterStatuses?.length > 0 ? (
+              <Table
+                columns={semesterColumns}
+                data={company.semesterStatuses}
+                hasMore={false}
+                loading={showSkeleton}
+              />
+            ) : (
+              <EmptyState body="Ingen semesterstatuser registrert" />
+            )}
+          </div>
+
+          <div>
+            <h3>Bedriftens arrangementer</h3>
+            {companyEvents.length > 0 ? (
+              <Table
+                columns={eventColumns}
+                data={companyEvents}
+                hasMore={showFetchMoreEvents}
+                loading={fetchingCompany}
+              />
+            ) : (
+              <EmptyState body="Ingen arrangementer registrert" />
+            )}
+          </div>
+
+          <div>
+            <h3>Bedriftens jobbannonser</h3>
+            {fetchingJoblistings && !joblistings.length ? (
+              <Skeleton className={sharedStyles.joblistingItem} />
+            ) : joblistings.length > 0 ? (
+              <Flex column gap="var(--spacing-sm)">
+                {joblistings.map((joblisting) => (
+                  <JoblistingItem key={joblisting.id} joblisting={joblisting} />
+                ))}
+              </Flex>
+            ) : (
+              <EmptyState body="Ingen tidligere jobbannonser" />
+            )}
+          </div>
 
           {company.contentTarget && (
             <CommentView


### PR DESCRIPTION
# Description

Slight ui changes

* Don't show empty company description
* Semester status fills entire table cell
* Better empty state on missing student contact
* Better spacing between all elements on page

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="892" alt="image" src="https://github.com/user-attachments/assets/f2a55438-5235-405b-9b65-e0f6fedd914a">
        </td>
        <td>
            <img width="892" alt="image" src="https://github.com/user-attachments/assets/dc03d9f4-da7f-4f2f-ab8f-d92383b1539f">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Just slight changes. Company description is still shown if it is given.