### PR TITLE
Add frame for winner of veldedighetsfest auction object "Ramme"

### DIFF
--- a/app/routes/users/components/UserProfile/index.tsx
+++ b/app/routes/users/components/UserProfile/index.tsx
@@ -123,7 +123,7 @@ const UserProfile = () => {
   }
 
   //If you wonder what this is, ask somebody
-  const FRAMEID = [6050, 5962, 7276, 7434, 7747, 8493];
+  const FRAMEID = [6050, 5962, 7276, 7325, 7434, 7747, 8493];
 
   const {
     pastMemberships = [],


### PR DESCRIPTION
# Description

Add frame for winner of veldedighetsfest auction object "Ramme".
(It was quite cheap actually :money_mouth_face: )

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Frame for user 7325
        </td>
        <td>
            It wasn't there
        </td>
        <td>
            It is there now
        </td>
    </tr>
</table>

# Testing

No testing needed. I have verified that the user ID (7325) is correct for the winner of the auction
---

Resolves ... (either GitHub issue or Linear task)
