### PR TITLE
Globally remove default styling from regular buttons

### DIFF
--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -18,6 +18,8 @@ button {
   cursor: pointer;
   border: none;
   background-color: transparent;
+  font-size: inherit;
+  color: inherit;
 }
 
 body {


### PR DESCRIPTION
# Description

At least the stylings we don't want - I've e.g. kept outline and font-weights.

This looks much worse on mobile, where a blue color is added as well. It's not "that" noticeable on laptop


# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
			<img width="215" alt="image" src="https://github.com/user-attachments/assets/4e44f509-9103-46d5-8ba4-1ce1fdd3567b">
        </td>
        <td>
           <img width="215" alt="image" src="https://github.com/user-attachments/assets/49450ceb-baa6-4881-b845-73ae6414aa28">
        </td>
    </tr>
    <tr>
        <td>
			<img width="393" alt="image" src="https://github.com/user-attachments/assets/6c9b7e74-d803-4254-90e8-f6bf56a0a528">
        </td>
        <td>
           <img width="393" alt="image" src="https://github.com/user-attachments/assets/d1043763-c6b6-4587-9d79-742cfe48be74">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Looks good now, both with and without ssr.

---

Resolves ABA-1118
