### PR TITLE
Fix crash on user profile page

### DIFF
--- a/app/routes/users/components/UserProfile/GroupMemberships.tsx
+++ b/app/routes/users/components/UserProfile/GroupMemberships.tsx
@@ -24,7 +24,7 @@ export const GroupMemberships = ({
 }) => {
   const groupEntities = useAppSelector(selectGroupEntities);
 
-  const { membershipsAsBadges = [], membershipsAsPills } = groupBy(
+  const { membershipsAsBadges = [], membershipsAsPills = [] } = groupBy(
     memberships.map((membership) => ({
       ...membership,
       abakusGroup: groupEntities[membership.abakusGroup] as PublicGroup,


### PR DESCRIPTION
# Description

I made an oopsie in #5043
It crashes when clicking a user profile on the event detail page because of invomplete data in the redux store.

# Result

no more crash:)

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves [LEGO-WEBAPP-25Y](https://abakus.sentry.io/issues/5986651245/)