### PR TITLE
Improve skeleton when fetching partially loaded detailed event

### DIFF
--- a/app/routes/events/components/EventDetail/AttendeeSection.tsx
+++ b/app/routes/events/components/EventDetail/AttendeeSection.tsx
@@ -64,7 +64,7 @@ export const AttendeeSection = ({
         minUserGridRows={minUserGridRows}
         maxUserGridRows={MAX_USER_GRID_ROWS}
         legacyRegistrationCount={event?.legacyRegistrationCount}
-        skeleton={fetching && !registrations}
+        skeleton={fetching && registrations.length === 0}
       />
 
       {loggedIn &&

--- a/app/routes/events/components/EventDetail/SidebarInfo.tsx
+++ b/app/routes/events/components/EventDetail/SidebarInfo.tsx
@@ -14,12 +14,11 @@ import styles from 'app/routes/events/components/EventDetail/EventDetail.css';
 import type { DetailedEvent } from 'app/store/models/Event';
 
 interface Props {
-  showSkeleton?: boolean;
   event?: DetailedEvent;
 }
 
-export const SidebarInfo = ({ showSkeleton, event }: Props) => {
-  return showSkeleton || !event ? (
+export const SidebarInfo = ({ event }: Props) => {
+  return !event ? (
     <Flex column gap="var(--spacing-sm)">
       <Skeleton array={3} className={styles.sidebarInfo} />
     </Flex>

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -152,7 +152,10 @@ const EventDetail = () => {
             event?.coverPlaceholder || event?.company?.logoPlaceholder
           }
           youtubeUrl={event?.youtubeUrl}
-          skeleton={showSkeleton}
+          skeleton={
+            fetching &&
+            !(event?.cover || event?.company?.logo || event?.youtubeUrl)
+          }
         />
       }
       title={
@@ -176,7 +179,7 @@ const EventDetail = () => {
           </div>
         )
       }
-      skeleton={showSkeleton}
+      skeleton={!event}
       dividerColor={color}
     >
       {event && (
@@ -191,22 +194,25 @@ const EventDetail = () => {
 
       <ContentSection>
         <ContentMain>
-          <DisplayContent content={event?.text || ''} skeleton={showSkeleton} />
+          <DisplayContent
+            content={event?.text || ''}
+            skeleton={fetching && !event?.text}
+          />
           <Flex className={styles.tagRow}>
             {event?.tags?.map((tag, i) => <Tag key={i} tag={tag} />)}
           </Flex>
         </ContentMain>
 
         <ContentSidebar>
-          <SidebarInfo showSkeleton={showSkeleton} event={event} />
+          <SidebarInfo event={event} />
 
           {event && ['OPEN', 'TBA'].includes(event.eventStatusType) ? (
             <JoinEventForm event={event} />
           ) : (
             <>
-              {hasRegistrationAccess && (
+              {(fetching || hasRegistrationAccess) && (
                 <AttendeeSection
-                  showSkeleton={showSkeleton}
+                  showSkeleton={fetching}
                   event={event}
                   currentRegistration={currentRegistration}
                   pools={pools as PoolWithRegistrations[]}

--- a/app/routes/events/components/RegisteredSummary.tsx
+++ b/app/routes/events/components/RegisteredSummary.tsx
@@ -137,7 +137,7 @@ const RegisteredSentence = ({
 const RegisteredSummary = ({ skeleton, ...props }: RegisteredSummaryProps) => {
   return (
     <Flex className={styles.summary}>
-      {skeleton && !props.registrations ? (
+      {skeleton && !props.registrations?.length ? (
         <Skeleton width="80%" />
       ) : (
         <RegisteredSentence {...props} />

--- a/app/routes/events/components/RegistrationMeta.tsx
+++ b/app/routes/events/components/RegistrationMeta.tsx
@@ -241,7 +241,7 @@ const PaymentStatus = ({
 };
 
 export const RegistrationMetaSkeleton = () => (
-  <Flex column gap="var(--spacing-sm)">
+  <Flex column gap="var(--spacing-sm)" margin="var(--spacing-sm) 0 0 0">
     <Skeleton array={2} className={styles.sidebarInfo} />
   </Flex>
 );


### PR DESCRIPTION
# Description

People (backup) were complaining that abakus.no, especially the event detail page has been very slow lately. I believe it just feels slower because skeleton loading broke after #4974
This fixes skeleton loading:)

# Result

https://github.com/user-attachments/assets/e09ebb44-201a-46e6-8445-09e82d14c7a4

# Testing

- [x] I have thoroughly tested my changes.

It now adds the correct skeleton components when entering event detail from frontpage and event list

---

Resolves ABA-1128
