### PR TITLE
Make semester statuses tags

### DIFF
--- a/app/components/Tags/Tag.tsx
+++ b/app/components/Tags/Tag.tsx
@@ -25,6 +25,8 @@ type Props = {
   link?: string;
   className?: string;
   active?: boolean;
+  textColor?: string;
+  backgroundColor?: string;
 };
 
 /**
@@ -38,6 +40,8 @@ const Tag = ({
   link,
   className,
   active,
+  textColor,
+  backgroundColor,
 }: Props) => (
   <div className={styles.linkSpacing}>
     {link ? (
@@ -50,6 +54,7 @@ const Tag = ({
           active && styles.active,
         )}
         to={link}
+        style={{ color: textColor, backgroundColor }}
       >
         {tag}
       </Link>
@@ -58,6 +63,7 @@ const Tag = ({
         gap="var(--spacing-xs)"
         alignItems="center"
         className={cx(styles.tag, styles[color], className)}
+        style={{ color: textColor, backgroundColor: backgroundColor }}
       >
         {icon && <Icon name={icon} size={iconSize ?? 16} />}
         {tag}

--- a/app/routes/bdb/components/AddSemester.tsx
+++ b/app/routes/bdb/components/AddSemester.tsx
@@ -213,10 +213,6 @@ const AddSemester = () => {
                         ),
                       });
                     }}
-                    style={{
-                      minHeight: '30px',
-                      padding: '10px',
-                    }}
                   />
                 </div>
               )}

--- a/app/routes/bdb/components/SemesterStatus.tsx
+++ b/app/routes/bdb/components/SemesterStatus.tsx
@@ -7,12 +7,7 @@ import {
 import { selectAllCompanySemesters } from 'app/reducers/companySemesters';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { NonEventContactStatus } from 'app/store/models/Company';
-import {
-  getStatusColor,
-  getContactStatuses,
-  selectMostProminentStatus,
-  getSemesterStatus,
-} from '../utils';
+import { getContactStatuses, getSemesterStatus } from '../utils';
 import styles from './SemesterStatus.css';
 import SemesterStatusContent from './SemesterStatusContent';
 import type { Semester } from 'app/models';
@@ -70,15 +65,7 @@ const SemesterStatus = ({ semesterStatus, semester, company }: Props) => {
   };
 
   return (
-    <Flex
-      alignItems="center"
-      className={styles.semesterStatus}
-      style={{
-        backgroundColor: getStatusColor(
-          selectMostProminentStatus(contactedStatuses),
-        ),
-      }}
-    >
+    <Flex alignItems="center" className={styles.semesterStatus}>
       <SemesterStatusContent
         contactedStatus={contactedStatuses}
         editFunction={(status) =>

--- a/app/routes/bdb/components/SemesterStatusContent.tsx
+++ b/app/routes/bdb/components/SemesterStatusContent.tsx
@@ -3,6 +3,8 @@ import { Check } from 'lucide-react';
 import { useState } from 'react';
 import Circle from 'app/components/Circle';
 import Dropdown from 'app/components/Dropdown';
+import Tags from 'app/components/Tags';
+import Tag from 'app/components/Tags/Tag';
 import {
   NonEventContactStatus,
   type CompanySemesterContactStatus,
@@ -12,6 +14,7 @@ import {
   getStatusColor,
   getStatusDisplayName,
   contactStatuses,
+  getStatusTextColor,
 } from '../utils';
 import type { CSSProperties } from 'react';
 
@@ -21,26 +24,24 @@ type Props = {
   style?: CSSProperties;
 };
 
-const SemesterStatusContent = ({
-  contactedStatus,
-  editFunction,
-  style,
-}: Props) => {
+const SemesterStatusContent = ({ contactedStatus, editFunction }: Props) => {
   const [displayDropdown, setDisplayDropdown] = useState(false);
 
   const statusesToRender = (
-    <div
-      style={{
-        ...style,
-      }}
-    >
+    <Tags>
       {contactedStatus.length > 0
         ? sortStatusesByProminence(contactedStatus)
             .slice()
-            .map((status) => getStatusDisplayName(status))
-            .join(', ')
+            .map((status) => (
+              <Tag
+                key={status}
+                tag={getStatusDisplayName(status)}
+                textColor={getStatusTextColor(status)}
+                backgroundColor={getStatusColor(status)}
+              />
+            ))
         : getStatusDisplayName()}
-    </div>
+    </Tags>
   );
 
   return (

--- a/app/routes/bdb/components/SemesterStatusContent.tsx
+++ b/app/routes/bdb/components/SemesterStatusContent.tsx
@@ -15,6 +15,7 @@ import {
   getStatusDisplayName,
   contactStatuses,
   getStatusTextColor,
+  NonEventContactStatusConfig,
 } from '../utils';
 import type { CSSProperties } from 'react';
 
@@ -27,20 +28,27 @@ type Props = {
 const SemesterStatusContent = ({ contactedStatus, editFunction }: Props) => {
   const [displayDropdown, setDisplayDropdown] = useState(false);
 
+  const notContactedStatus = NonEventContactStatus.NOT_CONTACTED;
   const statusesToRender = (
     <Tags>
-      {contactedStatus.length > 0
-        ? sortStatusesByProminence(contactedStatus)
-            .slice()
-            .map((status) => (
-              <Tag
-                key={status}
-                tag={getStatusDisplayName(status)}
-                textColor={getStatusTextColor(status)}
-                backgroundColor={getStatusColor(status)}
-              />
-            ))
-        : getStatusDisplayName()}
+      {contactedStatus.length > 0 ? (
+        sortStatusesByProminence(contactedStatus)
+          .slice()
+          .map((status) => (
+            <Tag
+              key={status}
+              tag={getStatusDisplayName(status)}
+              textColor={getStatusTextColor(status)}
+              backgroundColor={getStatusColor(status)}
+            />
+          ))
+      ) : (
+        <Tag
+          tag={getStatusDisplayName(notContactedStatus)}
+          textColor={getStatusTextColor(notContactedStatus)}
+          backgroundColor={getStatusColor(notContactedStatus)}
+        />
+      )}
     </Tags>
   );
 
@@ -66,6 +74,7 @@ const SemesterStatusContent = ({ contactedStatus, editFunction }: Props) => {
                 <button
                   onClick={() => editFunction(status)}
                   style={{
+                    color: active ? getStatusTextColor(status) : '',
                     backgroundColor: active ? getStatusColor(status) : '',
                   }}
                 >

--- a/app/routes/bdb/components/SemesterStatusContent.tsx
+++ b/app/routes/bdb/components/SemesterStatusContent.tsx
@@ -15,7 +15,6 @@ import {
   getStatusDisplayName,
   contactStatuses,
   getStatusTextColor,
-  NonEventContactStatusConfig,
 } from '../utils';
 import type { CSSProperties } from 'react';
 

--- a/app/routes/bdb/utils.tsx
+++ b/app/routes/bdb/utils.tsx
@@ -29,7 +29,7 @@ export const NonEventContactStatusConfig: Record<
   [NonEventContactStatus.NOT_INTERESTED]: {
     displayName: 'Ikke interessert',
     color: 'var(--danger-color)',
-    textColor: '#ff0000',
+    textColor: '#fff',
   },
   [NonEventContactStatus.CONTACTED]: {
     displayName: 'Kontaktet',
@@ -61,6 +61,12 @@ export const getStatusColor = (
   status: CompanySemesterContactStatus = NonEventContactStatus.NOT_CONTACTED,
 ) =>
   EventTypeConfig[status]?.color || NonEventContactStatusConfig[status]?.color;
+
+export const getStatusTextColor = (
+  status: CompanySemesterContactStatus = NonEventContactStatus.NOT_CONTACTED,
+) =>
+  EventTypeConfig[status]?.textColor ||
+  NonEventContactStatusConfig[status]?.textColor;
 
 export const sortStatusesByProminence = (
   statuses: CompanySemesterContactStatus[],

--- a/app/routes/bdb/utils.tsx
+++ b/app/routes/bdb/utils.tsx
@@ -19,7 +19,7 @@ export const NonEventContactStatusConfig: Record<
   [NonEventContactStatus.BEDEX]: {
     displayName: 'Bedex',
     color: colorForEventType(EventType.ALTERNATIVE_PRESENTATION),
-    textColor: '#fff',
+    textColor: 'var(--color-absolute-white)',
   },
   [NonEventContactStatus.INTERESTED]: {
     displayName: 'Interessert',
@@ -29,7 +29,7 @@ export const NonEventContactStatusConfig: Record<
   [NonEventContactStatus.NOT_INTERESTED]: {
     displayName: 'Ikke interessert',
     color: 'var(--danger-color)',
-    textColor: '#fff',
+    textColor: 'var(--color-absolute-white)',
   },
   [NonEventContactStatus.CONTACTED]: {
     displayName: 'Kontaktet',
@@ -39,7 +39,7 @@ export const NonEventContactStatusConfig: Record<
   [NonEventContactStatus.NOT_CONTACTED]: {
     displayName: 'Ikke kontaktet',
     color: 'var(--additive-background)',
-    textColor: 'var(--additive-text)',
+    textColor: 'var(--lego-font-color)',
   },
 };
 

--- a/app/routes/bdb/utils.tsx
+++ b/app/routes/bdb/utils.tsx
@@ -19,7 +19,7 @@ export const NonEventContactStatusConfig: Record<
   [NonEventContactStatus.BEDEX]: {
     displayName: 'Bedex',
     color: colorForEventType(EventType.ALTERNATIVE_PRESENTATION),
-    textColor: '#000',
+    textColor: '#fff',
   },
   [NonEventContactStatus.INTERESTED]: {
     displayName: 'Interessert',
@@ -39,7 +39,7 @@ export const NonEventContactStatusConfig: Record<
   [NonEventContactStatus.NOT_CONTACTED]: {
     displayName: 'Ikke kontaktet',
     color: 'var(--additive-background)',
-    textColor: '#000',
+    textColor: 'var(--additive-text)',
   },
 };
 


### PR DESCRIPTION
# Description

Replaces the filled cell semester status with tags representing the semester statuses of the company.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

| Before | After | 
| -- | -- |
| ![image](https://github.com/user-attachments/assets/f10e43fd-dc6c-43a9-adc6-35fbc2f46b6c) | ![image](https://github.com/user-attachments/assets/26620f65-d9ce-4dfa-ac9d-45781c720dbc) |
| ![image](https://github.com/user-attachments/assets/147c086e-484b-45dc-9f05-12182a3b6eaa) | ![image](https://github.com/user-attachments/assets/dc003c54-a515-4409-9350-9c55eec0c2cc) |


# Testing

- [x] I have thoroughly tested my changes.

Open bdb and verify the table has tags.

Resolves [ABA-1120](https://linear.app/abakus-webkom/issue/ABA-1120/turn-semester-statuses-into-pills-on-bdb)
