### PR TITLE
Prevent error with MazeMap on dev

### DIFF
--- a/app/components/MazemapEmbed/MazemapEmbed.css
+++ b/app/components/MazemapEmbed/MazemapEmbed.css
@@ -19,3 +19,7 @@
     236
   ); /* The color of a blank area in mazemap  */
 }
+
+.mazemapLink {
+  font-size: var(--font-size-sm);
+}

--- a/app/components/MazemapEmbed/MazemapLink.tsx
+++ b/app/components/MazemapEmbed/MazemapLink.tsx
@@ -1,3 +1,5 @@
+import styles from './MazemapEmbed.css';
+
 type Props = {
   mazemapPoi: number;
   linkText?: string;
@@ -11,6 +13,7 @@ const MazemapLink = ({ mazemapPoi, linkText }: Props) => (
     }
     rel="noreferrer noopener"
     target="_blank"
+    className={styles.mazemapLink}
   >
     {linkText || 'Åpne kart i ny fane'}
   </a>

--- a/app/components/MazemapEmbed/index.tsx
+++ b/app/components/MazemapEmbed/index.tsx
@@ -27,12 +27,14 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
   const [hasMounted, setHasMounted] = useState<boolean>(false);
   useEffect(() => setHasMounted(true), []);
   //import Mazemap dynamically to prevent ssr issues
-  const [Mazemap, setMazemap] = useState<MazeMap>(null);
+  const [Mazemap, setMazemap] = useState<MazeMap | null>(null);
   const [blockScrollZoom, setBlockScrollZoom] = useState<boolean>(false);
   const [blockTouchMovement, setBlockTouchZoom] = useState<boolean>(false);
   //initialize map only once, mazemapPoi will probably not change
   useEffect(() => {
-    import('mazemap').then((mazemap) => setMazemap(mazemap));
+    if (!__DEV__) {
+      import('mazemap').then((mazemap) => setMazemap(mazemap));
+    }
     if (!Mazemap || !hasMounted) return;
     const embeddedMazemap = new Mazemap.Map({
       container: 'mazemap-embed',


### PR DESCRIPTION
# Description

Annoying to always get an error when going into meetings

# Result

You end up with an empty map, but why would you need that in dev mode 🤷🏼‍♂️ 

<img width="250" alt="image" src="https://github.com/user-attachments/assets/61410572-1a8a-47a3-9757-3c4bbb511ae7">

# Testing

- [x] I have thoroughly tested my changes.

MazeMap works fine with ssr (prod)