### PR TITLE
Avoid flickering when toggling notifications dropdown

### DIFF
--- a/app/components/HeaderNotifications/index.tsx
+++ b/app/components/HeaderNotifications/index.tsx
@@ -103,11 +103,13 @@ const NotificationsDropdown = () => {
   );
 
   const { unreadCount } = notificationsData;
+
   return (
     <Dropdown
       show={notificationsOpen}
       toggle={() => {
-        setNotificationsOpen(!notificationsOpen);
+        setNotificationsOpen((prev) => !prev);
+
         if (!notificationsOpen) {
           dispatch(fetchNotificationFeed());
         } else {
@@ -117,7 +119,9 @@ const NotificationsDropdown = () => {
       closeOnContentClick
       triggerComponent={
         <Icon.Badge
-          iconNode={unreadCount > 0 ? <BellRing /> : <Bell />}
+          iconNode={
+            !notificationsOpen && unreadCount > 0 ? <BellRing /> : <Bell />
+          }
           badgeCount={notificationsOpen ? 0 : unreadCount}
         />
       }

--- a/app/reducers/notificationsFeed.ts
+++ b/app/reducers/notificationsFeed.ts
@@ -15,6 +15,7 @@ const notificationsFeed: Reducer<State> = produce((newState, action) => {
       break;
 
     case NotificationsFeed.MARK_ALL.SUCCESS:
+    case NotificationsFeed.MARK_ALL.BEGIN: // Optimistically marking all as read first to avoid flickering
       return initialState;
 
     default:


### PR DESCRIPTION
# Description

Solved by optimistically marking all as read and seen (not sure what the difference is?)

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
			<video src="https://github.com/user-attachments/assets/ba568008-2a40-4eea-9326-7747b9f38555" />
        </td>
        <td>
			<video src="https://github.com/user-attachments/assets/1b427c4c-98bf-48c7-91b4-b1109acf30c9" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See videos above