### PR TITLE
Fix current tab highlighting on email admin pages

### DIFF
--- a/app/routes/admin/email/index.tsx
+++ b/app/routes/admin/email/index.tsx
@@ -1,7 +1,7 @@
 import loadable from '@loadable/component';
 import { Page } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { Outlet, type RouteObject } from 'react-router-dom';
+import { Navigate, Outlet, type RouteObject } from 'react-router-dom';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 import pageNotFound from '../../pageNotFound';
 
@@ -18,11 +18,13 @@ const EmailRouteWrapper = () => (
     title="Administer E-post"
     tabs={
       <>
-        <NavigationTab href="/admin/email">Lister</NavigationTab>
-        <NavigationTab href="/admin/email/users?enabled=true">
+        <NavigationTab href="/admin/email/lists" matchSubpages>
+          Lister
+        </NavigationTab>
+        <NavigationTab href="/admin/email/users?enabled=true" matchSubpages>
           Brukere
         </NavigationTab>
-        <NavigationTab href="/admin/email/restricted">
+        <NavigationTab href="/admin/email/restricted" matchSubpages>
           Begrenset e-post
         </NavigationTab>
       </>
@@ -38,7 +40,7 @@ const emailRoute: RouteObject[] = [
   {
     Component: EmailRouteWrapper,
     children: [
-      { index: true, Component: EmailLists },
+      { index: true, element: <Navigate to="lists" replace /> },
       { path: 'lists', Component: EmailLists },
       { path: 'lists/new', Component: EmailListEditor },
       { path: 'lists/:emailListId', Component: EmailListEditor },


### PR DESCRIPTION
# Description

Selected tab was not highlighted in email admin pages when in an edit page.

# Result

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Edit e-mail list page
        </td>
        <td><img width="502" alt="Screenshot 2024-10-23 at 18 36 13" src="https://github.com/user-attachments/assets/3b20b2e3-5a80-4293-84d6-0791fb52ebf0"></td>
        <td><img width="502" alt="Screenshot 2024-10-23 at 18 36 33" src="https://github.com/user-attachments/assets/4d3f5ead-b810-4492-a3d2-d7d095b6bd10"></td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1139
