### PR TITLE
Add lending system MVP

### DIFF
--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -111,6 +111,13 @@ export const Joblistings = {
   DELETE: generateStatuses('Joblistings.DELETE') as AAT,
 };
 
+export const LendableObjects = {
+  FETCH: generateStatuses('LendableObject.FETCH_ALL') as AAT,
+  CREATE: generateStatuses('LendableObject.CREATE') as AAT,
+  EDIT: generateStatuses('LendableObject.EDIT') as AAT,
+  DELETE: generateStatuses('LendableObject.DELETE') as AAT,
+};
+
 /**
  *
  */

--- a/app/actions/LendableObjectActions.ts
+++ b/app/actions/LendableObjectActions.ts
@@ -3,7 +3,9 @@ import callAPI from 'app/actions/callAPI';
 import { lendableObjectSchema } from 'app/reducers';
 import type { EntityId } from '@reduxjs/toolkit';
 import type {
+  CreateLendableObject,
   DetailLendableObject,
+  EditLendableObject,
   ListLendableObject,
 } from 'app/store/models/LendableObject';
 
@@ -27,4 +29,28 @@ export const fetchLendableObjectById = (id: EntityId) =>
       errorMessage: 'Henting av utlånsobjekt feilet',
     },
     propagateError: true,
+  });
+
+export const editLendableObject = (data: EditLendableObject) =>
+  callAPI<DetailLendableObject>({
+    types: LendableObjects.EDIT,
+    endpoint: `/lending/objects/${data.id}/`,
+    method: 'PUT',
+    schema: lendableObjectSchema,
+    body: data,
+    meta: {
+      errorMessage: 'Endring av utlånsobjekt feilet',
+    },
+  });
+
+export const createLendableObject = (data: CreateLendableObject) =>
+  callAPI<DetailLendableObject>({
+    types: LendableObjects.CREATE,
+    endpoint: '/lendable-objects/',
+    method: 'POST',
+    schema: lendableObjectSchema,
+    body: data,
+    meta: {
+      errorMessage: 'Opprettelse av utlånsobjekt feilet',
+    },
   });

--- a/app/actions/LendableObjectActions.ts
+++ b/app/actions/LendableObjectActions.ts
@@ -1,0 +1,15 @@
+import { LendableObjects } from 'app/actions/ActionTypes';
+import callAPI from 'app/actions/callAPI';
+import { lendableObjectSchema } from 'app/reducers';
+import type { ListLendableObject } from 'app/store/models/LendableObject';
+
+export const fetchAllLendableObjects = () =>
+  callAPI<ListLendableObject[]>({
+    types: LendableObjects.FETCH,
+    endpoint: '/lending/objects/',
+    schema: [lendableObjectSchema],
+    meta: {
+      errorMessage: 'Henting av utlånsobjekter feilet',
+    },
+    propagateError: true,
+  });

--- a/app/actions/LendableObjectActions.ts
+++ b/app/actions/LendableObjectActions.ts
@@ -46,7 +46,7 @@ export const editLendableObject = (data: EditLendableObject) =>
 export const createLendableObject = (data: CreateLendableObject) =>
   callAPI<DetailLendableObject>({
     types: LendableObjects.CREATE,
-    endpoint: '/lendable-objects/',
+    endpoint: '/lending/objects/',
     method: 'POST',
     schema: lendableObjectSchema,
     body: data,

--- a/app/actions/LendableObjectActions.ts
+++ b/app/actions/LendableObjectActions.ts
@@ -1,7 +1,11 @@
 import { LendableObjects } from 'app/actions/ActionTypes';
 import callAPI from 'app/actions/callAPI';
 import { lendableObjectSchema } from 'app/reducers';
-import type { ListLendableObject } from 'app/store/models/LendableObject';
+import type { EntityId } from '@reduxjs/toolkit';
+import type {
+  DetailLendableObject,
+  ListLendableObject,
+} from 'app/store/models/LendableObject';
 
 export const fetchAllLendableObjects = () =>
   callAPI<ListLendableObject[]>({
@@ -10,6 +14,17 @@ export const fetchAllLendableObjects = () =>
     schema: [lendableObjectSchema],
     meta: {
       errorMessage: 'Henting av utlånsobjekter feilet',
+    },
+    propagateError: true,
+  });
+
+export const fetchLendableObjectById = (id: EntityId) =>
+  callAPI<DetailLendableObject>({
+    types: LendableObjects.FETCH,
+    endpoint: `/lending/objects/${id}/`,
+    schema: lendableObjectSchema,
+    meta: {
+      errorMessage: 'Henting av utlånsobjekt feilet',
     },
     propagateError: true,
   });

--- a/app/components/Search/utils.tsx
+++ b/app/components/Search/utils.tsx
@@ -29,6 +29,7 @@ import {
   Send,
   Tags,
   Users,
+  ShoppingCart,
 } from 'lucide-react';
 import ReadmeLogo from 'app/components/ReadmeLogo';
 import { Tag } from 'app/components/Tags';
@@ -76,6 +77,18 @@ const LINKS: Array<Link> = [
     ),
     icon: <MessagesSquare />,
     url: '/forum',
+  },
+  {
+    key: 'lending',
+    requireLogin: true,
+    title: (
+      <Flex alignItems="center" gap="var(--spacing-sm)">
+        Utlån
+        <Tag tag="Beta" color="purple" />
+      </Flex>
+    ),
+    icon: <ShoppingCart />,
+    url: '/lending',
   },
   {
     key: 'events',

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -79,6 +79,9 @@ export const companySchema = new schema.Entity(EntityType.Companies, {
   comments: [commentSchema],
 });
 export const joblistingsSchema = new schema.Entity(EntityType.Joblistings);
+export const lendableObjectSchema = new schema.Entity(
+  EntityType.LendableObjects,
+);
 export const announcementsSchema = new schema.Entity(EntityType.Announcements);
 export const feedActivitySchema = new schema.Entity(EntityType.FeedActivities);
 export const oauth2ApplicationSchema = new schema.Entity(

--- a/app/reducers/lendableObjects.ts
+++ b/app/reducers/lendableObjects.ts
@@ -1,0 +1,23 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { LendableObjects } from 'app/actions/ActionTypes';
+import { EntityType } from 'app/store/models/entities';
+import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
+import type { RootState } from 'app/store/createRootReducer';
+
+const legoAdapter = createLegoAdapter(EntityType.LendableObjects);
+
+const lendableObjectsSlice = createSlice({
+  name: EntityType.LendableObjects,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [LendableObjects.FETCH],
+    deleteActions: [LendableObjects.DELETE],
+  }),
+});
+
+export default lendableObjectsSlice.reducer;
+export const {
+  selectById: selectLendableObjectById,
+  selectAll: selectAllLendableObjects,
+} = legoAdapter.getSelectors((state: RootState) => state.lendableObjects);

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,5 +1,6 @@
 import loadable from '@loadable/component';
 import { type RouteObject } from 'react-router-dom';
+import lendingRoute from 'app/routes/lending';
 import adminRoute from './admin';
 import announcementsRoute from './announcements';
 import { AppRoute } from './app';
@@ -53,6 +54,7 @@ export const routerConfig: RouteObject[] = [
       { path: 'interest-groups/*', children: interestGroupsRoute },
       { path: 'interestgroups/*', children: interestGroupsRoute },
       { path: 'joblistings/*', children: joblistingsRoute },
+      { path: 'lending/*', children: lendingRoute },
       { path: 'meetings/*', children: meetingsRoute },
       { path: 'pages/*', children: pagesRoute },
       { path: 'photos/*', children: photosRoute },

--- a/app/routes/lending/components/LendableObjectCreate/index.tsx
+++ b/app/routes/lending/components/LendableObjectCreate/index.tsx
@@ -1,0 +1,19 @@
+import { Page } from '@webkom/lego-bricks';
+import { Helmet } from 'react-helmet-async';
+import { objectPermissionsInitialValues } from 'app/components/Form/ObjectPermissions';
+import { LendableObjectEditor } from 'app/routes/lending/components/LendableObjectEditor';
+
+export default function LendableObjectCreate() {
+  const title = 'Nytt ulånsobjekt';
+
+  return (
+    <Page title={title} back={{ href: `/lending/` }}>
+      <Helmet title={title} />
+      <LendableObjectEditor
+        initialValues={{
+          ...objectPermissionsInitialValues,
+        }}
+      />
+    </Page>
+  );
+}

--- a/app/routes/lending/components/LendableObjectDetail/index.tsx
+++ b/app/routes/lending/components/LendableObjectDetail/index.tsx
@@ -1,0 +1,75 @@
+import { Page, LinkButton, PageCover, Card } from '@webkom/lego-bricks';
+import { usePreparedEffect } from '@webkom/react-prepare';
+import { Warehouse } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
+import { useParams } from 'react-router-dom';
+import { fetchLendableObjectById } from 'app/actions/LendableObjectActions';
+import {
+  ContentMain,
+  ContentSection,
+  ContentSidebar,
+} from 'app/components/Content';
+import DisplayContent from 'app/components/DisplayContent';
+import TextWithIcon from 'app/components/TextWithIcon';
+import { selectLendableObjectById } from 'app/reducers/lendableObjects';
+import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+
+export const LendableObjectList = () => {
+  const { lendableObjectId } = useParams<'lendableObjectId'>();
+  const dispatch = useAppDispatch();
+  const fetching = useAppSelector((state) => state.lendableObjects.fetching);
+
+  usePreparedEffect(
+    'fetchLendableObjectById',
+    () => dispatch(fetchLendableObjectById(lendableObjectId!)),
+    [],
+  );
+
+  const lendableObject = useAppSelector((state) =>
+    selectLendableObjectById(state, lendableObjectId!),
+  );
+
+  const title = lendableObject ? `Utlån: ${lendableObject.title}` : undefined;
+
+  return (
+    <Page
+      title={title}
+      cover={<PageCover image={lendableObject?.image} skeleton={fetching} />}
+      actionButtons={
+        lendableObject &&
+        'actionGrant' in lendableObject &&
+        lendableObject.actionGrant.includes('edit') ? (
+          <LinkButton href={`/lending/${lendableObjectId}/edit`}>
+            Rediger
+          </LinkButton>
+        ) : undefined
+      }
+      back={{ href: '/lending' }}
+      skeleton={fetching}
+    >
+      <Helmet title={title || 'Utlån'} />
+      {lendableObject && (
+        <ContentSection>
+          <ContentMain>
+            {lendableObject && !lendableObject.canLend && (
+              <Card severity="warning">
+                Du har ikke tilgang til å låne dette objektet, men kan se det
+                pga. admin-rettigheter.
+              </Card>
+            )}
+            <DisplayContent content={lendableObject.description} />
+          </ContentMain>
+          <ContentSidebar>
+            <TextWithIcon
+              iconNode={<Warehouse />}
+              size={20}
+              content={lendableObject.location}
+            />
+          </ContentSidebar>
+        </ContentSection>
+      )}
+    </Page>
+  );
+};
+
+export default LendableObjectList;

--- a/app/routes/lending/components/LendableObjectDetail/index.tsx
+++ b/app/routes/lending/components/LendableObjectDetail/index.tsx
@@ -1,9 +1,7 @@
 import { Page, LinkButton, PageCover, Card } from '@webkom/lego-bricks';
-import { usePreparedEffect } from '@webkom/react-prepare';
 import { Warehouse } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
-import { fetchLendableObjectById } from 'app/actions/LendableObjectActions';
 import {
   ContentMain,
   ContentSection,
@@ -11,22 +9,12 @@ import {
 } from 'app/components/Content';
 import DisplayContent from 'app/components/DisplayContent';
 import TextWithIcon from 'app/components/TextWithIcon';
-import { selectLendableObjectById } from 'app/reducers/lendableObjects';
-import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import { useFetchedLendableObject } from 'app/routes/lending/useFetchedLendableObject';
 
 export const LendableObjectList = () => {
   const { lendableObjectId } = useParams<'lendableObjectId'>();
-  const dispatch = useAppDispatch();
-  const fetching = useAppSelector((state) => state.lendableObjects.fetching);
-
-  usePreparedEffect(
-    'fetchLendableObjectById',
-    () => dispatch(fetchLendableObjectById(lendableObjectId!)),
-    [],
-  );
-
-  const lendableObject = useAppSelector((state) =>
-    selectLendableObjectById(state, lendableObjectId!),
+  const { lendableObject, fetching } = useFetchedLendableObject(
+    lendableObjectId!,
   );
 
   const title = lendableObject ? `Utlån: ${lendableObject.title}` : undefined;
@@ -36,9 +24,7 @@ export const LendableObjectList = () => {
       title={title}
       cover={<PageCover image={lendableObject?.image} skeleton={fetching} />}
       actionButtons={
-        lendableObject &&
-        'actionGrant' in lendableObject &&
-        lendableObject.actionGrant.includes('edit') ? (
+        !fetching && lendableObject.actionGrant.includes('edit') ? (
           <LinkButton href={`/lending/${lendableObjectId}/edit`}>
             Rediger
           </LinkButton>

--- a/app/routes/lending/components/LendableObjectEdit/index.tsx
+++ b/app/routes/lending/components/LendableObjectEdit/index.tsx
@@ -1,0 +1,35 @@
+import { LoadingIndicator, Page } from '@webkom/lego-bricks';
+import { Helmet } from 'react-helmet-async';
+import { useParams } from 'react-router-dom';
+import { objectPermissionsToInitialValues } from 'app/components/Form/ObjectPermissions';
+import { LendableObjectEditor } from 'app/routes/lending/components/LendableObjectEditor';
+import { useFetchedLendableObject } from 'app/routes/lending/useFetchedLendableObject';
+
+export default function LendableObjectEdit() {
+  const { lendableObjectId } = useParams<'lendableObjectId'>();
+  const { lendableObject, fetching } = useFetchedLendableObject(
+    lendableObjectId!,
+  );
+
+  const title = fetching ? undefined : `Redigerer: ${lendableObject.title}`;
+
+  return (
+    <Page
+      title={title}
+      back={{ href: `/lending/${lendableObjectId}` }}
+      skeleton={fetching}
+    >
+      <Helmet title={title} />
+      {fetching ? (
+        <LoadingIndicator loading />
+      ) : (
+        <LendableObjectEditor
+          initialValues={{
+            ...lendableObject,
+            ...objectPermissionsToInitialValues(lendableObject),
+          }}
+        />
+      )}
+    </Page>
+  );
+}

--- a/app/routes/lending/components/LendableObjectEditor.tsx
+++ b/app/routes/lending/components/LendableObjectEditor.tsx
@@ -1,0 +1,108 @@
+import { Field } from 'react-final-form';
+import { useNavigate } from 'react-router-dom';
+import {
+  createLendableObject,
+  editLendableObject,
+} from 'app/actions/LendableObjectActions';
+import {
+  EditorField,
+  Fields,
+  Form,
+  ImageUploadField,
+  LegoFinalForm,
+  ObjectPermissions,
+  SubmitButton,
+  TextInput,
+} from 'app/components/Form';
+import { normalizeObjectPermissions } from 'app/components/Form/ObjectPermissions';
+import { useAppDispatch } from 'app/store/hooks';
+import { createValidator, required } from 'app/utils/validation';
+import type { EntityId } from '@reduxjs/toolkit';
+import type {
+  CreateLendableObject,
+  EditLendableObject,
+} from 'app/store/models/LendableObject';
+
+type FormValues = {
+  id?: EntityId;
+  title: string;
+  description: string;
+  image: string;
+  location: string;
+  canViewGroups?: { label: string; value: EntityId }[];
+  canEditGroups?: { label: string; value: EntityId }[];
+  canEditUsers?: { label: string; value: EntityId }[];
+};
+
+type Props = {
+  initialValues?: Partial<FormValues>;
+};
+
+const validate = createValidator({
+  title: [required()],
+  description: [required()],
+  location: [required()],
+});
+
+export const LendableObjectEditor = ({ initialValues }: Props) => {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  return (
+    <LegoFinalForm<FormValues>
+      initialValues={initialValues}
+      validate={validate}
+      onSubmit={async (values) => {
+        const transformedValues: CreateLendableObject | EditLendableObject = {
+          ...values,
+          ...normalizeObjectPermissions(values),
+        };
+        const res = await dispatch(
+          initialValues?.id
+            ? editLendableObject({ ...transformedValues, id: initialValues.id })
+            : createLendableObject({
+                ...values,
+                ...normalizeObjectPermissions(values),
+              }),
+        );
+        navigate(`/lending/${res.payload.result}`);
+      }}
+    >
+      {({ handleSubmit }) => (
+        <Form onSubmit={handleSubmit}>
+          <Field
+            name="image"
+            component={ImageUploadField}
+            aspectRatio={20 / 6}
+            img={initialValues?.image}
+          />
+          <Field
+            label="Navn"
+            name="title"
+            placeholder="Grill"
+            component={TextInput.Field}
+          />
+          <Field
+            label="Lokasjon"
+            name="location"
+            placeholder="A3-lageret"
+            component={TextInput.Field}
+          />
+          <Field
+            label="Beskrivelse"
+            name="description"
+            placeholder="Grill til utlån"
+            component={EditorField.Field}
+          />
+
+          <Fields
+            component={ObjectPermissions}
+            names={['canViewGroups', 'canEditUsers', 'canEditGroups']}
+          />
+
+          <SubmitButton>Lagre</SubmitButton>
+        </Form>
+      )}
+    </LegoFinalForm>
+  );
+};

--- a/app/routes/lending/components/LendableObjectList/LendableObjectList.module.css
+++ b/app/routes/lending/components/LendableObjectList/LendableObjectList.module.css
@@ -1,0 +1,35 @@
+@import url('~app/styles/variables.css');
+
+.lendableObjectsContainer {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: 1fr;
+  gap: var(--spacing-xl);
+
+  @media (width <= 60em) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (--small-viewport) {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}
+
+.lendableObjectCard {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  height: 100%;
+}
+
+.lendableObjectImage {
+  object-fit: cover;
+  height: 100%;
+}
+
+.lendableObjectFooter {
+  display: flex;
+  justify-content: center;
+  color: var(--lego-font-color);
+}

--- a/app/routes/lending/components/LendableObjectList/index.tsx
+++ b/app/routes/lending/components/LendableObjectList/index.tsx
@@ -1,0 +1,97 @@
+import {
+  Card,
+  LoadingIndicator,
+  Image,
+  Page,
+  filterSidebar,
+  FilterSection,
+} from '@webkom/lego-bricks';
+import { usePreparedEffect } from '@webkom/react-prepare';
+import { Helmet } from 'react-helmet-async';
+import { Link, useSearchParams } from 'react-router-dom';
+import { fetchAllLendableObjects } from 'app/actions/LendableObjectActions';
+import abakus_icon from 'app/assets/icon-192x192.png';
+import TextInput from 'app/components/Form/TextInput';
+import { selectAllLendableObjects } from 'app/reducers/lendableObjects';
+import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import styles from './LendableObjectList.module.css';
+import type { ListLendableObject } from 'app/store/models/LendableObject';
+
+const LendableObject = ({
+  lendableObject,
+}: {
+  lendableObject: ListLendableObject;
+}) => {
+  return (
+    <Link to={`/lending/${lendableObject.id}`}>
+      <Card isHoverable hideOverflow className={styles.lendableObjectCard}>
+        <Image
+          className={styles.lendableObjectImage}
+          src={lendableObject.image || abakus_icon}
+          alt={`${lendableObject.title}`}
+        />
+        <div className={styles.lendableObjectFooter}>
+          <h4>{lendableObject.title}</h4>
+        </div>
+      </Card>
+    </Link>
+  );
+};
+
+const LendableObjectList = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const dispatch = useAppDispatch();
+
+  usePreparedEffect(
+    'fetchAllLendableObjects',
+    () => dispatch(fetchAllLendableObjects()),
+    [],
+  );
+
+  const lendableObjects = useAppSelector(selectAllLendableObjects);
+  const fetching = useAppSelector((state) => state.lendableObjects.fetching);
+
+  const title = 'Utlån';
+  return (
+    <Page
+      title={title}
+      sidebar={filterSidebar({
+        children: (
+          <FilterSection title="Søk">
+            <TextInput
+              prefix="search"
+              placeholder="Grill, soundboks..."
+              onChange={(e) =>
+                setSearchParams(e.target.value && { search: e.target.value })
+              }
+            />
+          </FilterSection>
+        ),
+      })}
+    >
+      <Helmet title={title} />
+
+      <LoadingIndicator loading={fetching}>
+        <div className={styles.lendableObjectsContainer}>
+          {lendableObjects
+            .filter((lendableObjects) =>
+              searchParams.get('search')
+                ? lendableObjects.title
+                    .toLowerCase()
+                    .includes((searchParams.get('search') || '').toLowerCase())
+                : true,
+            )
+            .map((lendableObject) => (
+              <LendableObject
+                key={lendableObject.id}
+                lendableObject={lendableObject}
+              />
+            ))}
+        </div>
+      </LoadingIndicator>
+    </Page>
+  );
+};
+
+export default LendableObjectList;

--- a/app/routes/lending/index.tsx
+++ b/app/routes/lending/index.tsx
@@ -5,9 +5,13 @@ import type { RouteObject } from 'react-router-dom';
 const LendableObjectsList = loadable(
   () => import('./components/LendableObjectList'),
 );
+const LendableObjectDetail = loadable(
+  () => import('./components/LendableObjectDetail'),
+);
 
 const lendingRoute: RouteObject[] = [
   { index: true, Component: LendableObjectsList },
+  { path: ':lendableObjectId', Component: LendableObjectDetail },
   { path: '*', children: pageNotFound },
 ];
 

--- a/app/routes/lending/index.tsx
+++ b/app/routes/lending/index.tsx
@@ -1,0 +1,14 @@
+import loadable from '@loadable/component';
+import pageNotFound from '../pageNotFound';
+import type { RouteObject } from 'react-router-dom';
+
+const LendableObjectsList = loadable(
+  () => import('./components/LendableObjectList'),
+);
+
+const lendingRoute: RouteObject[] = [
+  { index: true, Component: LendableObjectsList },
+  { path: '*', children: pageNotFound },
+];
+
+export default lendingRoute;

--- a/app/routes/lending/index.tsx
+++ b/app/routes/lending/index.tsx
@@ -8,10 +8,18 @@ const LendableObjectsList = loadable(
 const LendableObjectDetail = loadable(
   () => import('./components/LendableObjectDetail'),
 );
+const LendableObjectEdit = loadable(
+  () => import('./components/LendableObjectEdit'),
+);
+const LendableObjectCreate = loadable(
+  () => import('./components/LendableObjectCreate'),
+);
 
 const lendingRoute: RouteObject[] = [
   { index: true, Component: LendableObjectsList },
   { path: ':lendableObjectId', Component: LendableObjectDetail },
+  { path: ':lendableObjectId/edit', Component: LendableObjectEdit },
+  { path: 'new', Component: LendableObjectCreate },
   { path: '*', children: pageNotFound },
 ];
 

--- a/app/routes/lending/useFetchedLendableObject.ts
+++ b/app/routes/lending/useFetchedLendableObject.ts
@@ -1,0 +1,38 @@
+import { usePreparedEffect } from '@webkom/react-prepare';
+import { useState } from 'react';
+import { fetchLendableObjectById } from 'app/actions/LendableObjectActions';
+import { selectLendableObjectById } from 'app/reducers/lendableObjects';
+import { useAppDispatch, useAppSelector } from 'app/store/hooks';
+import type { EntityId } from '@reduxjs/toolkit';
+import type {
+  DetailLendableObject,
+  UnknownLendableObject,
+} from 'app/store/models/LendableObject';
+
+export const useFetchedLendableObject = (lendableObjectId: EntityId) => {
+  const dispatch = useAppDispatch();
+  const [fetching, setFetching] = useState(true);
+
+  usePreparedEffect(
+    'fetchLendableObjectById',
+    () =>
+      dispatch(fetchLendableObjectById(lendableObjectId)).then(() =>
+        setFetching(false),
+      ),
+    [lendableObjectId],
+  );
+
+  const lendableObject = useAppSelector((state) =>
+    selectLendableObjectById(state, lendableObjectId!),
+  );
+
+  return { lendableObject, fetching } as
+    | {
+        lendableObject?: UnknownLendableObject;
+        fetching: true;
+      }
+    | {
+        lendableObject: DetailLendableObject;
+        fetching: false;
+      };
+};

--- a/app/store/createRootReducer.ts
+++ b/app/store/createRootReducer.ts
@@ -20,6 +20,7 @@ import galleryPictures from 'app/reducers/galleryPictures';
 import groups from 'app/reducers/groups';
 import imageGalleryEntries from 'app/reducers/imageGallery';
 import joblistings from 'app/reducers/joblistings';
+import lendableObjects from 'app/reducers/lendableObjects';
 import meetingInvitations from 'app/reducers/meetingInvitations';
 import meetings from 'app/reducers/meetings';
 import memberships from 'app/reducers/memberships';
@@ -68,6 +69,7 @@ const createRootReducer = () => {
     groups,
     imageGalleryEntries,
     joblistings,
+    lendableObjects,
     meetingInvitations,
     meetings,
     memberships,

--- a/app/store/models/LendableObject.ts
+++ b/app/store/models/LendableObject.ts
@@ -1,4 +1,5 @@
 import type { EntityId } from '@reduxjs/toolkit';
+import type { ActionGrant } from 'app/models';
 import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
 
 interface LendableObject {
@@ -7,12 +8,17 @@ interface LendableObject {
   description: string;
   image: string;
   location: string;
+  canLend: boolean;
+  actionGrant: ActionGrant;
 }
 
 export type ListLendableObject = Pick<
   LendableObject,
-  'id' | 'title' | 'description' | 'image' | 'location'
+  'id' | 'title' | 'description' | 'image' | 'location' | 'canLend'
 > &
   ObjectPermissionsMixin;
 
-export type UnknownLendableObject = ListLendableObject;
+export type DetailLendableObject = ListLendableObject &
+  Pick<LendableObject, 'actionGrant'>;
+
+export type UnknownLendableObject = ListLendableObject | DetailLendableObject;

--- a/app/store/models/LendableObject.ts
+++ b/app/store/models/LendableObject.ts
@@ -15,10 +15,21 @@ interface LendableObject {
 export type ListLendableObject = Pick<
   LendableObject,
   'id' | 'title' | 'description' | 'image' | 'location' | 'canLend'
-> &
-  ObjectPermissionsMixin;
+>;
 
 export type DetailLendableObject = ListLendableObject &
-  Pick<LendableObject, 'actionGrant'>;
+  Pick<LendableObject, 'actionGrant'> &
+  ObjectPermissionsMixin;
 
 export type UnknownLendableObject = ListLendableObject | DetailLendableObject;
+
+export type EditLendableObject = Pick<
+  LendableObject,
+  'id' | 'title' | 'description' | 'image' | 'location'
+> & {
+  canViewGroups: EntityId[];
+  canEditGroups: EntityId[];
+  canEditUsers: EntityId[];
+};
+
+export type CreateLendableObject = Omit<EditLendableObject, 'id'>;

--- a/app/store/models/LendableObject.ts
+++ b/app/store/models/LendableObject.ts
@@ -1,0 +1,18 @@
+import type { EntityId } from '@reduxjs/toolkit';
+import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
+
+interface LendableObject {
+  id: EntityId;
+  title: string;
+  description: string;
+  image: string;
+  location: string;
+}
+
+export type ListLendableObject = Pick<
+  LendableObject,
+  'id' | 'title' | 'description' | 'image' | 'location'
+> &
+  ObjectPermissionsMixin;
+
+export type UnknownLendableObject = ListLendableObject;

--- a/app/store/models/ObjectPermissionsMixin.d.ts
+++ b/app/store/models/ObjectPermissionsMixin.d.ts
@@ -1,8 +1,8 @@
-import type { EntityId } from '@reduxjs/toolkit';
 import type { FieldGroup } from 'app/store/models/Group';
+import type { PublicUser } from 'app/store/models/User';
 
 interface ObjectPermissionsMixin {
-  canEditUsers: EntityId[];
+  canEditUsers: PublicUser[];
   canViewGroups: FieldGroup[];
   canEditGroups: FieldGroup[];
   requireAuth: boolean;

--- a/app/store/models/entities.ts
+++ b/app/store/models/entities.ts
@@ -18,6 +18,7 @@ import type { UnknownGalleryPicture } from 'app/store/models/GalleryPicture';
 import type { UnknownGroup } from 'app/store/models/Group';
 import type { ImageGalleryEntry } from 'app/store/models/ImageGalleryEntry';
 import type { UnknownJoblisting } from 'app/store/models/Joblisting';
+import type { UnknownLendableObject } from 'app/store/models/LendableObject';
 import type { UnknownMeeting } from 'app/store/models/Meeting';
 import type { MeetingInvitation } from 'app/store/models/MeetingInvitation';
 import type Membership from 'app/store/models/Membership';
@@ -54,6 +55,7 @@ export enum EntityType {
   Groups = 'groups',
   ImageGalleryEntries = 'imageGalleryEntries',
   Joblistings = 'joblistings',
+  LendableObjects = 'lendableObjects',
   MeetingInvitations = 'meetingInvitations',
   Meetings = 'meetings',
   Memberships = 'memberships',
@@ -93,6 +95,7 @@ export default interface Entities {
   [EntityType.GalleryPictures]: Record<EntityId, UnknownGalleryPicture>;
   [EntityType.Groups]: Record<EntityId, UnknownGroup>;
   [EntityType.Joblistings]: Record<EntityId, UnknownJoblisting>;
+  [EntityType.LendableObjects]: Record<EntityId, UnknownLendableObject>;
   [EntityType.ImageGalleryEntries]: Record<EntityId, ImageGalleryEntry>;
   [EntityType.MeetingInvitations]: Record<EntityId, MeetingInvitation>;
   [EntityType.Meetings]: Record<EntityId, UnknownMeeting>;


### PR DESCRIPTION
# Description

Adds a simple MVP for the lending system. Currently you can only set description, location and image on the lendable objects. It also supports setting view-permissions per object for specific groups.

# Result

Added to the navigation menu
<img width="502" alt="Screenshot 2024-10-23 at 21 16 11" src="https://github.com/user-attachments/assets/d282b62c-9c63-437e-9b05-227898616988">

Empty state:
<img width="1119" alt="Screenshot 2024-10-23 at 21 16 26" src="https://github.com/user-attachments/assets/33016907-45f1-4321-972b-0106cb696c84">

List:
<img width="1119" alt="Screenshot 2024-10-23 at 21 19 02" src="https://github.com/user-attachments/assets/c2f096ea-e4c5-4dfc-8137-7a33d1385315">

Detail:
<img width="1119" alt="Screenshot 2024-10-23 at 21 19 24" src="https://github.com/user-attachments/assets/ed9e5232-576e-4888-b58b-e8ea227dbbea">

Detail as admin without view-rights (lending-rights) to this object (admins can see everything):
<img width="1119" alt="Screenshot 2024-10-23 at 21 19 40" src="https://github.com/user-attachments/assets/657de242-e6cc-482d-a10c-1f46bb6fc346">

Create/edit form
<img width="1119" alt="Screenshot 2024-10-23 at 21 21 05" src="https://github.com/user-attachments/assets/1b6db22d-9dd0-4b2e-b510-bda63b89a6b2">

Detail page on mobile:
<img width="360" alt="Screenshot 2024-10-23 at 21 22 22" src="https://github.com/user-attachments/assets/0f4bd879-dfae-4023-bb83-71e07801e175">

List page on mobile:
<img width="360" alt="Screenshot 2024-10-23 at 21 22 43" src="https://github.com/user-attachments/assets/72bbdcaa-dab6-4525-8ac5-f3ee7e39916d">

# Testing

- [x] I have thoroughly tested my changes.

It works:)

---

Resolves ABA-1046