### PR TITLE
Fix spacing under Info om Abakus

### DIFF
--- a/app/routes/pages/components/subcomponents/EmailItem/EmailItem.module.css
+++ b/app/routes/pages/components/subcomponents/EmailItem/EmailItem.module.css
@@ -15,10 +15,6 @@
   }
 }
 
-.recipient {
-  margin-bottom: -8px;
-}
-
 .logo {
   width: 40px;
   height: 40px;

--- a/app/routes/pages/components/subcomponents/EmailItem/index.tsx
+++ b/app/routes/pages/components/subcomponents/EmailItem/index.tsx
@@ -19,7 +19,7 @@ const EmailItem = ({ email, logo, recipient }: Props) => {
         />
       )}
       <div>
-        <div className={styles.recipient}>{readmeIfy(recipient)}</div>
+        <div>{readmeIfy(recipient)}</div>
         <a href={`mailto:${email}`}>{email}</a>
       </div>
     </div>


### PR DESCRIPTION
# Description

Fixed spacing issues with recipient and e-mail under Kontakt oss under Info om Abakus.

# Result

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Changed spacing.
        </td>
        <td>
            <img width="768" alt="Skjermbilde 2024-10-23 kl  21 23 06" src="https://github.com/user-attachments/assets/45408e8b-8296-4c0e-966c-0d41d0cd29a9">
        </td>
        <td>
            <img width="734" alt="Skjermbilde 2024-10-23 kl  22 02 24" src="https://github.com/user-attachments/assets/b220d8cb-ca9f-4b20-a53e-e2cda06fb7b9">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-1140
