### PR TITLE
Import from lodash-es instead of lodash

### DIFF
--- a/app/actions/ArticleActions.ts
+++ b/app/actions/ArticleActions.ts
@@ -1,4 +1,4 @@
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import callAPI from 'app/actions/callAPI';
 import { articleSchema } from 'app/reducers';
 import { Article } from './ActionTypes';

--- a/app/actions/callAPI.ts
+++ b/app/actions/callAPI.ts
@@ -1,4 +1,4 @@
-import { omit, isArray } from 'lodash';
+import { omit, isArray } from 'lodash-es';
 import { normalize } from 'normalizr';
 import { logout } from 'app/actions/UserActions';
 import { selectIsLoggedIn } from 'app/reducers/auth';

--- a/app/components/Form/LegoFinalForm.tsx
+++ b/app/components/Form/LegoFinalForm.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 import createFocusOnErrorDecorator from 'final-form-focus';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual } from 'lodash-es';
 import { Form } from 'react-final-form';
 import { handleSubmissionErrorFinalForm } from 'app/components/Form/utils';
 import type { FormProps } from 'react-final-form';

--- a/app/components/Header/ToggleTheme.tsx
+++ b/app/components/Header/ToggleTheme.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { MoonStar, Sun } from 'lucide-react';
 import { useCallback } from 'react';
 import { updateUserTheme } from 'app/actions/UserActions';

--- a/app/components/Poll/index.tsx
+++ b/app/components/Poll/index.tsx
@@ -1,6 +1,6 @@
 import { Accordion, Button, Flex, Icon, Skeleton } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { sortBy } from 'lodash';
+import { sortBy } from 'lodash-es';
 import {
   ChartNoAxesColumn,
   ChevronDown,

--- a/app/components/Search/index.tsx
+++ b/app/components/Search/index.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { autocomplete, toggleSearch } from 'app/actions/SearchActions';

--- a/app/components/Search/mazemapAutocomplete.tsx
+++ b/app/components/Search/mazemapAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { useEffect, useState } from 'react';
 import { stripHtmlTags } from './utils';
 import type { ComponentType } from 'react';

--- a/app/components/Search/utils.tsx
+++ b/app/components/Search/utils.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@webkom/lego-bricks';
-import { sample } from 'lodash';
+import { sample } from 'lodash-es';
 import {
   Banana,
   BookImage,

--- a/app/components/Search/withAutocomplete.tsx
+++ b/app/components/Search/withAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import { useState } from 'react';
 import { autocomplete } from 'app/actions/SearchActions';
 import { useAppDispatch } from 'app/store/hooks';

--- a/app/components/Table/BodyCell.tsx
+++ b/app/components/Table/BodyCell.tsx
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get } from 'lodash-es';
 import styles from './Table.module.css';
 import type { ColumnProps, ShowColumn, TableData } from '.';
 

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { debounce, isEmpty, get } from 'lodash';
+import { debounce, isEmpty, get } from 'lodash-es';
 import { useEffect, useMemo, useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroller';
 import BodyCell from './BodyCell';

--- a/app/components/UserAttendance/AttendanceModalContent.tsx
+++ b/app/components/UserAttendance/AttendanceModalContent.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { flatMap } from 'lodash';
+import { flatMap } from 'lodash-es';
 import { Send } from 'lucide-react';
 import { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';

--- a/app/components/UserValidator/index.tsx
+++ b/app/components/UserValidator/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Icon, Modal } from '@webkom/lego-bricks';
-import { get, debounce } from 'lodash';
+import { get, debounce } from 'lodash-es';
 import { ScanQrCode } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 import { QrReader } from 'react-qr-reader';

--- a/app/reducers/events.ts
+++ b/app/reducers/events.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { groupBy, orderBy } from 'lodash';
+import { groupBy, orderBy } from 'lodash-es';
 import moment from 'moment-timezone';
 import { normalize } from 'normalizr';
 import { createSelector } from 'reselect';

--- a/app/reducers/feeds.ts
+++ b/app/reducers/feeds.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { union } from 'lodash';
+import { union } from 'lodash-es';
 import { createSelector } from 'reselect';
 import { selectFeedActivityEntities } from 'app/reducers/feedActivities';
 import { asArray } from 'app/reducers/utils';

--- a/app/reducers/frontpage.ts
+++ b/app/reducers/frontpage.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { sortBy } from 'lodash';
+import { sortBy } from 'lodash-es';
 import moment from 'moment-timezone';
 import { createSelector } from 'reselect';
 import { Frontpage } from 'app/actions/ActionTypes';

--- a/app/reducers/notificationSettings.ts
+++ b/app/reducers/notificationSettings.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { keyBy } from 'lodash';
+import { keyBy } from 'lodash-es';
 import { createSelector } from 'reselect';
 import { NotificationSettings } from 'app/actions/ActionTypes';
 import type { RootState } from 'app/store/createRootReducer';

--- a/app/reducers/pages.ts
+++ b/app/reducers/pages.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { groupBy, sortBy, uniqBy } from 'lodash';
+import { groupBy, sortBy, uniqBy } from 'lodash-es';
 import { createSelector } from 'reselect';
 import { selectMembershipsForGroup } from 'app/reducers/memberships';
 import { EntityType } from 'app/store/models/entities';

--- a/app/reducers/pools.ts
+++ b/app/reducers/pools.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { without } from 'lodash';
+import { without } from 'lodash-es';
 import { normalize } from 'normalizr';
 import { eventSchema } from 'app/reducers';
 import { EntityType } from 'app/store/models/entities';

--- a/app/reducers/registrations.ts
+++ b/app/reducers/registrations.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { omit, union } from 'lodash';
+import { omit, union } from 'lodash-es';
 import moment from 'moment-timezone';
 import { normalize } from 'normalizr';
 import { eventSchema, registrationSchema } from 'app/reducers';

--- a/app/reducers/search.ts
+++ b/app/reducers/search.ts
@@ -1,5 +1,5 @@
 import { produce } from 'immer';
-import { get } from 'lodash';
+import { get } from 'lodash-es';
 import moment from 'moment-timezone';
 import { createSelector } from 'reselect';
 import { resolveGroupLink } from 'app/reducers/groups';

--- a/app/reducers/selectors.ts
+++ b/app/reducers/selectors.ts
@@ -1,4 +1,4 @@
-import { isArray } from 'lodash';
+import { isArray } from 'lodash-es';
 import createQueryString from 'app/utils/createQueryString';
 import { createInitialPagination } from 'app/utils/legoAdapter/buildPaginationReducer';
 import type { RootState } from 'app/store/createRootReducer';

--- a/app/reducers/surveys.ts
+++ b/app/reducers/surveys.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import { createSelector } from 'reselect';
 import {
   fetchSurvey,

--- a/app/routes/admin/groups/components/GroupPermissions.tsx
+++ b/app/routes/admin/groups/components/GroupPermissions.tsx
@@ -1,5 +1,5 @@
 import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
-import { sortBy } from 'lodash';
+import { sortBy } from 'lodash-es';
 import { Trash2 } from 'lucide-react';
 import { Fragment } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';

--- a/app/routes/announcements/components/AnnouncementsCreate.tsx
+++ b/app/routes/announcements/components/AnnouncementsCreate.tsx
@@ -1,5 +1,5 @@
 import { ButtonGroup, Card, Flex } from '@webkom/lego-bricks';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { Field } from 'react-final-form';
 import { useLocation } from 'react-router-dom';
 import {

--- a/app/routes/bdb/components/BdbDetail.tsx
+++ b/app/routes/bdb/components/BdbDetail.tsx
@@ -9,7 +9,7 @@ import {
   PageCover,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';

--- a/app/routes/company/components/CompanyDetail.tsx
+++ b/app/routes/company/components/CompanyDetail.tsx
@@ -9,7 +9,7 @@ import {
   Skeleton,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';

--- a/app/routes/contact/components/ContactForm.tsx
+++ b/app/routes/contact/components/ContactForm.tsx
@@ -1,6 +1,6 @@
 import { Card, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { Field } from 'react-final-form';
 import { Link } from 'react-router-dom';
 import { sendContactMessage } from 'app/actions/ContactActions';

--- a/app/routes/events/components/EventAdministrate/Allergies.tsx
+++ b/app/routes/events/components/EventAdministrate/Allergies.tsx
@@ -1,6 +1,6 @@
 import { Flex, Icon, LinkButton, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { FileDown } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
 import { fetchAllergies } from 'app/actions/EventActions';

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -1,6 +1,6 @@
 import { Flex, Page, Skeleton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { FilePenLine } from 'lucide-react';
 import { useEffect } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -8,7 +8,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { isEmpty, orderBy } from 'lodash';
+import { isEmpty, orderBy } from 'lodash-es';
 import { FolderOpen } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -7,7 +7,7 @@ import {
   LoadingIndicator,
   ProgressBar,
 } from '@webkom/lego-bricks';
-import { sumBy } from 'lodash';
+import { sumBy } from 'lodash-es';
 import { Info, UserMinus } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useEffect } from 'react';

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -1,4 +1,4 @@
-import { pick, sumBy, find } from 'lodash';
+import { pick, sumBy, find } from 'lodash-es';
 import moment from 'moment-timezone';
 import config from 'app/config';
 import { EventType } from 'app/store/models/Event';

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -8,7 +8,7 @@ import {
   Modal,
   Page,
 } from '@webkom/lego-bricks';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { ListRestart, Pencil } from 'lucide-react';
 import moment from 'moment-timezone';
 import diff from 'node-htmldiff';

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -7,7 +7,7 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { unionBy } from 'lodash';
+import { unionBy } from 'lodash-es';
 import { Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';

--- a/app/routes/pages/components/YoutubeCover.tsx
+++ b/app/routes/pages/components/YoutubeCover.tsx
@@ -1,6 +1,6 @@
 import { LoadingIndicator, PageCover } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { useState } from 'react';
 import Youtube from 'react-youtube';
 import getParamsFromUrl from 'app/utils/getParamsFromUrl';

--- a/app/routes/photos/components/GalleryEditor.tsx
+++ b/app/routes/photos/components/GalleryEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
-import { without } from 'lodash';
+import { without } from 'lodash-es';
 import { Images, Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';

--- a/app/routes/search/SearchPageWrapper.tsx
+++ b/app/routes/search/SearchPageWrapper.tsx
@@ -1,6 +1,6 @@
 import { Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import qs from 'qs';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { search } from 'app/actions/SearchActions';

--- a/app/routes/surveys/components/SurveyEditor/AddSurveyPage.tsx
+++ b/app/routes/surveys/components/SurveyEditor/AddSurveyPage.tsx
@@ -1,6 +1,6 @@
 import { LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import moment from 'moment-timezone';
 import { useNavigate } from 'react-router-dom';
 import { fetchEvent } from 'app/actions/EventActions';

--- a/app/routes/surveys/components/SurveyList/SurveyList.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyList.tsx
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { FolderOpen } from 'lucide-react';
 import EmptyState from 'app/components/EmptyState';
 import SurveyItem from './SurveyItem';

--- a/app/routes/tags/components/TagDetail.tsx
+++ b/app/routes/tags/components/TagDetail.tsx
@@ -1,6 +1,6 @@
 import { Card, Flex, LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { map, toPairs } from 'lodash';
+import { map, toPairs } from 'lodash-es';
 import { Helmet } from 'react-helmet-async';
 import { Link, useParams } from 'react-router-dom';
 import { fetch } from 'app/actions/TagActions';

--- a/app/routes/userValidator/WrappedValidator.tsx
+++ b/app/routes/userValidator/WrappedValidator.tsx
@@ -1,5 +1,5 @@
 import { Page } from '@webkom/lego-bricks';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 import qs from 'qs';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { autocomplete } from 'app/actions/SearchActions';

--- a/app/routes/users/components/UserProfile/GroupMemberships.tsx
+++ b/app/routes/users/components/UserProfile/GroupMemberships.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { groupBy, orderBy } from 'lodash';
+import { groupBy, orderBy } from 'lodash-es';
 import moment from 'moment-timezone';
 import { Link } from 'react-router-dom';
 import { CircularPicture } from 'app/components/Image';

--- a/app/routes/users/components/UserProfile/GroupTree.tsx
+++ b/app/routes/users/components/UserProfile/GroupTree.tsx
@@ -1,4 +1,4 @@
-import { uniqBy } from 'lodash';
+import { uniqBy } from 'lodash-es';
 import { useMemo } from 'react';
 import { ProfileSection } from 'app/routes/users/components/UserProfile/ProfileSection';
 import type { EntityId } from '@reduxjs/toolkit';

--- a/app/routes/users/components/UserProfile/Permissions.tsx
+++ b/app/routes/users/components/UserProfile/Permissions.tsx
@@ -1,4 +1,4 @@
-import { sortBy } from 'lodash';
+import { sortBy } from 'lodash-es';
 import { Link } from 'react-router-dom';
 import {
   InfoField,

--- a/app/routes/users/components/UserProfile/index.tsx
+++ b/app/routes/users/components/UserProfile/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
-import { uniqBy, orderBy } from 'lodash';
+import { uniqBy, orderBy } from 'lodash-es';
 import { QrCode, SettingsIcon } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';

--- a/app/store/middleware/messageMiddleware.ts
+++ b/app/store/middleware/messageMiddleware.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get } from 'lodash-es';
 import type { AnyAction, Middleware } from '@reduxjs/toolkit';
 
 const createMessageMiddleware =

--- a/app/store/middleware/sentryMiddleware.ts
+++ b/app/store/middleware/sentryMiddleware.ts
@@ -1,5 +1,5 @@
 import { jwtDecode } from 'jwt-decode';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import createSentryMiddleware from 'redux-sentry-middleware';
 import { selectCurrentUser } from 'app/reducers/auth';
 import type { RootState } from 'app/store/createRootReducer';

--- a/app/utils/createMonthlyCalendar.ts
+++ b/app/utils/createMonthlyCalendar.ts
@@ -1,4 +1,4 @@
-import { range, takeWhile, last } from 'lodash';
+import { range, takeWhile, last } from 'lodash-es';
 import moment from 'moment-timezone';
 import type { Moment } from 'moment-timezone';
 /**

--- a/app/utils/loadingIndicator.tsx
+++ b/app/utils/loadingIndicator.tsx
@@ -1,5 +1,5 @@
 import { LoadingIndicator } from '@webkom/lego-bricks';
-import { get } from 'lodash';
+import { get } from 'lodash-es';
 import type { LoadingIndicatorProps } from '@webkom/lego-bricks';
 import type { ComponentType } from 'react';
 /**

--- a/app/utils/mergeObjects.ts
+++ b/app/utils/mergeObjects.ts
@@ -1,4 +1,4 @@
-import { mergeWith } from 'lodash';
+import { mergeWith } from 'lodash-es';
 
 function overrideArrays(
   oldValue,

--- a/app/utils/urlifyString.tsx
+++ b/app/utils/urlifyString.tsx
@@ -1,4 +1,4 @@
-import { compact } from 'lodash';
+import { compact } from 'lodash-es';
 import * as React from 'react';
 import { isEmail, isURL } from 'validator';
 

--- a/app/utils/useQuery.ts
+++ b/app/utils/useQuery.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import qs from 'qs';
 import { useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { merge } from 'lodash-es';
 import moment from 'moment-timezone';
 import config from 'app/config';
 import { EDITOR_EMPTY } from 'app/utils/constants';

--- a/server/pageRenderer.ts
+++ b/server/pageRenderer.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { ChunkExtractor } from '@loadable/server';
-import { isEmpty } from 'lodash';
+import { isEmpty } from 'lodash-es';
 import { renderToString } from 'react-dom/server';
 import serialize from 'serialize-javascript';
 import { selectCurrentUser } from 'app/reducers/auth';


### PR DESCRIPTION
Vite is not a huge fan of commonjs modules, es-modules also allow for better tree-shaking of the lodash package. (meaning we don't include code we don't use in lego-webapp)