### PR TITLE
Fix errors when loading members on pages when unauthorized

### DIFF
--- a/app/routes/pages/components/PageDetail.tsx
+++ b/app/routes/pages/components/PageDetail.tsx
@@ -161,6 +161,8 @@ export type UnknownSection =
   | Section<GroupPage>
   | Section<null>;
 
+const fetchAllMembershipsWithDecendants = (groupId: EntityId) => fetchAllMemberships(groupId, true);
+
 const sections: Record<string, UnknownSection> = {
   generelt: {
     title: 'Generelt',
@@ -192,7 +194,7 @@ const sections: Record<string, UnknownSection> = {
     fetchAll: () => fetchAllWithType(GroupType.Board),
     fetchItemActions: [
       fetchGroup,
-      (groupId: EntityId) => fetchAllMemberships(groupId, true),
+      fetchAllMembershipsWithDecendants,
     ],
   },
   bedrifter: {
@@ -223,7 +225,7 @@ const sections: Record<string, UnknownSection> = {
     fetchAll: () => fetchAllWithType(GroupType.Committee),
     fetchItemActions: [
       fetchGroup,
-      (groupId: EntityId) => fetchAllMemberships(groupId, true),
+      fetchAllMembershipsWithDecendants,
     ],
   },
   revy: {
@@ -236,7 +238,7 @@ const sections: Record<string, UnknownSection> = {
     fetchAll: () => fetchAllWithType(GroupType.Revue),
     fetchItemActions: [
       fetchGroup,
-      (groupId: EntityId) => fetchAllMemberships(groupId, true),
+      fetchAllMembershipsWithDecendants
     ],
   },
   grupper: {
@@ -316,7 +318,7 @@ const loadData = async (
   let actionsToDispatch = fetchItemActions;
   if (!loggedIn) {
     actionsToDispatch = fetchItemActions.filter(
-      (action) => !action.toString().includes('fetchAllMemberships'),
+      (action) => action !== fetchAllMembershipsWithDecendants
     );
   }
 

--- a/app/routes/pages/components/PageDetail.tsx
+++ b/app/routes/pages/components/PageDetail.tsx
@@ -161,7 +161,8 @@ export type UnknownSection =
   | Section<GroupPage>
   | Section<null>;
 
-const fetchAllMembershipsWithDecendants = (groupId: EntityId) => fetchAllMemberships(groupId, true);
+const fetchAllMembershipsWithDecendants = (groupId: EntityId) =>
+  fetchAllMemberships(groupId, true);
 
 const sections: Record<string, UnknownSection> = {
   generelt: {
@@ -192,10 +193,7 @@ const sections: Record<string, UnknownSection> = {
     PageRenderer: GroupRenderer,
     hierarchySectionSelector: selectBoardsForHierarchy,
     fetchAll: () => fetchAllWithType(GroupType.Board),
-    fetchItemActions: [
-      fetchGroup,
-      fetchAllMembershipsWithDecendants,
-    ],
+    fetchItemActions: [fetchGroup, fetchAllMembershipsWithDecendants],
   },
   bedrifter: {
     title: 'Bedrifter',
@@ -223,10 +221,7 @@ const sections: Record<string, UnknownSection> = {
     PageRenderer: GroupRenderer,
     hierarchySectionSelector: selectCommitteeForHierarchy,
     fetchAll: () => fetchAllWithType(GroupType.Committee),
-    fetchItemActions: [
-      fetchGroup,
-      fetchAllMembershipsWithDecendants,
-    ],
+    fetchItemActions: [fetchGroup, fetchAllMembershipsWithDecendants],
   },
   revy: {
     title: 'Revy',
@@ -236,10 +231,7 @@ const sections: Record<string, UnknownSection> = {
     PageRenderer: GroupRenderer,
     hierarchySectionSelector: selectRevueForHierarchy,
     fetchAll: () => fetchAllWithType(GroupType.Revue),
-    fetchItemActions: [
-      fetchGroup,
-      fetchAllMembershipsWithDecendants
-    ],
+    fetchItemActions: [fetchGroup, fetchAllMembershipsWithDecendants],
   },
   grupper: {
     title: 'Grupper',
@@ -318,7 +310,7 @@ const loadData = async (
   let actionsToDispatch = fetchItemActions;
   if (!loggedIn) {
     actionsToDispatch = fetchItemActions.filter(
-      (action) => action !== fetchAllMembershipsWithDecendants
+      (action) => action !== fetchAllMembershipsWithDecendants,
     );
   }
 


### PR DESCRIPTION
When not logged in and trying to view pages that normally contains memberships, a 401 error would occur.

The previous approach using `toString()` does not work with SSR as it minimizes / bundles the code so the actual function name becomes something like `d(e)` not `fetchAllMemberships`. 

Resolves ABA-1129
