### PR TITLE
Prevent album cover image from growing large

### DIFF
--- a/app/routes/photos/components/GalleryPictureModal.module.css
+++ b/app/routes/photos/components/GalleryPictureModal.module.css
@@ -16,10 +16,9 @@
 }
 
 .galleryThumbnail {
-  width: 60px;
-  height: 60px;
+  max-width: 60px;
+  max-height: 60px;
   border-radius: 50%;
-  margin-right: var(--spacing-sm);
 }
 
 .dropdown {

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -283,7 +283,7 @@ const GalleryPictureModal = () => {
         <OnKeyDownHandler handler={handleKeyDown} />
         <Flex column gap="var(--spacing-md)">
           <Flex width="100%" justifyContent="space-between" alignItems="center">
-            <Flex justifyContent="space-between">
+            <Flex justifyContent="space-between" gap="var(--spacing-md)">
               <Image
                 className={styles.galleryThumbnail}
                 alt="Forsidebilde til album"

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -273,6 +273,7 @@ const GalleryPictureModal = () => {
         propertyGenerator={propertyGenerator}
         options={{ gallery, picture }}
       >
+        <title>{`${gallery.title} (${picture.id})`}</title>
         <link
           rel="canonical"
           href={`${config?.webUrl}/photos/${gallery.id}/picture/${picture.id}`}


### PR DESCRIPTION
# Description

yet another ssr issue

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
           <img src="https://github.com/user-attachments/assets/4993bd4d-9fdf-4e2f-b954-ca69b9cfe316" />
        </td>
        <td>
            <img src="https://github.com/user-attachments/assets/a2ada2f5-e07b-4d08-8c9e-c2aedd360ce6" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested with ssr

---

Resolves ABA-1145
Resolves ABA-1146