### PR TITLE
Remove comment field from join event form when not required

### DIFF
--- a/app/routes/events/components/Event.module.css
+++ b/app/routes/events/components/Event.module.css
@@ -20,17 +20,10 @@
   margin-top: var(--spacing-md);
 }
 
-.registrationPending {
-  line-height: 1.3;
-  text-align: center;
-  margin: var(--spacing-md) 0;
-}
-
-.registrationPendingHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  margin-bottom: var(--spacing-md);
+.registrationPendingTooltip {
+  display: inline;
+  vertical-align: middle;
+  margin-left: var(--spacing-xs);
 }
 
 .eventPrice {

--- a/app/routes/events/components/EventAdministrate/Allergies.tsx
+++ b/app/routes/events/components/EventAdministrate/Allergies.tsx
@@ -133,9 +133,8 @@ const Allergies = () => {
         title: 'Tilbakemelding',
         dataIndex: 'feedback',
         centered: false,
-        render: (feedback: RegistrationWithAllergies['feedback']) => (
-          <span>{feedback || '-'}</span>
-        ),
+        render: (feedback: RegistrationWithAllergies['feedback']) =>
+          feedback ? <span>{feedback}</span> : <EmptyState body="-" />,
         sorter: (a: RegistrationWithAllergies, b: RegistrationWithAllergies) =>
           a.feedback.localeCompare(b.feedback),
       })

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -8,7 +8,7 @@ import {
   ProgressBar,
 } from '@webkom/lego-bricks';
 import { sumBy } from 'lodash';
-import { Info, UserMinus } from 'lucide-react';
+import { CircleHelp, UserMinus } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useEffect } from 'react';
 import { Field } from 'react-final-form';
@@ -41,6 +41,7 @@ import {
   toReadableSemester,
 } from '../utils';
 import styles from './Event.module.css';
+import sharedStyles from './EventDetail/EventDetail.module.css';
 import PaymentRequestForm from './StripeElement';
 import type { EventRegistrationStatus } from 'app/models';
 import type { PoolRegistrationWithUser } from 'app/reducers/events';
@@ -104,21 +105,15 @@ const RegistrationPending = ({
 }: {
   reg_status?: EventRegistrationStatus;
 }) => (
-  <Card className={styles.registrationPending}>
-    <span className={styles.registrationPendingHeader}>
-      <h3>
-        Vi behandler din{' '}
-        {reg_status === 'PENDING_UNREGISTER'
-          ? 'avregistrering'
-          : 'registrering'}
-        .
-      </h3>
-    </span>
-    <p>
-      Det kan ta et øyeblikk eller to.
-      <br />
-      <i>Du trenger ikke refreshe siden.</i>
+  <Card severity="info" className={sharedStyles.card}>
+    <Card.Header>
+      Vi behandler din{' '}
+      {reg_status === 'PENDING_UNREGISTER' ? 'avregistrering' : 'registrering'}
+    </Card.Header>
+    <span>
+      Det kan ta et øyeblikk eller to, og du trenger ikke refreshe siden
       <Tooltip
+        className={styles.registrationPendingTooltip}
         content={
           <span>
             Avhengig av last på våre servere kan dette ta litt tid. Ved mistanke
@@ -134,9 +129,9 @@ const RegistrationPending = ({
           </span>
         }
       >
-        <Icon iconNode={<Info />} size={20} />
+        <Icon iconNode={<CircleHelp />} size={18} />
       </Tooltip>
-    </p>
+    </span>
     <ProgressBar />
   </Card>
 );
@@ -342,7 +337,7 @@ const JoinEventForm = ({ title, event, registration }: Props) => {
             )}
 
             {sumPenalties > 0 && event.heedPenalties && (
-              <Card severity="warning">
+              <Card severity="warning" className={sharedStyles.card}>
                 <Card.Header>NB!</Card.Header>
                 <p>
                   {sumPenalties > 2
@@ -448,7 +443,7 @@ const JoinEventForm = ({ title, event, registration }: Props) => {
                               <LoadingIndicator
                                 loading
                                 loadingStyle={{
-                                  margin: '5px auto',
+                                  margin: 'var(--spacing-sm) auto',
                                 }}
                               />
                             ))}

--- a/cypress/e2e/event_visit_spec.js
+++ b/cypress/e2e/event_visit_spec.js
@@ -29,12 +29,13 @@ describe('View event', () => {
     cy.get(c('Modal')).should('not.exist');
   });
 
-  it('Should be possible to update event details', () => {
-    cy.visit('/events/20');
+  it('Should only be possible to update event feedback for events where it is required', () => {
+    cy.visit('/events/19');
+    cy.get('#feedback').should('not.exist');
 
-    // Update message
+    cy.visit('/events/20');
     cy.contains('button', 'Oppdater').should('be.disabled');
-    cy.get('#feedback').click().type('This is some feedback text');
+    cy.get('#feedback').click().type('noe lættis');
     cy.contains('button', 'Oppdater').should('not.be.disabled').click();
     // We should get a toast confirming
     cy.contains('Tilbakemelding oppdatert');

--- a/packages/lego-bricks/src/components/LoadingIndicator/LoadingIndicator.module.css
+++ b/packages/lego-bricks/src/components/LoadingIndicator/LoadingIndicator.module.css
@@ -45,7 +45,7 @@
 .progressLine::before {
   height: 3px;
   width: 100%;
-  margin: 0;
+  margin-top: var(--spacing-sm);
 }
 
 .progressLine {


### PR DESCRIPTION
# Description

Just takes up unnecessary space

[This is needed for cypress to pass](https://github.com/webkom/lego/pull/3663)

## Unrelated change:

<table>
	<tr>
		<td>Before</td>
		<td>After</td>
	</tr>
	<tr>
		<td>
			<img src="https://github.com/user-attachments/assets/f78cfbda-4961-4117-bb5f-edb9b3c93bd3" />
		</td>
		<td>
			<img src="https://github.com/user-attachments/assets/318f1b93-51ed-4390-911e-07697eac88f9" />
		</td>
	</tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Registering with and without `event.feedbackRequired` still works fine. I also tested that the logic for submitting a registration through the comment form still works as expected

---

Resolves ABA-1150