### PR TITLE
Disable unregistration button after unregistration deadline

### DIFF
--- a/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
+++ b/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
@@ -36,6 +36,7 @@ type PresenceProps = {
 type UnregisterProps = {
   fetching: boolean;
   registration: SelectedAdminRegistration;
+  isUnregistrationClosed: boolean;
 };
 type StripeStatusProps = {
   registrationId: EntityId;
@@ -179,9 +180,13 @@ export const StripeStatus = ({
   );
 };
 
-export const Unregister = ({ fetching, registration }: UnregisterProps) => {
-  const { eventId } = useParams<{ eventId: string }>();
+export const Unregister = ({
+  fetching,
+  registration,
+  isUnregistrationClosed,
+}: UnregisterProps) => {
   const dispatch = useAppDispatch();
+  const { eventId } = useParams<{ eventId: string }>();
 
   return (
     <>
@@ -192,21 +197,28 @@ export const Unregister = ({ fetching, registration }: UnregisterProps) => {
           title="Bekreft avregistrering"
           message={`Er du sikker på at du vil melde av "${registration.user.fullName}"?`}
           onConfirm={() => {
-            eventId &&
-              dispatch(
-                unregister({
-                  eventId,
-                  registrationId: registration.id,
-                  admin: true,
-                }),
-              );
+            if (!eventId) return;
+            dispatch(
+              unregister({
+                eventId,
+                registrationId: registration.id,
+                admin: true,
+              }),
+            );
           }}
           closeOnConfirm
         >
           {({ openConfirmModal }) => (
             <Flex justifyContent="center">
-              <Tooltip content="Meld av bruker">
+              <Tooltip
+                content={
+                  isUnregistrationClosed
+                    ? 'Avregistreringsfrist har gått ut'
+                    : 'Meld av bruker'
+                }
+              >
                 <Icon
+                  disabled={isUnregistrationClosed}
                   onPress={openConfirmModal}
                   name="person-remove-outline"
                   size={18}

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
@@ -9,6 +9,7 @@ import {
   getEventSemesterFromStartTime,
   allConsentsAnswered,
   getConsent,
+  unregistrationIsClosed,
 } from 'app/routes/events/utils';
 import { isNotNullish } from 'app/utils';
 import { WEBKOM_GROUP_ID } from 'app/utils/constants';
@@ -215,6 +216,8 @@ export const RegisteredTable = ({
     (event.feedbackDescription && event.feedbackDescription !== '') ||
     hasNonEmptyFeedback;
 
+  const isUnregistrationClosed = unregistrationIsClosed(event);
+
   const columns: ColumnProps<Registration>[] = [
     {
       title: '#',
@@ -355,7 +358,13 @@ export const RegisteredTable = ({
       render: (
         fetching: Registration['unregistering'],
         registration: Registration,
-      ) => <Unregister fetching={!!fetching} registration={registration} />,
+      ) => (
+        <Unregister
+          fetching={!!fetching}
+          registration={registration}
+          isUnregistrationClosed={isUnregistrationClosed}
+        />
+      ),
     },
   ].filter(isNotNullish);
 

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -11,7 +11,7 @@ import type {
   Dateish,
   EventStatusType,
 } from 'app/models';
-import type { CompleteEvent } from 'app/store/models/Event';
+import type { AdministrateEvent, CompleteEvent } from 'app/store/models/Event';
 import type Penalty from 'app/store/models/Penalty';
 import type { PublicUser } from 'app/store/models/User';
 
@@ -283,9 +283,9 @@ export const registrationIsClosed = (
   return moment().isAfter(registrationCloseTime(event));
 };
 
-export const unregistrationCloseTime = (event: Event) =>
+const unregistrationCloseTime = (event: AdministrateEvent) =>
   moment(event.startTime).subtract(event.unregistrationDeadlineHours, 'hours');
-export const unregistrationIsClosed = (event: Event) => {
+export const unregistrationIsClosed = (event: AdministrateEvent) => {
   return moment().isAfter(unregistrationCloseTime(event));
 };
 

--- a/packages/lego-bricks/src/components/Icon/Icon.module.css
+++ b/packages/lego-bricks/src/components/Icon/Icon.module.css
@@ -29,12 +29,12 @@
   color: var(--lego-font-color);
   transition: background-color var(--easing-fast);
 
-  &:hover,
-  &:focus-visible {
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
     background-color: var(--additive-background);
   }
 
-  &:active {
+  &:active:not(:disabled) {
     background-color: var(--color-gray-2);
   }
 }
@@ -43,12 +43,12 @@
   composes: clickable;
   color: var(--danger-color);
 
-  &:hover,
-  &:focus-visible {
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
     background-color: var(--color-red-1);
   }
 
-  &:active {
+  &:active:not(:disabled) {
     background-color: var(--color-red-2);
   }
 }
@@ -57,12 +57,12 @@
   composes: clickable;
   color: var(--success-color);
 
-  &:hover,
-  &:focus-visible {
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
     background-color: var(--color-green-2);
   }
 
-  &:active {
+  &:active:not(:disabled) {
     background-color: var(--color-green-3);
   }
 }
@@ -71,12 +71,12 @@
   composes: clickable;
   color: var(--color-orange-6);
 
-  &:hover,
-  &:focus-visible {
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
     background-color: var(--color-orange-2);
   }
 
-  &:active {
+  &:active:not(:disabled) {
     background-color: var(--color-orange-3);
   }
 }
@@ -84,8 +84,4 @@
 .disabled {
   opacity: 0.5;
   cursor: not-allowed;
-
-  &:hover {
-    color: var(--color-orange-6);
-  }
 }

--- a/packages/lego-bricks/src/components/Icon/index.tsx
+++ b/packages/lego-bricks/src/components/Icon/index.tsx
@@ -64,11 +64,11 @@ export const Icon = ({
       {...props}
     >
       {to ? (
-        <Link href={to} className={classNames}>
+        <Link href={to} isDisabled={disabled} className={classNames}>
           {iconElement}
         </Link>
       ) : onPress ? (
-        <Button onPress={onPress} className={classNames}>
+        <Button onPress={onPress} isDisabled={disabled} className={classNames}>
           {iconElement}
         </Button>
       ) : (


### PR DESCRIPTION
# Description

I've lost count of all the times someone has mailed Webkom because they can't unregister users after the deadline has ran out

The Icon component's `disabled` prop did nothing, so that was also fixed 

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<img width="561" alt="image" src="https://github.com/user-attachments/assets/c110c2c5-4717-4375-9a61-db13268ca272">

# Testing

- [x] I have thoroughly tested my changes.

See image above. It is not disabled before the unregistration deadline 😄 

---

Resolves ABA-1149