### PR TITLE
Support toast types

### DIFF
--- a/app/components/Toast/Toast.module.css
+++ b/app/components/Toast/Toast.module.css
@@ -25,6 +25,7 @@
 .toast {
   display: flex;
   align-items: center;
+  gap: var(--spacing-sm);
   background-color: var(--toast-background);
   color: var(--inverted-font-color);
   font-size: var(--font-size-md);
@@ -32,11 +33,7 @@
   padding: var(--spacing-md);
   line-height: 20px;
   box-shadow: none;
-  border: 1px solid var(--border-gray);
-
-  .closeButton > button {
-    color: var(--inverted-font-color);
-  }
+  border: 1.5px solid var(--border-gray);
 
   @media (--mobile-device) {
     width: 100%;
@@ -55,6 +52,18 @@
   &[data-animation='exiting'] {
     animation: fade-out var(--easing-slow);
   }
+}
+
+.success {
+  background-color: var(--color-green-2);
+  border-color: var(--color-green-7);
+  color: var(--color-green-7);
+}
+
+.error {
+  background-color: var(--color-red-1);
+  border-color: var(--danger-color);
+  color: var(--danger-color);
 }
 
 @keyframes slide-in {

--- a/app/components/Toast/Toast.tsx
+++ b/app/components/Toast/Toast.tsx
@@ -5,9 +5,10 @@ import { useRef } from 'react';
 import styles from './Toast.module.module.css';
 import type { AriaToastProps } from '@react-aria/toast';
 import type { ToastState } from '@react-stately/toast';
+import type { ToastContent } from 'app/reducers/toasts';
 
-interface ToastProps extends AriaToastProps<string> {
-  state: ToastState<string>;
+interface ToastProps extends AriaToastProps<ToastContent> {
+  state: ToastState<ToastContent>;
 }
 
 export const Toast = ({ state, ...props }: ToastProps) => {
@@ -39,7 +40,7 @@ export const Toast = ({ state, ...props }: ToastProps) => {
         size={18}
       />
       <div {...contentProps}>
-        <div {...titleProps}>{props.toast.content}</div>
+        <div {...titleProps}>{props.toast.content.message}</div>
       </div>
     </div>
   );

--- a/app/components/Toast/Toast.tsx
+++ b/app/components/Toast/Toast.tsx
@@ -1,8 +1,9 @@
 import { useToast } from '@react-aria/toast';
 import { Icon } from '@webkom/lego-bricks';
+import cx from 'classnames';
 import { X } from 'lucide-react';
 import { useRef } from 'react';
-import styles from './Toast.module.module.css';
+import styles from './Toast.module.css';
 import type { AriaToastProps } from '@react-aria/toast';
 import type { ToastState } from '@react-stately/toast';
 import type { ToastContent } from 'app/reducers/toasts';
@@ -19,11 +20,13 @@ export const Toast = ({ state, ...props }: ToastProps) => {
     ref,
   );
 
+  const { message, type } = props.toast.content;
+
   return (
     <div
       {...toastProps}
       ref={ref}
-      className={styles.toast}
+      className={cx(styles.toast, type && styles[type])}
       // Use a data attribute to trigger animations in CSS.
       data-animation={props.toast.animation}
       onAnimationEnd={() => {
@@ -35,12 +38,13 @@ export const Toast = ({ state, ...props }: ToastProps) => {
     >
       <Icon
         {...closeButtonProps}
-        className={styles.closeButton}
         iconNode={<X />}
+        success={type === 'success'}
+        danger={type === 'error'}
         size={18}
       />
       <div {...contentProps}>
-        <div {...titleProps}>{props.toast.content.message}</div>
+        <div {...titleProps}>{message}</div>
       </div>
     </div>
   );

--- a/app/components/Toast/ToastProvider.tsx
+++ b/app/components/Toast/ToastProvider.tsx
@@ -4,13 +4,14 @@ import { ToastRegion } from 'app/components/Toast/ToastRegion';
 import { removeToast, selectToasts } from 'app/reducers/toasts';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import usePrevious from 'app/utils/usePrevious';
+import type { ToastContent } from 'app/reducers/toasts';
 
 const ToastProvider = () => {
   const dispatch = useAppDispatch();
   const toasts = useAppSelector(selectToasts);
   const previousToasts = usePrevious(toasts);
 
-  const toastState = useToastState<string>({
+  const toastState = useToastState<ToastContent>({
     maxVisibleToasts: 5,
     hasExitAnimation: true,
   });
@@ -21,10 +22,13 @@ const ToastProvider = () => {
 
     for (const toast of toasts) {
       if (!previous.find((t) => t.id === toast.id)) {
-        toastState.add(toast.message, {
-          timeout: toast.dismissAfter,
-          onClose: () => dispatch(removeToast(toast.id)),
-        });
+        toastState.add(
+          { message: toast.message, type: toast.type },
+          {
+            timeout: toast.dismissAfter,
+            onClose: () => dispatch(removeToast(toast.id)),
+          },
+        );
       }
     }
   }, [dispatch, previousToasts, toastState, toasts]);

--- a/app/components/Toast/ToastRegion.tsx
+++ b/app/components/Toast/ToastRegion.tsx
@@ -4,9 +4,10 @@ import { Toast } from 'app/components/Toast/Toast';
 import styles from './Toast.module.module.css';
 import type { AriaToastRegionProps } from '@react-aria/toast';
 import type { ToastState } from '@react-stately/toast';
+import type { ToastContent } from 'app/reducers/toasts';
 
 interface ToastRegionProps extends AriaToastRegionProps {
-  state: ToastState<string>;
+  state: ToastState<ToastContent>;
 }
 
 export const ToastRegion = ({ state, ...props }: ToastRegionProps) => {

--- a/app/components/Toast/ToastRegion.tsx
+++ b/app/components/Toast/ToastRegion.tsx
@@ -1,7 +1,7 @@
 import { useToastRegion } from '@react-aria/toast';
 import { useRef } from 'react';
 import { Toast } from 'app/components/Toast/Toast';
-import styles from './Toast.module.module.css';
+import styles from './Toast.module.css';
 import type { AriaToastRegionProps } from '@react-aria/toast';
 import type { ToastState } from '@react-stately/toast';
 import type { ToastContent } from 'app/reducers/toasts';

--- a/app/reducers/toasts.ts
+++ b/app/reducers/toasts.ts
@@ -7,9 +7,12 @@ import type { Optional } from 'utility-types';
 type Toast = {
   id: string;
   message: string;
+  type?: 'success' | 'error';
   dismissAfter: number;
   removed: boolean;
 };
+
+export type ToastContent = Pick<Toast, 'message' | 'type'>;
 
 const initialState = {
   items: [] as Toast[],

--- a/app/store/createStore.ts
+++ b/app/store/createStore.ts
@@ -6,6 +6,7 @@ import createMessageMiddleware from 'app/store/middleware/messageMiddleware';
 import promiseMiddleware from 'app/store/middleware/promiseMiddleware';
 import createSentryMiddleware from 'app/store/middleware/sentryMiddleware';
 import { isTruthy } from 'app/utils';
+import type { ToastContent } from 'app/reducers/toasts';
 import type { RootState } from 'app/store/createRootReducer';
 import type { GetCookie } from 'app/types';
 
@@ -37,10 +38,7 @@ const createStore = (
         .concat(
           new Tuple(
             createMessageMiddleware(
-              (message) =>
-                addToast({
-                  message,
-                }),
+              (content: ToastContent) => addToast(content),
               Sentry,
             ),
             Sentry && createSentryMiddleware(Sentry),

--- a/app/store/middleware/messageMiddleware.ts
+++ b/app/store/middleware/messageMiddleware.ts
@@ -1,8 +1,12 @@
 import { get } from 'lodash';
 import type { AnyAction, Middleware } from '@reduxjs/toolkit';
+import type { ToastContent } from 'app/reducers/toasts';
 
 const createMessageMiddleware =
-  (actionToDispatch: (message: string) => AnyAction, Sentry: any): Middleware =>
+  (
+    actionToDispatch: (content: ToastContent) => AnyAction,
+    Sentry: any,
+  ): Middleware =>
   ({ dispatch }) =>
   (next) =>
   (action) => {
@@ -14,16 +18,19 @@ const createMessageMiddleware =
     }
 
     let message;
+    let type;
 
     if (error) {
       message = typeof error === 'function' ? error(action.error) : error;
+      type = 'error';
       Sentry.captureException(action.payload);
     } else {
       message = success;
+      type = 'success';
     }
 
     if (actionToDispatch) {
-      dispatch(actionToDispatch(message));
+      dispatch(actionToDispatch({ message, type }));
     }
 
     return next(action);


### PR DESCRIPTION
# Description

Much faster and better feedback. Currently only support `success` and `error` (and the default `undefined`) - I don't think we'll need any more.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
			<img src="https://github.com/user-attachments/assets/fcc75b86-d074-4549-ac3f-eb2e65a57f5d" />
        </td>
        <td> 
			<img src="https://github.com/user-attachments/assets/05d2a5af-cfbd-4062-9737-eb9193a60a25" />
        </td>
    </tr>
    <tr>
        <td>
			<img src="https://github.com/user-attachments/assets/9eb39b4d-acad-4466-9064-92287f7454b1" />
        </td>
        <td>
			<img src="https://github.com/user-attachments/assets/38c6b05b-e482-4a0e-a2a3-1d07d1960e19" />
        </td>
    </tr>
    <tr>
        <td>
			<img src="https://github.com/user-attachments/assets/e06864b6-24ad-40e3-bda6-97e2fe4ae841" />
        </td>
        <td>
			<img src="https://github.com/user-attachments/assets/2584d243-dc56-4ff6-aebc-da3a5746abd4" />
        </td>
    </tr>
</table>



# Testing

- [x] I have thoroughly tested my changes.

See images above.

---

Resolves ABA-1147