### PR TITLE
Remove deprecated `redux-mock-store` dep

### DIFF
--- a/app/components/Comments/__tests__/CommentTree.spec.tsx
+++ b/app/components/Comments/__tests__/CommentTree.spec.tsx
@@ -1,24 +1,44 @@
+import { configureStore } from '@reduxjs/toolkit';
 import { mount, shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
-import configureStore from 'redux-mock-store';
 import { describe, it, expect } from 'vitest';
+import createRootReducer from 'app/store/createRootReducer';
 import { generateTreeStructure } from 'app/utils';
 import CommentTree from '../CommentTree';
 import comments from './fixtures/comments';
 
-const store = configureStore([])({
-  theme: {
-    theme: 'light',
+const store = configureStore({
+  reducer: createRootReducer(),
+  preloadedState: {
+    theme: {
+      theme: 'light',
+    },
+    auth: {
+      id: 1,
+      username: 'webkom',
+      token: 'token',
+      loginFailed: false,
+      loggingIn: false,
+      registrationToken: null,
+      studentConfirmed: true,
+    },
+    users: {
+      ids: [],
+      entities: {},
+      actionGrant: ['view'],
+      fetching: false,
+      paginationNext: {},
+    },
+    emojis: {
+      ids: [],
+      entities: {},
+      actionGrant: ['view'],
+      fetching: false,
+      paginationNext: {},
+    },
   },
-  auth: {},
-  users: {
-    entities: {},
-  },
-  emojis: {
-    ids: [],
-    entities: {},
-  },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
 });
 
 describe('<CommentTree />', () => {
@@ -43,6 +63,6 @@ describe('<CommentTree />', () => {
     const rootElements = wrapper.find('[data-ischild=false]');
     const rootElement = rootElements.at(1);
     const childTree = rootElement.find('[data-ischild=true]');
-    expect(childTree.text()).toMatch(comments[2].text);
+    expect(childTree.text()).toMatch(comments[2].text ?? '');
   });
 });

--- a/app/components/LoginForm/LoginForm.spec.tsx
+++ b/app/components/LoginForm/LoginForm.spec.tsx
@@ -1,17 +1,19 @@
+import { configureStore } from '@reduxjs/toolkit';
 import { mount } from 'enzyme';
 import { Field } from 'react-final-form';
 import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
 import { describe, it, expect } from 'vitest';
+import createRootReducer from 'app/store/createRootReducer';
 import LoginForm from './LoginForm';
 
 describe('components', () => {
   describe('LoginForm', () => {
     it('should render correctly', () => {
-      const login = () => {};
+      const store = configureStore({
+        reducer: createRootReducer(),
+        middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
+      });
 
-      const mockStore = configureStore();
-      const store = mockStore();
       const wrapper = mount(
         <Provider
           {...{
@@ -22,7 +24,6 @@ describe('components', () => {
         </Provider>,
       );
       const form = wrapper.find('form');
-      expect(form.hasClass('LoginForm')).toBe(true);
       const username = form.childAt(0);
       const password = form.childAt(1);
       expect(username.type()).toEqual(Field);

--- a/app/components/LoginForm/LoginForm.spec.tsx
+++ b/app/components/LoginForm/LoginForm.spec.tsx
@@ -18,7 +18,7 @@ describe('components', () => {
             store,
           }}
         >
-          <LoginForm login={login} className="LoginForm" />
+          <LoginForm />
         </Provider>,
       );
       const form = wrapper.find('form');

--- a/app/components/LoginForm/LoginForm.tsx
+++ b/app/components/LoginForm/LoginForm.tsx
@@ -8,17 +8,10 @@ import { SubmitButton } from 'app/components/Form/SubmitButton';
 import TextInput from 'app/components/Form/TextInput';
 import { useAppDispatch } from 'app/store/hooks';
 import { createValidator, required } from 'app/utils/validation';
-import type { Action } from 'app/types';
 
 type FormValues = {
   username: string;
   password: string;
-};
-
-type Props = {
-  className?: string;
-  postLoginFail?: (error: unknown) => void;
-  postLoginSuccess?: (res: Action) => any;
 };
 
 const validate = createValidator({
@@ -26,22 +19,13 @@ const validate = createValidator({
   password: [required()],
 });
 
-const LoginForm = (props: Props) => {
+const LoginForm = () => {
   const dispatch = useAppDispatch();
-
-  const {
-    postLoginSuccess = (res) => res,
-    postLoginFail = (error) => {
-      console.error(error);
-    },
-  } = props;
 
   const onSubmit = async (values: FormValues) => {
     try {
-      const res = await dispatch(login(values.username, values.password));
-      return postLoginSuccess(res);
+      await dispatch(login(values.username, values.password));
     } catch (error) {
-      postLoginFail(error);
       return { [FORM_ERROR]: 'Feil brukernavn eller passord' };
     }
   };
@@ -50,7 +34,7 @@ const LoginForm = (props: Props) => {
     <div onClick={(e) => e.stopPropagation()}>
       <LegoFinalForm onSubmit={onSubmit} validate={validate} subscription={{}}>
         {({ handleSubmit }) => (
-          <Form onSubmit={handleSubmit} className={props.className}>
+          <Form onSubmit={handleSubmit}>
             <Field
               name="username"
               placeholder="Brukernavn"

--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
     "prettier": "3.3.3",
     "process": "^0.11.10",
     "react-refresh": "^0.14.2",
-    "redux-mock-store": "^1.5.4",
     "style-loader": "^4.0.0",
     "stylelint": "^15.10.1",
     "stylelint-config-standard": "^34.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9571,11 +9571,6 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -11737,13 +11732,6 @@ redux-logger@^3.0.1:
   integrity sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==
   dependencies:
     deep-diff "^0.3.5"
-
-redux-mock-store@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
-  integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==
-  dependencies:
-    lodash.isplainobject "^4.0.6"
 
 redux-sentry-middleware@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
# Description

In [v1.5.5](https://github.com/webkom/lego-webapp/pull/5113) it officially deprecated the `configureStore` method.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

Tests pass. Manually tested the login form as well, and it catches errors fine.