### PR TITLE
Remove author field from meeting detail

### DIFF
--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -211,6 +211,7 @@ const MeetingDetails = () => {
                     iconNode={<ListRestart />}
                     size={20}
                     className="secondaryFontColor"
+                    data-test-id="changelog-dropdown-trigger"
                   />
                 }
               >

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -174,7 +174,7 @@ const MeetingDetails = () => {
       key: 'Sted',
       value: `${meeting.location}`,
     },
-    {
+    (!meeting.reportChangelogs || meeting.reportChangelogs.length === 0) && {
       key: 'Forfatter',
       value: <UserLink user={createdBy} />,
     },
@@ -201,7 +201,7 @@ const MeetingDetails = () => {
           )}
           <Flex alignItems="center" gap="var(--spacing-sm)">
             <h2>Referat</h2>
-            {meeting.reportChangelogs?.length > 1 && (
+            {meeting.reportChangelogs?.length > 0 && (
               <Dropdown
                 show={changelogOpen}
                 toggle={() => setChangelogOpen(!changelogOpen)}
@@ -209,7 +209,7 @@ const MeetingDetails = () => {
                 triggerComponent={
                   <Icon
                     iconNode={<ListRestart />}
-                    size={18}
+                    size={20}
                     className="secondaryFontColor"
                   />
                 }

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -118,12 +118,15 @@ describe('Create meeting', () => {
     cy.contains('div', 'Sted')
       .should('contain.text', 'Test location')
       .should('be.visible');
-    cy.contains('div', 'Forfatter')
-      .should('contain.text', 'webkom webkom')
-      .should('be.visible');
     cy.contains('div', 'Referent')
       .should('contain.text', 'bedkom bedkom')
       .should('be.visible');
+
+    cy.get(t('changelog-dropdown-trigger')).click();
+    cy.get(c('Dropdown-module__dropdownList'))
+      .find('li')
+      .should('have.length', 1);
+    cy.contains('span', 'webkom opprettet').should('be.visible');
 
     cy.contains(c('AttendanceStatus-module__poolBox'), 'Ikke svart')
       .should('contain.text', '2/2')
@@ -236,12 +239,15 @@ describe('Create meeting', () => {
     cy.contains('div', 'Sted')
       .should('contain.text', 'Abakus, Realfagbygget')
       .should('be.visible');
-    cy.contains('div', 'Forfatter')
-      .should('contain.text', 'webkom webkom')
-      .should('be.visible');
     cy.contains('div', 'Referent')
       .should('contain.text', 'webkom webkom')
       .should('be.visible');
+
+    cy.get(t('changelog-dropdown-trigger')).click();
+    cy.get(c('Dropdown-module__dropdownList'))
+      .find('li')
+      .should('have.length', 3); // The dropdown divider counts as one
+    cy.contains('span', 'webkom redigerte').should('be.visible');
 
     cy.contains(c('AttendanceStatus-module__poolBox'), 'Ikke svart')
       .should('contain.text', '2/2')


### PR DESCRIPTION
# Description

I'd like to make this resemble the event details more, but I have a trouble finding an icon for both "author" and "referent", so my plan is to iterate on this by first removing the author field and get people used to that :)

The first report changelog will say it was "opprettet" so that should be sufficient

<img width="270" alt="image" src="https://github.com/user-attachments/assets/985b35b0-c345-47f1-b932-7931dda501ee">


# Testing

- [x] I have thoroughly tested my changes.

It is now hidden if there are any report changelogs