### PR TITLE
Repace usage of deprecated event.which with event.key

### DIFF
--- a/app/components/Form/CheckBox.tsx
+++ b/app/components/Form/CheckBox.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { Keyboard } from 'app/utils/constants';
 import styles from './CheckBox.module.css';
 import { createField } from './Field';
 import type { ComponentProps, InputHTMLAttributes, KeyboardEvent } from 'react';
@@ -29,7 +30,7 @@ const CheckBox = ({
   const normalizedValue = inverted ? !checked : checked;
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
+    if (event.key === Keyboard.ENTER) {
       event.preventDefault();
 
       const inputElement = event.target as HTMLInputElement;

--- a/app/components/Form/RadioButton.tsx
+++ b/app/components/Form/RadioButton.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { Keyboard } from 'app/utils/constants';
 import { createField } from './Field';
 import styles from './RadioButton.module.css';
 import type { ComponentProps, InputHTMLAttributes, KeyboardEvent } from 'react';
@@ -18,7 +19,7 @@ function RadioButton({
   ...props
 }: Props) {
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
+    if (event.key === Keyboard.ENTER) {
       event.preventDefault();
 
       const inputElement = event.target as HTMLInputElement;

--- a/app/components/Form/TimePicker.tsx
+++ b/app/components/Form/TimePicker.tsx
@@ -18,7 +18,7 @@ const TimePickerInput = ({
   ...props
 }: TimePickerInputProps) => {
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    switch (e.which) {
+    switch (e.key) {
       case Keyboard.UP:
         onNext();
         break;

--- a/app/components/MazemapEmbed/index.tsx
+++ b/app/components/MazemapEmbed/index.tsx
@@ -1,6 +1,7 @@
 import { Flex } from '@webkom/lego-bricks';
 import { useEffect, useState } from 'react';
 import 'node_modules/mazemap/mazemap.min.css';
+import { Keyboard } from 'app/utils/constants';
 import styles from './MazemapEmbed.module.css';
 import MazemapLink from './MazemapLink';
 
@@ -63,13 +64,13 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
     let zoomButtonPressed = false;
 
     const onKeyDown = (e) => {
-      if (isMac ? e.key === 'Meta' : e.key === 'Control') {
+      if (isMac ? e.key === Keyboard.META : e.key === Keyboard.CONTROL) {
         zoomButtonPressed = true;
       }
     };
 
     const onKeyUp = (e) => {
-      if (isMac ? e.key === 'Meta' : e.key === 'Control') {
+      if (isMac ? e.key === Keyboard.META : e.key === Keyboard.CONTROL) {
         zoomButtonPressed = false;
       }
     };

--- a/app/components/Search/SearchPage.tsx
+++ b/app/components/Search/SearchPage.tsx
@@ -41,7 +41,7 @@ const SearchPage = <SearchType extends SearchResult>(
   const handleKeyDown = (e: KeyboardEvent) => {
     if (props.results.length === 0) return;
 
-    switch (e.which) {
+    switch (e.key) {
       case Keyboard.UP:
         e.preventDefault();
         setSelectedIndex(Math.max(0, selectedIndex - 1));

--- a/app/components/Search/index.tsx
+++ b/app/components/Search/index.tsx
@@ -30,7 +30,7 @@ const Search = () => {
   const onCloseSearch = () => dispatch(toggleSearch());
 
   const handleKeyDown = (e) => {
-    switch (e.which) {
+    switch (e.key) {
       case Keyboard.UP:
         e.preventDefault();
         setSelectedIndex(Math.max(-1, selectedIndex - 1));

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -29,6 +29,7 @@ import { selectPenaltyByUserId } from 'app/reducers/penalties';
 import { useRegistrationCountdown } from 'app/routes/events/components/useRegistrationCountdown';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { Presence } from 'app/store/models/Registration';
+import { Keyboard } from 'app/utils/constants';
 import { spyValues } from 'app/utils/formSpyUtils';
 import { createValidator, requiredIf } from 'app/utils/validation';
 import {
@@ -478,7 +479,10 @@ const JoinEventForm = ({
                                   component={TextInput.Field}
                                   className={styles.feedbackText}
                                   onKeyDown={(e) => {
-                                    if (e.key === 'Enter' && registration) {
+                                    if (
+                                      e.key === Keyboard.ENTER &&
+                                      registration
+                                    ) {
                                       // Prevent user from unregistering by pressing enter
                                       e.preventDefault();
 

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -242,7 +242,7 @@ const GalleryPictureModal = () => {
       return;
     }
 
-    switch (e.which) {
+    switch (e.key) {
       case Keyboard.LEFT:
         e.preventDefault();
         previousGalleryPicture();

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -1,12 +1,14 @@
 import config from 'app/config';
 
 export const Keyboard = {
-  ESCAPE: 27,
-  RIGHT: 39,
-  LEFT: 37,
-  ENTER: 13,
-  UP: 38,
-  DOWN: 40,
+  ESCAPE: 'Escape',
+  RIGHT: 'ArrowRight',
+  LEFT: 'ArrowLeft',
+  UP: 'ArrowUp',
+  DOWN: 'ArrowDown',
+  ENTER: 'Enter',
+  META: 'Meta',
+  CONTROL: 'Control',
 };
 
 export const ROLES = {


### PR DESCRIPTION
# Description

`event.which` is deprecated and may be removed from future browser versions. https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which
It can be replaced with `event.key`.

# Result

No functional or visual changes

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-1158
