### PR TITLE
Add PDF download to surveys

### DIFF
--- a/app/routes/surveys/components/AdminSideBar.tsx
+++ b/app/routes/surveys/components/AdminSideBar.tsx
@@ -9,7 +9,7 @@ import { useAppDispatch } from 'app/store/hooks';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant } from 'app/models';
 
-type GeneratedCSV = {
+type GeneratedFile = {
   url: string;
   filename: string;
 };
@@ -18,19 +18,22 @@ type Props = {
   surveyId: EntityId;
   actionGrant: ActionGrant;
   token: string | null;
-  exportSurvey?: () => Promise<GeneratedCSV>;
+  exportSurveyCSV?: () => Promise<GeneratedFile>;
+  exportSurveyPDF?: () => Promise<GeneratedFile>;
 };
 
 const AdminSideBar = ({
   surveyId,
   actionGrant,
   token,
-  exportSurvey,
+  exportSurveyCSV,
+  exportSurveyPDF,
 }: Props) => {
   const dispatch = useAppDispatch();
   const [copied, setCopied] = useState(false);
   const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout>();
-  const [generatedCSV, setGeneratedCSV] = useState<GeneratedCSV>();
+  const [generatedCSV, setGeneratedCSV] = useState<GeneratedFile>();
+  const [generatedPDF, setgeneratedPDF] = useState<GeneratedFile>();
   const canEdit = actionGrant.includes('edit');
   const shareLink = token
     ? `${config.webUrl}/surveys/${surveyId}/results/?token=${token}`
@@ -69,9 +72,8 @@ const AdminSideBar = ({
               Rediger
             </LinkButton>
 
-            {actionGrant &&
-              actionGrant.includes('csv') &&
-              exportSurvey &&
+            {actionGrant?.includes('csv') &&
+              exportSurveyCSV &&
               (generatedCSV ? (
                 <LinkButton
                   success
@@ -83,10 +85,30 @@ const AdminSideBar = ({
                 </LinkButton>
               ) : (
                 <Button
-                  onPress={async () => setGeneratedCSV(await exportSurvey())}
+                  onPress={async () => setGeneratedCSV(await exportSurveyCSV())}
                 >
                   <Icon iconNode={<FileUp />} size={19} />
                   Eksporter til CSV
+                </Button>
+              ))}
+
+            {actionGrant?.includes('csv') &&
+              exportSurveyPDF &&
+              (generatedPDF ? (
+                <LinkButton
+                  success
+                  href={generatedPDF.url}
+                  download={generatedPDF.filename}
+                >
+                  <Icon iconNode={<FileDown />} size={19} />
+                  Last ned PDF
+                </LinkButton>
+              ) : (
+                <Button
+                  onPress={async () => setgeneratedPDF(await exportSurveyPDF())}
+                >
+                  <Icon iconNode={<FileUp />} size={19} />
+                  Eksporter til PDF
                 </Button>
               ))}
 

--- a/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
@@ -5,7 +5,7 @@ import { useFetchedSurveySubmissions } from 'app/reducers/surveySubmissions';
 import { useFetchedSurvey } from 'app/reducers/surveys';
 import { useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
-import { SurveyDetailTabs, getCsvUrl } from '../../utils';
+import { SurveyDetailTabs, getCsvUrl, getPdfUrl } from '../../utils';
 import AdminSideBar from '../AdminSideBar';
 import type { DetailedSurvey } from 'app/store/models/Survey';
 import type { SurveySubmission } from 'app/store/models/SurveySubmission';
@@ -63,7 +63,7 @@ const SubmissionsPage = ({ children: Children }: Props) => {
           surveyId={survey.id}
           actionGrant={survey.actionGrant}
           token={survey.token}
-          exportSurvey={async () => {
+          exportSurveyCSV={async () => {
             const blob = await fetch(getCsvUrl(survey.id), {
               headers: {
                 Authorization: `Bearer ${authToken}`,
@@ -72,6 +72,17 @@ const SubmissionsPage = ({ children: Children }: Props) => {
             return {
               url: URL.createObjectURL(blob),
               filename: survey.title.replace(/ /g, '_') + '.csv',
+            };
+          }}
+          exportSurveyPDF={async () => {
+            const blob = await fetch(getPdfUrl(survey.id), {
+              headers: {
+                Authorization: `Bearer ${authToken}`,
+              },
+            }).then((response) => response.blob());
+            return {
+              url: URL.createObjectURL(blob),
+              filename: survey.title.replace(/ /g, '_') + '.pdf',
             };
           }}
         />

--- a/app/routes/surveys/utils.tsx
+++ b/app/routes/surveys/utils.tsx
@@ -31,6 +31,10 @@ export const SurveyDetailTabs = ({ surveyId }: { surveyId?: EntityId }) =>
 
 export const getCsvUrl = (surveyId: EntityId) =>
   `${config.serverUrl}/surveys/${surveyId}/csv/`;
+
+export const getPdfUrl = (surveyId: EntityId) =>
+  `${config.serverUrl}/surveys/${surveyId}/pdf/`;
+
 export const QuestionTypeOption = ({ iconName, option, ...props }: any) => (
   <div
     style={{


### PR DESCRIPTION
# Description

Depends on: https://github.com/webkom/lego/pull/3668

Adds PDF download to surveys

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/ff569a2d-1dce-4261-91c7-7a700c97025c"></td>
        <td><img src="https://github.com/user-attachments/assets/30317082-8e85-4106-8147-a7d499066a65"></td>
    </tr>
</table>

# Testing

- [ x] I have thoroughly tested my changes.

Tested manually

---

Resolves: ABA-1102
