### PR TITLE
Update waiting list placement calculation for more performant backend

### DIFF
--- a/app/routes/events/components/EventDetail/getWaitingListPosition.ts
+++ b/app/routes/events/components/EventDetail/getWaitingListPosition.ts
@@ -8,10 +8,8 @@ const isPermittedInPool = (
   user: PublicUserWithAbakusGroups,
   pool: PoolWithRegistrations,
 ) => {
-  return pool.permissionGroups.some((permissionGroup) =>
-    user.allAbakusGroupIds?.some(
-      (userGroup) => userGroup === permissionGroup.id,
-    ),
+  return pool.allPermissionGroupIds.some((permissionGroupId) =>
+    user.abakusGroups?.includes(permissionGroupId),
   );
 };
 

--- a/app/store/models/Pool.d.ts
+++ b/app/store/models/Pool.d.ts
@@ -8,6 +8,7 @@ interface CompletePool {
   capacity: number;
   activationDate: Dateish;
   permissionGroups: PublicGroup[];
+  allPermissionGroupIds: EntityId[];
   registrationCount: number;
   registrations: EntityId[];
 }
@@ -29,6 +30,7 @@ export type AuthPool = Pick<
   | 'capacity'
   | 'activationDate'
   | 'permissionGroups'
+  | 'allPermissionGroupIds'
   | 'registrationCount'
   | 'registrations'
 >;

--- a/app/store/models/User.ts
+++ b/app/store/models/User.ts
@@ -64,7 +64,6 @@ interface User {
   penalties: EntityId[];
   icalToken: string;
   abakusGroups: EntityId[];
-  allAbakusGroupIds: EntityId[];
   isAbakusMember: boolean;
   isAbakomMember: boolean;
   pastMemberships: PastMembership[];
@@ -137,10 +136,7 @@ export type PublicUser = Pick<
   | 'achievements'
 >;
 
-export type PublicUserWithAbakusGroups = Pick<
-  User,
-  'abakusGroups' | 'allAbakusGroupIds'
-> &
+export type PublicUserWithAbakusGroups = Pick<User, 'abakusGroups'> &
   PublicUser;
 
 export type PublicUserWithGroups = Pick<


### PR DESCRIPTION
# Description

Appearently my code in https://github.com/webkom/lego/pull/3642 caused "significant performance issues" and "increased loading times" on the event detail page. This is true, my bad.

I believe the issue getting the fairly expensive inherited groups for each person in the waiting list. Instead we can just get child-groups for all the applicable groups in the pools. This should be cheaper because there are fewer pools.

# Result

No visual changes

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
