### PR TITLE
Improve skeleton components on event detail page

### DIFF
--- a/app/routes/events/components/EventDetail/AttendeeSection.tsx
+++ b/app/routes/events/components/EventDetail/AttendeeSection.tsx
@@ -63,7 +63,7 @@ export const AttendeeSection = ({
         minUserGridRows={minUserGridRows}
         maxUserGridRows={MAX_USER_GRID_ROWS}
         legacyRegistrationCount={event?.legacyRegistrationCount}
-        skeleton={fetching && !registrations}
+        skeleton={fetching && !registrations.length}
       />
 
       {loggedIn &&

--- a/app/routes/events/components/EventDetail/SidebarInfo.tsx
+++ b/app/routes/events/components/EventDetail/SidebarInfo.tsx
@@ -29,9 +29,13 @@ export const SidebarInfo = ({ event }: Props) => {
           iconNode={<BriefcaseBusiness />}
           size={20}
           content={
-            <Link to={`/companies/${event.company.id}`}>
-              {event.company.name}
-            </Link>
+            event.company.name ? (
+              <Link to={`/companies/${event.company.id}`}>
+                {event.company.name}
+              </Link>
+            ) : (
+              <Skeleton className={styles.sidebarInfo} width={100} />
+            )
           }
           className={styles.sidebarInfo}
         />
@@ -57,7 +61,13 @@ export const SidebarInfo = ({ event }: Props) => {
         <TextWithIcon
           iconNode={<Coins />}
           size={20}
-          content={event.priceMember / 100 + ',-'}
+          content={
+            event.priceMember ? (
+              event.priceMember / 100 + ',-'
+            ) : (
+              <Skeleton className={styles.sidebarInfo} width={50} />
+            )
+          }
           className={styles.sidebarInfo}
         />
       )}

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -272,7 +272,7 @@ const EventDetail = () => {
 
           <Line />
 
-          {showSkeleton ? (
+          {fetching && !event?.createdBy && !event?.responsibleUsers ? (
             <Flex column gap="var(--spacing-sm)">
               <Flex gap="var(--spacing-md)" className={styles.sidebarInfo}>
                 Arrangør

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -6,6 +6,7 @@ import {
   Icon,
   LoadingIndicator,
   ProgressBar,
+  Skeleton,
 } from '@webkom/lego-bricks';
 import { sumBy } from 'lodash';
 import { CircleHelp, UserMinus } from 'lucide-react';
@@ -330,6 +331,8 @@ const JoinEventForm = ({
           registrationMessage(event)
         ) : (
           <>
+            {!event?.activationTime && <Skeleton array={2} height={35} />}
+
             {!formOpen && event.activationTime && (
               <div>
                 Åpner om{' '}


### PR DESCRIPTION
# Description

More fine-grained control over what components are shown as skeletons. See images below.

This page could still use a bit more work to make the skeletons actually match the real components.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

Event page entered from the frontpage:
<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Event without registration yet        </td>
        <td>

![Screenshot 2024-11-04 at 11 07 20](https://github.com/user-attachments/assets/79b1e400-eec6-4127-9c2e-b42125a3a7d8)
        </td>
        <td>

![Screenshot 2024-11-04 at 11 16 49](https://github.com/user-attachments/assets/4da968a4-d659-4d2c-8fba-230bed8a6e4f)
        </td>
    </tr>
    <tr>
        <td>
            Event with registration        </td>
        <td>

![Screenshot 2024-11-04 at 11 07 40](https://github.com/user-attachments/assets/cafb8728-752e-4c39-9ef2-976b3862ddbe)
        </td>
        <td>

![Screenshot 2024-11-04 at 11 06 16](https://github.com/user-attachments/assets/6dd50861-71bb-4d7e-861b-82d0aa031bec)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

I have loaded a bunch of events a bunch of times, and it looks less wrong than it did before:)

---

Resolves ABA-1164
