### PR TITLE
Navigate directly to survey answer page from UnansweredSurveys

### DIFF
--- a/app/routes/events/components/EventDetail/UnansweredSurveys.tsx
+++ b/app/routes/events/components/EventDetail/UnansweredSurveys.tsx
@@ -20,7 +20,7 @@ export const UnansweredSurveys = ({ event, currentRegistration }: Props) => {
       <ul>
         {event.unansweredSurveys.map((surveyId, i) => (
           <li key={surveyId}>
-            <Link to={`/surveys/${surveyId}`}>Undersøkelse {i + 1}</Link>
+            <Link to={`/surveys/${surveyId}/answer`}>Undersøkelse {i + 1}</Link>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
# Description

I heard from a non-admin that they can see all the admin options at `/surveys/<id>`, and go here every time they press the button to answer a survey. Instead of seeing this page, they can be directed to the `/surveys/<id>/answer` directly.

# Testing

- [x] I have thoroughly tested my changes.