### PR TITLE
Remove duplicate settings button

### DIFF
--- a/app/routes/users/components/UserProfile/UserProfile.module.css
+++ b/app/routes/users/components/UserProfile/UserProfile.module.css
@@ -79,10 +79,10 @@
 
 .settingsIcon {
   transition: transform var(--easing-medium);
+}
 
-  &:hover {
-    transform: rotate(90deg);
-  }
+.settingsButton:hover .settingsIcon {
+  transform: rotate(90deg);
 }
 
 .soMeIcon {

--- a/app/routes/users/components/UserProfile/index.tsx
+++ b/app/routes/users/components/UserProfile/index.tsx
@@ -157,12 +157,17 @@ const UserProfile = () => {
       title={user.fullName}
       actionButtons={
         showSettings && (
-          <Icon
-            iconNode={<SettingsIcon />}
-            size={22}
-            className={styles.settingsIcon}
-            to={`/users/${user.username}/settings/profile`}
-          />
+          <LinkButton
+            className={styles.settingsButton}
+            href={`/users/${user.username}/settings/profile`}
+          >
+            <Icon
+              iconNode={<SettingsIcon />}
+              size={19}
+              className={styles.settingsIcon}
+            />
+            Innstillinger
+          </LinkButton>
         )
       }
     >
@@ -194,12 +199,6 @@ const UserProfile = () => {
                 </Flex>
               </Modal>
             </DialogTrigger>
-          )}
-          {showSettings && (
-            <LinkButton href={`/users/${user.username}/settings/profile`}>
-              <Icon iconNode={<SettingsIcon />} size={19} />
-              Innstillinger
-            </LinkButton>
           )}
         </Flex>
         <Flex


### PR DESCRIPTION
# Description

No need for a duplicate settings button

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
			<img src="https://github.com/user-attachments/assets/1f148e31-9a3e-4929-bee6-d8e21fd90e02" />
        </td>
        <td>
			<img src="https://github.com/user-attachments/assets/c7b78d99-cff6-4a00-8af7-2e7cbf2431fa" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above.