### PR TITLE
Make qoute approving intuitive

### DIFF
--- a/app/routes/quotes/components/Quote.tsx
+++ b/app/routes/quotes/components/Quote.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { approve, deleteQuote, unapprove } from 'app/actions/QuoteActions';
+import { approve, deleteQuote } from 'app/actions/QuoteActions';
 import Dropdown from 'app/components/Dropdown';
 import Reactions from 'app/components/Reactions';
 import Reaction from 'app/components/Reactions/Reaction';
@@ -30,6 +30,7 @@ const Quote = ({
   const fetchingEmojis = useAppSelector((state) => state.emojis.fetching);
 
   const [deleting, setDeleting] = useState(false);
+  const [pippi, setPippi] = useState(true);
   const dispatch = useAppDispatch();
 
   let mappedEmojis: (Emoji & { hasReacted: boolean; reactionId: EntityId })[] =
@@ -93,17 +94,15 @@ const Quote = ({
                   iconName="ellipsis-horizontal"
                 >
                   <Dropdown.List>
-                    <Dropdown.ListItem>
-                      <button
-                        onClick={() =>
-                          quote.approved
-                            ? dispatch(unapprove(quote.id))
-                            : dispatch(approve(quote.id))
-                        }
-                      >
-                        {quote.approved ? 'Fjern godkjenning' : 'Godkjenn'}
-                      </button>
-                    </Dropdown.ListItem>
+                    {!quote.approved && pippi ? (
+                      <Dropdown.ListItem>
+                        <button onClick={() => dispatch(approve(quote.id))}>
+                          {'Godkjenn'}
+                        </button>
+                      </Dropdown.ListItem>
+                    ) : (
+                      <div></div>
+                    )}
 
                     {!deleting ? (
                       <Dropdown.ListItem danger>
@@ -113,8 +112,8 @@ const Quote = ({
                               e.preventDefault();
                               e.stopPropagation();
                             }
-
                             setDeleting(!deleting);
+                            setPippi(false);
                           }}
                         >
                           Slett
@@ -123,7 +122,7 @@ const Quote = ({
                     ) : (
                       <Dropdown.ListItem>
                         <button onClick={() => dispatch(deleteQuote(quote.id))}>
-                          Er du sikker?
+                          Jeg er sikker, slett den! Fyfy
                         </button>
                       </Dropdown.ListItem>
                     )}

--- a/app/routes/users/components/UserProfile/UserProfile.module.css
+++ b/app/routes/users/components/UserProfile/UserProfile.module.css
@@ -79,9 +79,13 @@
 
 .settingsIcon {
   transition: transform var(--easing-medium);
+}
 
+.settingsButton {
   &:hover {
-    transform: rotate(90deg);
+    .settingsIcon {
+      transform: rotate(90deg);
+    }
   }
 }
 

--- a/app/routes/users/components/UserProfile/index.tsx
+++ b/app/routes/users/components/UserProfile/index.tsx
@@ -157,12 +157,17 @@ const UserProfile = () => {
       title={user.fullName}
       actionButtons={
         showSettings && (
-          <Icon
-            iconNode={<SettingsIcon />}
-            size={22}
-            className={styles.settingsIcon}
-            to={`/users/${user.username}/settings/profile`}
-          />
+          <LinkButton
+            className={styles.settingsButton}
+            href={`/users/${user.username}/settings/profile`}
+          >
+            <Icon
+              iconNode={<SettingsIcon />}
+              size={22}
+              className={styles.settingsIcon}
+            />{' '}
+            Innstillinger
+          </LinkButton>
         )
       }
     >
@@ -194,12 +199,6 @@ const UserProfile = () => {
                 </Flex>
               </Modal>
             </DialogTrigger>
-          )}
-          {showSettings && (
-            <LinkButton href={`/users/${user.username}/settings/profile`}>
-              <Icon iconNode={<SettingsIcon />} size={19} />
-              Innstillinger
-            </LinkButton>
           )}
         </Flex>
         <Flex


### PR DESCRIPTION
# Description
Remove "Fjern godkjenning" as an option when a qoute is approved. When trying to delete a qoute, remove "Godkjenn" when "Er du sikker?" comes up.

![image](https://github.com/user-attachments/assets/95b77661-0b16-407c-aeb7-b596d313b896)

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.


- [X] I have thoroughly tested my changes.


