### PR TITLE
Make picture consent text shorter

### DIFF
--- a/lego-webapp/components/UserAttendance/RegistrationMeta.tsx
+++ b/lego-webapp/components/UserAttendance/RegistrationMeta.tsx
@@ -1,4 +1,5 @@
 import { Flex, Skeleton } from '@webkom/lego-bricks';
+import { CircleHelp } from 'lucide-react';
 import { PhotoConsentDomain } from 'app/models';
 import TextWithIcon from '~/components/TextWithIcon';
 import styles from '~/pages/events/@eventIdOrSlug/EventDetail.module.css';
@@ -77,10 +78,23 @@ const ConsentStatus = ({
 
     if (isConsentingWeb && isConsentingSoMe) {
       return (
-        <TextWithIconWrapper
-          iconName="camera-outline"
-          content={`Du samtykker til bilder på abakus.no og sosiale medier for semesteret ${readableEventSemester}`}
-        />
+        <Flex gap="var(--spacing-xs)">
+          <TextWithIconWrapper
+            iconName="camera-outline"
+            content={`Du samtykke${hasEnded ? 't' : 'r'} til bilder `}
+          />
+          <TextWithIcon
+            iconNode={<CircleHelp />}
+            content=""
+            tooltipContentIcon={
+              <>
+                Du samtykke{hasEnded ? 't' : 'r'} til bilder på abakus.no og
+                sosiale medier for {readableEventSemester}.
+              </>
+            }
+            size={14}
+          />
+        </Flex>
       );
     }
 


### PR DESCRIPTION
# Description

Make description for picture consent on events shorter

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.


<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>

![image](https://github.com/user-attachments/assets/054729b4-acd4-4457-a468-8e9c5b89bb07)
        </td>
        <td>

![image](https://github.com/user-attachments/assets/4db84733-5fdb-443a-9ba0-9f5e3aae1b37)
![image](https://github.com/user-attachments/assets/57fb62ff-a83c-4592-97b8-6e9219ac5779)
        </td>
    </tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.


Resolves ABA-830
