### PR TITLE
Add semester auto select to interest page

### DIFF
--- a/app/components/Form/SelectInput.tsx
+++ b/app/components/Form/SelectInput.tsx
@@ -80,7 +80,8 @@ const NO_OPTIONS_MESSAGE = 'Ingen treff';
 const LOADING_MESSAGE = 'Laster inn ...';
 
 const SelectInput = <
-  Option extends { label: string; value: number },
+  T,
+  Option extends { label: string; value: T },
   IsMulti extends boolean = false,
 >({
   name,

--- a/app/routes/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestList.tsx
@@ -241,8 +241,8 @@ const CompanyInterestList = () => {
                       language: 'norwegian',
                     })
                   : 'Vis alle semestre',
-                value: Number(currentCompanySemester?.id) ?? 9999,
-                year: currentCompanySemester?.year ?? 9999,
+                value: Number(currentCompanySemester?.id),
+                year: Number(currentCompanySemester?.year),
                 semester: currentCompanySemester?.semester ?? '',
               }}
               onChange={(e) =>


### PR DESCRIPTION
# Description

Makes the selected semester under company interest  the current semester by default.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/user-attachments/assets/7ef7bc5f-8e3a-449a-a438-6d2a2b85c55c


# Testing

- [x] I have thoroughly tested my changes.

Resolves [ABA-1048](https://linear.app/abakus-webkom/issue/ABA-1103/the-selected-semester-under-company-interest-should-be-the-current)