### PR TITLE
Add new achievements for penalty count and update rarity color mapping

### DIFF
--- a/app/routes/users/components/UserProfile/AchievementsBox.tsx
+++ b/app/routes/users/components/UserProfile/AchievementsBox.tsx
@@ -62,7 +62,7 @@ export const AchievementsBox = ({
                       </i>
                     </p>
                     <p>
-                      Opnådd den {moment(e.createdAt).format('D. MMMM YYYY')}
+                      Opnådd den {moment(e.updatedAt).format('D. MMMM YYYY')}
                     </p>
                     <p>{e.percentage.toFixed(1)}% har denne!</p>
                   </div>

--- a/app/store/models/User.ts
+++ b/app/store/models/User.ts
@@ -23,7 +23,7 @@ export interface PhotoConsent {
 export interface Achievement {
   id: number;
   identifier: string;
-  createdAt: Dateish;
+  updatedAt: Dateish;
   level: number;
   percentage: number;
 }

--- a/app/utils/achievementConstants.ts
+++ b/app/utils/achievementConstants.ts
@@ -128,6 +128,32 @@ const AchievementsInfo: Record<string, AchievementData[]> = {
       hidden: false,
     },
   ],
+  penalty_period: [
+    {
+      name: 'Pliktoppfyllende',
+      description: 'Gått 1 år uten prikk',
+      rarity: 0,
+      hidden: false,
+    },
+    {
+      name: 'Englebarn',
+      description: 'Gått 2 år uten prikk',
+      rarity: 3,
+      hidden: false,
+    },
+    {
+      name: 'Eksemplarisk',
+      description: 'Gått 3 år uten prikk',
+      rarity: 5,
+      hidden: false,
+    },
+    {
+      name: 'Flink pike',
+      description: 'Gått 4 år uten prikk',
+      rarity: 6,
+      hidden: false,
+    },
+  ],
 };
 
 export default AchievementsInfo;


### PR DESCRIPTION
# Description

Adds front-end part of the penalty achievements.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

See previous PR on achievements for visuals.
These look exactly the same with no changes except the text (name/description)

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
