### PR TITLE
Create Label component and improve radio/checkbox labels

### DIFF
--- a/app/components/Form/Field.module.css
+++ b/app/components/Form/Field.module.css
@@ -22,17 +22,3 @@
   font-size: var(--font-size-sm);
   border-radius: var(--border-radius-md);
 }
-
-.labelContent {
-  line-height: 1.8;
-}
-
-.description {
-  margin-left: var(--spacing-sm);
-}
-
-.required {
-  color: var(--danger-color);
-  font-weight: 600;
-  margin-left: 2px;
-}

--- a/app/components/Form/Field.tsx
+++ b/app/components/Form/Field.tsx
@@ -1,6 +1,6 @@
-import { Flex, Icon } from '@webkom/lego-bricks';
+import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import Tooltip from 'app/components/Tooltip';
+import { Label } from 'app/components/Form/Label';
 import styles from './Field.module.css';
 import type { ComponentType } from 'react';
 import type { FieldInputProps, FieldRenderProps } from 'react-final-form';
@@ -67,7 +67,6 @@ export function createField<T, ExtraProps extends object>(
       description,
       fieldClassName,
       labelClassName,
-      labelContentClassName,
       onChange,
       showErrors = true,
       className = null,
@@ -79,30 +78,6 @@ export function createField<T, ExtraProps extends object>(
     const hasError = showErrors && touched && anyError && anyError.length > 0;
     const fieldName = input?.name;
     const { noLabel, inlineLabel } = options || {};
-
-    const labelComponent = (
-      <Flex alignItems="center">
-        {label && (
-          <div
-            style={{
-              cursor: inlineLabel && !props.disabled ? 'pointer' : 'default',
-              fontSize: !inlineLabel ? 'var(--font-size-lg)' : 'inherit',
-            }}
-            className={cx(labelContentClassName, styles.labelContent)}
-          >
-            {label}
-          </div>
-        )}
-        {required && <span className={styles.required}>*</span>}
-        {description && (
-          <Flex className={styles.description}>
-            <Tooltip content={description}>
-              <Icon size={18} name="help-circle-outline" />
-            </Tooltip>
-          </Flex>
-        )}
-      </Flex>
-    );
 
     const component = (
       <Component
@@ -117,18 +92,6 @@ export function createField<T, ExtraProps extends object>(
       />
     );
 
-    const content = inlineLabel ? (
-      <Flex gap="var(--spacing-sm)">
-        {component}
-        {labelComponent}
-      </Flex>
-    ) : (
-      <>
-        {labelComponent}
-        {component}
-      </>
-    );
-
     return (
       <Flex
         column
@@ -139,11 +102,16 @@ export function createField<T, ExtraProps extends object>(
         )}
         style={fieldStyle}
       >
-        {noLabel ? (
-          content
-        ) : (
-          <label className={labelClassName}>{content}</label>
-        )}
+        <Label
+          className={labelClassName}
+          label={label}
+          noLabel={noLabel}
+          description={description}
+          inline={inlineLabel}
+          required={required}
+        >
+          {component}
+        </Label>
         {hasError && (
           <RenderErrorMessage error={anyError} fieldName={fieldName} />
         )}

--- a/app/components/Form/FieldSet.module.css
+++ b/app/components/Form/FieldSet.module.css
@@ -1,0 +1,7 @@
+.fieldSet {
+  border: 0;
+}
+
+.fieldSetLegend {
+  margin-bottom: var(--spacing-sm);
+}

--- a/app/components/Form/FieldSet.tsx
+++ b/app/components/Form/FieldSet.tsx
@@ -1,0 +1,28 @@
+import cx from 'classnames';
+import styles from 'app/components/Form/FieldSet.module.css';
+import { LabelText } from 'app/components/Form/Label';
+import type { HTMLProps, ReactNode } from 'react';
+
+type FieldSetProps = HTMLProps<HTMLFieldSetElement> & {
+  legend: string;
+  description?: string;
+  required?: boolean;
+  children: ReactNode;
+};
+export const FieldSet = ({
+  legend,
+  description,
+  required,
+  children,
+  ...fieldSetProps
+}: FieldSetProps) => (
+  <fieldset
+    className={cx(styles.fieldSet, fieldSetProps.className)}
+    {...fieldSetProps}
+  >
+    <legend className={styles.fieldSetLegend}>
+      <LabelText label={legend} description={description} required={required} />
+    </legend>
+    {children}
+  </fieldset>
+);

--- a/app/components/Form/Label.module.css
+++ b/app/components/Form/Label.module.css
@@ -1,0 +1,27 @@
+@import url('~app/styles/variables.css');
+
+.label {
+  font-size: var(--font-size-lg);
+  margin-bottom: var(--spacing-xs);
+}
+
+.inline {
+  cursor: pointer;
+
+  .label {
+    font-size: inherit;
+    margin-bottom: 0;
+  }
+}
+
+.required {
+  color: var(--danger-color);
+  font-weight: 600;
+  margin-left: 2px;
+}
+
+.description {
+  display: inline-block;
+  vertical-align: top;
+  margin-left: var(--spacing-sm);
+}

--- a/app/components/Form/Label.tsx
+++ b/app/components/Form/Label.tsx
@@ -1,0 +1,77 @@
+import { Flex, Icon } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import { HelpCircle } from 'lucide-react';
+import Tooltip from 'app/components/Tooltip';
+import styles from './Label.module.css';
+import type { HTMLProps, ReactNode } from 'react';
+
+type LabelTextProps = {
+  label: ReactNode;
+  description?: string;
+  required?: boolean;
+  className?: string;
+};
+
+export const LabelText = ({
+  label,
+  description,
+  required,
+  className,
+}: LabelTextProps) => (
+  <div className={cx(styles.label, className)}>
+    {label}
+    {required && <span className={styles.required}>*</span>}
+    {description && (
+      <Tooltip content={description} className={styles.description}>
+        <Icon size={20} iconNode={<HelpCircle />} />
+      </Tooltip>
+    )}
+  </div>
+);
+
+type LabelProps = HTMLProps<HTMLLabelElement> & {
+  label: ReactNode;
+  noLabel?: boolean;
+  description?: string;
+  required?: boolean;
+  inline?: boolean;
+};
+
+export const Label = ({
+  label,
+  noLabel,
+  description,
+  required,
+  inline,
+  children,
+  ...labelProps
+}: LabelProps) => {
+  const LabelComponent = noLabel ? 'span' : 'label';
+  return (
+    <LabelComponent {...labelProps}>
+      {inline ? (
+        <Flex
+          alignItems="center"
+          gap="var(--spacing-xs)"
+          className={styles.inline}
+        >
+          {children}
+          <LabelText
+            label={label}
+            description={description}
+            required={required}
+          />
+        </Flex>
+      ) : (
+        <>
+          <LabelText
+            label={label}
+            description={description}
+            required={required}
+          />
+          {children}
+        </>
+      )}
+    </LabelComponent>
+  );
+};

--- a/app/components/Form/MultiSelectGroup.module.css
+++ b/app/components/Form/MultiSelectGroup.module.css
@@ -2,24 +2,3 @@
   display: flex;
   flex-flow: row wrap;
 }
-
-.groupLabel {
-  font-size: var(--font-size-lg);
-}
-
-.radioLabel {
-  display: flex;
-  flex-direction: row;
-}
-
-.radioLabel:hover {
-  cursor: pointer;
-}
-
-.radioLabel > span {
-  font-size: var(--font-size-md);
-  margin-left: 15px;
-
-  /* For radio groups we want the label last: */
-  order: 1;
-}

--- a/app/components/Form/MultiSelectGroup.tsx
+++ b/app/components/Form/MultiSelectGroup.tsx
@@ -1,28 +1,36 @@
 import { Children, cloneElement } from 'react';
 import { FormSpy } from 'react-final-form';
+import { FieldSet } from 'app/components/Form/FieldSet';
 import { RenderErrorMessage } from './Field';
 import styles from './MultiSelectGroup.module.css';
 import type { ReactElement } from 'react';
 
 type Props = {
   name: string;
-  label?: string;
+  legend: string;
+  description?: string;
+  required?: boolean;
   children: ReactElement | ReactElement[];
 };
 
-const MultiSelectGroup = ({ name, label, children }: Props) => {
+const MultiSelectGroup = ({
+  name,
+  legend,
+  description,
+  required,
+  children,
+}: Props) => {
   return (
     <>
-      <label className={styles.groupLabel}>{label}</label>
-      <div className={styles.group}>
-        {Children.map(children, (child) =>
-          cloneElement(child, {
-            name,
-            fieldClassName: styles.radioField,
-            labelContentClassName: styles.radioLabel,
-          }),
-        )}
-      </div>
+      <FieldSet legend={legend} description={description} required={required}>
+        <div className={styles.group}>
+          {Children.map(children, (child) =>
+            cloneElement(child, {
+              name,
+            }),
+          )}
+        </div>
+      </FieldSet>
       <FormSpy
         subscription={{ errors: true, submitErrors: true, touched: true }}
       >

--- a/app/routes/bdb/components/AddSemester.tsx
+++ b/app/routes/bdb/components/AddSemester.tsx
@@ -172,7 +172,7 @@ const AddSemester = () => {
             />
 
             <div className={styles.choices}>
-              <MultiSelectGroup name="semester" label="Semester">
+              <MultiSelectGroup name="semester" legend="Semester">
                 <Field
                   name="Spring"
                   label="Vår"

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -289,7 +289,7 @@ const CompanyEditor = () => {
             </div>
 
             <div>
-              <MultiSelectGroup name="active" label="Aktiv bedrift?">
+              <MultiSelectGroup name="active" legend="Aktiv bedrift?">
                 <Field
                   name="Yes"
                   label="Ja"

--- a/app/routes/companyInterest/components/CompanyInterest.module.css
+++ b/app/routes/companyInterest/components/CompanyInterest.module.css
@@ -35,13 +35,6 @@
   width: 125px;
 }
 
-.heading {
-  font-weight: 500;
-  font-size: var(--font-size-lg);
-  line-height: 1.3;
-  margin: var(--spacing-sm) 0;
-}
-
 .topline {
   margin: 15px 0;
   padding: 10px 0;

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -1,7 +1,6 @@
-import { Card, Flex, Icon, LoadingIndicator, Page } from '@webkom/lego-bricks';
+import { Card, Flex, LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import arrayMutators from 'final-form-arrays';
-import { Info } from 'lucide-react';
 import { Field, FormSpy } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
@@ -29,7 +28,6 @@ import {
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { readmeIfy } from 'app/components/ReadmeLogo';
-import Tooltip from 'app/components/Tooltip';
 import { selectCompanyInterestById } from 'app/reducers/companyInterest';
 import {
   selectAllCompanySemesters,
@@ -547,7 +545,6 @@ const CompanyInterestPage = () => {
               label={FORM_LABELS.company.header[language]}
               placeholder={FORM_LABELS.company.placeholder[language]}
               filter={['companies.company']}
-              fieldClassName={styles.metaField}
               component={SelectInput.AutocompleteField}
               creatable
               required
@@ -576,10 +573,11 @@ const CompanyInterestPage = () => {
 
             <Flex wrap justifyContent="space-between">
               <Flex column className={styles.interestBox}>
-                <label htmlFor="companyType" className={styles.heading}>
-                  {FORM_LABELS.companyTypes[language]}
-                </label>
-                <MultiSelectGroup name="companyType">
+                <MultiSelectGroup
+                  required
+                  legend={FORM_LABELS.companyTypes[language]}
+                  name="companyType"
+                >
                   {Object.keys(COMPANY_TYPES).map((key) => (
                     <Field
                       key={key}
@@ -594,10 +592,11 @@ const CompanyInterestPage = () => {
                 </MultiSelectGroup>
               </Flex>
               <Flex column className={styles.interestBox}>
-                <label htmlFor="officeInTrondheim" className={styles.heading}>
-                  {FORM_LABELS.officeInTrondheim[language]}
-                </label>
-                <MultiSelectGroup name="officeInTrondheim">
+                <MultiSelectGroup
+                  legend={FORM_LABELS.officeInTrondheim[language]}
+                  required
+                  name="officeInTrondheim"
+                >
                   {Object.keys(OFFICE_IN_TRONDHEIM).map((key) => (
                     <Field
                       key={key}
@@ -612,29 +611,17 @@ const CompanyInterestPage = () => {
                 </MultiSelectGroup>
               </Flex>
               <Flex column className={styles.interestBox}>
-                <label htmlFor="companyCourseThemes" className={styles.heading}>
-                  <Flex alignItems="center" gap="var(--spacing-xs)">
-                    {FORM_LABELS.companyCourseThemes[language]}
-                    <Tooltip
-                      className={styles.tooltip}
-                      content={
-                        <span>
-                          {language === 'norwegian'
-                            ? 'Dette er temaer som studenter har uttrykt interesse for å lære mer om i vår bedriftsundersøkelse. Kryss av for de temaene dere kan ønske å holde kurs om eller snakke om på deres presentasjoner. (Uforpliktende)'
-                            : 'These are topics that students expressed interest in learning more about in our company survey. Check off the topics that you might be interested in arranging a course or workshop about or talk about in your presentations. (Non-binding)'}
-                        </span>
-                      }
-                    >
-                      <Icon iconNode={<Info />} size={20} />
-                    </Tooltip>
-                  </Flex>
-                </label>
-                <FieldArray
-                  label="companyCourseThemes"
+                <MultiSelectGroup
                   name="companyCourseThemes"
-                  language={language}
-                  component={SurveyOffersBox}
-                />
+                  legend={FORM_LABELS.companyCourseThemes[language]}
+                  description={FORM_LABELS.companyCourseThemesInfo[language]}
+                >
+                  <FieldArray
+                    name="companyCourseThemes"
+                    language={language}
+                    component={SurveyOffersBox}
+                  />
+                </MultiSelectGroup>
               </Flex>
             </Flex>
             <div className={styles.topline} />
@@ -649,10 +636,11 @@ const CompanyInterestPage = () => {
             />
             <Flex wrap justifyContent="space-between" gap="var(--spacing-md)">
               <Flex column className={styles.interestBox}>
-                <label htmlFor="semesters" className={styles.heading}>
-                  {FORM_LABELS.semesters[language]}
-                </label>
-                <MultiSelectGroup name="semesters">
+                <MultiSelectGroup
+                  name="semesters"
+                  legend={FORM_LABELS.semesters[language]}
+                  required
+                >
                   <FieldArray
                     name="semesters"
                     language={language}
@@ -661,10 +649,11 @@ const CompanyInterestPage = () => {
                 </MultiSelectGroup>
               </Flex>
               <Flex column className={styles.interestBox}>
-                <label htmlFor="events" className={styles.heading}>
-                  {FORM_LABELS.events[language]}
-                </label>
-                <MultiSelectGroup name="events">
+                <MultiSelectGroup
+                  name="events"
+                  legend={FORM_LABELS.events[language]}
+                  required
+                >
                   <FieldArray
                     name="events"
                     language={language}
@@ -673,34 +662,38 @@ const CompanyInterestPage = () => {
                 </MultiSelectGroup>
               </Flex>
               <Flex column className={styles.interestBox}>
-                <label htmlFor="collaborations" className={styles.heading}>
-                  {FORM_LABELS.collaborations[language]}
-                </label>
-                <FieldArray
+                <MultiSelectGroup
                   name="collaborations"
-                  language={language}
-                  component={CollaborationBox}
-                />
+                  legend={FORM_LABELS.collaborations[language]}
+                >
+                  <FieldArray
+                    name="collaborations"
+                    language={language}
+                    component={CollaborationBox}
+                  />
+                </MultiSelectGroup>
               </Flex>
             </Flex>
 
             <Flex wrap justifyContent="space-between">
               <Flex column className={styles.interestBox}>
-                <label htmlFor="targetGrades" className={styles.heading}>
-                  {FORM_LABELS.targetGrades[language]}
-                </label>
-                <FieldArray
+                <MultiSelectGroup
                   name="targetGrades"
-                  language={language}
-                  component={TargetGradeBox}
-                />
+                  legend={FORM_LABELS.targetGrades[language]}
+                >
+                  <FieldArray
+                    name="targetGrades"
+                    language={language}
+                    component={TargetGradeBox}
+                  />
+                </MultiSelectGroup>
               </Flex>
 
               <Flex column className={styles.interestBox}>
-                <label htmlFor="participantRange" className={styles.heading}>
-                  {FORM_LABELS.participantRange[language]}
-                </label>
-                <MultiSelectGroup name="participantRange">
+                <MultiSelectGroup
+                  name="participantRange"
+                  legend={FORM_LABELS.participantRange[language]}
+                >
                   {Object.keys(PARTICIPANT_RANGE_TYPES).map((key) => (
                     <Field
                       key={key}
@@ -714,14 +707,16 @@ const CompanyInterestPage = () => {
                 </MultiSelectGroup>
               </Flex>
               <Flex column className={styles.interestBox}>
-                <label htmlFor="otherOffers" className={styles.heading}>
-                  {FORM_LABELS.otherOffers[language]}
-                </label>
-                <FieldArray
+                <MultiSelectGroup
                   name="otherOffers"
-                  language={language}
-                  component={OtherBox}
-                />
+                  legend={FORM_LABELS.otherOffers[language]}
+                >
+                  <FieldArray
+                    name="otherOffers"
+                    language={language}
+                    component={OtherBox}
+                  />
+                </MultiSelectGroup>
               </Flex>
             </Flex>
             <h3 className={styles.topline}>

--- a/app/routes/companyInterest/components/CompanySemesterGUI.tsx
+++ b/app/routes/companyInterest/components/CompanySemesterGUI.tsx
@@ -105,7 +105,7 @@ const AddSemesterForm = () => {
             className={styles.yearForm}
             required
           />
-          <MultiSelectGroup name="semester" label="Semester">
+          <MultiSelectGroup name="semester" legend="Semester">
             <Field
               name="Spring"
               label="Vår"

--- a/app/routes/companyInterest/components/Translations.ts
+++ b/app/routes/companyInterest/components/Translations.ts
@@ -283,6 +283,12 @@ export const FORM_LABELS = {
     norwegian: 'Temaer som er relevant for dere',
     english: 'Topics that are relevant for you',
   },
+  companyCourseThemesInfo: {
+    norwegian:
+      'Dette er temaer som studenter har uttrykt interesse for å lære mer om i vår bedriftsundersøkelse. Kryss av for de temaene dere kan ønske å holde kurs om eller snakke om på deres presentasjoner. (Uforpliktende)',
+    english:
+      'These are topics that students expressed interest in learning more about in our company survey. Check off the topics that you might be interested in arranging a course or workshop about or talk about in your presentations. (Non-binding)',
+  },
   participantRange: {
     norwegian: 'Antall deltagere',
     english: 'Number of participants',

--- a/app/routes/events/components/EventEditor/EditorSection/Details.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Details.tsx
@@ -1,5 +1,4 @@
 import { Flex } from '@webkom/lego-bricks';
-import cx from 'classnames';
 import { Field } from 'react-final-form';
 import {
   SelectInput,
@@ -7,7 +6,7 @@ import {
   CheckBox,
   DatePicker,
 } from 'app/components/Form';
-import fieldStyles from 'app/components/Form/Field.module.css';
+import { Label } from 'app/components/Form/Label';
 import MazemapLink from 'app/components/MazemapEmbed/MazemapLink';
 import Tooltip from 'app/components/Tooltip';
 import { EventTypeConfig } from 'app/routes/events/utils';
@@ -86,20 +85,19 @@ const Details: React.FC<Props> = ({ values }) => {
       <Flex className={styles.editorSectionRow}>
         <Flex column className={styles.editorSectionColumn}>
           <Flex alignItems="center">
-            <label
+            <Label
+              label="Sted"
               htmlFor="react-select-mazemapPoi-input"
               className={styles.label}
-            >
-              Sted
-            </label>
-            <span className={fieldStyles.required}>*</span>
+              required
+            />
           </Flex>
           <Field
             label="Bruk MazeMap"
             name="useMazemap"
             type="checkbox"
             component={CheckBox.Field}
-            fieldClassName={cx(styles.metaField, styles.mazemap)}
+            withoutMargin
             className={styles.formField}
           />
           {!values.useMazemap ? (

--- a/app/routes/events/components/EventEditor/EventEditor.module.css
+++ b/app/routes/events/components/EventEditor/EventEditor.module.css
@@ -63,10 +63,6 @@
   margin-bottom: var(--spacing-sm);
 }
 
-.metaField.mazemap {
-  margin-bottom: 0;
-}
-
 .metaField input {
   padding-bottom: var(--spacing-xs);
   padding-top: var(--spacing-xs);

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -259,12 +259,14 @@ const MeetingEditor = () => {
               <Field
                 name="title"
                 label="Tittel"
+                required
                 placeholder="Ny tittel for møte"
                 component={TextInput.Field}
               />
               <Field
                 name="report"
                 label="Referat"
+                required
                 component={EditorField.Field}
               />
               <Field
@@ -308,13 +310,13 @@ const MeetingEditor = () => {
                 name="useMazemap"
                 type="checkbox"
                 component={CheckBox.Field}
-                withoutMargin
               />
               {spyValues<MeetingFormValues>((values) => {
                 return values?.useMazemap ? (
                   <Flex alignItems="center">
                     <Field
                       label="Mazemap-rom"
+                      required
                       name="mazemapPoi"
                       component={SelectInput.MazemapAutocomplete}
                       fieldClassName={styles.metaField}
@@ -331,6 +333,7 @@ const MeetingEditor = () => {
                   <Field
                     name="location"
                     label="Sted"
+                    required
                     placeholder="Sted for møte"
                     component={TextInput.Field}
                   />

--- a/app/routes/pages/components/PageEditor.tsx
+++ b/app/routes/pages/components/PageEditor.tsx
@@ -117,7 +117,7 @@ const PageEditor = () => {
       delete body.picture;
     }
 
-    dispatch(isNew ? createPage(body) : updatePage(pageSlug, body)).then(
+    return dispatch(isNew ? createPage(body) : updatePage(pageSlug, body)).then(
       (result) => {
         const slug = result.payload.result;
         const pageCategory = result.payload.entities.pages[slug].category;
@@ -162,11 +162,14 @@ const PageEditor = () => {
 
             <Flex justifyContent="space-between">
               <Field
+                label="Tittel"
+                required
                 placeholder="Title"
                 name="title"
                 component={TextInput.Field}
               />
               <Field
+                label="Kategori"
                 name="category"
                 component={SelectInput.Field}
                 placeholder="Velg kategori"

--- a/app/routes/users/components/UserConfirmation.tsx
+++ b/app/routes/users/components/UserConfirmation.tsx
@@ -141,6 +141,7 @@ const UserConfirmationForm = () => {
             })}
 
             <Field
+              required
               label="Gjenta passord"
               name="retypePassword"
               type="password"
@@ -149,6 +150,7 @@ const UserConfirmationForm = () => {
             />
 
             <Field
+              required
               name="firstName"
               placeholder="Fornavn"
               label="Fornavn"
@@ -157,6 +159,7 @@ const UserConfirmationForm = () => {
             />
 
             <Field
+              required
               name="lastName"
               label="Etternavn"
               placeholder="Etternavn"
@@ -164,13 +167,14 @@ const UserConfirmationForm = () => {
               component={TextInput.Field}
             />
 
-            <MultiSelectGroup label="Kjønn" name="gender">
+            <MultiSelectGroup required legend="Kjønn" name="gender">
               <Field
                 name="genderMan"
                 label="Mann"
                 value="male"
                 type="radio"
                 component={RadioButton.Field}
+                showErrors={false}
               />
               <Field
                 name="genderWoman"
@@ -178,6 +182,7 @@ const UserConfirmationForm = () => {
                 value="female"
                 type="radio"
                 component={RadioButton.Field}
+                showErrors={false}
               />
               <Field
                 name="genderOther"
@@ -185,6 +190,7 @@ const UserConfirmationForm = () => {
                 value="other"
                 type="radio"
                 component={RadioButton.Field}
+                showErrors={false}
               />
             </MultiSelectGroup>
 

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -197,7 +197,7 @@ const UserSettings = () => {
               />
             </Flex>
 
-            <MultiSelectGroup label="Fargetema" name="selectedTheme">
+            <MultiSelectGroup legend="Fargetema" name="selectedTheme">
               <Field
                 name="selectedTheme"
                 label="Auto"
@@ -222,7 +222,10 @@ const UserSettings = () => {
             </MultiSelectGroup>
 
             {showAbakusMembership && (
-              <MultiSelectGroup name="isAbakusMember" label="Medlem av Abakus?">
+              <MultiSelectGroup
+                name="isAbakusMember"
+                legend="Medlem av Abakus?"
+              >
                 <Field
                   name="isMemberYes"
                   label="Ja"


### PR DESCRIPTION
# Description

Refactored form labels to be a reusable component. This allows for less duplicated code and more consistency when using stand-alone labels outside of the `Field`-component.

Also added lots of missing required-stars (*) to various forms.

# Result

- Minor changes to label styling and spacing
- Added missing required stars
- Replaced info-tooltip icon
----
- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Company interest form
        </td>
        <td>

<img width="1154" alt="Screenshot 2024-11-10 at 23 39 24" src="https://github.com/user-attachments/assets/77902e40-2cc4-4ad6-ac56-25b51884da60">
        </td>
        <td>

<img width="1154" alt="Screenshot 2024-11-10 at 23 39 38" src="https://github.com/user-attachments/assets/886f85f1-72c7-40ae-aab4-c0b0768b129f">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

I have tested a lot of forms and different field types. Normal fields still work and focus as expected when clicking the label. Checkboxes and radio buttons select option when label is clicked, but nothing when the group-label is clicked.

---

Resolves ABA-1179
