### PR TITLE
Fix spelling error in achievement at profile page

### DIFF
--- a/app/routes/users/components/UserProfile/AchievementsBox.tsx
+++ b/app/routes/users/components/UserProfile/AchievementsBox.tsx
@@ -21,7 +21,7 @@ export const AchievementsBox = ({
     return [...achievements].sort(
       (a, b) =>
         AchievementsInfo[b.identifier][b.level].rarity -
-        AchievementsInfo[a.identifier][a.level].rarity,
+        AchievementsInfo[a.identifier][a.level].rarity
     );
   }, [achievements]);
 
@@ -62,7 +62,7 @@ export const AchievementsBox = ({
                       </i>
                     </p>
                     <p>
-                      Opnådd den {moment(e.updatedAt).format('D. MMMM YYYY')}
+                      Oppnådd den {moment(e.updatedAt).format('D. MMMM YYYY')}
                     </p>
                     <p>{e.percentage.toFixed(1)}% har denne!</p>
                   </div>

--- a/app/routes/users/components/UserProfile/AchievementsBox.tsx
+++ b/app/routes/users/components/UserProfile/AchievementsBox.tsx
@@ -21,7 +21,7 @@ export const AchievementsBox = ({
     return [...achievements].sort(
       (a, b) =>
         AchievementsInfo[b.identifier][b.level].rarity -
-        AchievementsInfo[a.identifier][a.level].rarity
+        AchievementsInfo[a.identifier][a.level].rarity,
     );
   }, [achievements]);
 


### PR DESCRIPTION
# Description

This commit changes the text when you hover over an achievement badge on a user's profile. Has changed the text from "Opnådd den ..." to "Oppnådd den ...", fixing a small spelling error :)
**bug-fix**

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ... (Too minor to create an issue? Just changed one letter...)
