### PR TITLE
Prevent endless skeleton loading on event details

### DIFF
--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -331,7 +331,9 @@ const JoinEventForm = ({
           registrationMessage(event)
         ) : (
           <>
-            {!event?.activationTime && <Skeleton array={2} height={35} />}
+            {!event?.activationTime && fetching && (
+              <Skeleton array={2} height={35} />
+            )}
 
             {!formOpen && event.activationTime && (
               <div>
@@ -366,7 +368,7 @@ const JoinEventForm = ({
             {!disabledForUser &&
               event.useConsent &&
               !hasRegisteredConsentForSemester && (
-                <Card severity="danger">
+                <Card severity="danger" className={sharedStyles.card}>
                   <Card.Header>NB!</Card.Header>
                   <p>
                     Du må ta stilling til bildesamtykke for semesteret{' '}


### PR DESCRIPTION
# Description

Fixed one of the card stylings as well

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img src="https://github.com/user-attachments/assets/09810469-9b5f-4d97-9589-1407633d5fde" />
        </td>
        <td>
			<img src="https://github.com/user-attachments/assets/fe752cbe-25d5-41f7-beca-efdcbb727e1a" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above