### PR TITLE
Fix toast icon mark for success

### DIFF
--- a/app/components/Toast/Toast.tsx
+++ b/app/components/Toast/Toast.tsx
@@ -1,7 +1,7 @@
 import { useToast } from '@react-aria/toast';
 import { Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { X } from 'lucide-react';
+import { Check, X } from 'lucide-react';
 import { useRef } from 'react';
 import styles from './Toast.module.css';
 import type { AriaToastProps } from '@react-aria/toast';
@@ -38,7 +38,7 @@ export const Toast = ({ state, ...props }: ToastProps) => {
     >
       <Icon
         {...closeButtonProps}
-        iconNode={<X />}
+        iconNode={type === 'success' ? <Check /> : <X />}
         success={type === 'success'}
         danger={type === 'error'}
         size={18}


### PR DESCRIPTION
# Description

Changes the icon on toast success to a checkmark. X can be confused with errors. Green/red distinction is not always a clear indication for red/green colorblind people.


# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
Changes the icon to checkmark for success
        </td>
        <td>
<img src="https://github.com/user-attachments/assets/8a8d580d-54ae-48a6-8620-22c8bfa1e3c2" />
        </td>
        <td>
<img src="https://github.com/user-attachments/assets/7bccb524-b90c-4cf1-ab29-ca2ca5cb6394" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Visually

---

Resolves ... My personal grudge
