### PR TITLE
Support previous events on event list (and a toggle switch!)

### DIFF
--- a/app/components/EventItem/RegistrationStatusTag.tsx
+++ b/app/components/EventItem/RegistrationStatusTag.tsx
@@ -1,5 +1,6 @@
 import { Flex, Icon } from '@webkom/lego-bricks';
 import { AlarmClock } from 'lucide-react';
+import moment from 'moment-timezone';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';
 import { useIsLoggedIn } from 'app/reducers/auth';
@@ -19,21 +20,23 @@ const RegistrationStatusTag = ({
   isRegistrationSameYear,
 }: Props) => {
   const loggedIn = useIsLoggedIn();
+  const isPastTenseNeeded = moment().isAfter(moment(event.startTime));
+  const wasIs = isPastTenseNeeded ? 'var' : 'er';
 
   const getRegistrationStatus = () => {
     if (
       event.eventStatusType === EventStatusType.OPEN ||
       event.eventStatusType === EventStatusType.INFINITE
     ) {
-      return 'Åpent for alle';
+      return `Arrangementet ${wasIs} åpent for alle`;
     }
 
     if (event.isAdmitted) {
-      return 'Du er påmeldt';
+      return `Du ${wasIs} påmeldt`;
     }
 
     if (event.userReg && event.eventStatusType === EventStatusType.NORMAL) {
-      return 'Du er på venteliste';
+      return `Du ${wasIs} på venteliste`;
     }
 
     if (!!event.activationTime) {
@@ -55,7 +58,7 @@ const RegistrationStatusTag = ({
       );
     }
 
-    return 'Påmelding er ikke bestemt';
+    return `Påmelding ${isPastTenseNeeded ? 'ble aldri' : 'er ikke'} bestemt`;
   };
 
   const getTagColor = () => {

--- a/app/components/Form/ToggleSwitch.module.css
+++ b/app/components/Form/ToggleSwitch.module.css
@@ -1,0 +1,61 @@
+.toggleSwitch {
+  --width: 2.6rem;
+  --height: 1.3rem;
+  --thumb-size: 0.9rem;
+  --border-hover: var(--color-gray-4);
+
+  position: relative;
+  width: var(--width);
+  height: var(--height);
+}
+
+.toggleSwitch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: var(--border-gray);
+  transition: var(--easing-medium);
+  transition-property: background-color, box-shadow;
+  border-radius: var(--height);
+}
+
+.slider::before {
+  content: '';
+  position: absolute;
+  left: 2.5px;
+  top: 50%;
+  transform: translateY(-50%);
+  height: var(--thumb-size);
+  width: var(--thumb-size);
+  background-color: white;
+  transition: var(--linear-medium);
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: var(--lego-red-color);
+}
+
+input:focus-visible + .slider {
+  box-shadow: 0 0 0 2px var(--border-hover) inset;
+}
+
+input:disabled + .slider {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.toggleSwitch:hover input:not(:disabled) + .slider {
+  box-shadow: 0 0 0 1.5px var(--border-hover) inset;
+}
+
+input:checked + .slider::before {
+  transform: translate(calc(var(--width) - var(--thumb-size) - 5px), -50%);
+}

--- a/app/components/Form/ToggleSwitch.module.css
+++ b/app/components/Form/ToggleSwitch.module.css
@@ -1,61 +1,55 @@
 .toggleSwitch {
-  --width: 2.6rem;
-  --height: 1.3rem;
-  --thumb-size: 0.9rem;
-  --border-hover: var(--color-gray-4);
-
   position: relative;
-  width: var(--width);
-  height: var(--height);
+  display: inline-block;
+  width: 2.25rem;
+  height: 1.25rem;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  outline: none;
 }
 
-.toggleSwitch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
+.toggleSwitch[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .slider {
   position: absolute;
-  cursor: pointer;
   inset: 0;
-  background-color: var(--border-gray);
+  background-color: var(--additive-background);
   transition: var(--easing-medium);
   transition-property: background-color, box-shadow;
-  border-radius: var(--height);
+  border-radius: var(--border-radius-lg);
 }
 
 .slider::before {
-  content: '';
   position: absolute;
-  left: 2.5px;
-  top: 50%;
-  transform: translateY(-50%);
-  height: var(--thumb-size);
-  width: var(--thumb-size);
-  background-color: white;
-  transition: var(--linear-medium);
+  content: '';
+  height: var(--spacing-md);
+  width: var(--spacing-md);
+  left: 2px;
+  bottom: 2px;
+  background-color: var(--color-absolute-white);
+  transition: var(--easing-medium);
   border-radius: 50%;
 }
 
-input:checked + .slider {
+.toggleSwitch[data-selected] .slider {
   background-color: var(--lego-red-color);
 }
 
-input:focus-visible + .slider {
-  box-shadow: 0 0 0 2px var(--border-hover) inset;
+.toggleSwitch[data-selected] .slider::before {
+  transform: translateX(var(--spacing-md));
 }
 
-input:disabled + .slider {
-  opacity: 0.5;
-  cursor: not-allowed;
+.toggleSwitch[data-focus-visible] .slider,
+.toggleSwitch:not([data-disabled]):hover .slider {
+  box-shadow: 0 0 0 1.5px var(--color-gray-4) inset;
 }
 
-.toggleSwitch:hover input:not(:disabled) + .slider {
-  box-shadow: 0 0 0 1.5px var(--border-hover) inset;
-}
-
-input:checked + .slider::before {
-  transform: translate(calc(var(--width) - var(--thumb-size) - 5px), -50%);
+.toggleSwitch[data-selected][data-focus-visible] .slider,
+.toggleSwitch[data-selected]:not([data-disabled]):hover .slider {
+  box-shadow: 0 0 0 1.5px var(--danger-color) inset;
 }

--- a/app/components/Form/ToggleSwitch.tsx
+++ b/app/components/Form/ToggleSwitch.tsx
@@ -1,0 +1,85 @@
+import { Flex } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import { Keyboard } from 'app/utils/constants';
+import { createField } from './Field';
+import styles from './ToggleSwitch.module.css';
+import type {
+  ComponentProps,
+  InputHTMLAttributes,
+  KeyboardEvent,
+  MouseEvent,
+} from 'react';
+import type { Overwrite } from 'utility-types';
+
+type Props = {
+  className?: string;
+} & Overwrite<
+  InputHTMLAttributes<HTMLInputElement>,
+  { onChange?: (checked: boolean) => void }
+>;
+
+const ToggleSwitch = ({
+  id,
+  checked,
+  value,
+  className,
+  disabled,
+  ...props
+}: Props) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === Keyboard.ENTER) {
+      event.preventDefault();
+      const inputElement = event.target as HTMLInputElement;
+      inputElement.click();
+    }
+  };
+
+  const handleClick = (e: MouseEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    if (!disabled) {
+      props.onChange?.(!isChecked);
+    }
+  };
+
+  const isInFormContext = value !== undefined;
+  // Supporting both string and boolean values
+  const isChecked = isInFormContext
+    ? typeof value === 'string'
+      ? value === 'true'
+      : !!value
+    : typeof checked === 'string'
+      ? checked === 'true'
+      : !!checked;
+
+  return (
+    <Flex wrap alignItems="center" gap="var(--spacing-sm)">
+      <div className={cx(styles.toggleSwitch, className)} onClick={handleClick}>
+        <input
+          {...props}
+          type="checkbox"
+          role="switch"
+          id={id}
+          {...(isInFormContext
+            ? { value: value, checked: isChecked }
+            : { checked: isChecked })}
+          aria-checked={isChecked}
+          disabled={disabled}
+          onChange={(e) => {
+            props.onChange?.(e.target.checked);
+          }}
+          onKeyDown={handleKeyDown}
+        />
+        <span className={styles.slider} />
+      </div>
+    </Flex>
+  );
+};
+
+const RawField = createField(ToggleSwitch);
+
+const StyledField = (props: ComponentProps<typeof RawField>) => (
+  <RawField {...props} />
+);
+
+ToggleSwitch.Field = StyledField;
+export default ToggleSwitch;

--- a/app/components/Form/ToggleSwitch.tsx
+++ b/app/components/Form/ToggleSwitch.tsx
@@ -1,76 +1,57 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Keyboard } from 'app/utils/constants';
+import { ToggleButton } from 'react-aria-components';
 import { createField } from './Field';
 import styles from './ToggleSwitch.module.css';
-import type {
-  ComponentProps,
-  InputHTMLAttributes,
-  KeyboardEvent,
-  MouseEvent,
-} from 'react';
+import type { ComponentProps, InputHTMLAttributes } from 'react';
+import type { ToggleButtonProps } from 'react-aria-components';
 import type { Overwrite } from 'utility-types';
 
 type Props = {
   className?: string;
-} & Overwrite<
-  InputHTMLAttributes<HTMLInputElement>,
-  { onChange?: (checked: boolean) => void }
->;
+  value?: string | boolean;
+  name?: string;
+  checked?: boolean;
+} & ToggleButtonProps &
+  Overwrite<
+    InputHTMLAttributes<HTMLInputElement>,
+    {
+      onChange?: ToggleButtonProps['onChange'];
+    }
+  >;
 
 const ToggleSwitch = ({
   id,
-  checked,
+  name,
   value,
+  checked,
   className,
-  disabled,
+  isDisabled,
+  onChange,
   ...props
 }: Props) => {
-  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === Keyboard.ENTER) {
-      event.preventDefault();
-      const inputElement = event.target as HTMLInputElement;
-      inputElement.click();
-    }
-  };
-
-  const handleClick = (e: MouseEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    if (!disabled) {
-      props.onChange?.(!isChecked);
-    }
-  };
-
   const isInFormContext = value !== undefined;
   // Supporting both string and boolean values
-  const isChecked = isInFormContext
+  const isSelected = isInFormContext
     ? typeof value === 'string'
       ? value === 'true'
       : !!value
-    : typeof checked === 'string'
-      ? checked === 'true'
-      : !!checked;
+    : checked;
 
   return (
     <Flex wrap alignItems="center" gap="var(--spacing-sm)">
-      <div className={cx(styles.toggleSwitch, className)} onClick={handleClick}>
-        <input
-          {...props}
-          type="checkbox"
-          role="switch"
-          id={id}
-          {...(isInFormContext
-            ? { value: value, checked: isChecked }
-            : { checked: isChecked })}
-          aria-checked={isChecked}
-          disabled={disabled}
-          onChange={(e) => {
-            props.onChange?.(e.target.checked);
-          }}
-          onKeyDown={handleKeyDown}
-        />
+      {/* A hidden input used in the e2e specs to find the field through the name attribute */}
+      <input type="hidden" name={name} value={isSelected ? 'true' : 'false'} />
+      <ToggleButton
+        {...props}
+        id={id}
+        isDisabled={isDisabled}
+        isSelected={isSelected}
+        onChange={onChange}
+        className={cx(styles.toggleSwitch, className)}
+      >
         <span className={styles.slider} />
-      </div>
+      </ToggleButton>
     </Flex>
   );
 };

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -18,15 +18,14 @@ import {
 import {
   TextEditor,
   TextInput,
-  RadioButton,
   SelectInput,
   ImageUploadField,
-  MultiSelectGroup,
   Form,
 } from 'app/components/Form';
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
+import ToggleSwitch from 'app/components/Form/ToggleSwitch';
 import { selectCompanyById } from 'app/reducers/companies';
 import { selectUserById } from 'app/reducers/users';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
@@ -51,6 +50,7 @@ type FormValues = {
   website?: string;
   address?: string;
   studentContact?: AutocompleteUser;
+  active?: boolean;
 };
 
 const TypedLegoForm = LegoFinalForm<FormValues>;
@@ -127,7 +127,7 @@ const CompanyEditor = () => {
           value: studentContact.id,
           label: studentContact.fullName,
         },
-        active: company.active ? 'true' : 'false',
+        active: company.active,
         phone: company.phone,
         companyType: company.companyType,
         paymentMail: company.paymentMail,
@@ -167,106 +167,91 @@ const CompanyEditor = () => {
         validate={validate}
         subscription={{}}
       >
-        {({ handleSubmit }) => {
-          return (
-            <Form onSubmit={handleSubmit}>
-              <Field
-                name="logo"
-                component={ImageUploadField}
-                aspectRatio={20 / 6}
-                img={company && company.logo}
-              />
+        {({ handleSubmit }) => (
+          <Form onSubmit={handleSubmit}>
+            <Field
+              name="logo"
+              component={ImageUploadField}
+              aspectRatio={20 / 6}
+              img={company && company.logo}
+            />
 
-              <Field
-                placeholder="Bedriftens navn"
-                name="name"
-                label="Navn"
-                required
-                component={TextInput.Field}
-              />
+            <Field
+              placeholder="Bedriftens navn"
+              name="name"
+              label="Navn"
+              required
+              component={TextInput.Field}
+            />
 
-              <Field
-                placeholder="Beskrivelse av bedriften"
-                name="description"
-                label="Beskrivelse"
-                component={TextEditor.Field}
-              />
+            <Field
+              placeholder="Beskrivelse av bedriften"
+              name="description"
+              label="Beskrivelse"
+              component={TextEditor.Field}
+            />
 
-              <Field
-                placeholder="Type bedrift"
-                label="Type bedrift"
-                name="companyType"
-                component={TextInput.Field}
-              />
+            <Field
+              placeholder="Type bedrift"
+              label="Type bedrift"
+              name="companyType"
+              component={TextInput.Field}
+            />
 
-              <Field
-                placeholder="mail@abakus.no"
-                name="paymentMail"
-                label="Fakturamail"
-                component={TextInput.Field}
-              />
+            <Field
+              placeholder="mail@abakus.no"
+              name="paymentMail"
+              label="Fakturamail"
+              component={TextInput.Field}
+            />
 
-              <Field
-                placeholder="123 45 678"
-                name="phone"
-                label="Telefon"
-                component={TextInput.Field}
-              />
+            <Field
+              placeholder="123 45 678"
+              name="phone"
+              label="Telefon"
+              component={TextInput.Field}
+            />
 
-              <Field
-                placeholder="https://www.abakus.no"
-                name="website"
-                label="Nettside"
-                component={TextInput.Field}
-              />
+            <Field
+              placeholder="https://www.abakus.no"
+              name="website"
+              label="Nettside"
+              component={TextInput.Field}
+            />
 
-              <Field
-                placeholder="Adresse"
-                name="address"
-                label="Adresse"
-                component={TextInput.Field}
-              />
+            <Field
+              placeholder="Adresse"
+              name="address"
+              label="Adresse"
+              component={TextInput.Field}
+            />
 
-              <Field
-                placeholder="Studentkontakt"
-                label="Studentkontakt"
-                name="studentContact"
-                component={SelectInput.AutocompleteField}
-                filter={[AutocompleteContentType.User]}
-              />
+            <Field
+              placeholder="Studentkontakt"
+              label="Studentkontakt"
+              name="studentContact"
+              component={SelectInput.AutocompleteField}
+              filter={[AutocompleteContentType.User]}
+            />
 
-              <div>
-                <MultiSelectGroup name="active" legend="Aktiv bedrift?">
-                  <Field
-                    name="Yes"
-                    label="Ja"
-                    value="true"
-                    type="radio"
-                    component={RadioButton.Field}
-                  />
-                  <Field
-                    name="No"
-                    label="Nei"
-                    value="false"
-                    type="radio"
-                    component={RadioButton.Field}
-                  />
-                </MultiSelectGroup>
-              </div>
+            <Field
+              name="active"
+              label="Aktiv bedrift?"
+              component={ToggleSwitch.Field}
+            />
 
-              <Field
-                placeholder="Bedriften ønsker kun kurs"
-                label="Notat fra Bedkom"
-                name="adminComment"
-                component={TextEditor.Field}
-                className={styles.adminNote}
-              />
+            <Field
+              placeholder="Bedriften ønsker kun kurs"
+              label="Notat fra Bedkom"
+              name="adminComment"
+              component={TextEditor.Field}
+              className={styles.adminNote}
+            />
 
-              <SubmissionError />
-              <SubmitButton>{isNew ? 'Opprett' : 'Lagre'}</SubmitButton>
-            </Form>
-          );
-        }}
+            <SubmissionError />
+            <SubmitButton>{isNew ? 'Opprett' : 'Lagre'}</SubmitButton>
+          </Form>
+        )}
       </TypedLegoForm>
     </Page>
   );

--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -27,6 +27,7 @@ import {
 } from 'app/components/Form';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
+import ToggleSwitch from 'app/components/Form/ToggleSwitch';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import { selectCompanyInterestById } from 'app/reducers/companyInterest';
 import {
@@ -60,7 +61,6 @@ import {
   SURVEY_OFFERS,
   TARGET_GRADES,
   FORM_LABELS,
-  OFFICE_IN_TRONDHEIM,
   COLLABORATION_TYPES,
   COMPANY_TYPES,
   TOOLTIP,
@@ -119,7 +119,7 @@ const EventBox = ({
   <FormSpy subscription={{ values: true }}>
     {(props) => {
       const filteredFields = fields.map((field) => field); // This is just to get an array instead of what fields is (which is an object that mimics an iterable). See: https://github.com/final-form/react-final-form-arrays#fieldarrayrenderprops
-      if (props.values.officeInTrondheim !== 'yes') {
+      if (!props.values.officeInTrondheim) {
         fields.forEach((field, index) => {
           if (fields.value[index].name == 'company_to_company') {
             filteredFields.splice(index, 1);
@@ -238,7 +238,7 @@ type CompanyInterestFormEntity = {
   companyToCompanyComment: string;
   companyPresentationComment: string;
   companyType: string;
-  officeInTrondheim: 'yes' | 'no';
+  officeInTrondheim: boolean;
 };
 
 const requiredIfEventType = (eventType: string) =>
@@ -266,7 +266,6 @@ const validate = createValidator({
   phone: [required()],
   comment: [required()],
   companyType: [required()],
-  officeInTrondheim: [required()],
   events: [required()],
   semesters: [required()],
   breakfastTalkComment: [requiredIfEventType('breakfast_talk')],
@@ -363,7 +362,7 @@ const CompanyInterestPage = () => {
         companyInterest?.targetGrades?.includes(Number(targetGrade)) || false,
     })),
     participantRange: (participantRange && participantRange[0]) || null,
-    officeInTrondheim: companyInterest?.officeInTrondheim ? 'yes' : 'no',
+    officeInTrondheim: companyInterest?.officeInTrondheim || false,
     semesters: edit
       ? semesters
           .map((semester) => ({
@@ -400,7 +399,7 @@ const CompanyInterestPage = () => {
       contactPerson: data.contactPerson,
       mail: data.mail,
       phone: data.phone,
-      officeInTrondheim: data.officeInTrondheim === 'yes',
+      officeInTrondheim: data.officeInTrondheim,
       semesters: data.semesters
         .filter((semester) => semester.checked)
         .map((semester) => semester.id),
@@ -590,23 +589,11 @@ const CompanyInterestPage = () => {
                 </MultiSelectGroup>
               </Flex>
               <Flex column className={styles.interestBox}>
-                <MultiSelectGroup
-                  legend={FORM_LABELS.officeInTrondheim[language]}
-                  required
+                <Field
                   name="officeInTrondheim"
-                >
-                  {Object.keys(OFFICE_IN_TRONDHEIM).map((key) => (
-                    <Field
-                      key={key}
-                      name={key}
-                      value={key}
-                      label={OFFICE_IN_TRONDHEIM[key][language]}
-                      type="radio"
-                      component={RadioButton.Field}
-                      showErrors={false}
-                    />
-                  ))}
-                </MultiSelectGroup>
+                  component={ToggleSwitch.Field}
+                  label={FORM_LABELS.officeInTrondheim[language]}
+                />
               </Flex>
               <Flex column className={styles.interestBox}>
                 <MultiSelectGroup

--- a/app/routes/companyInterest/components/Translations.ts
+++ b/app/routes/companyInterest/components/Translations.ts
@@ -157,11 +157,6 @@ export const COMPANY_TYPES: Record<
   company_types_governmental: { norwegian: 'Statlig', english: 'Governmental' },
 };
 
-export const OFFICE_IN_TRONDHEIM = {
-  yes: { norwegian: 'Ja', english: 'Yes' },
-  no: { norwegian: 'Nei', english: 'No' },
-};
-
 export const COLLABORATION_TYPES = {
   collaboration_omega: {
     norwegian: 'Samarbeid med Omega linjeforening',

--- a/app/routes/events/components/EventList.module.css
+++ b/app/routes/events/components/EventList.module.css
@@ -4,6 +4,12 @@
   margin-bottom: var(--spacing-md);
 }
 
+.skeletonEventGroupTitle {
+  width: 200px;
+  min-height: 28.59px;
+  margin: var(--spacing-sm) 0;
+}
+
 .bottomBorder {
   margin-top: var(--spacing-sm);
   border-top: 1px solid var(--border-gray);

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -5,8 +5,8 @@ import {
   Flex,
   Icon,
   LinkButton,
-  LoadingIndicator,
   Page,
+  Skeleton,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty, orderBy } from 'lodash';
@@ -18,12 +18,13 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { fetchEvents } from 'app/actions/EventActions';
 import EmptyState from 'app/components/EmptyState';
 import EventItem from 'app/components/EventItem';
+import eventItemStyles from 'app/components/EventItem/styles.module.css';
 import { CheckBox, RadioButton } from 'app/components/Form/';
 import { EventTime } from 'app/models';
 import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { selectAllEvents } from 'app/reducers/events';
 import { selectPaginationNext } from 'app/reducers/selectors';
-import sharedStyles from 'app/routes/joblistings/components/JoblistingList.module.css';
+import joblistingListStyles from 'app/routes/joblistings/components/JoblistingList.module.css';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { EntityType } from 'app/store/models/entities';
 import useQuery from 'app/utils/useQuery';
@@ -84,7 +85,7 @@ const EventListGroup = ({
 }) => {
   return isEmpty(events) ? null : (
     <div className={styles.eventGroup}>
-      <h3>{name}</h3>
+      <h3 className={styles.eventGroupTitle}>{name}</h3>
       <Flex column gap="var(--spacing-md)">
         {events.map((event) => (
           <EventItem key={event.id} event={event} showTags={false} />
@@ -371,9 +372,26 @@ const EventList = () => {
       <EventListGroup name="Neste uke" events={groupedEvents.nextWeek} />
       <EventListGroup name="Senere" events={groupedEvents.later} />
       {isEmpty(events) && pagination.fetching && (
-        <LoadingIndicator loading={pagination.fetching} />
+        <>
+          <div className={styles.eventGroup}>
+            {isEmpty(groupedEvents) && (
+              <Skeleton className={styles.skeletonEventGroupTitle} />
+            )}
+            <Flex column gap="var(--spacing-md)">
+              <Skeleton array={3} className={eventItemStyles.eventItem} />
+            </Flex>
+          </div>
+          <div className={styles.eventGroup}>
+            {isEmpty(groupedEvents) && (
+              <Skeleton className={styles.skeletonEventGroupTitle} />
+            )}
+            <Flex column gap="var(--spacing-md)">
+              <Skeleton array={5} className={eventItemStyles.eventItem} />
+            </Flex>
+          </div>
+        </>
       )}
-      {isEmpty(events) && !pagination.fetching && (
+      {isEmpty(groupedEvents) && !pagination.fetching && (
         <EmptyState
           iconNode={<FolderOpen />}
           header="Her var det tomt ..."
@@ -390,7 +408,7 @@ const EventList = () => {
               )}
             </>
           }
-          className={sharedStyles.emptyState}
+          className={joblistingListStyles.emptyState}
         />
       )}
       {(query.showPrevious === 'true'

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -3,15 +3,17 @@ import {
   FilterSection,
   filterSidebar,
   Flex,
+  Icon,
   LinkButton,
   LoadingIndicator,
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty, orderBy } from 'lodash';
-import { FolderOpen } from 'lucide-react';
+import { FilterX, FolderOpen } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { fetchEvents } from 'app/actions/EventActions';
 import EmptyState from 'app/components/EmptyState';
 import EventItem from 'app/components/EventItem';
@@ -20,6 +22,7 @@ import { EventTime } from 'app/models';
 import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { selectAllEvents } from 'app/reducers/events';
 import { selectPaginationNext } from 'app/reducers/selectors';
+import sharedStyles from 'app/routes/joblistings/components/JoblistingList.module.css';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { EntityType } from 'app/store/models/entities';
 import useQuery from 'app/utils/useQuery';
@@ -211,6 +214,13 @@ const EventList = () => {
     ),
     field,
   );
+  const totalCount = events.length;
+
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const clearQueryParams = () => {
+    navigate(pathname);
+  };
 
   const toggleEventType =
     (type: 'company_presentation' | 'course' | 'social' | 'other') => () => {
@@ -281,11 +291,27 @@ const EventList = () => {
       <EventListGroup name="Denne uken" events={groupedEvents.currentWeek} />
       <EventListGroup name="Neste uke" events={groupedEvents.nextWeek} />
       <EventListGroup name="Senere" events={groupedEvents.later} />
-      {isEmpty(events) && pagination.fetching && <LoadingIndicator loading />}
-      {isEmpty(events) && !pagination.fetching && (
+      {isEmpty(groupedEvents) && pagination.fetching && (
+        <LoadingIndicator loading />
+      )}
+      {isEmpty(groupedEvents) && !pagination.fetching && (
         <EmptyState
           iconNode={<FolderOpen />}
-          body="Ingen kommende arrangementer"
+          header="Her var det tomt ..."
+          body={
+            <>
+              Ingen arrangementer {totalCount > 0 && 'som matcher ditt filter'}{' '}
+              ligger
+              {totalCount === 0 && ' for øyeblikket'} ute
+              {totalCount > 0 && (
+                <Button flat onPress={clearQueryParams}>
+                  <Icon iconNode={<FilterX />} size={22} />
+                  Tøm filter
+                </Button>
+              )}
+            </>
+          }
+          className={sharedStyles.emptyState}
         />
       )}
       {pagination.hasMore && field === 'startTime' && (

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -20,6 +20,7 @@ import EmptyState from 'app/components/EmptyState';
 import EventItem from 'app/components/EventItem';
 import eventItemStyles from 'app/components/EventItem/styles.module.css';
 import { CheckBox, RadioButton } from 'app/components/Form/';
+import ToggleSwitch from 'app/components/Form/ToggleSwitch';
 import { EventTime } from 'app/models';
 import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { selectAllEvents } from 'app/reducers/events';
@@ -147,7 +148,7 @@ const EventList = () => {
   const loggedIn = useIsLoggedIn();
 
   const [previousStart, setPreviousStart] = useState(
-    moment().subtract(2, 'week'),
+    moment().subtract(1, 'month'),
   );
   const [previousEvents, setPreviousEvents] = useState<ListEvent[]>([]);
 
@@ -199,7 +200,7 @@ const EventList = () => {
 
   const fetchMore = () => {
     if (query.showPrevious === 'true') {
-      const newStart = previousStart.clone().subtract(1, 'week');
+      const newStart = previousStart.clone().subtract(1, 'month');
       setPreviousStart(newStart);
 
       return dispatch(
@@ -301,19 +302,12 @@ const EventList = () => {
         children: (
           <>
             <FilterSection title="Vis tidligere">
-              <RadioButton
-                name="showPrevious"
-                id="showPreviousYes"
-                label="Ja"
+              <ToggleSwitch
+                id="showPrevious"
                 checked={query.showPrevious === 'true'}
-                onChange={() => setQueryValue('showPrevious')('true')}
-              />
-              <RadioButton
-                name="showPrevious"
-                id="showPreviousNo"
-                label="Nei"
-                checked={query.showPrevious === 'false'}
-                onChange={() => setQueryValue('showPrevious')('false')}
+                onChange={(checked) =>
+                  setQueryValue('showPrevious')(checked ? 'true' : 'false')
+                }
               />
             </FilterSection>
             <FilterSection title="Arrangementstype">

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -15,7 +15,7 @@ import { Helmet } from 'react-helmet-async';
 import { fetchEvents } from 'app/actions/EventActions';
 import EmptyState from 'app/components/EmptyState';
 import EventItem from 'app/components/EventItem';
-import { CheckBox, SelectInput } from 'app/components/Form/';
+import { CheckBox, RadioButton } from 'app/components/Form/';
 import { EventTime } from 'app/models';
 import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { selectAllEvents } from 'app/reducers/events';
@@ -91,7 +91,7 @@ type Option = {
   value: FilterRegistrationsType;
   field: EventTime;
 };
-const filterRegDateOptions: Array<Option> = [
+const filterRegDateOptions: Option[] = [
   {
     filterRegDateFunc: (event) => !!event,
     label: 'Vis alle',
@@ -254,17 +254,18 @@ const EventList = () => {
               />
             </FilterSection>
             <FilterSection title="Påmelding">
-              <SelectInput
-                name="form-field-name"
-                value={regDateFilter}
-                onChange={(selectedOption) =>
-                  selectedOption &&
-                  setQueryValue('registrations')(selectedOption.value)
-                }
-                className={styles.select}
-                options={filterRegDateOptions}
-                isClearable={false}
-              />
+              {filterRegDateOptions.map((option) => (
+                <RadioButton
+                  key={option.value}
+                  name="registrations"
+                  id={option.value}
+                  label={option.label}
+                  checked={query.registrations === option.value}
+                  onChange={() => {
+                    setQueryValue('registrations')(option.value);
+                  }}
+                />
+              ))}
             </FilterSection>
           </>
         ),

--- a/app/routes/joblistings/components/JoblistingList.module.css
+++ b/app/routes/joblistings/components/JoblistingList.module.css
@@ -5,9 +5,11 @@
   text-align: center;
   margin: 0 auto;
   margin-top: var(--spacing-xl);
+  margin-bottom: var(--spacing-xl);
   line-height: 1.3;
 
   @media (--mobile-device) {
     margin-top: var(--spacing-md);
+    margin-bottom: var(--spacing-md);
   }
 }

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -180,7 +180,7 @@ const GalleryPictureModal = () => {
   );
 
   useEffect(() => {
-    if (pagination.hasMore && isLastLoadedImage) {
+    if (pagination.hasMore && isLastLoadedImage && galleryId) {
       dispatch(
         fetchGalleryPictures(galleryId, {
           next: true,

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -13,6 +13,7 @@ import {
 import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
+import ToggleSwitch from 'app/components/Form/ToggleSwitch';
 import { useCurrentUser } from 'app/reducers/auth';
 import { selectUserByUsername } from 'app/reducers/users';
 import DeleteUser from 'app/routes/users/components/UserSettings/DeleteUser';
@@ -222,25 +223,11 @@ const UserSettings = () => {
             </MultiSelectGroup>
 
             {showAbakusMembership && (
-              <MultiSelectGroup
+              <Field
                 name="isAbakusMember"
-                legend="Medlem av Abakus?"
-              >
-                <Field
-                  name="isMemberYes"
-                  label="Ja"
-                  value="true"
-                  type="radio"
-                  component={RadioButton.Field}
-                />
-                <Field
-                  name="isMemberNo"
-                  label="Nei"
-                  value="false"
-                  type="radio"
-                  component={RadioButton.Field}
-                />
-              </MultiSelectGroup>
+                label="Medlem av Abakus?"
+                component={ToggleSwitch.Field}
+              />
             )}
 
             <SubmissionError />

--- a/app/store/models/CompanyInterest.ts
+++ b/app/store/models/CompanyInterest.ts
@@ -25,7 +25,7 @@ interface CompleteCompanyInterest {
   phone: string;
   semesters: EntityId[];
   createdAt: Dateish;
-  officeInTrondheim: string;
+  officeInTrondheim: boolean;
   events: CompanyInterestEventType[];
   companyCourseThemes: string[];
   otherOffers: string[];

--- a/cypress/e2e/company_interest_spec.js
+++ b/cypress/e2e/company_interest_spec.js
@@ -17,7 +17,7 @@ const createCompanyInterest = () => {
   field('mail').click().type('webkom@webkom.no');
 
   field('phone').click().type('90909090');
-  field('officeInTrondheim').check();
+  field('officeInTrondheim').click({ force: true });
 
   field('semesters[0].checked').check();
   field('events[0].checked').check();


### PR DESCRIPTION
# Description

Specialisation project has finally been delivered! 🥳

This feature has been highly requested by various people. 

In addition, introduce a `ToggleSwitch` component for binary values (yes/no).

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<p>
	<video src="https://github.com/user-attachments/assets/db50da38-ce08-4c6d-81db-b097b63a9f73" />
</p>

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
			<img width="240" alt="image" src="https://github.com/user-attachments/assets/10d7cad4-afe3-4e84-be64-b7e8a039ee62">
        </td>
        <td>
            <img width="240" alt="image" src="https://github.com/user-attachments/assets/e3ffce6e-88de-4d83-b54a-2ddfdbeab954">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Previous events are still paginated properly.

The toggle switch has bene tested as both a field and a "normal" component.

---

Resolves ABA-492