### PR TITLE
Clean up toasts

### DIFF
--- a/app/actions/CompanyActions.ts
+++ b/app/actions/CompanyActions.ts
@@ -97,6 +97,7 @@ export function addCompany(data: Record<string, any>) {
     body: data,
     schema: companySchema,
     meta: {
+      successMessage: 'Bedrift lagt til',
       errorMessage: 'Legg til bedrift feilet',
     },
   });
@@ -110,6 +111,7 @@ export function editCompany({ companyId, ...data }: Record<string, any>) {
     body: data,
     schema: companySchema,
     meta: {
+      successMessage: 'Bedrift oppdatert',
       errorMessage: 'Endring av bedrift feilet',
     },
   });

--- a/app/actions/CompanyInterestActions.ts
+++ b/app/actions/CompanyInterestActions.ts
@@ -1,10 +1,8 @@
 import callAPI from 'app/actions/callAPI';
 import { companyInterestSchema } from 'app/reducers';
-import { addToast } from 'app/reducers/toasts';
 import { CompanyInterestForm } from './ActionTypes';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { CompanyInterestEntity } from 'app/reducers/companyInterest';
-import type { AppDispatch } from 'app/store/createStore';
 import type {
   DetailedCompanyInterest,
   ListCompanyInterest,
@@ -47,69 +45,47 @@ export function createCompanyInterest(
   data: CompanyInterestEntity,
   isEnglish: boolean,
 ) {
-  return (dispatch: AppDispatch) => {
-    return dispatch(
-      callAPI<DetailedCompanyInterest>({
-        types: CompanyInterestForm.CREATE,
-        endpoint: '/company-interests/',
-        method: 'POST',
-        schema: companyInterestSchema,
-        body: data,
-        meta: {
-          errorMessage: 'Opprette bedriftsinteresse feilet',
-        },
-      }),
-    ).then(() =>
-      dispatch(
-        addToast({
-          message: isEnglish
-            ? 'Submission successful!'
-            : 'Bedriftsinteresse opprettet!',
-        }),
-      ),
-    );
-  };
+  return callAPI<DetailedCompanyInterest>({
+    types: CompanyInterestForm.CREATE,
+    endpoint: '/company-interests/',
+    method: 'POST',
+    schema: companyInterestSchema,
+    body: data,
+    meta: {
+      successMessage: isEnglish
+        ? 'Submission successful!'
+        : 'Bedriftsinteresse opprettet!',
+      errorMessage: 'Opprette bedriftsinteresse feilet',
+    },
+  });
 }
 
 export function deleteCompanyInterest(id: EntityId) {
-  return (dispatch: AppDispatch) => {
-    return dispatch(
-      callAPI({
-        types: CompanyInterestForm.DELETE,
-        endpoint: `/company-interests/${id}/`,
-        method: 'DELETE',
-        meta: {
-          id,
-          errorMessage: 'Fjerning av bedriftsinteresse feilet!',
-        },
-      }),
-    ).then(() =>
-      dispatch(
-        addToast({
-          message: 'Bedriftsinteresse fjernet!',
-        }),
-      ),
-    );
-  };
+  return callAPI({
+    types: CompanyInterestForm.DELETE,
+    endpoint: `/company-interests/${id}/`,
+    method: 'DELETE',
+    meta: {
+      id,
+      successMessage: 'Bedriftsinteresse fjernet!',
+      errorMessage: 'Fjerning av bedriftsinteresse feilet!',
+    },
+  });
 }
 
 export function updateCompanyInterest(
   id: EntityId,
   data: CompanyInterestEntity,
 ) {
-  return (dispatch: AppDispatch) => {
-    return dispatch(
-      callAPI({
-        types: CompanyInterestForm.UPDATE,
-        endpoint: `/company-interests/${id}/`,
-        method: 'PATCH',
-        body: data,
-        meta: {
-          companyInterestId: id,
-          errorMessage: 'Endring av bedriftsinteresse feilet!',
-          successMessage: 'Bedriftsinteresse endret!',
-        },
-      }),
-    );
-  };
+  return callAPI<DetailedCompanyInterest>({
+    types: CompanyInterestForm.UPDATE,
+    endpoint: `/company-interests/${id}/`,
+    method: 'PATCH',
+    body: data,
+    meta: {
+      companyInterestId: id,
+      errorMessage: 'Endring av bedriftsinteresse feilet!',
+      successMessage: 'Bedriftsinteresse endret!',
+    },
+  });
 }

--- a/app/actions/ContactActions.ts
+++ b/app/actions/ContactActions.ts
@@ -8,5 +8,9 @@ export function sendContactMessage(contactForm: ContactForm) {
     method: 'POST',
     endpoint: '/contact-form/',
     body: contactForm,
+    meta: {
+      successMessage: 'Melding er sendt',
+      errorMessage: 'Kunne ikke sende melding',
+    },
   });
 }

--- a/app/actions/QuoteActions.ts
+++ b/app/actions/QuoteActions.ts
@@ -3,12 +3,13 @@ import { quoteSchema } from 'app/reducers';
 import { Quote } from './ActionTypes';
 import type { EntityId } from '@reduxjs/toolkit';
 import type QuoteType from 'app/store/models/Quote';
+import type { ParsedQs } from 'qs';
 
 export function fetchAll({
   query,
   next = false,
 }: {
-  query?: Record<string, any>;
+  query?: ParsedQs;
   next?: boolean;
 } = {}) {
   return callAPI<QuoteType[]>({
@@ -33,7 +34,7 @@ export function fetchQuote(quoteId: EntityId) {
     method: 'GET',
     meta: {
       quoteId,
-      errorMessage: 'Henting av quote feilet',
+      errorMessage: 'Henting av sitat feilet',
     },
     schema: quoteSchema,
     propagateError: true,
@@ -48,7 +49,7 @@ export function fetchRandomQuote(seenQuotes: EntityId[] = []) {
     method: 'GET',
     meta: {
       queryString,
-      errorMessage: 'Henting av tilfeldig quote feilet',
+      errorMessage: 'Henting av tilfeldig sitat feilet',
     },
     schema: quoteSchema,
   });
@@ -60,7 +61,7 @@ export function approve(quoteId: EntityId) {
     endpoint: `/quotes/${quoteId}/approve/`,
     method: 'PUT',
     meta: {
-      errorMessage: 'Godkjenning av quote feilet',
+      errorMessage: 'Godkjenning av sitat feilet',
       quoteId: Number(quoteId),
     },
   });
@@ -72,7 +73,7 @@ export function unapprove(quoteId: EntityId) {
     endpoint: `/quotes/${quoteId}/unapprove/`,
     method: 'PUT',
     meta: {
-      errorMessage: 'Underkjenning av quote feilet',
+      errorMessage: 'Underkjenning av sitat feilet',
       quoteId: Number(quoteId),
     },
   });
@@ -89,7 +90,7 @@ export function addQuotes({ text, source }: { text: string; source: string }) {
     },
     schema: quoteSchema,
     meta: {
-      errorMessage: 'Legg til quote feilet',
+      errorMessage: 'Kunne ikke legge til sitat',
     },
   });
 }
@@ -101,7 +102,7 @@ export function deleteQuote(id: EntityId) {
     method: 'DELETE',
     meta: {
       id,
-      errorMessage: 'Sletting av quote feilet',
+      errorMessage: 'Sletting av sitat feilet',
     },
   });
 }

--- a/app/components/Toast/Toast.module.css
+++ b/app/components/Toast/Toast.module.css
@@ -54,6 +54,10 @@
   }
 }
 
+.defaultIcon svg {
+  color: var(--inverted-font-color);
+}
+
 .success {
   background-color: var(--color-green-2);
   border-color: var(--color-green-7);

--- a/app/components/Toast/Toast.tsx
+++ b/app/components/Toast/Toast.tsx
@@ -41,6 +41,7 @@ export const Toast = ({ state, ...props }: ToastProps) => {
         iconNode={type === 'success' ? <Check /> : <X />}
         success={type === 'success'}
         danger={type === 'error'}
+        className={!type ? styles.defaultIcon : undefined}
         size={18}
       />
       <div {...contentProps}>

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -28,7 +28,6 @@ import LegoFinalForm from 'app/components/Form/LegoFinalForm';
 import SubmissionError from 'app/components/Form/SubmissionError';
 import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { selectCompanyById } from 'app/reducers/companies';
-import { addToast } from 'app/reducers/toasts';
 import { selectUserById } from 'app/reducers/users';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { AutocompleteContentType } from 'app/store/models/Autocomplete';
@@ -101,11 +100,6 @@ const CompanyEditor = () => {
     };
 
     dispatch(isNew ? addCompany(body) : editCompany(body)).then((res) => {
-      dispatch(
-        addToast({
-          message: isNew ? 'Bedrift lagt til' : 'Bedrift oppdatert',
-        }),
-      );
       navigate(`/bdb/${isNew ? res.payload.result : companyId}`);
     });
   };

--- a/app/routes/contact/components/ContactForm.tsx
+++ b/app/routes/contact/components/ContactForm.tsx
@@ -18,7 +18,6 @@ import { SubmitButton } from 'app/components/Form/SubmitButton';
 import { GroupType } from 'app/models';
 import { useIsLoggedIn } from 'app/reducers/auth';
 import { selectGroupById, selectGroupsByType } from 'app/reducers/groups';
-import { addToast } from 'app/reducers/toasts';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import { isNotNullish } from 'app/utils';
 import { createValidator, maxLength, required } from 'app/utils/validation';
@@ -68,22 +67,9 @@ const ContactForm = () => {
         ...data,
         recipient_group: data.recipient_group.value,
       }),
-    )
-      .then(() => {
-        form.reset();
-        dispatch(
-          addToast({
-            message: 'Melding er sendt',
-          }),
-        );
-      })
-      .catch(() =>
-        dispatch(
-          addToast({
-            message: 'Kunne ikke sende melding',
-          }),
-        ),
-      );
+    ).then(() => {
+      form.reset();
+    });
   };
 
   const hsRecipient = {

--- a/app/routes/quotes/components/AddQuote.tsx
+++ b/app/routes/quotes/components/AddQuote.tsx
@@ -56,7 +56,8 @@ const AddQuote = () => {
       dispatch(
         addToast({
           message:
-            'Sitat sendt inn. Hvis det blir godkjent vil det dukke opp her!',
+            'Sitat ble sendt inn, og vil dukke opp her hvis det blir godkjent!',
+          type: 'success',
           dismissAfter: 10000,
         }),
       );

--- a/app/store/middleware/websocketMiddleware.ts
+++ b/app/store/middleware/websocketMiddleware.ts
@@ -48,6 +48,11 @@ const createWebSocketMiddleware = (): Middleware<
           dispatch(
             addToast({
               message,
+              type: meta.successMessage
+                ? 'success'
+                : meta.errorMessage
+                  ? 'error'
+                  : undefined,
             }),
           );
         }


### PR DESCRIPTION
# Description

[Fix icon color on default toast types](https://github.com/webkom/lego-webapp/commit/521bdaa7268690f69500c7d045b6c3aa76799ffc)

---

[Refactor actions to use toasts the proper way](https://github.com/webkom/lego-webapp/commit/166b6be48f721f76169a02815879187903937343) 

These toasts were missing types since they were added in a "custom" way

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
			<img width="721" alt="image" src="https://github.com/user-attachments/assets/c7b1036c-b23f-47af-ada4-85f5d73807af">
        </td>
        <td>
           <img width="721" alt="image" src="https://github.com/user-attachments/assets/08bbd230-ab14-45fc-8624-addb16ed576f">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested that toasts are still shown as expected (with the correct type) in the cases where it was moved to be handled elsewhere.

---

Resolves ABA-1194