### PR TITLE
Hide back link on company interest page when not editing

### DIFF
--- a/app/routes/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/companyInterest/components/CompanyInterestPage.tsx
@@ -507,9 +507,7 @@ const CompanyInterestPage = () => {
   return (
     <Page
       title={title}
-      back={{
-        href: '/company-interest',
-      }}
+      back={edit ? { href: '/company-interest' } : undefined}
       actionButtons={
         !edit && (
           <Link to={isEnglish ? '/interesse' : '/register-interest'}>


### PR DESCRIPTION
# Description

The back link was visible for all users all the time, despite normal users not being able to view the page that it directs to. 

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="412" alt="image" src="https://github.com/user-attachments/assets/d76974b7-9ca0-4189-8cb1-6ff63a7fa4eb">
        </td>
        <td>
           <img width="412" alt="image" src="https://github.com/user-attachments/assets/b12c99a2-8c9e-43b9-9b7a-aee5f4968fd6">
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

It is now only shown when editing a submission.

---

Resolves ABA-1195