### PR TITLE
Include registration statuses to event items

### DIFF
--- a/app/components/EventItem/RegistrationStatusTag.tsx
+++ b/app/components/EventItem/RegistrationStatusTag.tsx
@@ -1,0 +1,87 @@
+import { Flex, Icon } from '@webkom/lego-bricks';
+import { AlarmClock } from 'lucide-react';
+import Tag from 'app/components/Tags/Tag';
+import Time from 'app/components/Time';
+import { useIsLoggedIn } from 'app/reducers/auth';
+import { EventStatusType } from 'app/store/models/Event';
+import utilities from 'app/styles/utilities.css';
+import type { ListEvent } from 'app/store/models/Event';
+
+type Props = {
+  event: ListEvent;
+  isRegistrationOpen: boolean;
+  isRegistrationSameYear: boolean;
+};
+
+const RegistrationStatusTag = ({
+  event,
+  isRegistrationOpen,
+  isRegistrationSameYear,
+}: Props) => {
+  const loggedIn = useIsLoggedIn();
+
+  const getRegistrationStatus = () => {
+    if (
+      event.eventStatusType === EventStatusType.OPEN ||
+      event.eventStatusType === EventStatusType.INFINITE
+    ) {
+      return 'Åpent for alle';
+    }
+
+    if (event.isAdmitted) {
+      return 'Du er påmeldt';
+    }
+
+    if (event.userReg && event.eventStatusType === EventStatusType.NORMAL) {
+      return 'Du er på venteliste';
+    }
+
+    if (!!event.activationTime) {
+      return (
+        <Flex alignItems="center" gap="var(--spacing-xs)">
+          <Icon
+            iconNode={<AlarmClock />}
+            size={14}
+            className={utilities.hiddenOnMobile}
+          />
+          <span>
+            Påmelding {isRegistrationOpen ? 'åpnet' : 'åpner'}{' '}
+            <Time
+              time={event.activationTime}
+              format={isRegistrationSameYear ? 'D. MMM HH:mm' : 'll HH:mm'}
+            />
+          </span>
+        </Flex>
+      );
+    }
+
+    return 'Påmelding er ikke bestemt';
+  };
+
+  const getTagColor = () => {
+    if (event.isAdmitted) {
+      return 'green';
+    }
+
+    if (event.userReg && event.eventStatusType === EventStatusType.NORMAL) {
+      return 'orange';
+    }
+
+    if (
+      event.eventStatusType === EventStatusType.OPEN ||
+      event.eventStatusType === EventStatusType.INFINITE
+    ) {
+      return 'red';
+    }
+
+    return isRegistrationOpen ? 'red' : 'gray';
+  };
+
+  if (!loggedIn) {
+    return null;
+  }
+
+  return <Tag tag={getRegistrationStatus()} color={getTagColor()} />;
+};
+
+export default RegistrationStatusTag;

--- a/app/components/EventItem/styles.module.css
+++ b/app/components/EventItem/styles.module.css
@@ -1,13 +1,15 @@
 .eventItem {
   min-height: 50px;
-  padding: var(--spacing-xs);
-  padding-left: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
   border-left: 4px solid transparent;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-md);
   line-height: 1.3;
   border-top-right-radius: var(--border-radius-lg);
   border-bottom-right-radius: var(--border-radius-lg);
+  color: var(--lego-font-color);
   transition: background-color var(--easing-fast);
 
   &:hover {
@@ -30,7 +32,6 @@
   color: var(--lego-font-color);
   margin: 0;
   word-break: break-word;
-  margin-bottom: var(--spacing-sm);
 }
 
 .eventTime {
@@ -38,7 +39,7 @@
 }
 
 .companyLogo {
-  width: 120px;
+  width: 140px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -51,11 +52,10 @@
 }
 
 .companyLogo img {
-  min-width: 120px;
+  min-width: 140px;
   max-height: 80px;
   object-fit: contain;
   background: white;
-  margin: var(--spacing-sm) var(--spacing-md) var(--spacing-sm) 0;
 }
 
 .companyLogoCompact img {

--- a/app/components/Tags/Tag.tsx
+++ b/app/components/Tags/Tag.tsx
@@ -2,6 +2,7 @@ import { Flex, Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { Link } from 'react-router-dom';
 import styles from './Tag.module.css';
+import type { ReactNode } from 'react';
 
 const tagColors = [
   'red',
@@ -18,7 +19,7 @@ const tagColors = [
 export type TagColors = (typeof tagColors)[number];
 
 type Props = {
-  tag: string;
+  tag: string | ReactNode;
   icon?: string;
   iconSize?: number;
   color?: TagColors;

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -17,7 +17,7 @@ import EmptyState from 'app/components/EmptyState';
 import EventItem from 'app/components/EventItem';
 import { CheckBox, SelectInput } from 'app/components/Form/';
 import { EventTime } from 'app/models';
-import { useCurrentUser } from 'app/reducers/auth';
+import { useCurrentUser, useIsLoggedIn } from 'app/reducers/auth';
 import { selectAllEvents } from 'app/reducers/events';
 import { selectPaginationNext } from 'app/reducers/selectors';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
@@ -134,6 +134,7 @@ const EventList = () => {
   );
 
   const icalToken = useCurrentUser()?.icalToken;
+  const loggedIn = useIsLoggedIn();
 
   const fetchQuery = {
     date_after: moment().format('YYYY-MM-DD'),
@@ -162,7 +163,7 @@ const EventList = () => {
           query: fetchQuery,
         }),
       ),
-    [],
+    [loggedIn],
   );
 
   const fetchMore = () =>

--- a/app/routes/users/components/UserProfile/index.tsx
+++ b/app/routes/users/components/UserProfile/index.tsx
@@ -44,7 +44,7 @@ import { GroupMemberships } from './GroupMemberships';
 import Penalties from './Penalties';
 import PhotoConsents from './PhotoConsents';
 import styles from './UserProfile.module.css';
-import type { ListEventWithUserRegistration } from 'app/store/models/Event';
+import type { ListEvent } from 'app/store/models/Event';
 import type { PublicGroup } from 'app/store/models/Group';
 import type { CurrentUser, PublicUserWithGroups } from 'app/store/models/User';
 import type { ExclusifyUnion } from 'app/types';
@@ -74,7 +74,7 @@ const UserProfile = () => {
     }),
   );
   const upcomingEvents = useAppSelector((state) =>
-    selectAllEvents<ListEventWithUserRegistration>(state, {
+    selectAllEvents<ListEvent>(state, {
       pagination: upcomingEventsPagination,
     }),
   );
@@ -87,7 +87,7 @@ const UserProfile = () => {
     }),
   );
   const previousEvents = useAppSelector((state) =>
-    selectAllEvents<ListEventWithUserRegistration>(state, {
+    selectAllEvents<ListEvent>(state, {
       pagination: previousEventsPagination,
     }),
   ).filter((e) => e.userReg);

--- a/app/store/models/Event.ts
+++ b/app/store/models/Event.ts
@@ -79,6 +79,7 @@ export interface CompleteEvent {
   responsibleUsers: PublicUser[];
   isForeignLanguage: boolean;
   unregistered: EntityId[];
+  userReg?: ReadRegistration;
 
   // for survey
   attendedCount: number;
@@ -134,13 +135,9 @@ export type ListEvent = Pick<
   | 'survey'
   | 'responsibleUsers'
   | 'actionGrant'
+  | 'userReg'
 > &
   ObjectPermissionsMixin;
-
-// Used for /upcoming and /previous endpoints
-export type ListEventWithUserRegistration = ListEvent & {
-  userReg?: ReadRegistration;
-};
 
 export type DetailedEvent = Pick<
   CompleteEvent,
@@ -282,7 +279,6 @@ export type AutocompleteEvent = Pick<
 export type UnknownEvent = (
   | PublicEvent
   | ListEvent
-  | ListEventWithUserRegistration
   | DetailedEvent
   | EventForSurvey
   | UserDetailedEvent

--- a/app/store/models/Event.ts
+++ b/app/store/models/Event.ts
@@ -188,6 +188,7 @@ export type DetailedEvent = Pick<
   | 'responsibleUsers'
   | 'isForeignLanguage'
   | 'actionGrant'
+  | 'isAdmitted'
 > &
   ObjectPermissionsMixin;
 


### PR DESCRIPTION
# Description

Makes it much easier to differentiate between the list of dates in the items.
There's no need to show the activation time for registrations if the user has
already registered.

Besides, people prefer to use the event list on /events rather than the
one on the user profile to view upcoming events.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

Look at _Deloitte AS_ and _Fadderpåmelding Kommunikasjonsteknologi_ to see event items with 2 dates ... difficult to differentiate between the two:

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="1218" alt="image" src="https://github.com/user-attachments/assets/ae57d025-53c8-4507-a65e-216530c086b2" />
        </td>
        <td>
            <img width="1218" alt="image" src="https://github.com/user-attachments/assets/7498cc1b-47fa-4855-ba9f-fac282c052e4" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested all event types, and the three different registration statuses (unregistered, waiting list and registered/admitted)