### PR TITLE
Extend DatePicker to support ranges

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -281,6 +281,7 @@ steps:
       - install_cypress
       - ssr
     environment:
+      TZ: Europe/Oslo
       CYPRESS_API_BASE_URL: http://api:8000
       CYPRESS_RESET_DB_API: http://legocypresshelper:3030
       CYPRESS_BASE_URL: http://ssr:3000
@@ -362,4 +363,4 @@ image_pull_secrets:
 
 ---
 kind: signature
-hmac: 4edd037ec61390966e80949fd80f036651109310c03b4a9e3ea2708bb68b3549
+hmac: 67ad38a63b7569ba2bb1386bb795cbe780df789dff66e27467af0e3c5df2df36

--- a/app/components/Form/DatePicker.module.css
+++ b/app/components/Form/DatePicker.module.css
@@ -1,16 +1,21 @@
+@import url('~app/styles/variables.css');
+
 .calendar th,
 .calendar td {
   width: calc(100% / 7);
   text-align: center;
   font-size: var(--font-size-md);
-  padding: var(--spacing-xs);
   transition: background var(--easing-blazingly-fast);
+}
+
+.calendar td {
+  padding: var(--spacing-xs) 0;
 }
 
 .dropdown {
   width: auto;
   max-width: 335px;
-  padding: 0 var(--spacing-md) var(--spacing-sm);
+  padding: 0 var(--spacing-md) var(--spacing-md);
   z-index: 20;
 }
 
@@ -22,6 +27,7 @@
   font-size: var(--font-size-lg);
   padding: var(--spacing-sm);
   text-transform: capitalize;
+  text-align: center;
 }
 
 .calendarItem {
@@ -31,7 +37,7 @@
   color: var(--lego-font-color);
   text-align: center;
   font-size: var(--font-size-md);
-  padding: var(--spacing-xs);
+  padding: var(--spacing-sm);
   transition: background var(--easing-blazingly-fast);
 
   &:hover:not(.today, .selectedDate) {
@@ -52,4 +58,32 @@
 .today:not(.selectedDate) {
   color: var(--lego-font-color);
   background-color: var(--additive-background);
+}
+
+.rangeDropdown {
+  width: auto;
+  max-width: 600px;
+  padding: 0 var(--spacing-md) var(--spacing-md);
+  z-index: 20;
+
+  @media (--small-viewport) {
+    max-width: 315px;
+  }
+}
+
+.inRange:not(.selectedDate) {
+  background-color: var(--additive-background);
+  border-radius: 0;
+}
+
+/* First selected date */
+td:has(.selectedDate):has(+ td .inRange) .calendarItem {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+/* Last selected date */
+td:has(.inRange) + td:has(.selectedDate) .calendarItem {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }

--- a/app/components/Form/DatePicker.tsx
+++ b/app/components/Form/DatePicker.tsx
@@ -148,14 +148,16 @@ const DatePicker = ({
           ? moment(value[1])
           : selected.clone().endOf('day');
 
-      handleChange([
-        selected
-          .clone()
-          .hour(showTimePicker ? 0 : selected.hour())
-          .minute(showTimePicker ? 0 : selected.minute())
-          .toISOString(),
-        endTime.toISOString(),
-      ]);
+      const newStartTime = selected
+        .clone()
+        .hour(showTimePicker ? 0 : selected.hour())
+        .minute(showTimePicker ? 0 : selected.minute());
+
+      const newEndTime = selected.isAfter(endTime)
+        ? selected.clone().endOf('day')
+        : endTime;
+
+      handleChange([newStartTime.toISOString(), newEndTime.toISOString()]);
       setSelectingEnd(true);
     } else {
       const [start] = Array.isArray(value) ? value : [null];

--- a/app/components/Form/DatePicker.tsx
+++ b/app/components/Form/DatePicker.tsx
@@ -137,7 +137,9 @@ const DatePicker = ({
         .minute(parsedValue.minute());
       handleChange(value.toISOString());
       handleBlur(value.toISOString());
-      setPickerOpen(false);
+      if (!showTimePicker) {
+        setPickerOpen(false);
+      }
       return;
     }
 
@@ -184,7 +186,9 @@ const DatePicker = ({
           .toISOString(),
       ]);
       setSelectingEnd(false);
-      setPickerOpen(false);
+      if (!showTimePicker) {
+        setPickerOpen(false);
+      }
     }
   };
 

--- a/app/components/Form/DatePicker.tsx
+++ b/app/components/Form/DatePicker.tsx
@@ -105,7 +105,7 @@ const DatePicker = ({
     if (open) {
       onFocus();
     } else {
-      handleBlur();
+      handleBlur(value);
     }
   };
 

--- a/app/components/Form/TextInput.tsx
+++ b/app/components/Form/TextInput.tsx
@@ -3,12 +3,13 @@ import cx from 'classnames';
 import { useMemo, useRef, useState } from 'react';
 import { createField } from './Field';
 import styles from './TextInput.module.css';
-import type { RefObject, InputHTMLAttributes } from 'react';
+import type { RefObject, InputHTMLAttributes, ReactNode } from 'react';
 import type { Overwrite } from 'utility-types';
 
 type Props = {
   type?: string;
   prefix?: string;
+  prefixIconNode?: ReactNode;
   suffix?: string;
   className?: string;
   inputRef?: RefObject<HTMLInputElement>;
@@ -30,6 +31,7 @@ const TextInput = ({
   disabled,
   inputRef,
   prefix,
+  prefixIconNode,
   suffix,
   readOnly,
   placeholder,
@@ -56,18 +58,18 @@ const TextInput = ({
         styles.input,
         styles.textInput,
         disabled && styles.disabled,
-        !prefix && styles.spacing,
+        !(prefix || prefixIconNode) && styles.spacing,
         removeBorder && styles.removeBorder,
         centered && styles.centered,
         className,
       )}
     >
-      {prefix && (
+      {(prefix || prefixIconNode) && (
         <div
           onClick={() => ref.current && ref.current.focus()}
           className={styles.prefix}
         >
-          <Icon name={prefix} size={16} />
+          <Icon name={prefix} iconNode={prefixIconNode} size={16} />
         </div>
       )}
       <input

--- a/app/components/Form/TimePicker.tsx
+++ b/app/components/Form/TimePicker.tsx
@@ -5,6 +5,7 @@ import parseDateValue from 'app/utils/parseDateValue';
 import { createField } from './Field';
 import TextInput from './TextInput';
 import styles from './TimePicker.module.css';
+import type { Dateish } from 'app/models';
 import type { ComponentProps, KeyboardEvent, SyntheticEvent } from 'react';
 
 type TimePickerInputProps = ComponentProps<typeof TextInput> & {
@@ -44,8 +45,8 @@ const TimePickerInput = ({
 };
 
 type Props = {
-  value?: string;
-  onChange: (newValue: string) => void;
+  value?: Dateish;
+  onChange: (newValue: Dateish) => void;
 };
 
 const max = {

--- a/app/components/Table/Table.module.css
+++ b/app/components/Table/Table.module.css
@@ -8,6 +8,13 @@
   width: 100%;
 }
 
+.wrapper thead {
+  background-color: var(--color-gray-2);
+  color: var(--color-gray-7);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
 /* https://stackoverflow.com/questions/36575846/how-to-make-div-fill-td-height-in-firefox */
 .td {
   height: 1px;

--- a/app/models.ts
+++ b/app/models.ts
@@ -287,6 +287,7 @@ export type TransformEvent = EventBase & {
   hasFeedbackQuestion: boolean;
   responsibleUsers: PublicUser[];
   isForeignLanguage: boolean;
+  date: [Dateish, Dateish];
 };
 
 export type Workplace = {

--- a/app/routes/events/components/EventAdministrate/Statistics.tsx
+++ b/app/routes/events/components/EventAdministrate/Statistics.tsx
@@ -2,7 +2,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { fetchAllWithType } from 'app/actions/GroupActions';
-import DatePicker from 'app/components/Form/DatePicker';
+import { DatePicker } from 'app/components/Form';
 import { GroupType, type Dateish } from 'app/models';
 import EventAttendeeStatistics from 'app/routes/events/components/EventAttendeeStatistics';
 import styles from 'app/routes/events/components/EventAttendeeStatistics.module.css';
@@ -17,41 +17,32 @@ const Statistics = () => {
     [],
   );
 
-  const [viewStartTime, setViewStartTime] = useState<Dateish>(
-    '2021-01-01T00:00:00.000Z',
-  );
-  const [viewEndTime, setViewEndTime] = useState<Dateish>(moment());
+  const [dateRange, setDateRange] = useState<[Dateish, Dateish]>([
+    moment().subtract(1, 'month').toISOString(),
+    moment().toISOString(),
+  ]);
 
-  const updateViewStartDate = (date: string) => {
-    setViewStartTime(date);
-  };
-
-  const updateViewEndDate = (date: string) => {
-    setViewEndTime(date);
+  const updateDateRange = (selectedDate: [Dateish, Dateish]) => {
+    setDateRange(selectedDate);
   };
 
   return (
     <>
       <div className={styles.filterContainer}>
-        <label>Startdato for sidevisning</label>
+        <label>Velg periode</label>
         <DatePicker
-          value={viewStartTime as string}
-          onChange={updateViewStartDate}
-          onBlur={() => {}}
-          onFocus={() => {}}
-        />
-        <label>Sluttdato for sidevisning</label>
-        <DatePicker
-          value={viewEndTime as string}
-          onChange={updateViewEndDate}
+          range
+          value={dateRange}
+          onChange={updateDateRange}
+          showTimePicker={false}
           onBlur={() => {}}
           onFocus={() => {}}
         />
       </div>
 
       <EventAttendeeStatistics
-        viewStartTime={viewStartTime}
-        viewEndTime={viewEndTime}
+        viewStartTime={dateRange[0]}
+        viewEndTime={dateRange[1]}
       />
     </>
   );

--- a/app/routes/events/components/EventEditor/EditorSection/Details.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Details.tsx
@@ -66,16 +66,9 @@ const Details: React.FC<Props> = ({ values }) => {
       </Flex>
       <Flex className={styles.editorSectionRow}>
         <Field
-          label="Starter"
-          name="startTime"
-          component={DatePicker.Field}
-          fieldClassName={styles.metaField}
-          className={styles.formField}
-          required
-        />
-        <Field
-          label="Slutter"
-          name="endTime"
+          label="Dato"
+          name="date"
+          range
           component={DatePicker.Field}
           fieldClassName={styles.metaField}
           className={styles.formField}

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -35,6 +35,8 @@ import time from 'app/utils/time';
 import {
   conditionalValidation,
   createValidator,
+  dateRequired,
+  datesAreInCorrectOrder,
   isInteger,
   legoEditorRequired,
   maxSize,
@@ -42,7 +44,6 @@ import {
   minSize,
   required,
   requiredIf,
-  timeIsAfter,
   timeIsAtLeastDurationAfter,
   validYoutubeUrl,
 } from 'app/utils/validation';
@@ -108,8 +109,9 @@ const validate = createValidator({
   ],
   registrationDeadlineHours: [isInteger('Kun hele timer')],
   unregistrationDeadlineHours: [isInteger('Kun hele timer')],
-  endTime: [
-    timeIsAfter('startTime', 'Sluttidspunkt kan ikke være før starttidspunkt'),
+  date: [
+    dateRequired('Du må velge start- og sluttdato'),
+    datesAreInCorrectOrder('Sluttidspunkt kan ikke være før starttidspunkt'),
   ],
   mergeTime: [
     conditionalValidation(
@@ -245,6 +247,8 @@ const EventEditor = () => {
             value: user.id,
           })),
         isForeignLanguage: event.isForeignLanguage,
+        date: event.startTime &&
+          event.endTime && [event.startTime, event.endTime],
         eventType: event.eventType && {
           label: displayNameForEventType(event.eventType),
           value: event.eventType,
@@ -266,14 +270,16 @@ const EventEditor = () => {
       }
     : {
         title: '',
-        startTime: time({
-          hours: 17,
-          minutes: 15,
-        }),
-        endTime: time({
-          hours: 20,
-          minutes: 15,
-        }),
+        date: [
+          time({
+            hours: 17,
+            minutes: 15,
+          }),
+          time({
+            hours: 20,
+            minutes: 15,
+          }),
+        ],
         description: '',
         text: '',
         eventType: '',

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -231,8 +231,8 @@ const calculateMergeTime = (data) =>
 // Takes the full data-object and input and transforms the event to the API format.
 export const transformEvent = (data: TransformEvent) => ({
   ...pick(data, eventCreateAndUpdateFields),
-  startTime: moment(data.startTime).toISOString(),
-  endTime: moment(data.endTime).toISOString(),
+  startTime: moment(data.date[0]).toISOString(),
+  endTime: moment(data.date[1]).toISOString(),
   mergeTime: calculateMergeTime(data),
   company: data.company && data.company.value,
   eventStatusType: data.eventStatusType && data.eventStatusType.value,

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -49,13 +49,15 @@ import { spyValues } from 'app/utils/formSpyUtils';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';
 import {
   createValidator,
+  datesAreInCorrectOrder,
+  dateRequired,
   ifField,
   ifNotField,
   legoEditorRequired,
   required,
-  timeIsAfter,
 } from 'app/utils/validation';
 import type { EntityId } from '@reduxjs/toolkit';
+import type { Dateish } from 'app/models';
 import type { AutocompleteGroup } from 'app/store/models/Group';
 import type { DetailedMeeting } from 'app/store/models/Meeting';
 import type { AutocompleteUser } from 'app/store/models/User';
@@ -75,8 +77,7 @@ export type MeetingFormValues = {
   title?: string;
   report?: string;
   description?: string;
-  startTime?: string;
-  endTime?: string;
+  date?: [Dateish, Dateish];
   useMazemap: boolean;
   mazemapPoi?: { value: number; label: string };
   location?: string;
@@ -88,16 +89,15 @@ export type MeetingFormValues = {
 const validate = createValidator({
   title: [required('Du må gi møtet en tittel')],
   report: [legoEditorRequired('Referatet kan ikke være tomt')],
+  date: [
+    dateRequired('Du må velge start- og sluttdato'),
+    datesAreInCorrectOrder('Sluttidspunkt kan ikke være før starttidspunkt'),
+  ],
   location: [
     ifNotField('useMazemap', required('Sted eller Mazemap-rom er påkrevd')),
   ],
   mazemapPoi: [
     ifField('useMazemap', required('Sted eller Mazemap-rom er påkrevd')),
-  ],
-  startTime: [required('Du må velge starttidspunkt')],
-  endTime: [
-    required('Du må velge sluttidspunkt'),
-    timeIsAfter('startTime', 'Sluttidspunkt kan ikke være før starttidspunkt'),
   ],
 });
 
@@ -184,25 +184,33 @@ const MeetingEditor = () => {
       }))
     : [];
 
-  const onSubmit = (values) =>
-    dispatch(isEditPage ? editMeeting(values) : createMeeting(values)).then(
-      (result) => {
-        const id = meetingId || result.payload.result;
-        const { groups, users } = values;
+  const onSubmit = (values) => {
+    const formValues = {
+      ...values,
+      startTime: values.date[0],
+      endTime: values.date[1],
+    };
+    delete formValues.date;
 
-        if (groups || users) {
-          return dispatch(
-            inviteUsersAndGroups({
-              id,
-              users,
-              groups,
-            }),
-          ).then(() => navigate(`/meetings/${id}`));
-        }
+    return dispatch(
+      isEditPage ? editMeeting(formValues) : createMeeting(formValues),
+    ).then((result) => {
+      const id = meetingId || result.payload.result;
+      const { groups, users } = values;
 
-        navigate(`/meetings/${id}`);
-      },
-    );
+      if (groups || users) {
+        return dispatch(
+          inviteUsersAndGroups({
+            id,
+            users,
+            groups,
+          }),
+        ).then(() => navigate(`/meetings/${id}`));
+      }
+
+      navigate(`/meetings/${id}`);
+    });
+  };
 
   const onDeleteMeeting = isEditPage
     ? () =>
@@ -215,6 +223,7 @@ const MeetingEditor = () => {
   const initialValues = isEditPage
     ? {
         ...meeting,
+        date: [meeting.startTime, meeting.endTime],
         reportAuthor: reportAuthor && {
           id: reportAuthor.id,
           value: reportAuthor.username,
@@ -229,8 +238,7 @@ const MeetingEditor = () => {
         useMazemap: meeting.mazemapPoi !== undefined && meeting.mazemapPoi > 0,
       }
     : {
-        startTime: time(16, 15),
-        endTime: time(18),
+        date: [time(16, 15), time(18)],
         report: EDITOR_EMPTY,
         useMazemap: true,
       };
@@ -279,31 +287,23 @@ const MeetingEditor = () => {
                 <FormSpy subscription={{ values: true }}>
                   {({ values }) => (
                     <Field
-                      name="startTime"
-                      label="Starttidspunkt"
+                      name="date"
+                      label="Dato"
+                      range
                       component={DatePicker.Field}
-                      onBlur={(value: string) => {
-                        const startTime = moment(value);
-                        const endTime = moment(values.endTime);
+                      onBlur={(value: [Dateish, Dateish]) => {
+                        const startTime = moment(value[0]);
+                        const endTime = moment(values.date[1]);
                         if (endTime.isBefore(startTime)) {
-                          form.change(
-                            'endTime',
-                            startTime
-                              .clone()
-                              .add(2, 'hours')
-                              .set('minute', 0)
-                              .toISOString(),
-                          );
+                          form.change('date', [
+                            startTime,
+                            endTime.clone().add(2, 'hours').set('minute', 0),
+                          ]);
                         }
                       }}
                     />
                   )}
                 </FormSpy>
-                <Field
-                  name="endTime"
-                  label="Sluttidspunkt"
-                  component={DatePicker.Field}
-                />
               </div>
               <Field
                 label="Bruk mazemap"

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -96,13 +96,6 @@ table {
   border-collapse: collapse;
 }
 
-thead {
-  background-color: var(--color-gray-2);
-  color: var(--color-gray-7);
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-}
-
 th,
 td {
   padding: var(--spacing-sm);

--- a/app/utils/parseDateValue.ts
+++ b/app/utils/parseDateValue.ts
@@ -1,8 +1,9 @@
 import moment from 'moment-timezone';
 import config from 'app/config';
+import type { Dateish } from 'app/models';
 import type { Moment } from 'moment';
 
-const parseDateValue = (value?: string): Moment => {
+const parseDateValue = (value?: Dateish): Moment => {
   if (value) return moment(value).tz(config.timezone);
   return moment().tz(config.timezone);
 };

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -267,3 +267,32 @@ export function createValidator(
     return merge(fieldValidatorErrors, rawValidatorErrors);
   };
 }
+
+/* Used for DatePicker (supports both single date and range) */
+export const dateRequired =
+  (message = 'Du må velge dato') =>
+  (value) => {
+    if (!value) return [false, message] as const;
+
+    if (Array.isArray(value)) {
+      // Range validation
+      return [value.length === 2 && value[0] && value[1], message] as const;
+    }
+
+    // Single date validation
+    return [!!value, message] as const;
+  };
+
+/* Used for DatePicker (supports both single date and range) */
+export const datesAreInCorrectOrder =
+  (message = 'Sluttidspunkt kan ikke være før starttidspunkt') =>
+  (value) => {
+    const firstDate = moment(value[0]);
+    const secondDate = moment(value[1]);
+
+    if (firstDate.isAfter(secondDate)) {
+      return [false, message] as const;
+    }
+
+    return [true] as const;
+  };

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -7,6 +7,7 @@ import {
   selectFieldDropdown,
   selectEditor,
   setDatePickerDate,
+  setDatePickerTime,
   uploadHeader,
   NO_OPTIONS_MESSAGE,
 } from '../support/utils.js';
@@ -262,8 +263,10 @@ describe('Create event', () => {
     dateObject.setDate(dateObject.getDate() + 1);
     const tomorrowDay = dateObject.getDate();
 
-    setDatePickerDate('startTime', tomorrowDay, tomorrowDay < todayDay);
-    setDatePickerDate('endTime', tomorrowDay, tomorrowDay < todayDay);
+    setDatePickerDate('date', tomorrowDay, tomorrowDay < todayDay);
+
+    setDatePickerTime('date', '10', '00', false); // Start time
+    setDatePickerTime('date', '12', '00', true); // End time
 
     // Select regitrationType
     selectField('eventStatusType').click();

--- a/cypress/e2e/create_meeting_spec.js
+++ b/cypress/e2e/create_meeting_spec.js
@@ -27,12 +27,11 @@ describe('Create meeting', () => {
 
     // verify initial values are set
     field('useMazemap').should('be.checked');
-    field('startTime').should('not.have.value', '');
-    field('endTime').should('not.have.value', '');
+    field('date').should('not.have.value', '');
 
     cy.contains('button', 'Opprett møte').should('be.disabled');
     // change the meeting time to enable submit button
-    field('startTime').click();
+    field('date').click();
     cy.get(c('TimePicker-module__arrowUp')).first().click();
     cy.contains('Nytt møte').click(); // Click on something to close the datepicker
 
@@ -44,19 +43,19 @@ describe('Create meeting', () => {
     fieldError('report').should('be.visible');
     fieldError('mazemapPoi').should('be.visible');
 
-    fieldError('startTime').should('not.exist');
-    fieldError('endTime').should('not.exist');
+    fieldError('date').should('not.exist');
     fieldError('description').should('not.exist');
 
-    setDatePickerTime('endTime', '19', '30');
-    setDatePickerTime('startTime', '20', '00');
+    setDatePickerTime('date', '19', '30', false);
+    setDatePickerTime('date', '20', '00', true);
 
-    fieldError('endTime').should('not.exist');
-    field('endTime').should('contain.value', '22:00');
+    fieldError('date').should('not.exist');
+    field('date').should('contain.value', '19:30');
+    field('date').should('contain.value', '20:00');
 
-    setDatePickerTime('endTime', '20', '30');
+    setDatePickerTime('date', '20', '30', true);
 
-    fieldError('endTime').should('not.exist');
+    fieldError('date').should('not.exist');
 
     field('useMazemap').click();
 
@@ -86,8 +85,8 @@ describe('Create meeting', () => {
 
     field('title').type('Test meeting');
     selectEditor().type('Meeting plan');
-    setDatePickerTime('startTime', '10', '00');
-    setDatePickerTime('endTime', '13', '37');
+    setDatePickerTime('date', '10', '00', false);
+    setDatePickerTime('date', '13', '37', true);
     field('useMazemap').click();
     field('location').type('Test location');
     selectFromSelectField('users', 'bedkom bedkom (bedkom)', 'bedkom');
@@ -96,8 +95,7 @@ describe('Create meeting', () => {
 
     fieldError('title').should('not.exist');
     fieldError('report').should('not.exist');
-    fieldError('startTime').should('not.exist');
-    fieldError('endTime').should('not.exist');
+    fieldError('date').should('not.exist');
     fieldError('location').should('not.exist');
     fieldError('reportAuthor').should('not.exist');
     fieldError('users').should('not.exist');
@@ -180,13 +178,11 @@ describe('Create meeting', () => {
 
     field('title').should('have.value', meeting.title);
     selectEditor().should('contain', meeting.report.replaceAll(/<.*?>/g, ''));
-    field('startTime').should(
+    field('date').should(
       'have.value',
-      moment(meeting.startTime).tz(config.timezone).format('lll'),
-    );
-    field('endTime').should(
-      'have.value',
-      moment(meeting.endTime).tz(config.timezone).format('lll'),
+      moment(meeting.startTime).format('lll') +
+        ' - ' +
+        moment(meeting.endTime).format('lll'),
     );
     field('description').should('have.value', meeting.description);
     field('location').should('have.value', meeting.location);
@@ -200,8 +196,8 @@ describe('Create meeting', () => {
     ).should('be.visible');
     cy.get(t('Modal__closeButton')).click();
 
-    setDatePickerTime('startTime', '17', '15');
-    setDatePickerTime('endTime', '20', '00');
+    setDatePickerTime('date', '17', '15', false);
+    setDatePickerTime('date', '20', '00', true);
     field('useMazemap').click();
     selectFromSelectField('mazemapPoi', 'Abakus, Realfagbygget', 'abakus');
     selectFromSelectField('users', 'bedkom bedkom (bedkom)', 'bedkom');
@@ -211,8 +207,7 @@ describe('Create meeting', () => {
 
     fieldError('title').should('not.exist');
     fieldError('report').should('not.exist');
-    fieldError('startTime').should('not.exist');
-    fieldError('endTime').should('not.exist');
+    fieldError('date').should('not.exist');
     fieldError('location').should('not.exist');
     fieldError('reportAuthor').should('not.exist');
     fieldError('users').should('not.exist');

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -53,16 +53,28 @@ export const selectEditor = (name, options = {}) =>
         .click()
     : cy.get('div[data-slate-editor="true"]', options).click().click();
 
-const selectDatePickerHours = () =>
-  cy.get(c('TimePicker-module__timePickerInput')).first().find('input');
-
-const selectDatePickerMinutes = () =>
-  cy.get(c('TimePicker-module__timePickerInput')).last().find('input');
-
-export const setDatePickerTime = (name, hours, minutes) => {
+export const setDatePickerTime = (name, hours, minutes, isEndTime = false) => {
   field(name).click();
-  selectDatePickerHours().click().clear().type(hours);
-  selectDatePickerMinutes().click().clear().type(minutes);
+
+  const timePickers = cy.get(c('TimePicker-module__timePicker'));
+  const timePickerIndex = isEndTime ? 3 : 0;
+  timePickers.eq(timePickerIndex).within(() => {
+    cy.get(c('timePickerInput'))
+      .first()
+      .find('input')
+      .click()
+      .clear()
+      .type(hours);
+
+    cy.get(c('timePickerInput'))
+      .last()
+      .find('input')
+      .click()
+      .clear()
+      .type(minutes);
+  });
+
+  // Click outside to close picker
   field(name).click();
 };
 
@@ -79,6 +91,8 @@ export const setDatePickerDate = (name, date, isNextMonth = false) => {
   cy.get('button:not(:disabled):not([class*="prevOrNextMonth"])')
     .contains(new RegExp('^' + date + '$', 'g'))
     .click();
+
+  field(name).click();
 };
 
 // Used to either confirm or deny the 3D secure pop-up from Stripe.


### PR DESCRIPTION
# Description

Better than having to use two separate date pickers to simulate it. The plan is to use this to filter on events on /events.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

Notice how the regular dropdown does not update which month is shown as default according to the value it is given (unlike the new range version 😎):

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="1079" alt="image" src="https://github.com/user-attachments/assets/9c8876ea-fb06-4938-8934-b7f222d4afd7" />
        </td>
        <td>
            <img width="1079" alt="image" src="https://github.com/user-attachments/assets/0c5da69c-4f6a-4ed9-9924-9a7d8f16f214" />
        </td>
    </tr>
    <tr>
        <td>
            <img width="1079" alt="image" src="https://github.com/user-attachments/assets/fa45fa1c-bac1-4f45-b8db-dba9288ad183" />
        </td>
        <td>
            <img width="1079" alt="image" src="https://github.com/user-attachments/assets/8bb7f674-38bd-490d-b2da-741f8482a213" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.
- Tested when start date and end date are the same days (but different times of the day)
- Tested as both fields and regular components (see images above)
- Tested that changes to global table styles does not affect the Table component
- Tested that it looks good on smaller viewports:
	<img width="250" alt="image" src="https://github.com/user-attachments/assets/381e5574-d393-4169-982b-e1c682e0d3a5" />

- Tested that the regular date picker still works :)