### PR TITLE
Improve look of toasts on smaller viewports

### DIFF
--- a/app/components/Toast/Toast.module.css
+++ b/app/components/Toast/Toast.module.css
@@ -15,10 +15,10 @@
   gap: var(--spacing-sm);
 
   @media (--mobile-device) {
-    bottom: 0;
-    left: 0;
-    right: 0;
-    gap: 0;
+    bottom: var(--spacing-sm);
+    left: var(--spacing-sm);
+    right: var(--spacing-sm);
+    gap: var(--spacing-sm);
   }
 }
 
@@ -37,8 +37,6 @@
 
   @media (--mobile-device) {
     width: 100%;
-    border-radius: 0;
-    border: none;
   }
 
   &[data-animation='entering'] {


### PR DESCRIPTION
# Description

Not a fan of the lack of spacings

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="" src="https://github.com/user-attachments/assets/ca9b2aaa-cae6-4f24-9084-34971a5064b7" />
        </td>
        <td>
            <img width="" src="https://github.com/user-attachments/assets/61bb1797-9cf0-4aa7-8cd3-2086c394a56a" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested on my iPhone (see images above)

---

Resolves ABA-1199