### PR TITLE
Only validate payment deadline if event is priced

### DIFF
--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -87,10 +87,15 @@ const validate = createValidator({
     ),
   ],
   paymentDueDate: [
-    timeIsAtLeastDurationAfter(
-      'unregistrationDeadline',
-      moment.duration(1, 'day'),
-      'Betalingsfristen må være minst 24 timer etter avregistreringsfristen',
+    conditionalValidation(
+      (allValues) => allValues.isPriced,
+      () => [
+        timeIsAtLeastDurationAfter(
+          'unregistrationDeadline',
+          moment.duration(1, 'day'),
+          'Betalingsfristen må være minst 24 timer etter avregistreringsfristen',
+        ),
+      ],
     ),
   ],
   isClarified: [


### PR DESCRIPTION
# Description

The date of the payment deadline was validated even though the event was not priced. As such, the warning that the date had to be changed was not shown, even though the event was not correctly validated if the unregistration deadline was later than a week after the creation date of the event (which is the default value for the payment deadline it seems).

Now the validation is only applied if isPriced is true.

# Result

Werks as expected.

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1211
