### PR TITLE
Improve and fix navigation tabs on smaller viewports

### DIFF
--- a/packages/lego-bricks/src/components/Tabs/TabContainer.module.css
+++ b/packages/lego-bricks/src/components/Tabs/TabContainer.module.css
@@ -2,23 +2,101 @@
   margin: var(--spacing-sm) 0 var(--spacing-md);
   position: relative;
   display: flex;
-  flex-wrap: wrap;
+  width: 100%;
+  overflow: hidden;
 }
 
 .tabList {
-  display: flex;
+  display: inline-flex;
   position: relative;
   border-bottom: 2px solid var(--border-gray);
   width: 100%;
+  overflow-x: auto;
+  white-space: nowrap;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+}
+
+.tabList::-webkit-scrollbar {
+  display: none;
+}
+
+.scrollButton {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  opacity: 0;
+  transition: opacity var(--easing-medium);
+
+  svg {
+    color: var(--secondary-font-color);
+    width: var(--font-size-md);
+    height: var(--font-size-md);
+  }
+}
+
+.scrollButton.left {
+  left: calc(-1 * var(--spacing-sm));
+}
+
+.scrollButton.right {
+  right: calc(-1 * var(--spacing-sm));
+}
+
+.container.showLeftShadow .scrollButton.left,
+.container.showRightShadow .scrollButton.right {
+  opacity: 1;
 }
 
 .indicator {
   position: absolute;
-  bottom: -2px;
+  bottom: 0;
   left: 0;
-  height: 2px;
+  height: 3px;
+  border-top-left-radius: var(--spacing-xs);
+  border-top-right-radius: var(--spacing-xs);
   background-color: var(--color-black);
   transition:
     transform var(--easing-medium),
     width var(--easing-medium);
+}
+
+.container::before,
+.container::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 2px;
+  width: 40px;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity var(--easing-medium);
+}
+
+.container::before {
+  left: 0;
+  background: linear-gradient(to right, var(--lego-card-color), transparent);
+}
+
+.container::after {
+  right: 0;
+  background: linear-gradient(to left, var(--lego-card-color), transparent);
+}
+
+.container.showLeftShadow::before {
+  opacity: 1;
+}
+
+.container.showRightShadow::after {
+  opacity: 1;
 }

--- a/packages/lego-bricks/src/components/Tabs/TabContainer.tsx
+++ b/packages/lego-bricks/src/components/Tabs/TabContainer.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames';
-import { useEffect, useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useEffect, useState, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import styles from './TabContainer.module.css';
 import type { ReactNode } from 'react';
@@ -12,7 +13,32 @@ type Props = {
 
 export const TabContainer = ({ className, lineColor, children }: Props) => {
   const [indicatorStyle, setIndicatorStyle] = useState<React.CSSProperties>({});
+  const [showLeftShadow, setShowLeftShadow] = useState(false);
+  const [showRightShadow, setShowRightShadow] = useState(false);
+  const tabListRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
+
+  const checkScroll = () => {
+    const element = tabListRef.current;
+    if (element) {
+      setShowLeftShadow(element.scrollLeft > 0);
+      setShowRightShadow(
+        Math.ceil(element.scrollLeft) <
+          element.scrollWidth - element.clientWidth - 1,
+      );
+    }
+  };
+
+  const handleScroll = (direction: 'left' | 'right') => {
+    const element = tabListRef.current;
+    if (element) {
+      const scrollAmount = element.clientWidth * 0.8;
+      element.scrollBy({
+        left: direction === 'left' ? -scrollAmount : scrollAmount,
+        behavior: 'smooth',
+      });
+    }
+  };
 
   useEffect(() => {
     const activeTab = document.querySelector('[data-active="true"]');
@@ -23,15 +49,62 @@ export const TabContainer = ({ className, lineColor, children }: Props) => {
         width: `${width}px`,
         transform: `translateX(${left}px)`,
       });
+
+      // Scroll into view
+      activeTab.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'nearest',
+      });
     }
+    checkScroll();
   }, [children, location.pathname]);
 
+  useEffect(() => {
+    const element = tabListRef.current;
+    if (element) {
+      element.addEventListener('scroll', checkScroll);
+      window.addEventListener('resize', checkScroll);
+      checkScroll();
+    }
+
+    return () => {
+      element?.removeEventListener('scroll', checkScroll);
+      window.removeEventListener('resize', checkScroll);
+    };
+  }, []);
+
   return (
-    <div className={cx(styles.container, className)}>
-      <div className={styles.tabList} style={{ borderColor: lineColor }}>
+    <div
+      className={cx(
+        styles.container,
+        className,
+        showLeftShadow && styles.showLeftShadow,
+        showRightShadow && styles.showRightShadow,
+      )}
+    >
+      <button
+        className={cx(styles.scrollButton, styles.left)}
+        onClick={() => handleScroll('left')}
+        aria-label="Scroll left"
+      >
+        <ChevronLeft />
+      </button>
+      <div
+        ref={tabListRef}
+        className={styles.tabList}
+        style={{ borderColor: lineColor }}
+      >
         {children}
         <div className={styles.indicator} style={indicatorStyle} />
       </div>
+      <button
+        className={cx(styles.scrollButton, styles.right)}
+        onClick={() => handleScroll('right')}
+        aria-label="Scroll right"
+      >
+        <ChevronRight />
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
# Description

The tabs now overflow nicely, with both a fade and arrow to indicate the scroll behaviour.

The tabs are now also scrolled into view if clicked on.

# Result

- [x] Changes look good on both light and dark theme.
- [yes] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Same as before when all tabs fit into view
        </td>
        <td>
            <img width="668" alt="image" src="https://github.com/user-attachments/assets/64e2ddc4-f904-4c47-a532-7571ede64ff3" />
        </td>
        <td>
            <img width="668" alt="image" src="https://github.com/user-attachments/assets/891bc6e3-68d2-4520-bf87-008cb8bc209f" />
        </td>
    </tr>
    <tr>
        <td>
            At the beginning
        </td>
        <td>
            <img width="509" alt="image" src="https://github.com/user-attachments/assets/8288408f-7fcc-4611-8c5d-8b4c4dea51fe" />
        </td>
        <td>
            <img width="509" alt="image" src="https://github.com/user-attachments/assets/deb72c2d-5b44-40e7-b307-b140abdab439" />
        </td>
    </tr>
    <tr>
        <td>
            At the end
        </td>
        <td>
            <img width="509" alt="image" src="https://github.com/user-attachments/assets/8288408f-7fcc-4611-8c5d-8b4c4dea51fe" />
        </td>
        <td>
        	<img width="509" alt="image" src="https://github.com/user-attachments/assets/7e8b6d13-3da9-403f-91f2-53c7f8150139" />
        </td>
    </tr>
</table>

https://github.com/user-attachments/assets/18876979-2987-4056-894c-0bfb338a5c7c

# Testing

- [x] I have thoroughly tested my changes.

Tested quite extensively on smaller views. A lot of edge cases have been tested, e.g. that arrows and shadows disappear when they should etc.