### PR TITLE
Support date range filtering on events

### DIFF
--- a/app/components/Form/ToggleSwitch.tsx
+++ b/app/components/Form/ToggleSwitch.tsx
@@ -3,22 +3,15 @@ import cx from 'classnames';
 import { ToggleButton } from 'react-aria-components';
 import { createField } from './Field';
 import styles from './ToggleSwitch.module.css';
-import type { ComponentProps, InputHTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 import type { ToggleButtonProps } from 'react-aria-components';
-import type { Overwrite } from 'utility-types';
 
 type Props = {
   className?: string;
   value?: string | boolean;
   name?: string;
   checked?: boolean;
-} & ToggleButtonProps &
-  Overwrite<
-    InputHTMLAttributes<HTMLInputElement>,
-    {
-      onChange?: ToggleButtonProps['onChange'];
-    }
-  >;
+} & ToggleButtonProps;
 
 const ToggleSwitch = ({
   id,
@@ -26,7 +19,6 @@ const ToggleSwitch = ({
   value,
   checked,
   className,
-  isDisabled,
   onChange,
   ...props
 }: Props) => {
@@ -45,7 +37,6 @@ const ToggleSwitch = ({
       <ToggleButton
         {...props}
         id={id}
-        isDisabled={isDisabled}
         isSelected={isSelected}
         onChange={onChange}
         className={cx(styles.toggleSwitch, className)}

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -97,13 +97,19 @@ const EventList = () => {
 
   const fetchQuery = {
     date_after:
-      query.showPrevious === 'true'
+      query.from ||
+      (query.showPrevious === 'true'
         ? previousStart.format('YYYY-MM-DD')
-        : moment().format('YYYY-MM-DD'),
+        : moment().format('YYYY-MM-DD')),
     date_before:
-      query.showPrevious === 'true' ? moment().format('YYYY-MM-DD') : undefined,
+      query.to ||
+      (query.showPrevious === 'true'
+        ? moment().format('YYYY-MM-DD')
+        : undefined),
     ordering: query.showPrevious === 'true' ? '-start_time' : 'start_time',
   };
+
+  console.log(fetchQuery);
 
   const { pagination } = useAppSelector(
     selectPaginationNext({
@@ -137,10 +143,19 @@ const EventList = () => {
           query: fetchQuery,
         }),
       ),
-    [loggedIn, query.showPrevious],
+    [loggedIn, query.from, query.to, query.showPrevious],
   );
 
   const fetchMore = () => {
+    if (query.from || query.to) {
+      return dispatch(
+        fetchEvents({
+          query: fetchQuery,
+          next: true,
+        }),
+      );
+    }
+
     if (query.showPrevious === 'true') {
       const newStart = previousStart.clone().subtract(1, 'month');
       setPreviousStart(newStart);
@@ -194,11 +209,6 @@ const EventList = () => {
     }
   };
 
-  const filterPreviousEvents = (event: ListEvent) =>
-    query.showPrevious === 'true'
-      ? moment(event[field]).isBefore(moment())
-      : true;
-
   useEffect(() => {
     if (!pagination.fetching && events.length > 0) {
       setPreviousEvents(events);
@@ -213,8 +223,7 @@ const EventList = () => {
             index === self.findIndex((e) => e.id === event.id),
         )
         .filter(filterRegDateFunc)
-        .filter(filterEventTypesFunc)
-        .filter(filterPreviousEvents),
+        .filter(filterEventTypesFunc),
       field,
       query.showPrevious === 'true' ? 'desc' : 'asc',
     ),
@@ -261,7 +270,8 @@ const EventList = () => {
           header="Her var det tomt ..."
           body={
             <>
-              Ingen arrangementer {totalCount > 0 && 'som matcher ditt filter'}{' '}
+              Ingen arrangementer{' '}
+              {totalCount > 0 || (!isEmpty(query) && 'som matcher ditt filter')}{' '}
               ligger
               {totalCount === 0 && ' for øyeblikket'} ute
               {totalCount > 0 && (
@@ -275,7 +285,7 @@ const EventList = () => {
           className={joblistingListStyles.emptyState}
         />
       )}
-      {(query.showPrevious === 'true'
+      {(query.showPrevious === 'true' && (!query.from || !query.to)
         ? previousPagination.hasMore
         : pagination.hasMore) && (
         <Button

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -109,8 +109,6 @@ const EventList = () => {
     ordering: query.showPrevious === 'true' ? '-start_time' : 'start_time',
   };
 
-  console.log(fetchQuery);
-
   const { pagination } = useAppSelector(
     selectPaginationNext({
       entity: EntityType.Events,
@@ -276,7 +274,7 @@ const EventList = () => {
               {totalCount === 0 && ' for øyeblikket'} ute
               {totalCount > 0 && (
                 <Button flat onPress={clearQueryParams}>
-                  <Icon iconNode={<FilterX />} size={22} />
+                  <Icon iconNode={<FilterX />} size={19} />
                   Tøm filter
                 </Button>
               )}

--- a/app/routes/events/components/EventsOverview.tsx
+++ b/app/routes/events/components/EventsOverview.tsx
@@ -123,20 +123,24 @@ const EventsOverview = () => {
                       showTimePicker={false}
                       onChange={(value) => {
                         if (!Array.isArray(value)) return;
-
                         const [from, to] = value;
-
                         const updates: Partial<typeof eventListDefaultQuery> =
                           {};
 
-                        if (from) {
+                        if (from && from !== '') {
                           updates.from = moment(from).format('YYYY-MM-DD');
                           updates.showPrevious = moment(from).isBefore(moment())
                             ? 'true'
                             : 'false';
+                        } else {
+                          updates.from = '';
+                          updates.showPrevious = 'false';
                         }
-                        if (to) {
+
+                        if (to && to !== '') {
                           updates.to = moment(to).format('YYYY-MM-DD');
+                        } else {
+                          updates.to = '';
                         }
 
                         setQueryValues(updates);

--- a/app/routes/events/components/EventsOverview.tsx
+++ b/app/routes/events/components/EventsOverview.tsx
@@ -109,6 +109,7 @@ const EventsOverview = () => {
                     <ToggleSwitch
                       id="showPrevious"
                       checked={query.showPrevious === 'true'}
+                      isDisabled={query.from !== ''}
                       onChange={(checked) =>
                         setQueryValue('showPrevious')(
                           checked ? 'true' : 'false',

--- a/app/routes/events/components/EventsOverview.tsx
+++ b/app/routes/events/components/EventsOverview.tsx
@@ -6,7 +6,7 @@ import {
 } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
 import { Outlet, useLocation } from 'react-router-dom';
-import { CheckBox, RadioButton } from 'app/components/Form';
+import { CheckBox, DatePicker, RadioButton } from 'app/components/Form';
 import ToggleSwitch from 'app/components/Form/ToggleSwitch';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 import { EventTime } from 'app/models';
@@ -19,9 +19,11 @@ type FilterEventType = 'company_presentation' | 'course' | 'social' | 'other';
 type FilterRegistrationsType = 'all' | 'open' | 'future';
 
 export const eventListDefaultQuery = {
+  showPrevious: '' as '' | 'true' | 'false',
+  from: '',
+  to: '',
   eventTypes: [] as FilterEventType[],
   registrations: 'all' as FilterRegistrationsType,
-  showPrevious: '' as '' | 'true' | 'false',
 };
 
 type Option = {
@@ -70,7 +72,9 @@ const EventsOverview = () => {
   const location = useLocation();
   const showFilters = location.pathname === '/events';
 
-  const { query, setQueryValue } = useQuery(eventListDefaultQuery);
+  const { query, setQueryValue, setQueryValues } = useQuery(
+    eventListDefaultQuery,
+  );
 
   const showCourse = query.eventTypes.includes('course');
   const showSocial = query.eventTypes.includes('social');
@@ -110,6 +114,35 @@ const EventsOverview = () => {
                           checked ? 'true' : 'false',
                         )
                       }
+                    />
+                  </FilterSection>
+                  <FilterSection title="Periode">
+                    <DatePicker
+                      range
+                      value={[query.from, query.to]}
+                      showTimePicker={false}
+                      onChange={(value) => {
+                        if (!Array.isArray(value)) return;
+
+                        const [from, to] = value;
+
+                        const updates: Partial<typeof eventListDefaultQuery> =
+                          {};
+
+                        if (from) {
+                          updates.from = moment(from).format('YYYY-MM-DD');
+                          updates.showPrevious = moment(from).isBefore(moment())
+                            ? 'true'
+                            : 'false';
+                        }
+                        if (to) {
+                          updates.to = moment(to).format('YYYY-MM-DD');
+                        }
+
+                        setQueryValues(updates);
+                      }}
+                      onBlur={() => {}}
+                      onFocus={() => {}}
                     />
                   </FilterSection>
                   <FilterSection title="Arrangementstype">

--- a/app/utils/parseDateValue.ts
+++ b/app/utils/parseDateValue.ts
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
 import config from 'app/config';
 import type { Dateish } from 'app/models';
-import type { Moment } from 'moment';
+import type { Moment } from 'moment-timezone';
 
 const parseDateValue = (value?: Dateish): Moment => {
   if (value) return moment(value).tz(config.timezone);

--- a/app/utils/useQuery.ts
+++ b/app/utils/useQuery.ts
@@ -74,10 +74,18 @@ const useQuery = <Values extends ParsedQs>(defaultValues: Values) => {
       });
     };
 
+  const setQueryValues = (updates: Partial<Values>) => {
+    setQuery({
+      ...query,
+      ...updates,
+    });
+  };
+
   return {
     query,
     setQuery,
     setQueryValue,
+    setQueryValues,
   };
 };
 

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -264,8 +264,9 @@ describe('Create event', () => {
     const tomorrowDay = dateObject.getDate();
 
     setDatePickerDate('date', tomorrowDay, tomorrowDay < todayDay);
-
     setDatePickerTime('date', '10', '00', false); // Start time
+
+    setDatePickerDate('date', tomorrowDay, tomorrowDay < todayDay);
     setDatePickerTime('date', '12', '00', true); // End time
 
     // Select regitrationType

--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -263,10 +263,12 @@ describe('Create event', () => {
     dateObject.setDate(dateObject.getDate() + 1);
     const tomorrowDay = dateObject.getDate();
 
+    // Clicking three times to first clear the date then set both start and end to tomorrow
     setDatePickerDate('date', tomorrowDay, tomorrowDay < todayDay);
-    setDatePickerTime('date', '10', '00', false); // Start time
+    setDatePickerDate('date', tomorrowDay, tomorrowDay < todayDay);
+    setDatePickerDate('date', tomorrowDay, tomorrowDay < todayDay);
 
-    setDatePickerDate('date', tomorrowDay, tomorrowDay < todayDay);
+    setDatePickerTime('date', '10', '00', false); // Start time
     setDatePickerTime('date', '12', '00', true); // End time
 
     // Select regitrationType

--- a/cypress/e2e/joblistings_specs.js
+++ b/cypress/e2e/joblistings_specs.js
@@ -44,6 +44,7 @@ describe('Create joblisting', () => {
     const description = 'A joblisting description';
     const text = 'Joblisting text';
     selectEditor('description').type(description);
+    cy.wait(500);
     selectEditor('text').type(text);
 
     selectEditor('description', { timeout: 2000 }).should(


### PR DESCRIPTION
# Description

Highly requested and very useful!

Had to make some changes to the date picker and query hook.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/71843fac-5909-4db8-b1c1-5601d5e7a068" />

# Testing

- [x] I have thoroughly tested my changes.

Tested on hard refreshes, many different date ranges, together with the `query.showPrevious` and the "Load more" button.