### PR TITLE
Add semester arrows to BDB

### DIFF
--- a/app/routes/bdb/components/BdbPage.tsx
+++ b/app/routes/bdb/components/BdbPage.tsx
@@ -176,20 +176,19 @@ const BdbPage = () => {
       </Card>
 
       <Flex width="fit-content">
-        <button
-          onClick={() =>
+        <Icon
+          iconNode={<ChevronLeft />}
+          onPress={() =>
             setQuery({
               ...query,
               semester: getSemesterSlugOffset(
                 currentCompanySemester!.id,
                 companySemesters,
-                -1,
+                'previous',
               ),
             })
           }
-        >
-          <Icon iconNode={<ChevronLeft />} />
-        </button>
+        />
         <SelectInput
           name="semester"
           options={companySemesters
@@ -219,20 +218,19 @@ const BdbPage = () => {
             })
           }
         />
-        <button
-          onClick={() =>
+        <Icon
+          iconNode={<ChevronRight />}
+          onPress={() =>
             setQuery({
               ...query,
               semester: getSemesterSlugOffset(
                 currentCompanySemester!.id,
                 companySemesters,
-                1,
+                'next',
               ),
             })
           }
-        >
-          <Icon iconNode={<ChevronRight />} />
-        </button>
+        />
       </Flex>
 
       <Table

--- a/app/routes/bdb/components/BdbPage.tsx
+++ b/app/routes/bdb/components/BdbPage.tsx
@@ -1,5 +1,6 @@
-import { Card, Flex } from '@webkom/lego-bricks';
+import { Card, Flex, Icon } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchAllAdmin, fetchSemesters } from 'app/actions/CompanyActions';
@@ -16,6 +17,7 @@ import {
   getClosestCompanySemester,
   getCompanySemesterBySlug,
   getSemesterSlugById,
+  getSemesterSlugOffset,
   getSemesterStatus,
   semesterToHumanReadable,
 } from '../utils';
@@ -174,6 +176,20 @@ const BdbPage = () => {
       </Card>
 
       <Flex width="fit-content">
+        <button
+          onClick={() =>
+            setQuery({
+              ...query,
+              semester: getSemesterSlugOffset(
+                currentCompanySemester!.id,
+                companySemesters,
+                -1,
+              ),
+            })
+          }
+        >
+          <Icon iconNode={<ChevronLeft />} />
+        </button>
         <SelectInput
           name="semester"
           options={companySemesters
@@ -203,6 +219,20 @@ const BdbPage = () => {
             })
           }
         />
+        <button
+          onClick={() =>
+            setQuery({
+              ...query,
+              semester: getSemesterSlugOffset(
+                currentCompanySemester!.id,
+                companySemesters,
+                1,
+              ),
+            })
+          }
+        >
+          <Icon iconNode={<ChevronRight />} />
+        </button>
       </Flex>
 
       <Table

--- a/app/routes/bdb/utils.tsx
+++ b/app/routes/bdb/utils.tsx
@@ -158,6 +158,18 @@ export const getSemesterSlugById = (
   return `${semester.year}${semester.semester === 'autumn' ? 'h' : 'v'}`;
 };
 
+export const getSemesterSlugOffset = (
+  id: EntityId,
+  companySemesters: CompanySemester[],
+  offset: number,
+) => {
+  return getSemesterSlugById(
+    companySemesters.find((semester) => semester.id === (id as number) + offset)
+      ?.id as number,
+    companySemesters,
+  );
+};
+
 export const httpCheck = (link: string) => {
   const httpLink =
     link.startsWith('http://') || link.startsWith('https://')

--- a/app/routes/bdb/utils.tsx
+++ b/app/routes/bdb/utils.tsx
@@ -161,11 +161,13 @@ export const getSemesterSlugById = (
 export const getSemesterSlugOffset = (
   id: EntityId,
   companySemesters: CompanySemester[],
-  offset: number,
+  offset: 'previous' | 'next',
 ) => {
   return getSemesterSlugById(
-    companySemesters.find((semester) => semester.id === (id as number) + offset)
-      ?.id as number,
+    companySemesters.find(
+      (semester) =>
+        semester.id === (id as number) + (offset === 'previous' ? -1 : 1),
+    )?.id as number,
     companySemesters,
   );
 };


### PR DESCRIPTION
# Description

Adds arrows to each side of the semester dropdown in BDB to easily go to the next/previous semester.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/user-attachments/assets/31cc1518-41dd-4d8b-b058-72793c9f9540

# Testing

- [x] I have thoroughly tested my changes.

Open BDB and verify that the semester arrows work correctly.

---

Resolves [ABA-1048](https://linear.app/abakus-webkom/issue/ABA-1216/add-semester-navigation-buttons)
