### PR TITLE
Introduce a collapsableAfter prop to the table component

### DIFF
--- a/app/components/Table/BodyCell.tsx
+++ b/app/components/Table/BodyCell.tsx
@@ -1,15 +1,21 @@
 import { get } from 'lodash';
 import styles from './Table.module.css';
-import type { ColumnProps, ShowColumn, TableData } from '.';
+import type { ColumnProps, ShowColumn } from '.';
+import type { EntityId } from '@reduxjs/toolkit';
 
-type CellProps = {
-  column: ColumnProps;
-  data: TableData;
+type CellProps<T> = {
+  column: ColumnProps<T>;
+  data: T;
   index: number;
   showColumn: ShowColumn;
 };
 
-const BodyCell: React.FC<CellProps> = ({ column, data, index, showColumn }) => {
+const BodyCell = <T extends { id: EntityId }>({
+  column,
+  data,
+  index,
+  showColumn,
+}: CellProps<T>) => {
   if (column.columnChoices) {
     if (Object.keys(showColumn).length === 0) {
       return null;

--- a/app/components/Table/HeadCell.tsx
+++ b/app/components/Table/HeadCell.tsx
@@ -12,9 +12,10 @@ import Dropdown from 'app/components/Dropdown';
 import { TextInput, RadioButton, CheckBox } from 'app/components/Form';
 import styles from './Table.module.css';
 import type { ColumnProps, Filters, IsShown, ShowColumn, Sort } from '.';
+import type { EntityId } from '@reduxjs/toolkit';
 
-type HeadCellProps = {
-  column: ColumnProps;
+type HeadCellProps<T> = {
+  column: ColumnProps<T>;
   index: number;
   sort: Sort;
   filters: Filters;
@@ -26,7 +27,7 @@ type HeadCellProps = {
   setShowColumn: React.Dispatch<React.SetStateAction<ShowColumn>>;
 };
 
-const HeadCell: React.FC<HeadCellProps> = ({
+const HeadCell = <T extends { id: EntityId }>({
   column,
   index,
   sort,
@@ -37,7 +38,7 @@ const HeadCell: React.FC<HeadCellProps> = ({
   setFilters,
   setIsShown,
   setShowColumn,
-}) => {
+}: HeadCellProps<T>) => {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const onSortInput = (dataIndex: any, sorter: any) => {

--- a/app/components/Table/Table.module.css
+++ b/app/components/Table/Table.module.css
@@ -2,6 +2,27 @@
 
 .wrapper {
   overflow-x: auto;
+  width: 100%;
+  position: relative;
+}
+
+.tableContainer {
+  width: 100%;
+  position: relative;
+}
+
+.fadeOverlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 100px;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    var(--lego-card-color) 90%
+  );
+  pointer-events: none;
 }
 
 .wrapper table {

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -1,5 +1,7 @@
+import { Button, Flex, Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { debounce, isEmpty, get } from 'lodash';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroller';
 import BodyCell from './BodyCell';
@@ -55,6 +57,7 @@ type TableProps<T extends { id: EntityId }> = {
   rowKey?: string;
   columns: ColumnProps<T>[];
   data: T[];
+  collapseAfter?: number;
   hasMore: boolean;
   loading: boolean;
   onChange?: (queryFilters: QueryFilters, querySort: Sort) => void;
@@ -94,6 +97,7 @@ const Table = <T extends { id: EntityId }>({
   className,
   onChange,
   onLoad,
+  collapseAfter,
   ...props
 }: TableProps<T>) => {
   const [sort, setSort] = useState<Sort>({});
@@ -102,6 +106,7 @@ const Table = <T extends { id: EntityId }>({
   );
   const [isShown, setIsShown] = useState<IsShown>({});
   const [showColumn, setShowColumn] = useState<ShowColumn>({});
+  const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
     const initialShowColumn = {};
@@ -180,60 +185,87 @@ const Table = <T extends { id: EntityId }>({
 
   const visibleColumns = columns.filter(isVisible);
 
+  const filteredAndSortedData = sortedData.filter(filter);
+  const displayData =
+    collapseAfter && !isExpanded
+      ? filteredAndSortedData.slice(0, collapseAfter)
+      : filteredAndSortedData;
+
   return (
-    <div className={cx(styles.wrapper, className)}>
-      <table>
-        <thead>
-          <tr>
-            {visibleColumns.map((column, index) => (
-              <HeadCell
-                key={column.dataIndex + column.title}
-                column={column}
-                index={index}
-                sort={sort}
-                filters={filters}
-                isShown={isShown}
-                showColumn={showColumn}
-                setSort={setSort}
-                setFilters={setFilters}
-                setIsShown={setIsShown}
-                setShowColumn={setShowColumn}
-              />
-            ))}
-          </tr>
-        </thead>
-        <InfiniteScroll
-          element="tbody"
-          hasMore={hasMore && !loading}
-          loadMore={loadMore}
-          threshold={50}
-        >
-          {sortedData.filter(filter).map((data) => (
-            <tr key={data[rowKey]}>
+    <Flex
+      column
+      alignItems="center"
+      gap="var(--spacing-md)"
+      className={cx(styles.wrapper, className)}
+    >
+      <div className={styles.tableContainer}>
+        <table>
+          <thead>
+            <tr>
               {visibleColumns.map((column, index) => (
-                <BodyCell
-                  key={column.title + column.dataIndex}
+                <HeadCell
+                  key={column.dataIndex + column.title}
                   column={column}
-                  data={data}
                   index={index}
+                  sort={sort}
+                  filters={filters}
+                  isShown={isShown}
                   showColumn={showColumn}
+                  setSort={setSort}
+                  setFilters={setFilters}
+                  setIsShown={setIsShown}
+                  setShowColumn={setShowColumn}
                 />
               ))}
             </tr>
-          ))}
-          {loading &&
-            Array.from({ length: 10 }).map((_, index) => (
-              <tr key={index}>
-                {Array.from({ length: visibleColumns.length }).map(
-                  (_, index) => (
-                    <td key={index} className={styles.loader} />
-                  ),
-                )}
+          </thead>
+          <InfiniteScroll
+            element="tbody"
+            hasMore={hasMore && !loading && (!collapseAfter || isExpanded)}
+            loadMore={loadMore}
+            threshold={50}
+          >
+            {displayData.map((data) => (
+              <tr key={data[rowKey]}>
+                {visibleColumns.map((column, index) => (
+                  <BodyCell
+                    key={column.title + column.dataIndex}
+                    column={column}
+                    data={data}
+                    index={index}
+                    showColumn={showColumn}
+                  />
+                ))}
               </tr>
             ))}
-        </InfiniteScroll>
-      </table>
-    </div>
+            {loading &&
+              Array.from({ length: 10 }).map((_, index) => (
+                <tr key={index}>
+                  {Array.from({ length: visibleColumns.length }).map(
+                    (_, index) => (
+                      <td key={index} className={styles.loader} />
+                    ),
+                  )}
+                </tr>
+              ))}
+          </InfiniteScroll>
+        </table>
+        {collapseAfter &&
+          filteredAndSortedData.length > collapseAfter &&
+          !isExpanded && <div className={styles.fadeOverlay} />}
+      </div>
+      {collapseAfter && filteredAndSortedData.length > collapseAfter && (
+        <Button flat onPress={() => setIsExpanded((prev) => !prev)}>
+          <Icon
+            iconNode={isExpanded ? <ChevronUp /> : <ChevronDown />}
+            size={19}
+          />
+          {isExpanded
+            ? 'Vis mindre'
+            : `Vis alle ${filteredAndSortedData.length} rader`}
+        </Button>
+      )}
+    </Flex>
   );
 };
 

--- a/app/routes/events/components/EventAdministrate/Attendees.tsx
+++ b/app/routes/events/components/EventAdministrate/Attendees.tsx
@@ -1,6 +1,7 @@
 import { Flex } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
 import { useParams } from 'react-router-dom';
+import { ContentMain } from 'app/components/Content';
 import EmptyState from 'app/components/EmptyState';
 import {
   selectRegistrationGroups,
@@ -61,65 +62,69 @@ const Attendees = () => {
   const eventHasEnded = moment().isAfter(event?.endTime);
 
   return (
-    <>
-      <Flex alignItems="center" justifyContent="space-between">
-        <h3>Påmeldte</h3>
-        <div>
-          <div className={styles.attendeeStatistics}>
-            {`${registerCount}/${event?.registrationCount || '?'} ${
-              eventHasEnded ? 'møtte opp' : 'har møtt opp'
-            }`}
+    <ContentMain>
+      <Flex column gap="var(--spacing-sm)">
+        <Flex alignItems="center" justifyContent="space-between">
+          <h3>Påmeldte</h3>
+          <div>
+            <div className={styles.attendeeStatistics}>
+              {`${registerCount}/${event?.registrationCount || '?'} ${
+                eventHasEnded ? 'møtte opp' : 'har møtt opp'
+              }`}
+            </div>
+            <div className={styles.attendeeStatistics}>
+              {`${adminRegisterCount}/${event?.registrationCount || '?'} ${
+                eventHasEnded ? 'ble' : 'er'
+              } adminpåmeldt`}
+            </div>
+            <div className={styles.attendeeStatistics}>
+              {registeredPaidCount > 0
+                ? `${registeredPaidCount}/${
+                    event?.registrationCount
+                  } registrerte ${eventHasEnded ? 'betalte' : 'har betalt'}`
+                : ''}
+            </div>
+            <div className={styles.attendeeStatistics}>
+              {unRegisteredPaidCount > 0
+                ? `${unRegisteredPaidCount}/${
+                    unregistered.length
+                  } avregistrerte ${eventHasEnded ? 'betalte' : 'har betalt'}`
+                : ''}
+            </div>
           </div>
-          <div className={styles.attendeeStatistics}>
-            {`${adminRegisterCount}/${event?.registrationCount || '?'} ${
-              eventHasEnded ? 'ble' : 'er'
-            } adminpåmeldt`}
-          </div>
-          <div className={styles.attendeeStatistics}>
-            {registeredPaidCount > 0
-              ? `${registeredPaidCount}/${
-                  event?.registrationCount
-                } registrerte ${eventHasEnded ? 'betalte' : 'har betalt'}`
-              : ''}
-          </div>
-          <div className={styles.attendeeStatistics}>
-            {unRegisteredPaidCount > 0
-              ? `${unRegisteredPaidCount}/${
-                  unregistered.length
-                } avregistrerte ${eventHasEnded ? 'betalte' : 'har betalt'}`
-              : ''}
-          </div>
-        </div>
+        </Flex>
+
+        {registered.length === 0 && !loading ? (
+          <EmptyState body="Ingen påmeldte" />
+        ) : (
+          event && (
+            <RegisteredTable
+              event={event}
+              registered={registered}
+              loading={loading}
+              showPresence={showPresence}
+              showUnregister={showUnregister}
+              pools={pools}
+            />
+          )
+        )}
       </Flex>
 
-      {registered.length === 0 && !loading ? (
-        <EmptyState body="Ingen påmeldte" />
-      ) : (
-        event && (
-          <RegisteredTable
-            event={event}
-            registered={registered}
-            loading={loading}
-            showPresence={showPresence}
-            showUnregister={showUnregister}
-            pools={pools}
-          />
-        )
-      )}
-
-      <h3>Avmeldte</h3>
-      {unregistered.length === 0 && !loading ? (
-        <EmptyState body="Ingen avmeldte" />
-      ) : (
-        event && (
-          <UnregisteredTable
-            unregistered={unregistered}
-            loading={loading}
-            event={event}
-          />
-        )
-      )}
-    </>
+      <Flex column gap="var(--spacing-sm)">
+        <h3>Avmeldte</h3>
+        {unregistered.length === 0 && !loading ? (
+          <EmptyState body="Ingen avmeldte" />
+        ) : (
+          event && (
+            <UnregisteredTable
+              unregistered={unregistered}
+              loading={loading}
+              event={event}
+            />
+          )
+        )}
+      </Flex>
+    </ContentMain>
   );
 };
 

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
@@ -374,6 +374,7 @@ export const RegisteredTable = ({
       columns={columns}
       loading={loading}
       data={registered}
+      collapseAfter={20}
     />
   );
 };
@@ -395,10 +396,9 @@ export const UnregisteredTable = ({
       title: 'Bruker',
       dataIndex: 'user',
       filterMessage: 'Filtrer på navn',
+      centered: false,
       render: (user: Registration['user']) => (
-        <Tooltip content={user.fullName}>
-          <Link to={`/users/${user.username}`}>{user.username}</Link>
-        </Tooltip>
+        <Link to={`/users/${user.username}`}>{user.fullName}</Link>
       ),
     },
     {
@@ -448,6 +448,7 @@ export const UnregisteredTable = ({
       columns={columns}
       loading={loading}
       data={unregistered}
+      collapseAfter={20}
     />
   );
 };


### PR DESCRIPTION
# Description

For tables that are not paginated, it's good to be able to collapse them
to prevent long render times

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/9619242f-2dcd-4a1d-b866-fe6de1bce2e6" />

# Testing

- [x] I have thoroughly tested my changes.

