### PR TITLE
Update event register deadline on start time selection

### DIFF
--- a/app/routes/events/components/EventEditor/EditorSection/Registration.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Registration.tsx
@@ -14,9 +14,9 @@ import Attendance from 'app/components/UserAttendance/Attendance';
 import {
   containsAllergier,
   eventStatusTypes,
-  registrationCloseTime,
+  registrationEditingCloseTime,
   tooLow,
-  unregistrationCloseTime,
+  unregistrationEditingCloseTime,
 } from 'app/routes/events/utils';
 import { spyValues } from 'app/utils/formSpyUtils';
 import styles from '../EventEditor.module.css';
@@ -144,7 +144,7 @@ const NormalOrInfiniteStatusType: React.FC<NormalOrInfiniteStatusTypeProps> = ({
           component={TextInput.Field}
         />
         <span className={styles.registrationDeadlineHours}>
-          Stenger <FormatTime time={registrationCloseTime(values)} />
+          Stenger <FormatTime time={registrationEditingCloseTime(values)} />
         </span>
       </div>
       <div>
@@ -166,7 +166,8 @@ const NormalOrInfiniteStatusType: React.FC<NormalOrInfiniteStatusTypeProps> = ({
               component={TextInput.Field}
             />
             <span className={styles.unregistrationDeadlineHours}>
-              Stenger <FormatTime time={unregistrationCloseTime(values)} />
+              Stenger{' '}
+              <FormatTime time={unregistrationEditingCloseTime(values)} />
             </span>
           </div>
         )}

--- a/app/routes/events/utils.ts
+++ b/app/routes/events/utils.ts
@@ -112,6 +112,7 @@ export type EditingEvent = Event & {
   authors: Option[];
   responsibleUsers: PublicUser[];
   saveToImageGallery: boolean;
+  date: [Dateish, Dateish];
 };
 
 // Event fields that should be created or updated based on the API.
@@ -274,6 +275,10 @@ const paymentSuccessMappings = {
 export const hasPaid = (paymentStatus: string) =>
   paymentSuccessMappings[paymentStatus];
 
+export const registrationEditingCloseTime = (
+  event: Pick<EditingEvent, 'date' | 'registrationDeadlineHours'>,
+) => moment(event.date[0]).subtract(event.registrationDeadlineHours, 'hours');
+
 export const registrationCloseTime = (
   event: Pick<CompleteEvent, 'startTime' | 'registrationDeadlineHours'>,
 ) => moment(event.startTime).subtract(event.registrationDeadlineHours, 'hours');
@@ -283,6 +288,10 @@ export const registrationIsClosed = (
 ) => {
   return moment().isAfter(registrationCloseTime(event));
 };
+
+export const unregistrationEditingCloseTime = (
+  event: Pick<EditingEvent, 'date' | 'unregistrationDeadlineHours'>,
+) => moment(event.date[0]).subtract(event.unregistrationDeadlineHours, 'hours');
 
 export const unregistrationCloseTime = (
   event: Pick<CompleteEvent, 'startTime' | 'unregistrationDeadlineHours'>,


### PR DESCRIPTION

# Description
The description is supposed to show the time for when registering closes by subtracting x hours to starting time. 
Previously it calculated this using the current time (when creating new event) or the previously set starting time (when editing) and did not update when choosing a new starting time.
This was confusing and negated the point of having the description at all imo so I fixed it.

Unsure of the implementation so feedback is appreciated:)

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
        
Red = :(
Green = :)
        </td>
        <td>

<img width="309" alt="Skjermbilde 2025-01-07 kl  15 55 35" src="https://github.com/user-attachments/assets/16584cb1-05f9-43de-9219-9a28919238b8" />
        </td>
        <td>

<img width="310" alt="Skjermbilde 2025-01-07 kl  15 55 19" src="https://github.com/user-attachments/assets/23459cbf-6474-49cf-94a9-18a0819964d5" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

I have tested by editing the start time of events and creating new events. I also tested registering and unregistering from events before and after editing the deadline. Works as expected.

---

Resolves ABA-1228
