### PR TITLE
bug-fix css for eventType name

### DIFF
--- a/packages/lego-bricks/src/components/Layout/Page/Page.module.css
+++ b/packages/lego-bricks/src/components/Layout/Page/Page.module.css
@@ -39,8 +39,9 @@
 }
 
 .buttonGroup {
-  flex-grow: 1;
+  flex-grow: 0;
   justify-content: flex-end;
+  margin-left: auto;
 }
 
 .description {


### PR DESCRIPTION
# Description
Event Type text and buttons were positioned wrong. Aligned it correctly by changing JustifyComponent to flex-end in the ButtonGroup. 

# Result

- [x]  Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

before:
![image](https://github.com/user-attachments/assets/057f24d7-09fc-491f-82e6-79f5daf723d6)
![image](https://github.com/user-attachments/assets/06f8e3e6-3d6d-4f15-8d71-44152db8497b)

after:  

![image](https://github.com/user-attachments/assets/77cde770-b4fd-4ad0-b016-69484f760d12)
![image](https://github.com/user-attachments/assets/f4cd2d83-6489-456c-9102-8ec135ae6dbb)
          
 

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1230


