### PR TITLE
Add: A new toggle button for advanced settings

### DIFF
--- a/app/routes/users/components/UserSettings/UserSettings.module.css
+++ b/app/routes/users/components/UserSettings/UserSettings.module.css
@@ -13,8 +13,3 @@
     flex-direction: column;
   }
 }
-
-.advancedSettings {
-  cursor: pointer;
-  border-radius: 4px;
-}

--- a/app/routes/users/components/UserSettings/UserSettings.module.css
+++ b/app/routes/users/components/UserSettings/UserSettings.module.css
@@ -17,10 +17,4 @@
 .advancedSettings {
   cursor: pointer;
   border-radius: 4px;
-
-  /*
-  &:hover {
-    background-color: var(--additive-background);
-  }
-  */
 }

--- a/app/routes/users/components/UserSettings/UserSettings.module.css
+++ b/app/routes/users/components/UserSettings/UserSettings.module.css
@@ -13,3 +13,14 @@
     flex-direction: column;
   }
 }
+
+.advancedSettings {
+  cursor: pointer;
+  border-radius: 4px;
+
+  /*
+  &:hover {
+    background-color: var(--additive-background);
+  }
+  */
+}

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -267,14 +267,16 @@ const UserSettings = () => {
               </div>
             )}
           >
-            <div>
-              <h2>Endre passord</h2>
-              <ChangePassword />
-            </div>
-            <div>
-              <h2 className={styles.deleteUser}>Slett bruker</h2>
-              <DeleteUser />
-            </div>
+            <Flex column gap="var(--spacing-md)">
+              <div>
+                <h2>Endre passord</h2>
+                <ChangePassword />
+              </div>
+              <div>
+                <h2 className={styles.deleteUser}>Slett bruker</h2>
+                <DeleteUser />
+              </div>
+            </Flex>
           </Accordion>
         </Flex>
       )}

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -1,9 +1,4 @@
-import {
-  Accordion,
-  Flex,
-  Icon,
-  LoadingIndicator,
-} from '@webkom/lego-bricks';
+import { Accordion, Flex, Icon, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { ChevronRight, Github, Linkedin, Mail } from 'lucide-react';
 import { Field } from 'react-final-form';

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -248,12 +248,12 @@ const UserSettings = () => {
           </Form>
         )}
       </TypedLegoForm>
-
+      
       {isCurrentUser && (
         <Accordion
           triggerComponent={({ onClick, disabled, rotateClassName }) => (
             <div className={ styles.advancedSettings }  onClick={onClick}>
-              <Flex gap={5} alignItems="center">
+              <Flex gap="var(--spacing-sm)" alignItems="center">
                 <h2>Avansert</h2>
                 {!disabled && (
                   <Icon

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -1,6 +1,5 @@
 import {
   Accordion,
-  Button,
   Flex,
   Icon,
   LoadingIndicator,
@@ -45,7 +44,6 @@ import ChangePassword from './ChangePassword';
 import UserImage from './UserImage';
 import styles from './UserSettings.module.css';
 import type { CurrentUser } from 'app/store/models/User';
-import { divide } from 'lodash';
 
 type GenderKey = keyof typeof Gender;
 

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -1,6 +1,12 @@
-import { Flex, Icon, LoadingIndicator } from '@webkom/lego-bricks';
+import {
+  Accordion,
+  Button,
+  Flex,
+  Icon,
+  LoadingIndicator,
+} from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Github, Linkedin, Mail } from 'lucide-react';
+import { ChevronRight, Github, Linkedin, Mail } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { fetchUser, updateUser } from 'app/actions/UserActions';
@@ -39,6 +45,7 @@ import ChangePassword from './ChangePassword';
 import UserImage from './UserImage';
 import styles from './UserSettings.module.css';
 import type { CurrentUser } from 'app/store/models/User';
+import { divide } from 'lodash';
 
 type GenderKey = keyof typeof Gender;
 
@@ -243,7 +250,22 @@ const UserSettings = () => {
       </TypedLegoForm>
 
       {isCurrentUser && (
-        <>
+        <Accordion
+          triggerComponent={({ onClick, disabled, rotateClassName }) => (
+            <div className={ styles.advancedSettings }  onClick={onClick}>
+              <Flex gap={5} alignItems="center">
+                <h2>Avansert</h2>
+                {!disabled && (
+                  <Icon
+                    onPress={onClick}
+                    iconNode={<ChevronRight />}
+                    className={rotateClassName}
+                  />
+                )}
+              </Flex>
+            </div>
+          )}
+        >
           <div>
             <h2>Endre passord</h2>
             <ChangePassword />
@@ -252,7 +274,7 @@ const UserSettings = () => {
             <h2 className={styles.deleteUser}>Slett bruker</h2>
             <DeleteUser />
           </div>
-        </>
+        </Accordion>
       )}
     </ContentMain>
   );

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -248,33 +248,35 @@ const UserSettings = () => {
           </Form>
         )}
       </TypedLegoForm>
-      
+
       {isCurrentUser && (
-        <Accordion
-          triggerComponent={({ onClick, disabled, rotateClassName }) => (
-            <div className={ styles.advancedSettings }  onClick={onClick}>
-              <Flex gap="var(--spacing-sm)" alignItems="center">
-                <h2>Avansert</h2>
-                {!disabled && (
-                  <Icon
-                    onPress={onClick}
-                    iconNode={<ChevronRight />}
-                    className={rotateClassName}
-                  />
-                )}
-              </Flex>
+        <Flex column gap="var(--spacing-md)">
+          <Accordion
+            triggerComponent={({ onClick, disabled, rotateClassName }) => (
+              <div className={styles.advancedSettings} onClick={onClick}>
+                <Flex gap="var(--spacing-sm)" alignItems="center">
+                  <h2>Avansert</h2>
+                  {!disabled && (
+                    <Icon
+                      onPress={onClick}
+                      iconNode={<ChevronRight />}
+                      className={rotateClassName}
+                    />
+                  )}
+                </Flex>
+              </div>
+            )}
+          >
+            <div>
+              <h2>Endre passord</h2>
+              <ChangePassword />
             </div>
-          )}
-        >
-          <div>
-            <h2>Endre passord</h2>
-            <ChangePassword />
-          </div>
-          <div>
-            <h2 className={styles.deleteUser}>Slett bruker</h2>
-            <DeleteUser />
-          </div>
-        </Accordion>
+            <div>
+              <h2 className={styles.deleteUser}>Slett bruker</h2>
+              <DeleteUser />
+            </div>
+          </Accordion>
+        </Flex>
       )}
     </ContentMain>
   );

--- a/cypress/e2e/password_change_spec.js
+++ b/cypress/e2e/password_change_spec.js
@@ -12,6 +12,7 @@ describe('Change password', () => {
 
   it('can change password', () => {
     cy.visit('/users/me/settings/profile');
+    cy.get('h2').contains('Avansert').click();
 
     button('Endre passord').should('be.disabled');
     field('password').type(password).blur();
@@ -27,6 +28,7 @@ describe('Change password', () => {
 
   it('should require certain password strength', () => {
     cy.visit('/users/me/settings/profile');
+    cy.get('h2').contains('Avansert').click();
 
     field('password').type(password).blur();
     fieldError('newPassword').should('not.exist');


### PR DESCRIPTION
# Description

Added a toggle button for changing of password in settings profile. This makes the page less messy.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Now a toggle button for changing of password and deletion of account</td>
        <td><img width="1128" alt="Screenshot 2025-01-22 at 20 54 36" src="https://github.com/user-attachments/assets/fa9cfa82-4248-4622-a012-83d26e182d01" /></td>
        <td>
<img width="1121" alt="Screenshot 2025-01-22 at 20 54 11" src="https://github.com/user-attachments/assets/ddc69b35-f6f6-4504-9a94-ef5f9e4a9d59" />
</td>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1242
