### PR TITLE
Add group filters to attendance modal

### DIFF
--- a/app/components/UserAttendance/AttendanceModalContent.module.css
+++ b/app/components/UserAttendance/AttendanceModalContent.module.css
@@ -119,3 +119,27 @@
   transition: opacity var(--linear-fast);
   opacity: 0.4;
 }
+
+.groupFilters {
+  position: relative;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.collapsedIndicator {
+  position: absolute;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  height: 50%;
+  background: linear-gradient(to bottom, transparent, var(--color-white) 90%);
+}
+
+.groupFilterButton {
+  cursor: pointer;
+
+  &.selected {
+    background-color: var(--lego-font-color);
+    color: var(--inverted-font-color);
+  }
+}

--- a/app/components/UserAttendance/AttendanceModalContent.tsx
+++ b/app/components/UserAttendance/AttendanceModalContent.tsx
@@ -6,14 +6,18 @@ import { useState, useMemo } from 'react';
 import { Link } from 'react-router';
 import { TextInput } from 'app/components/Form';
 import { ProfilePicture } from 'app/components/Image';
+import { GroupFilter } from 'app/components/UserAttendance/GroupFilter';
 import EmptyState from '../EmptyState';
 import styles from './AttendanceModalContent.module.css';
 import type { EntityId } from '@reduxjs/toolkit';
-import type { PublicUser } from 'app/store/models/User';
+import type {
+  PublicUser,
+  PublicUserWithAbakusGroups,
+} from 'app/store/models/User';
 
 export type AttendanceModalRegistration = {
   id: EntityId;
-  user: PublicUser;
+  user: PublicUser | PublicUserWithAbakusGroups;
   pool?: EntityId;
 };
 
@@ -66,18 +70,28 @@ const AttendanceModalContent = ({
   selectedPool,
   isMeeting,
 }: Props) => {
-  const [filter, setFilter] = useState<string>('');
+  const [search, setSearch] = useState<string>('');
+  const [groupFilter, setGroupFilter] = useState<EntityId | null>(null);
 
   const amendedPools = useMemo(() => generateAmendedPools(pools), [pools]);
 
   const registrations = useMemo(
+    () => amendedPools[selectedPool]?.registrations,
+    [amendedPools, selectedPool],
+  );
+
+  const filteredRegistrations = useMemo(
     () =>
-      amendedPools[selectedPool]?.registrations.filter((registration) => {
-        return registration.user.fullName
-          .toLowerCase()
-          .includes(filter.toLowerCase());
-      }),
-    [filter, amendedPools, selectedPool],
+      registrations.filter(
+        (registration) =>
+          registration.user.fullName
+            .toLowerCase()
+            .includes(search.toLowerCase()) &&
+          (groupFilter && 'abakusGroups' in registration.user
+            ? registration.user.abakusGroups.includes(groupFilter)
+            : true),
+      ),
+    [registrations, search, groupFilter],
   );
 
   return (
@@ -86,13 +100,21 @@ const AttendanceModalContent = ({
         type="text"
         prefix="search"
         placeholder="Søk etter navn"
-        onChange={(e) => setFilter(e.target.value)}
+        onChange={(e) => setSearch(e.target.value)}
         className={styles.searchInput}
       />
 
+      {!isMeeting && (
+        <GroupFilter
+          registrations={registrations}
+          groupFilter={groupFilter}
+          setGroupFilter={setGroupFilter}
+        />
+      )}
+
       <ul className={styles.list}>
-        {registrations.length > 0 ? (
-          registrations?.map((registration) => (
+        {filteredRegistrations.length > 0 ? (
+          filteredRegistrations?.map((registration) => (
             <li key={registration.id}>
               <Flex
                 alignItems="center"

--- a/app/components/UserAttendance/AttendanceModalContent.tsx
+++ b/app/components/UserAttendance/AttendanceModalContent.tsx
@@ -71,7 +71,7 @@ const AttendanceModalContent = ({
   isMeeting,
 }: Props) => {
   const [search, setSearch] = useState<string>('');
-  const [groupFilter, setGroupFilter] = useState<EntityId | null>(null);
+  const [groupFilter, setGroupFilter] = useState<EntityId[] | null>(null);
 
   const amendedPools = useMemo(() => generateAmendedPools(pools), [pools]);
 
@@ -88,7 +88,9 @@ const AttendanceModalContent = ({
             .toLowerCase()
             .includes(search.toLowerCase()) &&
           (groupFilter && 'abakusGroups' in registration.user
-            ? registration.user.abakusGroups.includes(groupFilter)
+            ? registration.user.abakusGroups.some((groupId) =>
+                groupFilter.includes(groupId),
+              )
             : true),
       ),
     [registrations, search, groupFilter],
@@ -106,7 +108,6 @@ const AttendanceModalContent = ({
 
       {!isMeeting && (
         <GroupFilter
-          registrations={registrations}
           groupFilter={groupFilter}
           setGroupFilter={setGroupFilter}
         />

--- a/app/components/UserAttendance/GroupFilter.tsx
+++ b/app/components/UserAttendance/GroupFilter.tsx
@@ -1,0 +1,85 @@
+import { Flex } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import { useMemo, useState } from 'react';
+import Pill from 'app/components/Pill';
+import styles from 'app/components/UserAttendance/AttendanceModalContent.module.css';
+import { selectCurrentUser } from 'app/reducers/auth';
+import { selectAllGroups } from 'app/reducers/groups';
+import { useAppSelector } from 'app/store/hooks';
+import type { EntityId } from '@reduxjs/toolkit';
+import type { AttendanceModalRegistration } from 'app/components/UserAttendance/AttendanceModalContent';
+
+const excludeFilterGroups: EntityId[] = [
+  1, // Users
+  2, // Abakus
+  47, // Formaterte
+];
+
+type Props = {
+  registrations: AttendanceModalRegistration[];
+  groupFilter: EntityId | null;
+  setGroupFilter: (group: EntityId | null) => void;
+};
+
+export const GroupFilter = ({
+  registrations,
+  groupFilter,
+  setGroupFilter,
+}: Props) => {
+  const currentUser = useAppSelector(selectCurrentUser);
+  const allGroups = useAppSelector(selectAllGroups);
+  const [hovered, setHovered] = useState(false);
+  const expanded = hovered || groupFilter !== null;
+
+  const topGroups = useMemo(
+    () =>
+      allGroups
+        .filter(
+          (group) =>
+            currentUser?.abakusGroups.includes(group.id) &&
+            !excludeFilterGroups.includes(group.id),
+        )
+        .map(
+          (group) =>
+            [
+              group,
+              registrations.filter(
+                (reg) =>
+                  'abakusGroups' in reg.user &&
+                  reg.user.abakusGroups.includes(group.id),
+              ).length,
+            ] as const,
+        )
+        .sort((a, b) => b[1] - a[1]),
+    [allGroups, currentUser?.abakusGroups, registrations],
+  );
+
+  return (
+    <Flex
+      wrap
+      gap="var(--spacing-sm)"
+      style={{ maxHeight: expanded ? undefined : '3rem' }}
+      className={styles.groupFilters}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {topGroups.map(([group]) => (
+        <Pill
+          key={group.id}
+          onClick={() =>
+            groupFilter === group.id
+              ? setGroupFilter(null)
+              : setGroupFilter(group.id)
+          }
+          className={cx(
+            styles.groupFilterButton,
+            groupFilter === group.id && styles.selected,
+          )}
+        >
+          {group.name}
+        </Pill>
+      ))}
+      {!expanded && <div className={styles.collapsedIndicator} />}
+    </Flex>
+  );
+};

--- a/app/components/UserAttendance/GroupFilter.tsx
+++ b/app/components/UserAttendance/GroupFilter.tsx
@@ -1,62 +1,41 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import Pill from 'app/components/Pill';
 import styles from 'app/components/UserAttendance/AttendanceModalContent.module.css';
-import { selectCurrentUser } from 'app/reducers/auth';
-import { selectAllGroups } from 'app/reducers/groups';
-import { useAppSelector } from 'app/store/hooks';
 import type { EntityId } from '@reduxjs/toolkit';
-import type { AttendanceModalRegistration } from 'app/components/UserAttendance/AttendanceModalContent';
-
-const excludeFilterGroups: EntityId[] = [
-  1, // Users
-  2, // Abakus
-  47, // Formaterte
-  227, // Baksida-Komite
-  228, // Baksida-Revy
-  92, // Kasserere
-  242, // Klassetillitsvalgt
-];
 
 type Props = {
-  registrations: AttendanceModalRegistration[];
-  groupFilter: EntityId | null;
-  setGroupFilter: (group: EntityId | null) => void;
+  groupFilter: EntityId[] | null;
+  setGroupFilter: (group: EntityId[] | null) => void;
 };
 
-export const GroupFilter = ({
-  registrations,
-  groupFilter,
-  setGroupFilter,
-}: Props) => {
-  const currentUser = useAppSelector(selectCurrentUser);
-  const allGroups = useAppSelector(selectAllGroups);
+const filterableGroups = [
+  {
+    name: '1. Klasse',
+    ids: [16, 22],
+  },
+  {
+    name: '2. Klasse',
+    ids: [17, 23],
+  },
+  {
+    name: '3. Klasse',
+    ids: [18, 24],
+  },
+  {
+    name: '4. Klasse',
+    ids: [19, 25],
+  },
+  {
+    name: '5. Klasse',
+    ids: [20, 26],
+  },
+];
+
+export const GroupFilter = ({ groupFilter, setGroupFilter }: Props) => {
   const [hovered, setHovered] = useState(false);
   const expanded = hovered || groupFilter !== null;
-
-  const topGroups = useMemo(
-    () =>
-      allGroups
-        .filter(
-          (group) =>
-            currentUser?.abakusGroups.includes(group.id) &&
-            !excludeFilterGroups.includes(group.id),
-        )
-        .map(
-          (group) =>
-            [
-              group,
-              registrations.filter(
-                (reg) =>
-                  'abakusGroups' in reg.user &&
-                  reg.user.abakusGroups.includes(group.id),
-              ).length,
-            ] as const,
-        )
-        .sort((a, b) => b[1] - a[1]),
-    [allGroups, currentUser?.abakusGroups, registrations],
-  );
 
   return (
     <Flex
@@ -67,17 +46,17 @@ export const GroupFilter = ({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      {topGroups.map(([group]) => (
+      {filterableGroups.map((group) => (
         <Pill
-          key={group.id}
+          key={group.name}
           onClick={() =>
-            groupFilter === group.id
+            groupFilter === group.ids
               ? setGroupFilter(null)
-              : setGroupFilter(group.id)
+              : setGroupFilter(group.ids)
           }
           className={cx(
             styles.groupFilterButton,
-            groupFilter === group.id && styles.selected,
+            groupFilter === group.ids && styles.selected,
           )}
         >
           {group.name}

--- a/app/components/UserAttendance/GroupFilter.tsx
+++ b/app/components/UserAttendance/GroupFilter.tsx
@@ -13,6 +13,10 @@ const excludeFilterGroups: EntityId[] = [
   1, // Users
   2, // Abakus
   47, // Formaterte
+  227, // Baksida-Komite
+  228, // Baksida-Revy
+  92, // Kasserere
+  242, // Klassetillitsvalgt
 ];
 
 type Props = {


### PR DESCRIPTION
# Description

Add buttons to filter registrations by membership in groups. Makes it easier to find friends attending events.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

Filter buttons:
<img width="495" alt="Screenshot 2025-01-25 at 08 31 07" src="https://github.com/user-attachments/assets/e8c92001-3e7c-4148-ac46-77f7cb686c00" />

With filter active:
<img width="495" alt="Screenshot 2025-01-25 at 08 33 08" src="https://github.com/user-attachments/assets/3c525a76-fe6f-48ac-ac3e-6e8242cdab87" />

The groups shown are only groups you are a member of, sorted by the number of attendees in each group.

# Testing

- [x] I have thoroughly tested my changes.

Works pretty well:)

---

Resolves ABA-1246
