### PR TITLE
Remove reaction tooltip on comments

### DIFF
--- a/app/components/Tooltip/index.tsx
+++ b/app/components/Tooltip/index.tsx
@@ -31,7 +31,7 @@ const Tooltip = ({
       className={className}
       style={style}
       onClick={onClick}
-      onMouseEnter={() => setHovered(!disabled && true)}
+      onMouseEnter={() => setHovered(!disabled && !!content && true)}
       onMouseLeave={() => setHovered(false)}
     >
       <Popover


### PR DESCRIPTION
# Description

Removes the empty tooltip when hovering on reactions in comments.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections

| Before | After |
| -- | -- |
| ![Screenshot From 2025-01-26 17-04-58](https://github.com/user-attachments/assets/3276f735-8ff6-4bc0-a4d4-1ed30c0d7b88) | ![Screenshot From 2025-01-26 17-05-12](https://github.com/user-attachments/assets/cab3e545-e804-4bd7-98fc-55bc72d27f7f) |

# Testing

- [x] I have thoroughly tested my changes.

Verify that reaction tooltip on comments is not appearing.

Resolves [ABA-1250](https://linear.app/abakus-webkom/issue/ABA-1250/remove-reaction-tooltip-on-comments)