### PR TITLE
Fix emoji search bar to fill the remaining space.

### DIFF
--- a/app/components/Reactions/ReactionPickerFooter.module.css
+++ b/app/components/Reactions/ReactionPickerFooter.module.css
@@ -2,10 +2,9 @@
 
 .reactionPickerFooter {
   width: 100%;
-  height: 50px;
-  display: flex;
+  height: 60px;
   align-items: center;
-  padding: 15px;
+  padding: 5px 15px 0;
   background-color: var(--lego-card-color);
   border-top: 1px solid var(--border-gray);
   border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);


### PR DESCRIPTION
# Description

Fixed the emoji search bar not completely filling the box

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            

Search bar filling the entire box
        </td>
        <td>
            ![image](https://github.com/user-attachments/assets/dd2c504e-879a-4fdc-8672-423aa5b59771)
        </td>
        <td>
            ![image](https://github.com/user-attachments/assets/5ae324b4-3e81-4c96-9c2a-3d5919f096b6)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested light/dark theme and re-scaling the screen. 

---

Resolves ABA-527
