### PR TITLE
Minor styling improvements to mazemap link

### DIFF
--- a/app/components/MazemapEmbed/MazemapEmbed.module.css
+++ b/app/components/MazemapEmbed/MazemapEmbed.module.css
@@ -21,5 +21,9 @@
 }
 
 .mazemapLink {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: 0.2rem;
   font-size: var(--font-size-sm);
 }

--- a/app/components/MazemapEmbed/MazemapLink.tsx
+++ b/app/components/MazemapEmbed/MazemapLink.tsx
@@ -1,22 +1,30 @@
+import { Icon } from '@webkom/lego-bricks';
+import { LucideSquareArrowOutUpRight } from 'lucide-react';
+import { Link } from 'react-router';
 import styles from './MazemapEmbed.module.css';
+import type { CSSProperties } from 'react';
 
 type Props = {
   mazemapPoi: number;
   linkText?: string;
+  style?: CSSProperties;
+  iconOnly?: boolean;
 };
 
-const MazemapLink = ({ mazemapPoi, linkText }: Props) => (
-  <a
-    href={
+const MazemapLink = ({ mazemapPoi, linkText, style, iconOnly }: Props) => (
+  <Link
+    to={
       'https://use.mazemap.com/#v=1&sharepoitype=poi&campusid=1&sharepoi=' +
       mazemapPoi
     }
     rel="noreferrer noopener"
     target="_blank"
     className={styles.mazemapLink}
+    style={style}
   >
-    {linkText || 'Åpne kart i ny fane'}
-  </a>
+    <Icon iconNode={<LucideSquareArrowOutUpRight />} size={19} />
+    {!iconOnly && (linkText || 'Åpne kart i ny fane')}
+  </Link>
 );
 
 export default MazemapLink;

--- a/app/components/MazemapEmbed/index.tsx
+++ b/app/components/MazemapEmbed/index.tsx
@@ -180,7 +180,7 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
   }
 
   return (
-    <Flex column gap="var(--spacing-xs)">
+    <Flex column gap="var(--spacing-sm)">
       <div
         style={{
           height: props.height || 400,

--- a/app/routes/events/components/EventEditor/EditorSection/Details.tsx
+++ b/app/routes/events/components/EventEditor/EditorSection/Details.tsx
@@ -108,7 +108,8 @@ const Details: React.FC<Props> = ({ values }) => {
                 <Tooltip content="Åpne stedet i MazeMap">
                   <MazemapLink
                     mazemapPoi={values.mazemapPoi?.value}
-                    linkText="↗️"
+                    iconOnly
+                    style={{ position: 'relative', top: '0.8rem' }}
                   />
                 </Tooltip>
               )}

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -309,20 +309,21 @@ const MeetingEditor = () => {
                 type="checkbox"
                 component={CheckBox.Field}
               />
-              {spyValues<MeetingFormValues>((values) => {
-                return values?.useMazemap ? (
-                  <Flex alignItems="center">
+              {spyValues<MeetingFormValues>((values) =>
+                values?.useMazemap ? (
+                  <Flex gap="var(--spacing-sm)">
                     <Field
-                      label="MazeMap-rom"
+                      label="Mazemap-rom"
                       required
                       name="mazemapPoi"
                       component={SelectInput.MazemapAutocomplete}
                       placeholder="R1, Abakus, Kjel4"
                     />
-                    {values?.mazemapPoi?.value > 0 && (
+                    {values?.mazemapPoi?.value && (
                       <MazemapLink
-                        mazemapPoi={values?.mazemapPoi?.value}
-                        linkText="↗️"
+                        mazemapPoi={values.mazemapPoi?.value}
+                        iconOnly
+                        style={{ position: 'relative', top: '0.8rem' }}
                       />
                     )}
                   </Flex>
@@ -334,9 +335,8 @@ const MeetingEditor = () => {
                     placeholder="Sted for møte"
                     component={TextInput.Field}
                   />
-                );
-              })}
-
+                ),
+              )}
               <RowSection>
                 <Field
                   name="users"


### PR DESCRIPTION
# Description

Minor visual changes

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [ ] Changes look good with slower Internet connections.

| Before | After |
| ---- | ---- |
| ![Skjermbilde 2025-01-29 kl  20 51 16](https://github.com/user-attachments/assets/8d155d0f-e07e-4b9d-8af8-5dc7d4cf1acf)|![Skjermbilde 2025-01-29 kl  20 51 33](https://github.com/user-attachments/assets/9e3a89c9-a69f-4844-a1ad-8f9e7c5c2bcc)|
| ![Skjermbilde 2025-01-29 kl  20 50 37](https://github.com/user-attachments/assets/7447954a-b13d-4847-9001-08e5a22afb06) | ![Skjermbilde 2025-01-29 kl  20 53 46](https://github.com/user-attachments/assets/4a9ac65f-38bc-410e-9893-fa4a28482d1c)|



# Testing

- [x] I have thoroughly tested my changes.


