### PR TITLE
Add: information about prikk

### DIFF
--- a/app/routes/users/components/UserProfile/Penalties.module.css
+++ b/app/routes/users/components/UserProfile/Penalties.module.css
@@ -41,5 +41,5 @@
   position: absolute;
   top: 0px;
   right: 0px;
-  color: black;
+  color: var(--secondary-font-color);
 }

--- a/app/routes/users/components/UserProfile/Penalties.module.css
+++ b/app/routes/users/components/UserProfile/Penalties.module.css
@@ -39,7 +39,7 @@
 
 .infoIcon {
   position: absolute;
-  top: 0px;
-  right: 0px;
+  top: 0;
+  right: 0;
   color: var(--secondary-font-color);
 }

--- a/app/routes/users/components/UserProfile/Penalties.module.css
+++ b/app/routes/users/components/UserProfile/Penalties.module.css
@@ -30,3 +30,16 @@
   height: 1px;
   background-color: var(--border-gray);
 }
+
+.cardContainer {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.infoIcon {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  color: black;
+}

--- a/app/routes/users/components/UserProfile/Penalties.tsx
+++ b/app/routes/users/components/UserProfile/Penalties.tsx
@@ -94,7 +94,7 @@ const Penalties = ({ userId }: Props) => {
         <a href="https://abakus.no/pages/arrangementer/26-arrangementsregler">
           <Icon
             name="information-circle-outline"
-            size={25}
+            size={22}
             className={styles.infoIcon}
           />
         </a>

--- a/app/routes/users/components/UserProfile/Penalties.tsx
+++ b/app/routes/users/components/UserProfile/Penalties.tsx
@@ -12,8 +12,6 @@ import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './Penalties.module.css';
 import PenaltyForm from './PenaltyForm';
 import type { EntityId } from '@reduxjs/toolkit';
-import { Heading1, icons } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 type Props = {
   userId: EntityId;

--- a/app/routes/users/components/UserProfile/Penalties.tsx
+++ b/app/routes/users/components/UserProfile/Penalties.tsx
@@ -93,7 +93,7 @@ const Penalties = ({ userId }: Props) => {
             </Flex>
           </>
         )}
-        <a href={`https://abakus.no/pages/arrangementer/26-arrangementsregler`}>
+        <a href="https://abakus.no/pages/arrangementer/26-arrangementsregler">
           <Icon
             name="information-circle-outline"
             size={25}

--- a/app/routes/users/components/UserProfile/Penalties.tsx
+++ b/app/routes/users/components/UserProfile/Penalties.tsx
@@ -12,6 +12,8 @@ import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import styles from './Penalties.module.css';
 import PenaltyForm from './PenaltyForm';
 import type { EntityId } from '@reduxjs/toolkit';
+import { Heading1, icons } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 type Props = {
   userId: EntityId;
@@ -27,69 +29,78 @@ const Penalties = ({ userId }: Props) => {
 
   return (
     <ProfileSection title="Prikker">
-      {penalties.length ? (
-        <>
-          {penalties.map((penalty, index) => (
-            <>
-              <Flex key={penalty.id} column gap="var(--spacing-sm)">
-                <span className={styles.weight}>
-                  {penalty.weight} {penalty.weight > 1 ? 'prikker' : 'prikk'}
-                </span>
-                <LinkInfoField
-                  name="Fra arragement"
-                  to={`/events/${
-                    penalty.sourceEvent.slug || penalty.sourceEvent.id
-                  }`}
-                >
-                  {penalty.sourceEvent.title}
-                </LinkInfoField>
-                <InfoField name="Begrunnelse">{penalty.reason}</InfoField>
-                <InfoField name="Utgår">
-                  <FormatTime
-                    time={penalty.exactExpiration}
-                    className={cx('secondaryFontColor', styles.time)}
-                  />
-                </InfoField>
-
-                {canDeletePenalties && (
-                  <ConfirmModal
-                    title="Slett prikk"
-                    message="Er du sikker på at du vil slette denne prikken?"
-                    onConfirm={() => {
-                      dispatch(deletePenalty(penalty.id));
-                    }}
-                    closeOnConfirm
+      <div className={styles.cardContainer}>
+        {penalties.length ? (
+          <>
+            {penalties.map((penalty, index) => (
+              <>
+                <Flex key={penalty.id} column gap="var(--spacing-sm)">
+                  <span className={styles.weight}>
+                    {penalty.weight} {penalty.weight > 1 ? 'prikker' : 'prikk'}
+                  </span>
+                  <LinkInfoField
+                    name="Fra arragement"
+                    to={`/events/${
+                      penalty.sourceEvent.slug || penalty.sourceEvent.id
+                    }`}
                   >
-                    {({ openConfirmModal }) => (
-                      <Button danger onPress={openConfirmModal}>
-                        Slett prikk
-                      </Button>
-                    )}
-                  </ConfirmModal>
-                )}
-              </Flex>
+                    {penalty.sourceEvent.title}
+                  </LinkInfoField>
+                  <InfoField name="Begrunnelse">{penalty.reason}</InfoField>
+                  <InfoField name="Utgår">
+                    <FormatTime
+                      time={penalty.exactExpiration}
+                      className={cx('secondaryFontColor', styles.time)}
+                    />
+                  </InfoField>
 
-              {index !== penalties.length - 1 && (
-                <div className={styles.divider} />
-              )}
-            </>
-          ))}
-        </>
-      ) : (
-        <>
-          <Flex alignItems="center" gap="var(--spacing-md)">
-            <Icon
-              name="thumbs-up-outline"
-              size={40}
-              className={styles.success}
-            />
-            <Flex column className={cx('secondaryFontColor', styles.info)}>
-              <span>Puh ...</span>
-              <span>Du har ingen prikker!</span>
+                  {canDeletePenalties && (
+                    <ConfirmModal
+                      title="Slett prikk"
+                      message="Er du sikker på at du vil slette denne prikken?"
+                      onConfirm={() => {
+                        dispatch(deletePenalty(penalty.id));
+                      }}
+                      closeOnConfirm
+                    >
+                      {({ openConfirmModal }) => (
+                        <Button danger onPress={openConfirmModal}>
+                          Slett prikk
+                        </Button>
+                      )}
+                    </ConfirmModal>
+                  )}
+                </Flex>
+
+                {index !== penalties.length - 1 && (
+                  <div className={styles.divider} />
+                )}
+              </>
+            ))}
+          </>
+        ) : (
+          <>
+            <Flex alignItems="center" gap="var(--spacing-md)">
+              <Icon
+                name="thumbs-up-outline"
+                size={40}
+                className={styles.success}
+              />
+              <Flex column className={cx('secondaryFontColor', styles.info)}>
+                <span>Puh ...</span>
+                <span>Du har ingen prikker!</span>
+              </Flex>
             </Flex>
-          </Flex>
-        </>
-      )}
+          </>
+        )}
+        <a href={`https://abakus.no/pages/arrangementer/26-arrangementsregler`}>
+          <Icon
+            name="information-circle-outline"
+            size={25}
+            className={styles.infoIcon}
+          />
+        </a>
+      </div>
 
       <PenaltyForm userId={userId} />
     </ProfileSection>


### PR DESCRIPTION
# Description

Added a information button about "prikk". Just a link to in-depth information about prikk-system (/arrangementsregler). Thought it would be nice to have a shortcut.

Please take a look at my css, I think it may be a bit clumsy. The button currently does not look good in dark mode because its black. What do you think about the placement of the button? Tried to get it next to "Prikker" title, but that was hard, because of profileSection-comp does not allow Icon, i think.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [ ] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Add information button</td>
        <td><img width="371" alt="Screenshot 2025-01-31 at 11 22 25" src="https://github.com/user-attachments/assets/0aa7da26-7391-4052-bba5-04becae7b4f8" /></td>
        <td><img width="383" alt="Screenshot 2025-01-31 at 11 21 55" src="https://github.com/user-attachments/assets/65e11be9-940c-4d83-8151-ad5cbb2effd0" /></td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-1258
