### PR TITLE
Add skeletons and accordions to survey result and submissions

### DIFF
--- a/app/components/Chart/BarChart.tsx
+++ b/app/components/Chart/BarChart.tsx
@@ -1,15 +1,24 @@
+import { Skeleton } from '@webkom/lego-bricks';
 import { BarChart, Bar, Cell, XAxis, YAxis } from 'recharts';
 import { CHART_COLORS } from 'app/components/Chart/utils';
+import styles from './Chart.module.css';
 import type { DistributionDataPoint } from 'app/components/Chart/utils';
 
 type Props = {
   distributionData: DistributionDataPoint[];
   chartColors?: string[];
+  fetching?: boolean;
 };
 const DistributionBarChart = ({
   chartColors = CHART_COLORS,
   distributionData,
+  fetching = false,
 }: Props) => {
+
+  if (fetching) {
+    return <Skeleton width={307} height={321} className={styles.barChartSkeleton} />;
+  }
+
   return (
     <BarChart
       width={375}

--- a/app/components/Chart/BarChart.tsx
+++ b/app/components/Chart/BarChart.tsx
@@ -14,9 +14,10 @@ const DistributionBarChart = ({
   distributionData,
   fetching = false,
 }: Props) => {
-
   if (fetching) {
-    return <Skeleton width={307} height={321} className={styles.barChartSkeleton} />;
+    return (
+      <Skeleton width={307} height={321} className={styles.barChartSkeleton} />
+    );
   }
 
   return (

--- a/app/components/Chart/Chart.module.css
+++ b/app/components/Chart/Chart.module.css
@@ -26,3 +26,13 @@
   color: var(--secondary-font-color);
   line-height: 1.3;
 }
+
+.pieChartSkeleton {
+  border-radius: 100%;
+  margin: calc(calc(275px - 224px) / 2) calc(calc(300px - 224px) / 2);
+}
+
+.barChartSkeleton {
+  border-radius: var(--border-radius-lg);
+  margin: 20px 30px 10px 15px;
+}

--- a/app/components/Chart/PieChart.tsx
+++ b/app/components/Chart/PieChart.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@webkom/lego-bricks';
+import { Flex, Skeleton } from '@webkom/lego-bricks';
 import { useEffect, useState } from 'react';
 import { PieChart, Cell, Pie, Tooltip } from 'recharts';
 import {
@@ -11,10 +11,12 @@ import type { DistributionDataPoint } from 'app/components/Chart/utils';
 type Props = {
   distributionData: DistributionDataPoint[];
   chartColors?: string[];
+  fetching?: boolean;
 };
 const DistributionPieChart = ({
   chartColors = CHART_COLORS,
   distributionData,
+  fetching = false,
 }: Props) => {
   const [opacity, setOpacity] = useState<{ [key: string]: number }>({});
 
@@ -46,6 +48,10 @@ const DistributionPieChart = ({
       }, {}),
     );
   };
+
+  if (fetching) {
+    return <Skeleton width={224} height={224} className={styles.pieChartSkeleton} />;
+  }
 
   return (
     <PieChart width={300} height={275}>

--- a/app/components/Chart/PieChart.tsx
+++ b/app/components/Chart/PieChart.tsx
@@ -50,7 +50,9 @@ const DistributionPieChart = ({
   };
 
   if (fetching) {
-    return <Skeleton width={224} height={224} className={styles.pieChartSkeleton} />;
+    return (
+      <Skeleton width={224} height={224} className={styles.pieChartSkeleton} />
+    );
   }
 
   return (

--- a/app/routes/surveys/components/Submissions/Results.tsx
+++ b/app/routes/surveys/components/Submissions/Results.tsx
@@ -103,7 +103,7 @@ const Results = ({
     },
     {
       icon: 'chatbox-ellipses',
-      data: fetchingSubmissions ? "?" : numberOfSubmissions,
+      data: fetchingSubmissions ? '?' : numberOfSubmissions,
       meta: 'Har svart',
     },
   ];

--- a/app/routes/surveys/components/Submissions/Results.tsx
+++ b/app/routes/surveys/components/Submissions/Results.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import { produce } from 'immer';
+import { useOutletContext } from 'react-router-dom';
 import { editSurvey } from 'app/actions/SurveyActions';
 import DistributionBarChart from 'app/components/Chart/BarChart';
 import ChartLabel from 'app/components/Chart/ChartLabel';
@@ -16,6 +17,7 @@ import {
 } from 'app/store/models/SurveyQuestion';
 import { QuestionTypeValue, QuestionTypeOption } from '../../utils';
 import styles from '../surveys.module.css';
+import type { SurveysRouteContext } from '../..';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { DistributionDataPoint } from 'app/components/Chart/utils';
 import type { EventForSurvey } from 'app/store/models/Event';
@@ -34,7 +36,7 @@ type Props = {
 };
 type Info = {
   icon: string;
-  data: number;
+  data: number | string;
   meta: string;
 };
 type EventDataProps = {
@@ -81,11 +83,12 @@ const Results = ({
   const event = useAppSelector(
     (state) => selectEventById<EventForSurvey>(state, survey.event)!,
   );
+  const { fetchingSubmissions } = useOutletContext<SurveysRouteContext>();
 
   const info: Info[] = [
     {
       icon: 'person',
-      data: event.registrationCount,
+      data: event.registrationCount || 0,
       meta: 'Påmeldte',
     },
     {
@@ -100,7 +103,7 @@ const Results = ({
     },
     {
       icon: 'chatbox-ellipses',
-      data: numberOfSubmissions,
+      data: fetchingSubmissions ? "?" : numberOfSubmissions,
       meta: 'Har svart',
     },
   ];
@@ -188,11 +191,13 @@ const Results = ({
                       <DistributionPieChart
                         distributionData={pieData}
                         chartColors={chartColors}
+                        fetching={fetchingSubmissions}
                       />
                     ) : (
                       <DistributionBarChart
                         distributionData={pieData}
                         chartColors={chartColors}
+                        fetching={fetchingSubmissions}
                       />
                     )}
 

--- a/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
@@ -8,7 +8,13 @@ import styles from '../surveys.module.css';
 import type { SurveysRouteContext } from 'app/routes/surveys';
 import type { SurveySubmission } from 'app/store/models/SurveySubmission';
 
-const SubmissionItem = ({ submission, index }: { submission: SurveySubmission, index: number }) => {
+const SubmissionItem = ({
+  submission,
+  index,
+}: {
+  submission: SurveySubmission;
+  index: number;
+}) => {
   const [open, setOpen] = useState(false);
   const { survey } = useOutletContext<SurveysRouteContext>();
   return (
@@ -46,10 +52,16 @@ const SubmissionItem = ({ submission, index }: { submission: SurveySubmission, i
 };
 
 const SubmissionPage = () => {
-  const { submissions, fetchingSubmissions } = useOutletContext<SurveysRouteContext>();
+  const { submissions, fetchingSubmissions } =
+    useOutletContext<SurveysRouteContext>();
 
   if (fetchingSubmissions) {
-    return <Skeleton array={5} className={cx(styles.answerTrigger, styles.submissionSkeleton)} />
+    return (
+      <Skeleton
+        array={5}
+        className={cx(styles.answerTrigger, styles.submissionSkeleton)}
+      />
+    );
   }
 
   return (

--- a/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
@@ -1,4 +1,6 @@
+import { Accordion, Button, Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { ChevronRight } from 'lucide-react';
 import { useOutletContext } from 'react-router-dom';
 import StaticSubmission from '../StaticSubmission';
 import styles from '../surveys.module.css';
@@ -7,19 +9,41 @@ import type { SurveysRouteContext } from 'app/routes/surveys';
 const SubmissionPage = () => {
   const { submissions, survey } = useOutletContext<SurveysRouteContext>();
   return (
-    <ul>
-      {submissions.map((submission, i) => (
-        <li key={submission.id}>
-          <h3>Svar {i + 1}</h3>
+    <>
+      <ul>
+        {submissions.map((submission, i) => (
+          <li key={submission.id}>
+            <Accordion 
+              triggerComponent={({ onClick, rotateClassName }) => (
+                <div 
+                  className={styles.answerTrigger} 
+                  onClick={onClick}
+                >
+                  <h3>Svar {i + 1}</h3>
+                  <Icon
+                    onPress={onClick}
+                    iconNode={<ChevronRight />}
+                    className={rotateClassName}
+                  />
+                </div>
+          )}
+            >
+              <ul className={cx(styles.answers, styles.detailQuestions)}>
+                {survey.questions && (
+                  <StaticSubmission survey={survey} submission={submission} />
+                )}
+              </ul>
+            </Accordion>
+          </li>
+        ))}
+      </ul>
 
-          <ul className={cx(styles.answers, styles.detailQuestions)}>
-            {survey.questions && (
-              <StaticSubmission survey={survey} submission={submission} />
-            )}
-          </ul>
-        </li>
-      ))}
-    </ul>
+      <Button
+        onPress={() => {console.log("Fetching more submissions")}}
+      >
+        Last inn mer
+      </Button>
+    </>
   );
 };
 

--- a/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
@@ -1,49 +1,63 @@
-import { Accordion, Button, Icon } from '@webkom/lego-bricks';
+import { Accordion, Icon, Skeleton } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { ChevronRight } from 'lucide-react';
+import { useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import StaticSubmission from '../StaticSubmission';
 import styles from '../surveys.module.css';
 import type { SurveysRouteContext } from 'app/routes/surveys';
+import type { SurveySubmission } from 'app/store/models/SurveySubmission';
+
+const SubmissionItem = ({ submission, index }: { submission: SurveySubmission, index: number }) => {
+  const [open, setOpen] = useState(false);
+  const { survey } = useOutletContext<SurveysRouteContext>();
+  return (
+    <li key={submission.id}>
+      <Accordion
+        animated={false}
+        triggerComponent={({ onClick, rotateClassName }) => (
+          <div
+            className={styles.answerTrigger}
+            onClick={() => {
+              setOpen(!open);
+              onClick();
+            }}
+          >
+            <h3>Svar {index + 1}</h3>
+            <Icon
+              onPress={() => {
+                setOpen(!open);
+                onClick();
+              }}
+              iconNode={<ChevronRight />}
+              className={rotateClassName}
+            />
+          </div>
+        )}
+      >
+        <div className={cx(styles.answers, styles.detailQuestions)}>
+          {open && survey.questions && (
+            <StaticSubmission survey={survey} submission={submission} />
+          )}
+        </div>
+      </Accordion>
+    </li>
+  );
+};
 
 const SubmissionPage = () => {
-  const { submissions, survey } = useOutletContext<SurveysRouteContext>();
-  return (
-    <>
-      <ul>
-        {submissions.map((submission, i) => (
-          <li key={submission.id}>
-            <Accordion 
-              triggerComponent={({ onClick, rotateClassName }) => (
-                <div 
-                  className={styles.answerTrigger} 
-                  onClick={onClick}
-                >
-                  <h3>Svar {i + 1}</h3>
-                  <Icon
-                    onPress={onClick}
-                    iconNode={<ChevronRight />}
-                    className={rotateClassName}
-                  />
-                </div>
-          )}
-            >
-              <ul className={cx(styles.answers, styles.detailQuestions)}>
-                {survey.questions && (
-                  <StaticSubmission survey={survey} submission={submission} />
-                )}
-              </ul>
-            </Accordion>
-          </li>
-        ))}
-      </ul>
+  const { submissions, fetchingSubmissions } = useOutletContext<SurveysRouteContext>();
 
-      <Button
-        onPress={() => {console.log("Fetching more submissions")}}
-      >
-        Last inn mer
-      </Button>
-    </>
+  if (fetchingSubmissions) {
+    return <Skeleton array={5} className={cx(styles.answerTrigger, styles.submissionSkeleton)} />
+  }
+
+  return (
+    <ul>
+      {submissions.map((submission, i) => (
+        <SubmissionItem key={submission.id} submission={submission} index={i} />
+      ))}
+    </ul>
   );
 };
 

--- a/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
@@ -30,7 +30,12 @@ const SubmissionsPage = ({ children: Children }: Props) => {
   return (
     <ContentSection>
       <ContentMain>
-        <Children survey={survey!} event={event!} submissions={submissions} fetchingSubmissions={fetchingSubmissions} />
+        <Children
+          survey={survey!}
+          event={event!}
+          submissions={submissions}
+          fetchingSubmissions={fetchingSubmissions}
+        />
       </ContentMain>
 
       <AdminSideBar

--- a/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
@@ -14,6 +14,7 @@ type ChildProps = {
   survey: DetailedSurvey;
   event: EventForSurvey;
   submissions: SurveySubmission[];
+  fetchingSubmissions: boolean;
 };
 export type SubmissionsPageChild = ComponentType<ChildProps>;
 
@@ -22,14 +23,14 @@ type Props = {
 };
 
 const SubmissionsPage = ({ children: Children }: Props) => {
-  const { survey, event, submissions } =
+  const { survey, event, submissions, fetchingSubmissions } =
     useOutletContext<SurveysRouteContext>();
   const authToken = useAppSelector((state) => state.auth.token);
 
   return (
     <ContentSection>
       <ContentMain>
-        <Children survey={survey!} event={event!} submissions={submissions} />
+        <Children survey={survey!} event={event!} submissions={submissions} fetchingSubmissions={fetchingSubmissions} />
       </ContentMain>
 
       <AdminSideBar

--- a/app/routes/surveys/components/Submissions/SubmissionsSummary.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsSummary.tsx
@@ -15,7 +15,8 @@ import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 import type { ReactNode } from 'react';
 
 const SubmissionsSummary = () => {
-  const { submissions, survey, fetchingSubmissions } = useOutletContext<SurveysRouteContext>();
+  const { submissions, survey, fetchingSubmissions } =
+    useOutletContext<SurveysRouteContext>();
   const dispatch = useAppDispatch();
 
   const generateTextAnswers = (question: SurveyQuestion): ReactNode => {

--- a/app/routes/surveys/components/Submissions/SubmissionsSummary.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsSummary.tsx
@@ -1,4 +1,4 @@
-import { Flex, Icon } from '@webkom/lego-bricks';
+import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
 import { useOutletContext } from 'react-router-dom';
 import { hideAnswer, showAnswer } from 'app/actions/SurveySubmissionActions';
 import EmptyState from 'app/components/EmptyState';
@@ -15,7 +15,7 @@ import type { SurveyQuestion } from 'app/store/models/SurveyQuestion';
 import type { ReactNode } from 'react';
 
 const SubmissionsSummary = () => {
-  const { submissions, survey } = useOutletContext<SurveysRouteContext>();
+  const { submissions, survey, fetchingSubmissions } = useOutletContext<SurveysRouteContext>();
   const dispatch = useAppDispatch();
 
   const generateTextAnswers = (question: SurveyQuestion): ReactNode => {
@@ -66,6 +66,10 @@ const SubmissionsSummary = () => {
         );
       })
       .filter(isNotNullish);
+
+    if (fetchingSubmissions) {
+      return <Skeleton array={5} className={styles.textAnswerSkeleton} />;
+    }
 
     return texts.length === 0 ? <EmptyState body="Ingen svar" /> : texts;
   };

--- a/app/routes/surveys/components/SurveyList/SurveyItem.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyItem.tsx
@@ -1,4 +1,5 @@
 import { Image } from '@webkom/lego-bricks';
+import cx from 'classnames';
 import { Link } from 'react-router-dom';
 import Time from 'app/components/Time';
 import { selectEventById } from 'app/reducers/events';
@@ -19,7 +20,7 @@ const SurveyItem = ({ survey }: Props) => {
 
   return (
     <div
-      className={styles.surveyItem}
+      className={cx(styles.surveyItem, styles.surveyItemBorder)}
       style={{
         borderColor: colorForEventType(survey.templateType || event?.eventType),
       }}

--- a/app/routes/surveys/components/SurveyList/SurveyList.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyList.tsx
@@ -1,6 +1,9 @@
+import { Skeleton } from '@webkom/lego-bricks';
+import cx from 'classnames';
 import { isEmpty } from 'lodash';
 import { FolderOpen } from 'lucide-react';
 import EmptyState from 'app/components/EmptyState';
+import styles from '../surveys.module.css';
 import SurveyItem from './SurveyItem';
 import type { DetailedSurvey } from 'app/store/models/Survey';
 
@@ -25,6 +28,12 @@ const SurveyList = ({ surveys, fetching, isTemplates }: Props) => {
       {surveys.map((survey) => (
         <SurveyItem key={survey.id} survey={survey} />
       ))}
+      {fetching && (
+        <Skeleton
+          array={7 - surveys.length}
+          className={cx(styles.surveyItem, styles.surveySkeleton)}
+        />
+      )}
     </div>
   );
 };

--- a/app/routes/surveys/components/SurveysWrapper.tsx
+++ b/app/routes/surveys/components/SurveysWrapper.tsx
@@ -19,7 +19,9 @@ const SurveysWrapper = () => {
     surveyId,
   );
   const fetchingSurveys = useAppSelector((state) => state.surveys.fetching);
-  const fetchingSubmissions = useAppSelector((state) => state.surveySubmissions.fetching);
+  const fetchingSubmissions = useAppSelector(
+    (state) => state.surveySubmissions.fetching,
+  );
 
   if (!survey) {
     return <LoadingPage loading={fetchingSurveys} />;
@@ -42,7 +44,16 @@ const SurveysWrapper = () => {
       tabs={!isTemplate && <SurveyDetailTabs surveyId={survey.id} />}
     >
       <Helmet title={survey.title} />
-      <Outlet context={{ survey, event, submissions, fetchingSubmissions } as SurveysRouteContext} />
+      <Outlet
+        context={
+          {
+            survey,
+            event,
+            submissions,
+            fetchingSubmissions,
+          } as SurveysRouteContext
+        }
+      />
     </Page>
   );
 };

--- a/app/routes/surveys/components/SurveysWrapper.tsx
+++ b/app/routes/surveys/components/SurveysWrapper.tsx
@@ -18,10 +18,11 @@ const SurveysWrapper = () => {
     'surveySubmissions',
     surveyId,
   );
-  const fetching = useAppSelector((state) => state.surveys.fetching);
+  const fetchingSurveys = useAppSelector((state) => state.surveys.fetching);
+  const fetchingSubmissions = useAppSelector((state) => state.surveySubmissions.fetching);
 
   if (!survey) {
-    return <LoadingPage loading={fetching} />;
+    return <LoadingPage loading={fetchingSurveys} />;
   }
 
   const isTemplate = !!survey.templateType;
@@ -41,7 +42,7 @@ const SurveysWrapper = () => {
       tabs={!isTemplate && <SurveyDetailTabs surveyId={survey.id} />}
     >
       <Helmet title={survey.title} />
-      <Outlet context={{ survey, event, submissions } as SurveysRouteContext} />
+      <Outlet context={{ survey, event, submissions, fetchingSubmissions } as SurveysRouteContext} />
     </Page>
   );
 };

--- a/app/routes/surveys/components/surveys.module.css
+++ b/app/routes/surveys/components/surveys.module.css
@@ -254,3 +254,21 @@
     justify-content: center;
   }
 }
+
+.answerTrigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md);
+  margin-left: calc(-1 * var(--spacing-md));
+  gap: var(--spacing-md);
+  height: fit-content;
+  border-radius: var(--border-radius-lg);
+  color: var(--lego-font-color);
+  transition: background-color var(--easing-fast);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--additive-background);
+  }
+}

--- a/app/routes/surveys/components/surveys.module.css
+++ b/app/routes/surveys/components/surveys.module.css
@@ -263,7 +263,6 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-md);
-  margin-left: calc(-1 * var(--spacing-md));
   gap: var(--spacing-md);
   height: fit-content;
   border-radius: var(--border-radius-lg);

--- a/app/routes/surveys/components/surveys.module.css
+++ b/app/routes/surveys/components/surveys.module.css
@@ -6,6 +6,9 @@
   margin-bottom: 15px;
   display: flex;
   justify-content: space-between;
+}
+
+.surveryItemBorder {
   border-color: var(--color-orange-5);
 }
 
@@ -271,4 +274,16 @@
   &:hover {
     background-color: var(--additive-background);
   }
+}
+
+.surveySkeleton {
+  height: 70.2px;
+}
+
+.submissionSkeleton {
+  height: 76.6px;
+}
+
+.textAnswerSkeleton {
+  height: 36.8px;
 }

--- a/app/routes/surveys/index.tsx
+++ b/app/routes/surveys/index.tsx
@@ -63,6 +63,7 @@ export type SurveysRouteContext = {
   survey: DetailedSurvey;
   event: EventForSurvey;
   submissions: SurveySubmission[];
+  fetchingSubmissions: boolean;
 };
 
 const surveysRoute: RouteObject[] = [
@@ -86,10 +87,10 @@ const surveysRoute: RouteObject[] = [
         path: 'submissions',
         Component: () => (
           <SubmissionsPage>
-            {({ survey, event, submissions }) => (
+            {({ survey, event, submissions, fetchingSubmissions }) => (
               <Outlet
                 context={
-                  { survey, event, submissions } satisfies SurveysRouteContext
+                  { survey, event, submissions, fetchingSubmissions } satisfies SurveysRouteContext
                 }
               />
             )}

--- a/app/routes/surveys/index.tsx
+++ b/app/routes/surveys/index.tsx
@@ -90,7 +90,12 @@ const surveysRoute: RouteObject[] = [
             {({ survey, event, submissions, fetchingSubmissions }) => (
               <Outlet
                 context={
-                  { survey, event, submissions, fetchingSubmissions } satisfies SurveysRouteContext
+                  {
+                    survey,
+                    event,
+                    submissions,
+                    fetchingSubmissions,
+                  } satisfies SurveysRouteContext
                 }
               />
             )}


### PR DESCRIPTION
# Description

For larger events, the survey page is suffers from performance issues since there is a large amount of submissions. This PR aims to improve user feedback. 

Also make each submission into accordions for better usability but also remove the content (the answers) from the virtual dom when they are not expanded to improve performance. This requires disabling animations for the accordions, but I think that is fine. 

There was an idea to paginate the page with individual answers, however since the result/summary needs all submissions anyways that solution does not make  much sense.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

Images of skeleton components are not included, but they are added to the following places:
 - /surveys
 - PieChart, BarChart and TextAnswers (used on /surveys/<id>/submissions/summary and on /events/<id>/administrate/statistics but does not seem to apply there)
 - /surveys/<id>/submissions/individual

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Accordions on `/surveys/<id>/submissions/individual`
        </td>
        <td> 

![Screenshot 2025-02-01 at 16 48 37](https://github.com/user-attachments/assets/06a4c11b-dfdc-45bf-ab7d-b7d866feb3eb)
        </td>
        <td> 

![Screenshot 2025-02-01 at 16 38 27](https://github.com/user-attachments/assets/ef83ecda-d569-4e91-aaf3-f59a203dee8e)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes. 

Seems to work :)

---

Resolves ABA-1259

