### PR TITLE
Move z-index of pizza reactions higher

### DIFF
--- a/app/components/Tooltip/Tooltip.module.css
+++ b/app/components/Tooltip/Tooltip.module.css
@@ -35,3 +35,7 @@
 .arrow {
   animation: fade-in 0.2s;
 }
+
+.zIndex {
+  z-index: 6;
+}

--- a/app/components/Tooltip/index.tsx
+++ b/app/components/Tooltip/index.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import { useState } from 'react';
 import { Popover, ArrowContainer } from 'react-tiny-popover';
 import styles from './Tooltip.module.css';
@@ -37,7 +38,7 @@ const Tooltip = ({
       <Popover
         isOpen={hovered}
         positions={positions}
-        containerClassName={containerClassName}
+        containerClassName={cx(containerClassName, styles.zIndex)}
         content={({ position, childRect, popoverRect }) => (
           <ArrowContainer
             position={position}


### PR DESCRIPTION
# Description

Pretty self-explanatory, was under mazemap controls, now its in front of it (applied to all popovers, but seems to be fine)

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [ ] Changes look good on both light and dark theme.
- [ ] Changes look good with different viewports (mobile, tablet, etc.).
- [ ] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
