### PR TITLE
Cleanup StripeElement implementation

### DIFF
--- a/app/routes/events/components/Stripe.module.css
+++ b/app/routes/events/components/Stripe.module.css
@@ -11,7 +11,7 @@
   border-radius: var(--border-radius-lg);
 }
 
-.elementsLedgend {
+.elementsLegend {
   text-align: center;
   padding: 0 var(--spacing-md);
 }


### PR DESCRIPTION
# Description
`StripeElement.tsx` was missing some types, and it appeared to have some errors originating from faulty refactoring and packages being bumped without updating the implementation. These should now be rectified to match the official docs🤞.

Card payments have always been working, but apple pay has not worked in a while. It's handled through Stripes' `Payment Request Button` (where I've located and hopefully fixed the stuff that seemed erroneous), and that seems pretty hard to test properly outside of a production environment.. soo we might have to deploy and try to use it for the next signup with payments - although I'll keep searching for ways to test it.

The way we do this (using `Payment Request Button`) is deprecated, but with these changes I think Apple Pay and the likes should work for now. We should however migrate it to use `Express Checkout Element` soon.

Changes
* Apply correct types
* Rectify methods that were not matching the official documentation
* Add more error responses

# Result

Should be no visual changes

# Testing

- [x] I have thoroughly tested my changes.

The section under "Test your integration" in the docs (https://docs.stripe.com/stripe-js/elements/payment-request-button?client=react&testing=apple-pay) basically only details prerequisites for the payment button to show up - which gives no guarantee that the implementation works correctly.  
Plus the button only shows up under a verified domain, with https://, so it will not show up in e.g. cypress.

TODO
- [x] Verify that the existing stripe cypress tests still work

---

Resolves ABA-1270
