### PR TITLE
Add 'Wish event thursday' to other events on company interest page

### DIFF
--- a/app/routes/bdb/components/companyInterest/components/Translations.ts
+++ b/app/routes/bdb/components/companyInterest/components/Translations.ts
@@ -133,6 +133,10 @@ export const OTHER_OFFERS = {
     norwegian: 'Profilering på sosiale medier',
     english: 'Profiling on social media',
   },
+  thursday_event: {
+    norwegian: 'Ønsker arrangement torsdag',
+    english: 'Wish event thursday,',
+  },
 };
 
 export const COMPANY_TYPES: Record<

--- a/app/routes/bdb/components/companyInterest/components/Translations.ts
+++ b/app/routes/bdb/components/companyInterest/components/Translations.ts
@@ -135,7 +135,7 @@ export const OTHER_OFFERS = {
   },
   thursday_event: {
     norwegian: 'Ønsker arrangement torsdag',
-    english: 'Wish event thursday,',
+    english: 'Wish event thursday',
   },
 };
 


### PR DESCRIPTION
# Description

Added an option under other events on company interest page that got requested by bedkom: 
![Skjermbilde 2025-02-10 kl  10 34 47](https://github.com/user-attachments/assets/ca46de3b-cd5e-47d5-ad3b-cf97fa265d71)

But not sure if this little change is all that is needed?

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [ ] Changes look good with slower Internet connections.

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td>
            <img src="https://github.com/user-attachments/assets/8be857b5-8e16-4f91-84f3-8b10b2354482" alt="Before Image" width="300">
        </td>
        <td>
            <img src="https://github.com/user-attachments/assets/e4b171a6-d2f2-4a63-8e7e-9d18719ffde2" alt="After Image" width="300">
        </td>
    </tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-1271
