### PR TITLE
Fix sidebar bug in achievements and move link

### DIFF
--- a/app/routes/achievements/components/index.tsx
+++ b/app/routes/achievements/components/index.tsx
@@ -4,9 +4,11 @@ import { RadioButton } from 'app/components/Form';
 import useQuery from 'app/utils/useQuery';
 import { AchievementTabs } from './utils';
 
-const showFilters = location.pathname === '/achievements/overview';
-
 const AchievementsPageWrapper = () => {
+  const showFilters =
+    location.pathname === '/achievements' ||
+    location.pathname === '/achievements/';
+
   const { query, setQueryValue, setQuery } = useQuery({
     min_rarity: 'any',
     max_rarity: 'any',

--- a/app/routes/achievements/components/utils.tsx
+++ b/app/routes/achievements/components/utils.tsx
@@ -2,7 +2,7 @@ import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 
 export const AchievementTabs = () => (
   <>
-    <NavigationTab href="/achievements/overview">Oversikt</NavigationTab>
+    <NavigationTab href="/achievements">Oversikt</NavigationTab>
     <NavigationTab href="/achievements/leaderboard">Topplister</NavigationTab>
   </>
 );

--- a/app/routes/achievements/index.tsx
+++ b/app/routes/achievements/index.tsx
@@ -11,7 +11,6 @@ const achievementRoute: RouteObject[] = [
     Component: AchievementsPageWrapper,
     children: [
       { index: true, Component: Overview },
-      { path: 'overview', Component: Overview },
       { path: 'leaderboard', Component: Leaderboard },
     ],
   },

--- a/app/routes/users/components/UserProfile/Achievements.tsx
+++ b/app/routes/users/components/UserProfile/Achievements.tsx
@@ -2,6 +2,7 @@ import { Button, Flex } from '@webkom/lego-bricks';
 import { Trophy } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import Tooltip from 'app/components/Tooltip';
 import AchievementsInfo, {
   rarityToColorMap,
@@ -33,7 +34,7 @@ export const Achievements = ({
   return (
     <div className={styles.achievements}>
       <h3>Trofeer</h3>
-      <Flex wrap gap="var(--spacing-lg)">
+      <Flex wrap gap="var(--spacing-sm) var(--spacing-md)">
         {topAchievements.map((e) => (
           <Tooltip
             key={AchievementsInfo[e.identifier][e.level].name}
@@ -97,16 +98,21 @@ export const Achievements = ({
           </Tooltip>
         ))}
       </Flex>
-      {achievements.length > MAX_ACHIEVEMENTS && (
-        <Button
-          onPress={() => {
-            setShowAll((prev) => !prev);
-          }}
-          className={styles.showAllButton}
-        >
-          {showAll ? 'Vis færre' : 'Vis alle'}
-        </Button>
-      )}
+      <Flex gap="var(--spacing-md)" className={styles.trophyLinks}>
+        {achievements.length > MAX_ACHIEVEMENTS && (
+          <Button
+            onPress={() => {
+              setShowAll((prev) => !prev);
+            }}
+          >
+            {showAll ? 'Vis færre' : 'Vis alle'}
+          </Button>
+        )}
+
+        <Link to="/achievements">
+          <Button>Topplister</Button>
+        </Link>
+      </Flex>
     </div>
   );
 };

--- a/app/routes/users/components/UserProfile/UserProfile.module.css
+++ b/app/routes/users/components/UserProfile/UserProfile.module.css
@@ -117,6 +117,6 @@
   justify-content: space-between;
 }
 
-.showAllButton {
+.trophyLinks {
   margin-top: var(--spacing-md);
 }

--- a/app/routes/users/components/UserProfile/index.tsx
+++ b/app/routes/users/components/UserProfile/index.tsx
@@ -16,7 +16,7 @@ import { QrCode, SettingsIcon } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
 import { QRCode } from 'react-qrcode-logo';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { fetchPrevious, fetchUpcoming } from 'app/actions/EventActions';
 import { fetchAllWithType } from 'app/actions/GroupActions';
 import { fetchUser } from 'app/actions/UserActions';
@@ -215,9 +215,6 @@ const UserProfile = () => {
             <Achievements achievements={user.achievements} />
           )}
         </Flex>
-        <Link to="/achievements">
-          <Button>Topplister</Button>
-        </Link>
       </Flex>
 
       <Flex wrap className={styles.content}>


### PR DESCRIPTION
# Description

Fixed some bugs in the achievements
* The location check used to toggle the sidebar was above the component, which caused it to only be reloaded when you refresh the page, not when navigating
* The location check is sorta suboptimal, but at least now it covers both `/achievements` and `/achievements/`
* The overview page was accessible from both `/achievements` and `/achievements/overview`. The user page used the former, and the internal navigation links used the latter, and the nav-link active state only listened to the latter. Now they all use `/achievements`
* The "Topplister" button used to be placed next to the badges, now it is displayed under the trophies - which makes more sense imo

# Result

Resolved the bugs mentioned above.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td><img width="219" alt="image" src="https://github.com/user-attachments/assets/299de08e-7f9c-4314-84eb-b9d89c9db541" /></td>
        <td><img width="295" alt="image" src="https://github.com/user-attachments/assets/7aa289a1-3e67-45a6-b0ae-47bc8c718520" /></td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
