### PR TITLE
Upgrade to react router v7

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -135,7 +135,7 @@ steps:
       - echo "server stopped"
 
   - name: setup
-    image: node:18-alpine
+    image: node:20-alpine
     when:
       event: [push]
       branch:
@@ -156,7 +156,7 @@ steps:
       - yarn --frozen-lockfile --cache-folder /tmp/cache
 
   - name: build_packages
-    image: node:18-alpine
+    image: node:20-alpine
     when:
       event: [push]
       branch:
@@ -167,7 +167,7 @@ steps:
       - yarn build:packages
 
   - name: build_server
-    image: node:18-alpine
+    image: node:20-alpine
     when:
       event: [push]
       branch:
@@ -179,7 +179,7 @@ steps:
       - yarn build:server
 
   - name: build_client
-    image: node:18-alpine
+    image: node:20-alpine
     when:
       event: [push]
       branch:
@@ -191,7 +191,7 @@ steps:
       - yarn build:client
 
   - name: test
-    image: node:18-alpine
+    image: node:20-alpine
     when:
       event: [push]
       branch:
@@ -203,7 +203,7 @@ steps:
       - yarn test:packages
 
   - name: lint
-    image: node:18-alpine
+    image: node:20-alpine
     when:
       event: [push]
       branch:
@@ -215,7 +215,7 @@ steps:
       - yarn lint:packages
 
   - name: typescript
-    image: node:18-slim
+    image: node:20-slim
     when:
       event: [push]
       branch:
@@ -227,7 +227,7 @@ steps:
     failure: ignore
 
   - name: typescript_packages
-    image: node:18-slim
+    image: node:20-slim
     when:
       event: [push]
       branch:
@@ -238,7 +238,7 @@ steps:
       - yarn types:packages
 
   - name: install_cypress
-    image: node:18-alpine
+    image: node:20-alpine
     when:
       event: [push]
       branch:
@@ -251,7 +251,7 @@ steps:
       - yarn cypress install
 
   - name: ssr
-    image: node:18-alpine
+    image: node:20-alpine
     detach: true
     when:
       event: [push]
@@ -269,7 +269,7 @@ steps:
       - yarn ssr
 
   - name: cypress
-    image: cypress/browsers:node-18.15.0-chrome-106.0.5249.61-1-ff-99.0.1-edge-114.0.1823.51-1
+    image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1
     shm_size: 512m
     ipc: host
     when:

--- a/app/Root.tsx
+++ b/app/Root.tsx
@@ -1,6 +1,6 @@
 import { HelmetProvider } from 'react-helmet-async';
 import { Provider } from 'react-redux';
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter } from 'react-router';
 import ErrorBoundary from 'app/components/ErrorBoundary';
 import { ThemeContextListener } from 'app/utils/themeUtils';
 import routerConfig from './routes';

--- a/app/components/Banner/index.tsx
+++ b/app/components/Banner/index.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from './Banner.module.css';
 import type { ReactNode } from 'react';
 import type { $Keys } from 'utility-types';

--- a/app/components/Comments/Comment.tsx
+++ b/app/components/Comments/Comment.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, Icon } from '@webkom/lego-bricks';
 import { Reply, Trash2 } from 'lucide-react';
 import moment from 'moment';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { deleteComment } from 'app/actions/CommentActions';
 import CommentForm from 'app/components/CommentForm';
 import DisplayContent from 'app/components/DisplayContent';

--- a/app/components/Comments/__tests__/CommentTree.spec.tsx
+++ b/app/components/Comments/__tests__/CommentTree.spec.tsx
@@ -1,7 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { mount, shallow } from 'enzyme';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect } from 'vitest';
 import createRootReducer from 'app/store/createRootReducer';
 import { generateTreeStructure } from 'app/utils';

--- a/app/components/EventItem/index.tsx
+++ b/app/components/EventItem/index.tsx
@@ -8,7 +8,7 @@ import {
   Timer,
 } from 'lucide-react';
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Pill from 'app/components/Pill';
 import Tag from 'app/components/Tags/Tag';
 import Time from 'app/components/Time';

--- a/app/components/Feed/Tag.tsx
+++ b/app/components/Feed/Tag.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from 'app/components/Feed/context.module.css';
 import type { TagComponent } from 'app/components/Feed/ActivityRenderer';
 

--- a/app/components/Feed/activity.tsx
+++ b/app/components/Feed/activity.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@webkom/lego-bricks';
 import Linkify from 'linkify-react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { LinkTag } from 'app/components/Feed/Tag';
 import { ProfilePicture } from 'app/components/Image';
 import Time from 'app/components/Time';

--- a/app/components/Footer/index.tsx
+++ b/app/components/Footer/index.tsx
@@ -2,7 +2,7 @@ import { Flex, Icon, Image } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { Facebook, Instagram, Linkedin, Slack } from 'lucide-react';
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import bekk from 'app/assets/bekk_short_white.svg';
 import octocat from 'app/assets/octocat.png';
 import { useIsLoggedIn } from 'app/reducers/auth';

--- a/app/components/GroupMember/index.tsx
+++ b/app/components/GroupMember/index.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ProfilePicture } from 'app/components/Image';
 import { ROLES, type RoleType } from 'app/utils/constants';
 import styles from './GroupMember.module.css';

--- a/app/components/Header/Navbar/Item.tsx
+++ b/app/components/Header/Navbar/Item.tsx
@@ -1,5 +1,5 @@
 import { Flex, Icon } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TextWithIcon from 'app/components/TextWithIcon';
 import styles from './Item.module.css';
 import type { ReactNode } from 'react';

--- a/app/components/Header/Navbar/Navbar.tsx
+++ b/app/components/Header/Navbar/Navbar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import Dropdown from 'app/components/Dropdown';
 import { useIsLoggedIn } from 'app/reducers/auth';
 import AboutDropdown from './AboutDropdown';

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import { Menu, CircleUser, LogOut, Settings, Users, X } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
-import { Link, NavLink, useNavigate } from 'react-router-dom';
+import { Link, NavLink, useNavigate } from 'react-router';
 import { fetchAll as fetchMeetings } from 'app/actions/MeetingActions';
 import { toggleSearch } from 'app/actions/SearchActions';
 import { logout } from 'app/actions/UserActions';

--- a/app/components/HeaderNotifications/index.tsx
+++ b/app/components/HeaderNotifications/index.tsx
@@ -3,7 +3,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
 import { Bell, BellOff, BellRing } from 'lucide-react';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchNotificationFeed } from 'app/actions/FeedActions';
 import {
   fetchNotificationData,

--- a/app/components/JoblistingItem/index.tsx
+++ b/app/components/JoblistingItem/index.tsx
@@ -1,7 +1,7 @@
 import { Flex, Icon, Image } from '@webkom/lego-bricks';
 import { CalendarClock } from 'lucide-react';
 import moment from 'moment';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   jobType,
   Year,

--- a/app/components/NavigationTab/NavigationTab.tsx
+++ b/app/components/NavigationTab/NavigationTab.tsx
@@ -1,9 +1,9 @@
 import { Tab } from '@webkom/lego-bricks';
 import qs from 'qs';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import type { ParsedQs } from 'qs';
 import type { ReactNode } from 'react';
-import type { Location } from 'react-router-dom';
+import type { Location } from 'react-router';
 
 type QueryValue = ParsedQs[string];
 

--- a/app/components/Poll/index.tsx
+++ b/app/components/Poll/index.tsx
@@ -9,7 +9,7 @@ import {
   Info,
 } from 'lucide-react';
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { votePoll } from 'app/actions/PollActions';
 import EmptyState from 'app/components/EmptyState';
 import Tooltip from 'app/components/Tooltip';

--- a/app/components/ResolveLink.tsx
+++ b/app/components/ResolveLink.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { ReactNode } from 'react';
 
 type Props = {

--- a/app/components/Search/SearchPage.tsx
+++ b/app/components/Search/SearchPage.tsx
@@ -1,6 +1,6 @@
 import qs from 'qs';
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import SearchPageInput from 'app/components/Search/SearchPageInput';
 import SearchPageResults from 'app/components/Search/SearchPageResults';
 import { Keyboard } from 'app/utils/constants';

--- a/app/components/Search/SearchPageResults.tsx
+++ b/app/components/Search/SearchPageResults.tsx
@@ -1,7 +1,7 @@
 import { Flex, Icon, Skeleton, Image } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { FolderOpen, FolderSearch } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import EmptyState from 'app/components/EmptyState';
 import { ProfilePicture } from 'app/components/Image';
 import { isUserResult } from 'app/reducers/search';

--- a/app/components/Search/SearchResults.tsx
+++ b/app/components/Search/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { Flex, Icon, Image } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Time from 'app/components/Time';
 import { ProfilePicture } from '../Image';
 import styles from './Search.module.css';

--- a/app/components/Search/index.tsx
+++ b/app/components/Search/index.tsx
@@ -1,6 +1,6 @@
 import { debounce } from 'lodash';
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { autocomplete, toggleSearch } from 'app/actions/SearchActions';
 import { useIsLoggedIn } from 'app/reducers/auth';
 import { selectAutocompleteRedux } from 'app/reducers/search';

--- a/app/components/Tags/Tag.tsx
+++ b/app/components/Tags/Tag.tsx
@@ -1,6 +1,6 @@
 import { Flex, Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from './Tag.module.css';
 import type { ReactNode } from 'react';
 

--- a/app/components/UserAttendance/AttendanceModalContent.tsx
+++ b/app/components/UserAttendance/AttendanceModalContent.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import { flatMap } from 'lodash';
 import { Send } from 'lucide-react';
 import { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { TextInput } from 'app/components/Form';
 import { ProfilePicture } from 'app/components/Image';
 import EmptyState from '../EmptyState';

--- a/app/components/UserGrid/index.tsx
+++ b/app/components/UserGrid/index.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ProfilePicture } from 'app/components/Image';
 import Tooltip from 'app/components/Tooltip';
 import styles from './UserGrid.module.css';

--- a/app/components/UserLink/index.tsx
+++ b/app/components/UserLink/index.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ProfilePicture } from '../Image';
 import type { UnknownUser } from 'app/store/models/User';
 

--- a/app/components/UserValidator/index.tsx
+++ b/app/components/UserValidator/index.tsx
@@ -3,7 +3,7 @@ import { get, debounce } from 'lodash';
 import { Check, ScanQrCode, X } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 import { QrReader } from 'react-qr-reader';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { autocomplete } from 'app/actions/SearchActions';
 import goodSound from 'app/assets/good-sound.mp3';
 import SearchPage from 'app/components/Search/SearchPage';

--- a/app/render.tsx
+++ b/app/render.tsx
@@ -1,5 +1,5 @@
 import { createRoot, hydrateRoot } from 'react-dom/client';
-import { matchRoutes } from 'react-router-dom';
+import { matchRoutes } from 'react-router';
 import routerConfig from 'app/routes';
 import Root from './Root';
 import type { Store } from 'app/store/createStore';

--- a/app/routes/achievements/components/Leaderboard.tsx
+++ b/app/routes/achievements/components/Leaderboard.tsx
@@ -1,5 +1,5 @@
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchLeaderboardUsers } from 'app/actions/AchievementActions';
 import { ContentMain } from 'app/components/Content';
 import Table from 'app/components/Table';

--- a/app/routes/achievements/components/index.tsx
+++ b/app/routes/achievements/components/index.tsx
@@ -1,5 +1,5 @@
 import { FilterSection, filterSidebar, Flex, Page } from '@webkom/lego-bricks';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { RadioButton } from 'app/components/Form';
 import useQuery from 'app/utils/useQuery';
 import { AchievementTabs } from './utils';

--- a/app/routes/achievements/index.tsx
+++ b/app/routes/achievements/index.tsx
@@ -1,5 +1,5 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const Leaderboard = lazyComponent(() => import('./components/Leaderboard'));
 const Overview = lazyComponent(() => import('./components/Overview'));

--- a/app/routes/admin/email/components/EmailListEditor.tsx
+++ b/app/routes/admin/email/components/EmailListEditor.tsx
@@ -1,6 +1,6 @@
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   createEmailList,
   editEmailList,

--- a/app/routes/admin/email/components/EmailLists.tsx
+++ b/app/routes/admin/email/components/EmailLists.tsx
@@ -1,6 +1,6 @@
 import { Card, Flex, LinkButton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetch } from 'app/actions/EmailListActions';
 import { ContentMain } from 'app/components/Content';
 import Table from 'app/components/Table';

--- a/app/routes/admin/email/components/EmailUserEditor.tsx
+++ b/app/routes/admin/email/components/EmailUserEditor.tsx
@@ -1,7 +1,7 @@
 import { Card, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   createEmailUser,
   editEmailUser,

--- a/app/routes/admin/email/components/EmailUsers.tsx
+++ b/app/routes/admin/email/components/EmailUsers.tsx
@@ -1,6 +1,6 @@
 import { Card, Flex, LinkButton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetch } from 'app/actions/EmailUserActions';
 import { fetchAllWithType } from 'app/actions/GroupActions';
 import { ContentMain } from 'app/components/Content';

--- a/app/routes/admin/email/components/RestrictedMailEditor.tsx
+++ b/app/routes/admin/email/components/RestrictedMailEditor.tsx
@@ -2,7 +2,7 @@ import { Icon, LinkButton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Download } from 'lucide-react';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   createRestrictedMail,
   fetchRestrictedMail,

--- a/app/routes/admin/email/components/RestrictedMails.tsx
+++ b/app/routes/admin/email/components/RestrictedMails.tsx
@@ -1,7 +1,7 @@
 import { Card, Flex, LinkButton } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetch } from 'app/actions/RestrictedMailActions';
 import { ContentMain } from 'app/components/Content';
 import Table from 'app/components/Table';

--- a/app/routes/admin/email/index.tsx
+++ b/app/routes/admin/email/index.tsx
@@ -1,6 +1,6 @@
 import { Page } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { Navigate, Outlet, type RouteObject } from 'react-router-dom';
+import { Navigate, Outlet, type RouteObject } from 'react-router';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../../pageNotFound';

--- a/app/routes/admin/groups/components/AddGroupPermission.tsx
+++ b/app/routes/admin/groups/components/AddGroupPermission.tsx
@@ -1,5 +1,5 @@
 import { Field } from 'react-final-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { editGroup } from 'app/actions/GroupActions';
 import { Form, LegoFinalForm } from 'app/components/Form';
 import { SubmitButton } from 'app/components/Form/SubmitButton';

--- a/app/routes/admin/groups/components/GroupForm/index.tsx
+++ b/app/routes/admin/groups/components/GroupForm/index.tsx
@@ -1,5 +1,5 @@
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { createGroup, editGroup } from 'app/actions/GroupActions';
 import {
   Form,

--- a/app/routes/admin/groups/components/GroupMembers.tsx
+++ b/app/routes/admin/groups/components/GroupMembers.tsx
@@ -1,6 +1,6 @@
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fetchMembershipsPagination } from 'app/actions/GroupActions';
 import { ContentMain } from 'app/components/Content';
 import { selectGroupById } from 'app/reducers/groups';

--- a/app/routes/admin/groups/components/GroupMembersList.tsx
+++ b/app/routes/admin/groups/components/GroupMembersList.tsx
@@ -1,7 +1,7 @@
 import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
 import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { removeMember, addMember } from 'app/actions/GroupActions';
 import { SelectInput } from 'app/components/Form';
 import Table from 'app/components/Table';

--- a/app/routes/admin/groups/components/GroupPage.tsx
+++ b/app/routes/admin/groups/components/GroupPage.tsx
@@ -1,7 +1,7 @@
 import { Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Helmet } from 'react-helmet-async';
-import { Outlet, useLocation, useParams } from 'react-router-dom';
+import { Outlet, useLocation, useParams } from 'react-router';
 import { fetchAll, fetchGroup } from 'app/actions/GroupActions';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 import { selectGroupById, selectAllGroups } from 'app/reducers/groups';

--- a/app/routes/admin/groups/components/GroupPermissions.tsx
+++ b/app/routes/admin/groups/components/GroupPermissions.tsx
@@ -2,7 +2,7 @@ import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
 import { sortBy } from 'lodash';
 import { Trash2 } from 'lucide-react';
 import { Fragment } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import { editGroup } from 'app/actions/GroupActions';
 import { ContentMain } from 'app/components/Content';
 import EmptyState from 'app/components/EmptyState';

--- a/app/routes/admin/groups/components/GroupTree.tsx
+++ b/app/routes/admin/groups/components/GroupTree.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TreeView from 'react-treeview';
 import { generateTreeStructure } from 'app/utils';
 import './GroupTree.module.css';

--- a/app/routes/admin/groups/components/__tests__/GroupMembers.spec.tsx
+++ b/app/routes/admin/groups/components/__tests__/GroupMembers.spec.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { describe, it, expect } from 'vitest';
 import GroupMembersList from '../GroupMembersList';
 

--- a/app/routes/admin/groups/components/__tests__/GroupTree.spec.tsx
+++ b/app/routes/admin/groups/components/__tests__/GroupTree.spec.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TreeView from 'react-treeview';
 import { describe, it, expect } from 'vitest';
 import GroupTree from '../GroupTree';

--- a/app/routes/admin/groups/components/groupPageRoute.ts
+++ b/app/routes/admin/groups/components/groupPageRoute.ts
@@ -1,5 +1,5 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const GroupForm = lazyComponent(() => import('./GroupForm'));
 const GroupMembers = lazyComponent(() => import('./GroupMembers'));

--- a/app/routes/admin/index.tsx
+++ b/app/routes/admin/index.tsx
@@ -1,7 +1,7 @@
 import pageNotFound from '../pageNotFound';
 import emailRoute from './email';
 import groupPageRoute from './groups/components/groupPageRoute';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const adminRoute: RouteObject[] = [
   { path: 'groups/:groupId/*', children: groupPageRoute },

--- a/app/routes/announcements/components/AnnouncementItem.tsx
+++ b/app/routes/announcements/components/AnnouncementItem.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonGroup, Flex } from '@webkom/lego-bricks';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   deleteAnnouncement,
   sendAnnouncement,

--- a/app/routes/announcements/components/AnnouncementsCreate.tsx
+++ b/app/routes/announcements/components/AnnouncementsCreate.tsx
@@ -1,7 +1,7 @@
 import { ButtonGroup, Card, Flex } from '@webkom/lego-bricks';
 import { isEmpty } from 'lodash';
 import { Field } from 'react-final-form';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import {
   createAnnouncement,
   sendAnnouncement,

--- a/app/routes/announcements/index.tsx
+++ b/app/routes/announcements/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const AnnouncementsList = lazyComponent(
   () => import('./components/AnnouncementsList'),

--- a/app/routes/app/AppRoute.tsx
+++ b/app/routes/app/AppRoute.tsx
@@ -2,7 +2,7 @@ import { Provider as LegoBricksProvider } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router';
 import { fetchMeta } from 'app/actions/MetaActions';
 import { loginAutomaticallyIfPossible } from 'app/actions/UserActions';
 import coverPhoto from 'app/assets/cover.png';

--- a/app/routes/articles/components/ArticleDetail.tsx
+++ b/app/routes/articles/components/ArticleDetail.tsx
@@ -2,7 +2,7 @@ import { LinkButton, LoadingPage, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment-timezone';
 import { useEffect } from 'react';
-import { useNavigate, useParams, Link } from 'react-router-dom';
+import { useNavigate, useParams, Link } from 'react-router';
 import { fetchArticle } from 'app/actions/ArticleActions';
 import CommentView from 'app/components/Comments/CommentView';
 import DisplayContent from 'app/components/DisplayContent';

--- a/app/routes/articles/components/ArticleEditor.tsx
+++ b/app/routes/articles/components/ArticleEditor.tsx
@@ -12,7 +12,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   createArticle,
   deleteArticle,

--- a/app/routes/articles/components/ArticleList.tsx
+++ b/app/routes/articles/components/ArticleList.tsx
@@ -1,7 +1,7 @@
 import { Image, LinkButton, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchAll } from 'app/actions/ArticleActions';
 import { fetchPopular } from 'app/actions/TagActions';
 import Paginator from 'app/components/Paginator';

--- a/app/routes/articles/index.tsx
+++ b/app/routes/articles/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const ArticleList = lazyComponent(() => import('./components/ArticleList'));
 const ArticleEditor = lazyComponent(() => import('./components/ArticleEditor'));

--- a/app/routes/auth/index.tsx
+++ b/app/routes/auth/index.tsx
@@ -1,4 +1,4 @@
-import { type RouteObject } from 'react-router-dom';
+import { type RouteObject } from 'react-router';
 import { lazyComponent } from 'app/utils/lazyComponent';
 
 const LoginPage = lazyComponent(() => import('./components/LoginPage'));

--- a/app/routes/bdb/components/AddSemester.tsx
+++ b/app/routes/bdb/components/AddSemester.tsx
@@ -3,7 +3,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   addSemester,
   addSemesterStatus,

--- a/app/routes/bdb/components/BdbDetail.tsx
+++ b/app/routes/bdb/components/BdbDetail.tsx
@@ -14,7 +14,7 @@ import { Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import {
   deleteCompanyContact,
   deleteSemesterStatus,

--- a/app/routes/bdb/components/BdbOverview.tsx
+++ b/app/routes/bdb/components/BdbOverview.tsx
@@ -1,6 +1,6 @@
 import { Flex, LinkButton, Page } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 import { Tag } from 'app/components/Tags';
 

--- a/app/routes/bdb/components/BdbPage.tsx
+++ b/app/routes/bdb/components/BdbPage.tsx
@@ -2,7 +2,7 @@ import { Card, Flex, Icon } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchAllAdmin, fetchSemesters } from 'app/actions/CompanyActions';
 import { ContentMain } from 'app/components/Content';
 import { SelectInput } from 'app/components/Form';

--- a/app/routes/bdb/components/CompanyContactEditor.tsx
+++ b/app/routes/bdb/components/CompanyContactEditor.tsx
@@ -1,7 +1,7 @@
 import { LoadingPage, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   addCompanyContact,
   editCompanyContact,

--- a/app/routes/bdb/components/CompanyEditor.tsx
+++ b/app/routes/bdb/components/CompanyEditor.tsx
@@ -8,7 +8,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   addCompany,
   deleteCompany,

--- a/app/routes/bdb/components/StudentContactEditor.tsx
+++ b/app/routes/bdb/components/StudentContactEditor.tsx
@@ -1,7 +1,7 @@
 import { LoadingPage, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   editCompany,
   fetchAdmin,

--- a/app/routes/bdb/components/companyInterest/components/CompanyInterestList.tsx
+++ b/app/routes/bdb/components/companyInterest/components/CompanyInterestList.tsx
@@ -8,7 +8,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { FileDown, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchSemesters } from 'app/actions/CompanyActions';
 import {
   deleteCompanyInterest,

--- a/app/routes/bdb/components/companyInterest/components/CompanyInterestPage.tsx
+++ b/app/routes/bdb/components/companyInterest/components/CompanyInterestPage.tsx
@@ -4,7 +4,7 @@ import arrayMutators from 'final-form-arrays';
 import { Field, FormSpy } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
-import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import {
   fetchSemesters,
   fetchSemestersForInterestform,

--- a/app/routes/bdb/index.tsx
+++ b/app/routes/bdb/index.tsx
@@ -1,4 +1,4 @@
-import { type RouteObject } from 'react-router-dom';
+import { type RouteObject } from 'react-router';
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
 

--- a/app/routes/brand/index.tsx
+++ b/app/routes/brand/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const BrandPage = lazyComponent(() => import('./components/BrandPage'));
 

--- a/app/routes/company/components/CompaniesPage.tsx
+++ b/app/routes/company/components/CompaniesPage.tsx
@@ -14,7 +14,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import InfiniteScroll from 'react-infinite-scroller';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchAll } from 'app/actions/CompanyActions';
 import { CheckBox, TextInput } from 'app/components/Form';
 import { selectAllPaginatedCompanies } from 'app/reducers/companies';

--- a/app/routes/company/components/CompanyDetail.tsx
+++ b/app/routes/company/components/CompanyDetail.tsx
@@ -13,7 +13,7 @@ import { isEmpty } from 'lodash';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fetch } from 'app/actions/CompanyActions';
 import { fetchEvents } from 'app/actions/EventActions';
 import { fetchAll as fetchAllJoblistings } from 'app/actions/JoblistingActions';

--- a/app/routes/company/index.tsx
+++ b/app/routes/company/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const CompaniesPage = lazyComponent(() => import('./components/CompaniesPage'));
 const CompanyDetail = lazyComponent(() => import('./components/CompanyDetail'));

--- a/app/routes/contact/components/ContactForm.tsx
+++ b/app/routes/contact/components/ContactForm.tsx
@@ -2,7 +2,7 @@ import { Card, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty } from 'lodash';
 import { Field } from 'react-final-form';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { sendContactMessage } from 'app/actions/ContactActions';
 import { fetchAllWithType, fetchGroup } from 'app/actions/GroupActions';
 import {

--- a/app/routes/contact/index.tsx
+++ b/app/routes/contact/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const Contact = lazyComponent(() => import('./components/Contact'));
 

--- a/app/routes/errors/HTTPError.tsx
+++ b/app/routes/errors/HTTPError.tsx
@@ -1,6 +1,6 @@
 import { Flex, PageContainer } from '@webkom/lego-bricks';
 import { useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { setStatusCode } from 'app/reducers/routing';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
 import renderAbakus from './renderAbakus';

--- a/app/routes/events/components/Admin.tsx
+++ b/app/routes/events/components/Admin.tsx
@@ -15,7 +15,7 @@ import {
 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { deleteEvent } from 'app/actions/EventActions';
 import AnnouncementInLine from 'app/components/AnnouncementInLine';
 import { TextInput } from 'app/components/Form';

--- a/app/routes/events/components/Analytics.tsx
+++ b/app/routes/events/components/Analytics.tsx
@@ -2,7 +2,7 @@ import { Flex } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment-timezone';
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   Area,
   AreaChart,

--- a/app/routes/events/components/Calendar.tsx
+++ b/app/routes/events/components/Calendar.tsx
@@ -2,7 +2,7 @@ import { Icon } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import moment, { type Moment } from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fetchEvents } from 'app/actions/EventActions';
 import { useCurrentUser } from 'app/reducers/auth';
 import { useAppDispatch } from 'app/store/hooks';

--- a/app/routes/events/components/CalendarCell.tsx
+++ b/app/routes/events/components/CalendarCell.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames';
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createSelector } from 'reselect';
 import Pill from 'app/components/Pill';
 import Popover from 'app/components/Popover';

--- a/app/routes/events/components/EventAdministrate/Abacard.tsx
+++ b/app/routes/events/components/EventAdministrate/Abacard.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { markUsernamePresent } from 'app/actions/EventActions';
 import Validator from 'app/components/UserValidator';
 import { selectEventById, selectRegistrationGroups } from 'app/reducers/events';

--- a/app/routes/events/components/EventAdministrate/AdminRegister.tsx
+++ b/app/routes/events/components/EventAdministrate/AdminRegister.tsx
@@ -1,6 +1,6 @@
 import { LoadingIndicator } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { adminRegister, waitinglistPoolId } from 'app/actions/EventActions';
 import {
   TextEditor,

--- a/app/routes/events/components/EventAdministrate/Allergies.tsx
+++ b/app/routes/events/components/EventAdministrate/Allergies.tsx
@@ -2,7 +2,7 @@ import { Flex, Icon, LinkButton, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty } from 'lodash';
 import { FileDown } from 'lucide-react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { fetchAllergies } from 'app/actions/EventActions';
 import EmptyState from 'app/components/EmptyState';
 import Table from 'app/components/Table';

--- a/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
+++ b/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
@@ -6,7 +6,7 @@ import {
 } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { Button } from 'react-aria-components';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   unregister,
   updatePayment,

--- a/app/routes/events/components/EventAdministrate/Attendees.tsx
+++ b/app/routes/events/components/EventAdministrate/Attendees.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { ContentMain } from 'app/components/Content';
 import EmptyState from 'app/components/EmptyState';
 import {

--- a/app/routes/events/components/EventAdministrate/EventAdministrateIndex.tsx
+++ b/app/routes/events/components/EventAdministrate/EventAdministrateIndex.tsx
@@ -1,7 +1,7 @@
 import { Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Helmet } from 'react-helmet-async';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useParams } from 'react-router';
 import { fetchAdministrate } from 'app/actions/EventActions';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 import Tooltip from 'app/components/Tooltip';

--- a/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
+++ b/app/routes/events/components/EventAdministrate/RegistrationTables.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Table from 'app/components/Table';
 import Time from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';

--- a/app/routes/events/components/EventAdministrate/index.tsx
+++ b/app/routes/events/components/EventAdministrate/index.tsx
@@ -1,4 +1,4 @@
-import { type RouteObject } from 'react-router-dom';
+import { type RouteObject } from 'react-router';
 import pageNotFound from 'app/routes/pageNotFound';
 import { lazyComponent } from 'app/utils/lazyComponent';
 

--- a/app/routes/events/components/EventAttendeeStatistics.tsx
+++ b/app/routes/events/components/EventAttendeeStatistics.tsx
@@ -1,7 +1,7 @@
 import { Card, Flex } from '@webkom/lego-bricks';
 import { Send } from 'lucide-react';
 import moment from 'moment';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   CartesianGrid,
   Legend,

--- a/app/routes/events/components/EventDetail/SidebarInfo.tsx
+++ b/app/routes/events/components/EventDetail/SidebarInfo.tsx
@@ -6,7 +6,7 @@ import {
   Languages,
   MapPin,
 } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { MazemapButton } from 'app/components/MazemapEmbed/MazemapButton';
 import TextWithIcon from 'app/components/TextWithIcon';
 import { FromToTime } from 'app/components/Time';

--- a/app/routes/events/components/EventDetail/UnansweredSurveys.tsx
+++ b/app/routes/events/components/EventDetail/UnansweredSurveys.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from './EventDetail.module.css';
 import type { PoolRegistrationWithUser } from 'app/reducers/events';
 import type { AuthUserDetailedEvent } from 'app/store/models/Event';

--- a/app/routes/events/components/EventDetail/index.tsx
+++ b/app/routes/events/components/EventDetail/index.tsx
@@ -4,7 +4,7 @@ import { isEmpty } from 'lodash';
 import { FilePenLine } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useEffect } from 'react';
-import { useNavigate, useParams, Link } from 'react-router-dom';
+import { useNavigate, useParams, Link } from 'react-router';
 import { fetchEvent } from 'app/actions/EventActions';
 import CommentView from 'app/components/Comments/CommentView';
 import {

--- a/app/routes/events/components/EventDetail/infoLists.tsx
+++ b/app/routes/events/components/EventDetail/infoLists.tsx
@@ -1,6 +1,6 @@
 import { CircleHelp } from 'lucide-react';
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TextWithIcon from 'app/components/TextWithIcon';
 import { FormatTime } from 'app/components/Time';
 import Tooltip from 'app/components/Tooltip';

--- a/app/routes/events/components/EventEditor/index.tsx
+++ b/app/routes/events/components/EventEditor/index.tsx
@@ -10,7 +10,7 @@ import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
-import { useNavigate, useParams, Link, useLocation } from 'react-router-dom';
+import { useNavigate, useParams, Link, useLocation } from 'react-router';
 import { createEvent, editEvent, fetchEvent } from 'app/actions/EventActions';
 import {
   uploadFile as _uploadFile,

--- a/app/routes/events/components/EventList.tsx
+++ b/app/routes/events/components/EventList.tsx
@@ -5,7 +5,7 @@ import { FilterX, FolderOpen } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
+import { useLocation, useNavigate, useOutletContext } from 'react-router';
 import { fetchEvents } from 'app/actions/EventActions';
 import EmptyState from 'app/components/EmptyState';
 import EventItem from 'app/components/EventItem';

--- a/app/routes/events/components/EventsOverview.tsx
+++ b/app/routes/events/components/EventsOverview.tsx
@@ -5,7 +5,7 @@ import {
   FilterSection,
 } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router';
 import { CheckBox, DatePicker, RadioButton } from 'app/components/Form';
 import ToggleSwitch from 'app/components/Form/ToggleSwitch';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';

--- a/app/routes/events/components/JoinEventForm.tsx
+++ b/app/routes/events/components/JoinEventForm.tsx
@@ -13,7 +13,7 @@ import { CircleHelp, UserMinus } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useEffect } from 'react';
 import { Field } from 'react-final-form';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { register, unregister, updateFeedback } from 'app/actions/EventActions';
 import {
   Form,

--- a/app/routes/events/components/RegisteredSummary.tsx
+++ b/app/routes/events/components/RegisteredSummary.tsx
@@ -1,5 +1,5 @@
 import { Flex, Skeleton } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Tooltip from 'app/components/Tooltip';
 import styles from './Registrations.module.css';
 import type { EntityId } from '@reduxjs/toolkit';

--- a/app/routes/events/components/RegistrationMeta.tsx
+++ b/app/routes/events/components/RegistrationMeta.tsx
@@ -1,5 +1,5 @@
 import { Flex, Skeleton } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TextWithIcon from 'app/components/TextWithIcon';
 import { PhotoConsentDomain } from 'app/models';
 import {

--- a/app/routes/events/index.tsx
+++ b/app/routes/events/index.tsx
@@ -1,7 +1,7 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
 import eventAdministrateRoute from './components/EventAdministrate';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const Calendar = lazyComponent(() => import('./components/Calendar'));
 const EventDetail = lazyComponent(() => import('./components/EventDetail'));

--- a/app/routes/forum/components/ForumDetail.tsx
+++ b/app/routes/forum/components/ForumDetail.tsx
@@ -1,6 +1,6 @@
 import { LinkButton, LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fetchForum } from 'app/actions/ForumActions';
 import { selectForumById } from 'app/reducers/forums';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';

--- a/app/routes/forum/components/ForumEditor.tsx
+++ b/app/routes/forum/components/ForumEditor.tsx
@@ -9,7 +9,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   createForum,
   deleteForum,

--- a/app/routes/forum/components/ForumListEntry.tsx
+++ b/app/routes/forum/components/ForumListEntry.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from './ForumList.module.css';
 import type { PublicForum } from 'app/store/models/Forum';
 

--- a/app/routes/forum/components/ThreadDetail.tsx
+++ b/app/routes/forum/components/ThreadDetail.tsx
@@ -1,7 +1,7 @@
 import { LinkButton, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { fetchThreadByForum } from 'app/actions/ForumActions';
 import { CommentView } from 'app/components/Comments';
 import DisplayContent from 'app/components/DisplayContent';

--- a/app/routes/forum/components/ThreadEditor.tsx
+++ b/app/routes/forum/components/ThreadEditor.tsx
@@ -9,7 +9,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   createThread,
   deleteThread,

--- a/app/routes/forum/components/ThreadListEntry.tsx
+++ b/app/routes/forum/components/ThreadListEntry.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from './ForumList.module.css';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { PublicThread } from 'app/store/models/Forum';

--- a/app/routes/forum/index.tsx
+++ b/app/routes/forum/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const ForumDetail = lazyComponent(() => import('./components/ForumDetail'));
 const ForumEditor = lazyComponent(() => import('./components/ForumEditor'));

--- a/app/routes/frontpage/components/ArticleItem.tsx
+++ b/app/routes/frontpage/components/ArticleItem.tsx
@@ -1,5 +1,5 @@
 import { Card, Image } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useAppSelector } from 'app/store/hooks';
 import truncateString from 'app/utils/truncateString';
 import styles from './ArticleItem.module.css';

--- a/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
+++ b/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
@@ -3,7 +3,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment-timezone';
 import { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchData, fetchReadmes } from 'app/actions/FrontpageActions';
 import { fetchRandomQuote } from 'app/actions/QuoteActions';
 import Poll from 'app/components/Poll';

--- a/app/routes/frontpage/components/CompactEvents.tsx
+++ b/app/routes/frontpage/components/CompactEvents.tsx
@@ -1,7 +1,7 @@
 import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
 import { Pin } from 'lucide-react';
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Circle from 'app/components/Circle';
 import EmptyState from 'app/components/EmptyState';
 import Time from 'app/components/Time';

--- a/app/routes/frontpage/components/FrontpageEventItem.tsx
+++ b/app/routes/frontpage/components/FrontpageEventItem.tsx
@@ -1,5 +1,5 @@
 import { Card, Flex, Image } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useIsLoggedIn } from 'app/reducers/auth';
 import { colorForEventType } from 'app/routes/events/utils';
 import { useAppSelector } from 'app/store/hooks';

--- a/app/routes/frontpage/components/Pinned.tsx
+++ b/app/routes/frontpage/components/Pinned.tsx
@@ -1,5 +1,5 @@
 import { Card, Flex, Image } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { isEvent } from 'app/reducers/frontpage';
 import { useAppSelector } from 'app/store/hooks';
 import styles from './Pinned.module.css';

--- a/app/routes/frontpage/components/UpcomingRegistrations.tsx
+++ b/app/routes/frontpage/components/UpcomingRegistrations.tsx
@@ -2,7 +2,7 @@ import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
 import { AlarmClock, Leaf } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import EmptyState from 'app/components/EmptyState';
 import { selectAllEvents } from 'app/reducers/events';
 import { colorForEventType } from 'app/routes/events/utils';

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { type RouteObject } from 'react-router-dom';
+import { type RouteObject } from 'react-router';
 import lendingRoute from 'app/routes/lending';
 import { lazyComponent } from 'app/utils/lazyComponent';
 import achievementRoute from './achievements';

--- a/app/routes/interestgroups/components/InterestGroup.tsx
+++ b/app/routes/interestgroups/components/InterestGroup.tsx
@@ -1,6 +1,6 @@
 import { Flex, Image } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ABAKUS_ICON from 'app/assets/icon-192x192.png';
 import styles from './InterestGroup.module.css';
 import type { Group } from 'app/models';

--- a/app/routes/interestgroups/components/InterestGroupApplyCreateApplication.tsx
+++ b/app/routes/interestgroups/components/InterestGroupApplyCreateApplication.tsx
@@ -1,6 +1,6 @@
 import { Page } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from './InterestGroup.module.css';
 
 const InterestGroupApplyCreate = () => {

--- a/app/routes/interestgroups/components/InterestGroupDetail.tsx
+++ b/app/routes/interestgroups/components/InterestGroupDetail.tsx
@@ -12,7 +12,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Pencil } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   fetchAllMemberships,
   fetchGroup,

--- a/app/routes/interestgroups/components/InterestGroupEdit.tsx
+++ b/app/routes/interestgroups/components/InterestGroupEdit.tsx
@@ -1,7 +1,7 @@
 import { LoadingPage, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fetchGroup } from 'app/actions/GroupActions';
 import { selectGroupById } from 'app/reducers/groups';
 import GroupForm from 'app/routes/admin/groups/components/GroupForm';

--- a/app/routes/interestgroups/components/InterestGroupList.tsx
+++ b/app/routes/interestgroups/components/InterestGroupList.tsx
@@ -2,7 +2,7 @@ import { LinkButton, Page, Flex, Icon } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Info, HandCoins, Plus } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchAllWithType } from 'app/actions/GroupActions';
 import { ContentMain } from 'app/components/Content';
 import { GroupType } from 'app/models';

--- a/app/routes/interestgroups/components/InterestGroupMemberModal.tsx
+++ b/app/routes/interestgroups/components/InterestGroupMemberModal.tsx
@@ -1,7 +1,7 @@
 import { Flex, Icon, Modal } from '@webkom/lego-bricks';
 import sortBy from 'lodash/sortBy';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TextInput from 'app/components/Form/TextInput';
 import { ProfilePicture } from 'app/components/Image';
 import Tooltip from 'app/components/Tooltip';

--- a/app/routes/interestgroups/components/InterestGroupMoneyApplication.tsx
+++ b/app/routes/interestgroups/components/InterestGroupMoneyApplication.tsx
@@ -1,6 +1,6 @@
 import { Page } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from './InterestGroup.module.css';
 
 const InterestGroupApplyCash = () => {

--- a/app/routes/interestgroups/index.tsx
+++ b/app/routes/interestgroups/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const InterestGroupList = lazyComponent(
   () => import('./components/InterestGroupList'),

--- a/app/routes/joblistings/components/JoblistingDetail.tsx
+++ b/app/routes/joblistings/components/JoblistingDetail.tsx
@@ -2,7 +2,7 @@ import { Flex, Icon, LinkButton, LoadingPage, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Pencil } from 'lucide-react';
 import { useEffect } from 'react';
-import { useNavigate, useParams, Link } from 'react-router-dom';
+import { useNavigate, useParams, Link } from 'react-router';
 import { fetchJoblisting } from 'app/actions/JoblistingActions';
 import {
   ContentSection,

--- a/app/routes/joblistings/components/JoblistingEditor.tsx
+++ b/app/routes/joblistings/components/JoblistingEditor.tsx
@@ -11,7 +11,7 @@ import { Trash2 } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { fetchCompanyContacts } from 'app/actions/CompanyActions';
 import {
   createJoblisting,

--- a/app/routes/joblistings/components/JoblistingList.tsx
+++ b/app/routes/joblistings/components/JoblistingList.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex, Icon, Skeleton } from '@webkom/lego-bricks';
 import { FilterX, FolderOpen } from 'lucide-react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import EmptyState from 'app/components/EmptyState';
 import JoblistingItem from 'app/components/JoblistingItem';
 import sharedStyles from 'app/components/JoblistingItem/JoblistingItem.module.css';

--- a/app/routes/joblistings/components/JoblistingPage.tsx
+++ b/app/routes/joblistings/components/JoblistingPage.tsx
@@ -3,7 +3,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment-timezone';
 import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { fetchAll } from 'app/actions/JoblistingActions';
 import { selectAllJoblistings } from 'app/reducers/joblistings';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';

--- a/app/routes/joblistings/index.tsx
+++ b/app/routes/joblistings/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const JoblistingsPage = lazyComponent(
   () => import('./components/JoblistingPage'),

--- a/app/routes/lending/components/LendableObjectDetail/index.tsx
+++ b/app/routes/lending/components/LendableObjectDetail/index.tsx
@@ -1,7 +1,7 @@
 import { Page, LinkButton, PageCover, Card } from '@webkom/lego-bricks';
 import { Warehouse } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   ContentMain,
   ContentSection,

--- a/app/routes/lending/components/LendableObjectEdit/index.tsx
+++ b/app/routes/lending/components/LendableObjectEdit/index.tsx
@@ -1,6 +1,6 @@
 import { LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { objectPermissionsToInitialValues } from 'app/components/Form/ObjectPermissions';
 import { LendableObjectEditor } from 'app/routes/lending/components/LendableObjectEditor';
 import { useFetchedLendableObject } from 'app/routes/lending/useFetchedLendableObject';

--- a/app/routes/lending/components/LendableObjectEditor.tsx
+++ b/app/routes/lending/components/LendableObjectEditor.tsx
@@ -1,5 +1,5 @@
 import { Field } from 'react-final-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   createLendableObject,
   editLendableObject,

--- a/app/routes/lending/components/LendableObjectList/index.tsx
+++ b/app/routes/lending/components/LendableObjectList/index.tsx
@@ -10,7 +10,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { FolderOpen } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchAllLendableObjects } from 'app/actions/LendableObjectActions';
 import abakus_icon from 'app/assets/icon-192x192.png';
 import EmptyState from 'app/components/EmptyState';

--- a/app/routes/lending/index.tsx
+++ b/app/routes/lending/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const LendableObjectsList = lazyComponent(
   () => import('./components/LendableObjectList'),

--- a/app/routes/meetings/MeetingDetailWrapper.tsx
+++ b/app/routes/meetings/MeetingDetailWrapper.tsx
@@ -1,6 +1,6 @@
 import { usePreparedEffect } from '@webkom/react-prepare';
 import qs from 'qs';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import {
   fetchMeeting,
   answerMeetingInvitation,

--- a/app/routes/meetings/components/MeetingAnswer.tsx
+++ b/app/routes/meetings/components/MeetingAnswer.tsx
@@ -1,5 +1,5 @@
 import { LoadingIndicator, Button } from '@webkom/lego-bricks';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { resetMeetingToken } from 'app/reducers/meetings';
 import { useAppDispatch } from 'app/store/hooks';
 import { MeetingInvitationStatus } from 'app/store/models/MeetingInvitation';

--- a/app/routes/meetings/components/MeetingDetail.tsx
+++ b/app/routes/meetings/components/MeetingDetail.tsx
@@ -14,7 +14,7 @@ import moment from 'moment-timezone';
 import diff from 'node-htmldiff';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { setInvitationStatus } from 'app/actions/MeetingActions';
 import AddToCalendar from 'app/components/AddToCalendar/AddToCalendar';
 import AnnouncementInLine from 'app/components/AnnouncementInLine';

--- a/app/routes/meetings/components/MeetingEditor.tsx
+++ b/app/routes/meetings/components/MeetingEditor.tsx
@@ -13,7 +13,7 @@ import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Field, FormSpy } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { fetchMemberships } from 'app/actions/GroupActions';
 import {
   createMeeting,

--- a/app/routes/meetings/components/MeetingList.tsx
+++ b/app/routes/meetings/components/MeetingList.tsx
@@ -11,7 +11,7 @@ import { CalendarOff } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchAll } from 'app/actions/MeetingActions';
 import EmptyState from 'app/components/EmptyState';
 import { Tag } from 'app/components/Tags';

--- a/app/routes/meetings/index.tsx
+++ b/app/routes/meetings/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const MeetingList = lazyComponent(() => import('./components/MeetingList'));
 const MeetingEditor = lazyComponent(() => import('./components/MeetingEditor'));

--- a/app/routes/pageNotFound/index.tsx
+++ b/app/routes/pageNotFound/index.tsx
@@ -1,5 +1,5 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const HTTPError = lazyComponent(() => import('app/routes/errors/HTTPError'));
 

--- a/app/routes/pages/components/LandingPage.tsx
+++ b/app/routes/pages/components/LandingPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import bannerDarkMode from 'app/assets/om-abakus-banner-dark-mode.png';
 import bannerLightMode from 'app/assets/om-abakus-banner.png';
 import { useIsLoggedIn } from 'app/reducers/auth';

--- a/app/routes/pages/components/PageDetail.tsx
+++ b/app/routes/pages/components/PageDetail.tsx
@@ -8,7 +8,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   fetchAllMemberships,
   fetchAllWithType,

--- a/app/routes/pages/components/PageEditor.tsx
+++ b/app/routes/pages/components/PageEditor.tsx
@@ -12,7 +12,7 @@ import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { uploadFile } from 'app/actions/FileActions';
 import {
   createPage,

--- a/app/routes/pages/components/PageHierarchy.tsx
+++ b/app/routes/pages/components/PageHierarchy.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@webkom/lego-bricks';
 import { ChevronDown } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router';
 import { readmeIfy } from 'app/components/ReadmeLogo';
 import styles from './PageHierarchy.module.css';
 import type { PageDetailParams } from 'app/routes/pages/components/PageDetail';

--- a/app/routes/pages/index.tsx
+++ b/app/routes/pages/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const PageEditor = lazyComponent(() => import('./components/PageEditor'));
 const PageDetail = lazyComponent(() => import('./components/PageDetail'));

--- a/app/routes/photos/components/GalleryDetail.tsx
+++ b/app/routes/photos/components/GalleryDetail.tsx
@@ -8,7 +8,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { ImageDown, ImagePlus, Images, Pencil } from 'lucide-react';
 import { useState } from 'react';
-import { useParams, useNavigate, Outlet } from 'react-router-dom';
+import { useParams, useNavigate, Outlet } from 'react-router';
 import { fetchGallery, fetchGalleryMetadata } from 'app/actions/GalleryActions';
 import {
   fetchGalleryPictures,

--- a/app/routes/photos/components/GalleryDetailsRow.tsx
+++ b/app/routes/photos/components/GalleryDetailsRow.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Time from 'app/components/Time';
 import styles from './GalleryDetailsRow.module.css';
 import type { DetailedGallery } from 'app/store/models/Gallery';

--- a/app/routes/photos/components/GalleryEditor.tsx
+++ b/app/routes/photos/components/GalleryEditor.tsx
@@ -17,7 +17,7 @@ import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import {
   createGallery,
   deleteGallery,

--- a/app/routes/photos/components/GalleryPictureEditForm.tsx
+++ b/app/routes/photos/components/GalleryPictureEditForm.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonGroup, LoadingPage } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { updatePicture } from 'app/actions/GalleryPictureActions';
 import {
   Form,

--- a/app/routes/photos/components/GalleryPictureModal.tsx
+++ b/app/routes/photos/components/GalleryPictureModal.tsx
@@ -9,7 +9,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import throttle from 'lodash/throttle';
 import { Download, Pencil } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { Link, useParams, useNavigate, Outlet } from 'react-router-dom';
+import { Link, useParams, useNavigate, Outlet } from 'react-router';
 import { useSwipeable, RIGHT, LEFT } from 'react-swipeable';
 import { updateGalleryCover } from 'app/actions/GalleryActions';
 import {

--- a/app/routes/photos/components/Overview.tsx
+++ b/app/routes/photos/components/Overview.tsx
@@ -2,7 +2,7 @@ import { LinkButton, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Images } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { fetchGalleries } from 'app/actions/GalleryActions';
 import EmptyState from 'app/components/EmptyState';
 import Gallery from 'app/components/Gallery';

--- a/app/routes/photos/index.tsx
+++ b/app/routes/photos/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const Overview = lazyComponent(() => import('./components/Overview'));
 const GalleryEditor = lazyComponent(() => import('./components/GalleryEditor'));

--- a/app/routes/polls/components/PollDetail.tsx
+++ b/app/routes/polls/components/PollDetail.tsx
@@ -3,7 +3,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import { Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fetchPoll } from 'app/actions/PollActions';
 import Poll from 'app/components/Poll';
 import { selectPollById } from 'app/reducers/polls';

--- a/app/routes/polls/components/PollEditor.tsx
+++ b/app/routes/polls/components/PollEditor.tsx
@@ -10,7 +10,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { createPoll, deletePoll, editPoll } from 'app/actions/PollActions';
 import {
   Form,

--- a/app/routes/polls/components/PollsList.tsx
+++ b/app/routes/polls/components/PollsList.tsx
@@ -2,7 +2,7 @@ import { Card, Flex, Icon, LinkButton, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { CircleCheck, CircleX } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { fetchAll } from 'app/actions/PollActions';
 import Paginator from 'app/components/Paginator';
 import { selectAllPolls } from 'app/reducers/polls';

--- a/app/routes/polls/index.tsx
+++ b/app/routes/polls/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const PollsList = lazyComponent(() => import('./components/PollsList'));
 const PollCreator = lazyComponent(() => import('./components/PollEditor'), {

--- a/app/routes/quotes/components/AddQuote.tsx
+++ b/app/routes/quotes/components/AddQuote.tsx
@@ -2,7 +2,7 @@ import { Page } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { addQuotes } from 'app/actions/QuoteActions';
 import { ContentMain } from 'app/components/Content';
 import {

--- a/app/routes/quotes/components/Quote.tsx
+++ b/app/routes/quotes/components/Quote.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { approve, deleteQuote, unapprove } from 'app/actions/QuoteActions';
 import Dropdown from 'app/components/Dropdown';
 import Reactions from 'app/components/Reactions';

--- a/app/routes/quotes/components/QuotePage.tsx
+++ b/app/routes/quotes/components/QuotePage.tsx
@@ -9,7 +9,7 @@ import {
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { FolderOpen } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fetchEmojis } from 'app/actions/EmojiActions';
 import { fetchAll, fetchQuote } from 'app/actions/QuoteActions';
 import EmptyState from 'app/components/EmptyState';

--- a/app/routes/quotes/index.tsx
+++ b/app/routes/quotes/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const QuotePage = lazyComponent(() => import('./components/QuotePage'));
 const AddQuote = lazyComponent(() => import('./components/AddQuote'));

--- a/app/routes/search/SearchPageWrapper.tsx
+++ b/app/routes/search/SearchPageWrapper.tsx
@@ -3,7 +3,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import { debounce } from 'lodash';
 import qs from 'qs';
 import { Helmet } from 'react-helmet-async';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { search } from 'app/actions/SearchActions';
 import SearchPage from 'app/components/Search/SearchPage';
 import { selectResult } from 'app/reducers/search';

--- a/app/routes/search/index.tsx
+++ b/app/routes/search/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const SearchPageWrapper = lazyComponent(() => import('./SearchPageWrapper'));
 

--- a/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
+++ b/app/routes/surveys/components/AddSubmission/AddSubmissionPage.tsx
@@ -2,7 +2,7 @@ import { Card, LoadingIndicator, Page, PageCover } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import {
   addSubmission,
   fetchUserSubmission,

--- a/app/routes/surveys/components/Submissions/Results.tsx
+++ b/app/routes/surveys/components/Submissions/Results.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import { produce } from 'immer';
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router';
 import { editSurvey } from 'app/actions/SurveyActions';
 import DistributionBarChart from 'app/components/Chart/BarChart';
 import ChartLabel from 'app/components/Chart/ChartLabel';

--- a/app/routes/surveys/components/Submissions/SubmissionPublicResultsPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionPublicResultsPage.tsx
@@ -4,7 +4,7 @@ import {
   Page,
   PageCover,
 } from '@webkom/lego-bricks';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import EmptyState from 'app/components/EmptyState';
 import { useFetchedSurvey } from 'app/reducers/surveys';
 import { useAppSelector } from 'app/store/hooks';

--- a/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
@@ -2,7 +2,7 @@ import { Accordion, Icon, Skeleton } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { ChevronRight } from 'lucide-react';
 import { useState } from 'react';
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router';
 import StaticSubmission from '../StaticSubmission';
 import styles from '../surveys.module.css';
 import type { SurveysRouteContext } from 'app/routes/surveys';

--- a/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsPage.tsx
@@ -1,4 +1,4 @@
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router';
 import { ContentSection, ContentMain } from 'app/components/Content';
 import { useAppSelector } from 'app/store/hooks';
 import { guardLogin } from 'app/utils/replaceUnlessLoggedIn';

--- a/app/routes/surveys/components/Submissions/SubmissionsSummary.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsSummary.tsx
@@ -1,5 +1,5 @@
 import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router';
 import { hideAnswer, showAnswer } from 'app/actions/SurveySubmissionActions';
 import EmptyState from 'app/components/EmptyState';
 import Tooltip from 'app/components/Tooltip';

--- a/app/routes/surveys/components/SurveyDetail.tsx
+++ b/app/routes/surveys/components/SurveyDetail.tsx
@@ -1,10 +1,5 @@
 import { LinkButton, LoadingPage } from '@webkom/lego-bricks';
-import {
-  Link,
-  useNavigate,
-  useOutletContext,
-  useParams,
-} from 'react-router-dom';
+import { Link, useNavigate, useOutletContext, useParams } from 'react-router';
 import { ContentSection, ContentMain } from 'app/components/Content';
 import Time from 'app/components/Time';
 import { displayNameForEventType } from 'app/routes/events/utils';

--- a/app/routes/surveys/components/SurveyEditor/AddSurveyPage.tsx
+++ b/app/routes/surveys/components/SurveyEditor/AddSurveyPage.tsx
@@ -2,7 +2,7 @@ import { LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty } from 'lodash';
 import moment from 'moment-timezone';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { fetchEvent } from 'app/actions/EventActions';
 import { addSurvey } from 'app/actions/SurveyActions';
 import { selectEventById } from 'app/reducers/events';

--- a/app/routes/surveys/components/SurveyEditor/EditSurveyPage.tsx
+++ b/app/routes/surveys/components/SurveyEditor/EditSurveyPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingIndicator, Page } from '@webkom/lego-bricks';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { editSurvey } from 'app/actions/SurveyActions';
 import { useFetchedSurvey, useFetchedTemplate } from 'app/reducers/surveys';
 import SurveyForm from 'app/routes/surveys/components/SurveyEditor/SurveyForm';

--- a/app/routes/surveys/components/SurveyEditor/SurveyForm.tsx
+++ b/app/routes/surveys/components/SurveyEditor/SurveyForm.tsx
@@ -4,7 +4,7 @@ import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Dropdown from 'app/components/Dropdown';
 import {
   Form,

--- a/app/routes/surveys/components/SurveyList/SurveyItem.tsx
+++ b/app/routes/surveys/components/SurveyList/SurveyItem.tsx
@@ -1,6 +1,6 @@
 import { Image } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Time from 'app/components/Time';
 import { selectEventById } from 'app/reducers/events';
 import { colorForEventType } from 'app/routes/events/utils';

--- a/app/routes/surveys/components/SurveysOverview.tsx
+++ b/app/routes/surveys/components/SurveysOverview.tsx
@@ -1,5 +1,5 @@
 import { LinkButton, Page } from '@webkom/lego-bricks';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 
 const SurveysOverview = () => {

--- a/app/routes/surveys/components/SurveysWrapper.tsx
+++ b/app/routes/surveys/components/SurveysWrapper.tsx
@@ -1,6 +1,6 @@
 import { LoadingPage, Page, PageCover } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useParams } from 'react-router';
 import { useFetchedSurveySubmissions } from 'app/reducers/surveySubmissions';
 import { useFetchedSurvey } from 'app/reducers/surveys';
 import { useAppSelector } from 'app/store/hooks';

--- a/app/routes/surveys/index.tsx
+++ b/app/routes/surveys/index.tsx
@@ -1,4 +1,4 @@
-import { Outlet, type RouteObject } from 'react-router-dom';
+import { Outlet, type RouteObject } from 'react-router';
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
 import type { EventForSurvey } from 'app/store/models/Event';

--- a/app/routes/tags/components/TagCloud.tsx
+++ b/app/routes/tags/components/TagCloud.tsx
@@ -1,7 +1,7 @@
 import { LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { TagCloud as Cloud } from 'react-tagcloud';
 import { fetchAll } from 'app/actions/TagActions';
 import { selectAllTags } from 'app/reducers/tags';

--- a/app/routes/tags/components/TagDetail.tsx
+++ b/app/routes/tags/components/TagDetail.tsx
@@ -2,7 +2,7 @@ import { Card, Flex, LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { map, toPairs } from 'lodash';
 import { Helmet } from 'react-helmet-async';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { fetch } from 'app/actions/TagActions';
 import { selectTagById } from 'app/reducers/tags';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';

--- a/app/routes/tags/index.tsx
+++ b/app/routes/tags/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const TagCloud = lazyComponent(() => import('./components/TagCloud'));
 const TagDetail = lazyComponent(() => import('./components/TagDetail'));

--- a/app/routes/timeline/index.tsx
+++ b/app/routes/timeline/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const TimelinePage = lazyComponent(() => import('./components/TimelinePage'));
 

--- a/app/routes/userValidator/WrappedValidator.tsx
+++ b/app/routes/userValidator/WrappedValidator.tsx
@@ -1,7 +1,7 @@
 import { Page } from '@webkom/lego-bricks';
 import { debounce } from 'lodash';
 import qs from 'qs';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { autocomplete } from 'app/actions/SearchActions';
 import { fetchUser } from 'app/actions/UserActions';
 import Validator from 'app/components/UserValidator';

--- a/app/routes/userValidator/index.tsx
+++ b/app/routes/userValidator/index.tsx
@@ -1,6 +1,6 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const WrappedValidator = lazyComponent(() => import('./WrappedValidator'));
 

--- a/app/routes/users/components/UserConfirmation.tsx
+++ b/app/routes/users/components/UserConfirmation.tsx
@@ -4,7 +4,7 @@ import { normalize } from 'normalizr';
 import qs from 'qs';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { User } from 'app/actions/ActionTypes';
 import {
   createUser,

--- a/app/routes/users/components/UserProfile/Achievements.tsx
+++ b/app/routes/users/components/UserProfile/Achievements.tsx
@@ -2,7 +2,7 @@ import { Button, Flex } from '@webkom/lego-bricks';
 import { Trophy } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Tooltip from 'app/components/Tooltip';
 import AchievementsInfo, {
   rarityToColorMap,

--- a/app/routes/users/components/UserProfile/AchievementsBox.tsx
+++ b/app/routes/users/components/UserProfile/AchievementsBox.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import { Trophy } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Tooltip from 'app/components/Tooltip';
 import AchievementsInfo, {
   rarityToColorMap,

--- a/app/routes/users/components/UserProfile/EmailLists.tsx
+++ b/app/routes/users/components/UserProfile/EmailLists.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Tooltip from 'app/components/Tooltip';
 import {
   InfoField,

--- a/app/routes/users/components/UserProfile/GroupMemberships.tsx
+++ b/app/routes/users/components/UserProfile/GroupMemberships.tsx
@@ -2,7 +2,7 @@ import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { groupBy, orderBy } from 'lodash';
 import moment from 'moment-timezone';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { CircularPicture } from 'app/components/Image';
 import Pill from 'app/components/Pill';
 import Tooltip from 'app/components/Tooltip';

--- a/app/routes/users/components/UserProfile/Permissions.tsx
+++ b/app/routes/users/components/UserProfile/Permissions.tsx
@@ -1,5 +1,5 @@
 import { sortBy } from 'lodash';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   InfoField,
   ProfileSection,

--- a/app/routes/users/components/UserProfile/ProfileSection.tsx
+++ b/app/routes/users/components/UserProfile/ProfileSection.tsx
@@ -1,5 +1,5 @@
 import { Card, Flex } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styles from 'app/routes/users/components/UserProfile/UserProfile.module.css';
 import type { ReactNode } from 'react';
 

--- a/app/routes/users/components/UserProfile/UserInfo.tsx
+++ b/app/routes/users/components/UserProfile/UserInfo.tsx
@@ -1,5 +1,5 @@
 import { Flex, Icon } from '@webkom/lego-bricks';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   EmailInfoField,
   InfoField,

--- a/app/routes/users/components/UserProfile/index.tsx
+++ b/app/routes/users/components/UserProfile/index.tsx
@@ -16,7 +16,7 @@ import { QrCode, SettingsIcon } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet-async';
 import { QRCode } from 'react-qrcode-logo';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fetchPrevious, fetchUpcoming } from 'app/actions/EventActions';
 import { fetchAllWithType } from 'app/actions/GroupActions';
 import { fetchUser } from 'app/actions/UserActions';

--- a/app/routes/users/components/UserResetPassword.tsx
+++ b/app/routes/users/components/UserResetPassword.tsx
@@ -1,6 +1,6 @@
 import { Card, Page } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { resetPassword } from 'app/actions/UserActions';
 import {
   Form,

--- a/app/routes/users/components/UserSettings/ChangePassword.tsx
+++ b/app/routes/users/components/UserSettings/ChangePassword.tsx
@@ -1,5 +1,5 @@
 import { Field } from 'react-final-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { changePassword } from 'app/actions/UserActions';
 import {
   Form,

--- a/app/routes/users/components/UserSettings/DeleteUser.tsx
+++ b/app/routes/users/components/UserSettings/DeleteUser.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@webkom/lego-bricks';
 import { useState } from 'react';
 import { Field } from 'react-final-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { deleteUser } from 'app/actions/UserActions';
 import { TextInput, Form, LegoFinalForm } from 'app/components/Form';
 import { SubmitButton } from 'app/components/Form/SubmitButton';

--- a/app/routes/users/components/UserSettings/StudentConfirmation.tsx
+++ b/app/routes/users/components/UserSettings/StudentConfirmation.tsx
@@ -1,7 +1,7 @@
 import { ButtonGroup, Card, Modal } from '@webkom/lego-bricks';
 import qs from 'qs';
 import { useEffect, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router';
 import {
   type ConfirmStudentAuthResponse,
   confirmStudentAuth,

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -2,7 +2,7 @@ import { Accordion, Flex, Icon, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { ChevronRight, Github, Linkedin, Mail } from 'lucide-react';
 import { Field } from 'react-final-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { fetchUser, updateUser } from 'app/actions/UserActions';
 import { ContentMain } from 'app/components/Content';
 import {

--- a/app/routes/users/components/UserSettings/UserSettingsIndex.tsx
+++ b/app/routes/users/components/UserSettings/UserSettingsIndex.tsx
@@ -1,6 +1,6 @@
 import { Page } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useParams } from 'react-router';
 import { NavigationTab } from 'app/components/NavigationTab/NavigationTab';
 import { useCurrentUser } from 'app/reducers/auth';
 import { useIsCurrentUser } from 'app/routes/users/utils';

--- a/app/routes/users/components/UserSettings/UserSettingsOAuth2.tsx
+++ b/app/routes/users/components/UserSettings/UserSettingsOAuth2.tsx
@@ -9,7 +9,7 @@ import { usePreparedEffect } from '@webkom/react-prepare';
 import keys from 'lodash/keys';
 import { Copy, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   deleteOAuth2Grant,
   fetchOAuth2Applications,

--- a/app/routes/users/components/UserSettings/UserSettingsOAuth2Form.tsx
+++ b/app/routes/users/components/UserSettings/UserSettingsOAuth2Form.tsx
@@ -1,6 +1,6 @@
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Field } from 'react-final-form';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import {
   createOAuth2Application,
   fetchOAuth2Application,

--- a/app/routes/users/components/UserSettings/index.tsx
+++ b/app/routes/users/components/UserSettings/index.tsx
@@ -1,4 +1,4 @@
-import { type RouteObject } from 'react-router-dom';
+import { type RouteObject } from 'react-router';
 import pageNotFound from 'app/routes/pageNotFound';
 import { lazyComponent } from 'app/utils/lazyComponent';
 

--- a/app/routes/users/index.tsx
+++ b/app/routes/users/index.tsx
@@ -1,7 +1,7 @@
 import { lazyComponent } from 'app/utils/lazyComponent';
 import pageNotFound from '../pageNotFound';
 import userSettingsRoute from './components/UserSettings';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 const UserConfirmationForm = lazyComponent(
   () => import('./components/UserConfirmation'),

--- a/app/utils/useQuery.ts
+++ b/app/utils/useQuery.ts
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash';
 import qs from 'qs';
 import { useMemo } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import type { ParsedQs } from 'qs';
 
 /**

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-qr-reader": "^3.0.0-beta-1",
     "react-qrcode-logo": "^3.0.0",
     "react-redux": "^9.1.2",
-    "react-router-dom": "6.21.1",
+    "react-router": "^7.1.5",
     "react-select": "^5.9.0",
     "react-soundplayer": "^1.0.4",
     "react-swipeable": "7.0.1",

--- a/packages/lego-bricks/README.md
+++ b/packages/lego-bricks/README.md
@@ -28,7 +28,7 @@ For client-side routing (with f.ex. `react-router`) and certain dark-mode featur
 
 ```typescript jsx
 import { Provider } from '@webkom/lego-webapp';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 const App = () => {
   const navigate = useNavigate();

--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -48,10 +48,10 @@
   "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^16.0.0"
+    "react-router": "^7.0.0"
   },
   "peerDependenciesMeta": {
-    "react-router-dom": {
+    "react-router": {
       "optional": true
     }
   },

--- a/packages/lego-bricks/src/components/Layout/Page/Sidebar.tsx
+++ b/packages/lego-bricks/src/components/Layout/Page/Sidebar.tsx
@@ -1,7 +1,7 @@
 import cx from 'classnames';
 import { FilterX, X } from 'lucide-react';
 import { createContext, useContext } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { Button } from '../../Button';
 import { Icon } from '../../Icon';
 import Flex from '../Flex';

--- a/packages/lego-bricks/src/components/Tabs/TabContainer.tsx
+++ b/packages/lego-bricks/src/components/Tabs/TabContainer.tsx
@@ -1,7 +1,7 @@
 import cx from 'classnames';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect, useState, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styles from './TabContainer.module.css';
 import type { ReactNode } from 'react';
 

--- a/packages/lego-bricks/src/reactRouter.ts
+++ b/packages/lego-bricks/src/reactRouter.ts
@@ -1,8 +1,8 @@
-import type ReactRouter from 'react-router-dom';
+import type { default as ReactRouter } from 'react-router';
 
 export const importReactRouter = async () => {
   try {
-    return (await import('react-router-dom')) as typeof ReactRouter;
+    return (await import('react-router')) as typeof ReactRouter;
   } catch (e) {
     throw new Error(
       'Unable to import react-router-dom. Make sure it is installed in your project or avoid using features that depend on it.',

--- a/packages/lego-bricks/vite.config.ts
+++ b/packages/lego-bricks/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     },
     sourcemap: true,
     rollupOptions: {
-      external: ['react', 'react-dom', 'react-router-dom'],
+      external: ['react', 'react-dom', 'react-router'],
       output: {
         globals: {
           react: 'React',

--- a/server/ssr.tsx
+++ b/server/ssr.tsx
@@ -7,14 +7,14 @@ import {
   createStaticHandler,
   createStaticRouter,
   StaticRouterProvider,
-} from 'react-router-dom/server';
+} from 'react-router';
 import createStore from 'app/store/createStore';
 import routerConfig from '../app/routes';
 import pageRenderer from './pageRenderer';
 import createFetchRequest from './request';
 import type { RootState } from 'app/store/createRootReducer';
 import type { Request, Response } from 'express';
-import type { StaticHandlerContext } from 'react-router-dom/server';
+import type { StaticHandlerContext } from 'react-router';
 
 const serverSideTimeoutInMs = 4000;
 export const helmetContext = {}; // AntiPattern because of babel

--- a/yarn.lock
+++ b/yarn.lock
@@ -3393,11 +3393,6 @@
     redux-thunk "^3.1.0"
     reselect "^5.1.0"
 
-"@remix-run/router@1.14.1":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.14.1.tgz#6d2dd03d52e604279c38911afc1079d58c50a755"
-  integrity sha512-Qg4DMQsfPNAs88rb2xkdk03N3bjK4jgX5fR24eHCTR9q6PrhZQZ4UJBPzCHJkIpTRN1UKxx2DzjZmnC+7Lj0Ow==
-
 "@restart/hooks@^0.4.7":
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.4.15.tgz#70990085c9b79d1f3e140db824b29218bdc2b5bb"
@@ -4123,6 +4118,11 @@
   integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
   dependencies:
     "@types/node" "*"
+
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
 "@types/d3-array@^3.0.3":
   version "3.2.1"
@@ -6191,6 +6191,11 @@ cookie@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
   integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
+
+cookie@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
+  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
 copy-anything@^2.0.1:
   version "2.0.6"
@@ -11394,20 +11399,15 @@ react-remove-scroll@^2.6.2:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
 
-react-router-dom@6.21.1:
-  version "6.21.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.21.1.tgz#58b459d2fe1841388c95bb068f85128c45e27349"
-  integrity sha512-QCNrtjtDPwHDO+AO21MJd7yIcr41UetYt5jzaB9Y1UYaPTCnVuJq6S748g1dE11OQlCFIQg+RtAA1SEZIyiBeA==
+react-router@^7.1.5:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.1.5.tgz#c9e19d329d9ce2215fdae844ab6b023b911094db"
+  integrity sha512-8BUF+hZEU4/z/JD201yK6S+UYhsf58bzYIDq2NS1iGpwxSXDu7F+DeGSkIXMFBuHZB21FSiCzEcUb18cQNdRkA==
   dependencies:
-    "@remix-run/router" "1.14.1"
-    react-router "6.21.1"
-
-react-router@6.21.1:
-  version "6.21.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.21.1.tgz#8db7ee8d7cfc36513c9a66b44e0897208c33be34"
-  integrity sha512-W0l13YlMTm1YrpVIOpjCADJqEUpz1vm+CMo47RuFX4Ftegwm6KOYsL5G3eiE52jnJpKvzm6uB/vTKTPKM8dmkA==
-  dependencies:
-    "@remix-run/router" "1.14.1"
+    "@types/cookie" "^0.6.0"
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
+    turbo-stream "2.4.0"
 
 react-select@^5.9.0:
   version "5.9.0"
@@ -12158,6 +12158,11 @@ serve-static@1.16.2, serve-static@^1.16.2:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.19.0"
+
+set-cookie-parser@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz#3016f150072202dfbe90fadee053573cc89d2943"
+  integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
 
 set-function-length@^1.1.1:
   version "1.1.1"
@@ -13013,6 +13018,11 @@ tunnel-agent@^0.6.0:
   integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
   dependencies:
     safe-buffer "^5.0.1"
+
+turbo-stream@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/turbo-stream/-/turbo-stream-2.4.0.tgz#1e4fca6725e90fa14ac4adb782f2d3759a5695f0"
+  integrity sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
# Description

Despite the clickbait title some minor changes were necessary, but the migration did go very smoothly. A lot of imports have changed, as everything is now exported from `react-router`, instead of `react-router-dom`. I also had to bump node to v20.

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1284
