### PR TITLE
Improve presence icons on event administrate page

### DIFF
--- a/app/routes/events/components/EventAdministrate/Administrate.module.css
+++ b/app/routes/events/components/EventAdministrate/Administrate.module.css
@@ -68,36 +68,8 @@
   color: var(--color-blue-6);
 }
 
-.greenIcon {
-  color: var(--success-color);
-
-  ion-icon {
-    color: var(--success-color);
-  }
-}
-
-.tooLateIcon {
-  width: 34px;
-  height: 34px;
-  padding: 0.375rem;
-  cursor: pointer;
-  border-radius: 50%;
-
-  &:hover {
-    background-color: var(--additive-background);
-  }
-}
-
-.questionIcon ion-icon {
+.questionIcon {
   color: var(--color-blue-6);
-}
-
-.redIcon {
-  color: var(--danger-color);
-
-  ion-icon {
-    color: var(--danger-color);
-  }
 }
 
 .consentIcon {
@@ -110,7 +82,31 @@
 }
 
 .transparent {
-  opacity: 0.3;
+  opacity: 0.7;
+  color: var(--secondary-font-color);
+}
+
+.activeSuccess,
+.activeEdit,
+.activeInfo,
+.activeDanger {
+  border-radius: 50%;
+}
+
+.activeSuccess {
+  background-color: var(--color-green-1);
+}
+
+.activeEdit {
+  background-color: var(--color-orange-1);
+}
+
+.activeInfo {
+  background-color: var(--color-blue-1);
+}
+
+.activeDanger {
+  background-color: var(--color-red-1);
 }
 
 a.transparent:hover {

--- a/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
+++ b/app/routes/events/components/EventAdministrate/AttendeeElements.tsx
@@ -5,6 +5,7 @@ import {
   LoadingIndicator,
 } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { Check, HelpCircle, Turtle, X } from 'lucide-react';
 import { Button } from 'react-aria-components';
 import { useParams } from 'react-router';
 import {
@@ -19,15 +20,20 @@ import styles from './Administrate.module.css';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { EventRegistrationPaymentStatus } from 'app/models';
 import type { SelectedAdminRegistration } from 'app/reducers/events';
+import type { ReactNode } from 'react';
 import type { PressEvent } from 'react-aria-components';
 
 type TooltipIconProps = {
   onPress?: (e: PressEvent) => void;
   content: string;
   transparent?: boolean;
-  iconName?: string;
+  iconNode?: ReactNode;
   iconClass: string;
   disabled?: boolean;
+  success?: boolean;
+  edit?: boolean;
+  danger?: boolean;
+  info?: boolean;
 };
 type PresenceProps = {
   presence: Presence;
@@ -47,21 +53,29 @@ export const TooltipIcon = ({
   onPress,
   content,
   transparent,
-  iconName,
+  iconNode,
   iconClass,
   disabled = false,
+  success,
+  edit,
+  danger,
+  info,
 }: TooltipIconProps) => {
   const classNames = cx(iconClass, transparent && styles.transparent);
 
   return (
     <Tooltip content={content}>
-      {iconName ? (
+      {iconNode ? (
         <Icon
-          name={iconName}
+          iconNode={iconNode}
           className={classNames}
           onPress={onPress}
           disabled={disabled}
           size={22}
+          success={success}
+          edit={edit}
+          danger={danger}
+          info={info}
         />
       ) : (
         <Button onPress={onPress} isDisabled={disabled}>
@@ -80,48 +94,38 @@ export const PresenceIcons = ({ presence, registrationId }: PresenceProps) => {
     <Flex alignItems="center" justifyContent="center">
       <TooltipIcon
         content="Møtte opp"
-        iconName="checkmark"
-        iconClass={styles.greenIcon}
-        transparent={presence !== 'PRESENT'}
+        iconNode={<Check />}
+        iconClass={cx(
+          presence !== 'PRESENT' && styles.transparent,
+          presence === 'PRESENT' && styles.activeSuccess,
+        )}
+        success={presence === 'PRESENT'}
         onPress={() =>
           eventId &&
           dispatch(updatePresence(eventId, registrationId, Presence.PRESENT))
         }
       />
-      <Tooltip content="Møtte for sent opp (gir 1 prikk)">
-        <div
-          className={cx(
-            styles.tooLateIcon,
-            presence !== 'LATE' && styles.transparent,
-          )}
-          onClick={() => {
-            eventId &&
-              dispatch(updatePresence(eventId, registrationId, Presence.LATE));
-          }}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="22"
-            height="22"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="var(--color-orange-6)"
-            strokeWidth="1.4"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="m12 10 2 4v3a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-3a8 8 0 1 0-16 0v3a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-3l2-4h4Z" />
-            <path d="M4.82 7.9 8 10" />
-            <path d="M15.18 7.9 12 10" />
-            <path d="M16.93 10H20a2 2 0 0 1 0 4H2" />
-          </svg>
-        </div>
-      </Tooltip>
+      <TooltipIcon
+        content="Møtte for sent opp (gir 1 prikk)"
+        iconNode={<Turtle />}
+        iconClass={cx(
+          presence !== 'LATE' && styles.transparent,
+          presence === 'LATE' && styles.activeEdit,
+        )}
+        edit={presence === 'LATE'}
+        onPress={() =>
+          eventId &&
+          dispatch(updatePresence(eventId, registrationId, Presence.LATE))
+        }
+      />
       <TooltipIcon
         content="Ukjent"
-        iconClass={styles.questionIcon}
-        iconName="help-outline"
-        transparent={presence !== 'UNKNOWN'}
+        iconNode={<HelpCircle />}
+        iconClass={cx(
+          presence !== 'UNKNOWN' && styles.transparent,
+          presence === 'UNKNOWN' && styles.activeInfo,
+        )}
+        info={presence === 'UNKNOWN'}
         onPress={() =>
           eventId &&
           dispatch(updatePresence(eventId, registrationId, Presence.UNKNOWN))
@@ -129,9 +133,12 @@ export const PresenceIcons = ({ presence, registrationId }: PresenceProps) => {
       />
       <TooltipIcon
         content="Møtte ikke opp (gir 2 prikker)"
-        iconClass={styles.redIcon}
-        iconName="close-outline"
-        transparent={presence !== 'NOT_PRESENT'}
+        iconNode={<X />}
+        iconClass={cx(
+          presence !== 'NOT_PRESENT' && styles.transparent,
+          presence === 'NOT_PRESENT' && styles.activeDanger,
+        )}
+        danger={presence === 'NOT_PRESENT'}
         onPress={() =>
           eventId &&
           dispatch(

--- a/packages/lego-bricks/src/components/Icon/Icon.module.css
+++ b/packages/lego-bricks/src/components/Icon/Icon.module.css
@@ -81,6 +81,20 @@
   }
 }
 
+.info {
+  composes: clickable;
+  color: var(--color-blue-6);
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background-color: var(--color-blue-2);
+  }
+
+  &:active:not(:disabled) {
+    background-color: var(--color-blue-3);
+  }
+}
+
 .disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/packages/lego-bricks/src/components/Icon/index.tsx
+++ b/packages/lego-bricks/src/components/Icon/index.tsx
@@ -17,6 +17,7 @@ type Props = {
   danger?: boolean; // name: trash
   success?: boolean; // name: checkmark
   edit?: boolean; // name: pencil
+  info?: boolean;
   disabled?: boolean;
 } & Omit<ComponentProps<typeof Flex>, 'onClick'>;
 
@@ -34,6 +35,7 @@ export const Icon = forwardRef<HTMLButtonElement & HTMLAnchorElement, Props>(
       danger = false,
       success = false,
       edit = false,
+      info = false,
       disabled = false,
       ...props
     }: Props,
@@ -44,6 +46,7 @@ export const Icon = forwardRef<HTMLButtonElement & HTMLAnchorElement, Props>(
       danger && styles.danger,
       success && styles.success,
       edit && styles.edit,
+      info && styles.info,
       disabled && styles.disabled,
     );
 


### PR DESCRIPTION
# Description

Requested by Fagkom

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img width="305" alt="image" src="https://github.com/user-attachments/assets/8ee20fc2-4aa8-4917-96e6-e22e10931baf" />
        </td>
        <td>
            <img width="305" alt="image" src="https://github.com/user-attachments/assets/5c9978d4-e2e0-4cd9-b0ce-95fee66d2e9c" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

See images above.