### PR TITLE
FEAT: Option to remove inactive interest groups

### DIFF
--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -170,7 +170,7 @@ export const Membership = {
 };
 export const MembershipHistory = {
   DELETE: generateStatuses('MembershipHistory.DELETE') as AAT,
-}
+};
 /**
  *
  */

--- a/app/actions/ActionTypes.ts
+++ b/app/actions/ActionTypes.ts
@@ -168,7 +168,9 @@ export const Membership = {
   JOIN_GROUP: generateStatuses('Membership.JOIN_GROUP') as AAT,
   LEAVE_GROUP: generateStatuses('Membership.LEAVE_GROUP') as AAT,
 };
-
+export const MembershipHistory = {
+  DELETE: generateStatuses('MembershipHistory.DELETE') as AAT,
+}
 /**
  *
  */

--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -32,7 +32,13 @@ export function addMember({ groupId, userId, role }: AddMemberArgs) {
   });
 }
 
-export const deleteMembershipHistory = ({ groupId, userId }: { groupId:EntityId, userId?:EntityId }) => {
+export const deleteMembershipHistory = ({
+  groupId,
+  userId,
+}: {
+  groupId: EntityId;
+  userId?: EntityId;
+}) => {
   return callAPI({
     types: MembershipHistory.DELETE,
     endpoint: `/membership-history`,

--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -1,6 +1,6 @@
 import callAPI from 'app/actions/callAPI';
 import { groupSchema, membershipSchema } from 'app/reducers';
-import { Group, Membership } from './ActionTypes';
+import { Group, Membership, MembershipHistory } from './ActionTypes';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { GroupType } from 'app/models';
 import type { TransformedMembership } from 'app/reducers/memberships';
@@ -31,6 +31,21 @@ export function addMember({ groupId, userId, role }: AddMemberArgs) {
     },
   });
 }
+
+export const deleteMembershipHistory = ({ groupId, userId }: { groupId:EntityId, userId?:EntityId }) => {
+  return callAPI({
+    types: MembershipHistory.DELETE,
+    endpoint: `/membership-history`,
+    method: 'DELETE',
+    body: {
+      groupId: groupId,
+    },
+    meta: {
+      userId: userId,
+      groupId: groupId,
+    },
+  });
+};
 
 export function removeMember(membership: {
   id: EntityId;

--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -41,11 +41,8 @@ export const deleteMembershipHistory = ({
 }) => {
   return callAPI({
     types: MembershipHistory.DELETE,
-    endpoint: `/membership-history/`,
+    endpoint: `/membership-history/${groupId}`,
     method: 'DELETE',
-    body: {
-      groupId: groupId,
-    },
     meta: {
       userId: userId,
       groupId: groupId,

--- a/app/actions/GroupActions.ts
+++ b/app/actions/GroupActions.ts
@@ -41,7 +41,7 @@ export const deleteMembershipHistory = ({
 }) => {
   return callAPI({
     types: MembershipHistory.DELETE,
-    endpoint: `/membership-history`,
+    endpoint: `/membership-history/`,
     method: 'DELETE',
     body: {
       groupId: groupId,

--- a/app/components/Image/CircularPicture.tsx
+++ b/app/components/Image/CircularPicture.tsx
@@ -1,4 +1,4 @@
-import { Image, PressEvent } from '@webkom/lego-bricks';
+import { Image } from '@webkom/lego-bricks';
 import type { ComponentProps } from 'react';
 
 type Props = {

--- a/app/components/Image/CircularPicture.tsx
+++ b/app/components/Image/CircularPicture.tsx
@@ -1,4 +1,4 @@
-import { Image } from '@webkom/lego-bricks';
+import { Image, PressEvent } from '@webkom/lego-bricks';
 import type { ComponentProps } from 'react';
 
 type Props = {

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -9,8 +9,7 @@ import { User, Event, MembershipHistory } from '../actions/ActionTypes';
 import type { PhotoConsent } from '../models';
 import type { AnyAction, EntityId } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
-import { ActionMenu } from 'packages/lego-bricks/src/components/Layout/Page/ActionMenu';
-import { CurrentUser } from 'app/store/models/User';
+import type { CurrentUser } from 'app/store/models/User';
 
 export type UserEntity = {
   id: number;

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -5,10 +5,12 @@ import { eventSchema, registrationSchema } from 'app/reducers';
 import { selectGroupEntities } from 'app/reducers/groups';
 import { EntityType } from 'app/store/models/entities';
 import createLegoAdapter from 'app/utils/legoAdapter/createLegoAdapter';
-import { User, Event } from '../actions/ActionTypes';
+import { User, Event, MembershipHistory } from '../actions/ActionTypes';
 import type { PhotoConsent } from '../models';
 import type { AnyAction, EntityId } from '@reduxjs/toolkit';
 import type { RootState } from 'app/store/createRootReducer';
+import { ActionMenu } from 'packages/lego-bricks/src/components/Layout/Page/ActionMenu';
+import { CurrentUser } from 'app/store/models/User';
 
 export type UserEntity = {
   id: number;
@@ -47,6 +49,12 @@ const usersSlice = createSlice({
       });
       addCase(User.FETCH_LEADERBOARD.FAILURE, (state) => {
         state.fetchingAchievements = false;
+      });
+      addCase(MembershipHistory.DELETE.SUCCESS, (state, action) => {
+        const user = state.entities[action.meta.userId] as CurrentUser;
+        user.pastMemberships = user.pastMemberships.filter(
+          (membership) => membership.abakusGroup.id !== action.meta.groupId,
+        );
       });
     },
     extraMatchers: (addMatcher) => {

--- a/app/routes/users/components/UserProfile/GroupMemberships.tsx
+++ b/app/routes/users/components/UserProfile/GroupMemberships.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import { groupBy, orderBy } from 'lodash';
 import { CircleMinus } from 'lucide-react';
 import moment from 'moment-timezone';
-import { Link } from 'react-router';
+import { Link, useParams } from 'react-router';
 import { deleteMembershipHistory } from 'app/actions/GroupActions';
 import { CircularPicture } from 'app/components/Image';
 import Pill from 'app/components/Pill';

--- a/app/routes/users/components/UserProfile/GroupMemberships.tsx
+++ b/app/routes/users/components/UserProfile/GroupMemberships.tsx
@@ -1,6 +1,7 @@
-import { Flex } from '@webkom/lego-bricks';
+import { Flex, Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { groupBy, orderBy } from 'lodash';
+import { CircleMinus } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Link } from 'react-router';
 import { CircularPicture } from 'app/components/Image';
@@ -104,24 +105,33 @@ const GroupBadge = ({
   const lastMembership = sortedMemberships[sortedMemberships.length - 1];
   const { id, name, logo } = abakusGroup;
   const groupElement = (
-    <Tooltip
-      key={id}
-      content={badgeTooltip(
-        abakusGroup.name,
-        firstMembership.startDate || firstMembership.createdAt,
-        lastMembership.endDate,
-      )}
-    >
-      <CircularPicture
-        alt={name}
-        src={logo!}
-        size={50}
-        className={cx(
-          styles.membershipBadge,
-          !activeMembership && styles.inactive,
+    <div className={styles.badges}>
+      <Tooltip
+        key={id}
+        content={badgeTooltip(
+          abakusGroup.name,
+          firstMembership.startDate || firstMembership.createdAt,
+          lastMembership.endDate,
         )}
-      />
-    </Tooltip>
+      >
+        <CircularPicture
+          alt={name}
+          src={logo!}
+          size={50}
+          className={cx(
+            styles.membershipBadge,
+            !activeMembership && styles.inactive,
+          )}
+        />
+        {!activeMembership && (
+          <Icon
+            className={styles.removeBadge}
+            iconNode={<CircleMinus />}
+            size={14}
+          />
+        )}
+      </Tooltip>
+    </div>
   );
   const link = resolveGroupLink(abakusGroup);
 

--- a/app/routes/users/components/UserProfile/GroupMemberships.tsx
+++ b/app/routes/users/components/UserProfile/GroupMemberships.tsx
@@ -103,7 +103,6 @@ const GroupBadge = ({
 }: {
   memberships: Optional<PastMembership, 'startDate' | 'endDate'>[];
 }) => {
-  //const isCurrentUser = isCurrentUser("MariaMelsnes");
   const activeMembership = memberships.find(
     (membership) => membership.isActive,
   );
@@ -113,8 +112,8 @@ const GroupBadge = ({
   const isCurrentUser = useIsCurrentUser(params.username);
 
   useEffect(() => {
-    console.log(params, isCurrentUser)
-  }, [params, isCurrentUser])
+    console.log(params, isCurrentUser);
+  }, [params, isCurrentUser]);
 
   const abakusGroup = memberships[0].abakusGroup;
   if (!abakusGroup.showBadge) return null;
@@ -160,7 +159,7 @@ const GroupBadge = ({
       </Link>
       {!activeMembership && isCurrentUser && isInterestGroup && (
         <ConfirmModal
-          title="Slett Historikk"
+          title="Fjern historikk"
           message={
             <>
               Dette vil slette historikken din med{' '}

--- a/app/routes/users/components/UserProfile/GroupMemberships.tsx
+++ b/app/routes/users/components/UserProfile/GroupMemberships.tsx
@@ -1,30 +1,23 @@
-import {
-  Button,
-  ConfirmModal,
-  Flex,
-  Icon,
-  PressEvent,
-} from '@webkom/lego-bricks';
+import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { groupBy, orderBy } from 'lodash';
 import { CircleMinus } from 'lucide-react';
 import moment from 'moment-timezone';
 import { Link } from 'react-router';
+import { deleteMembershipHistory } from 'app/actions/GroupActions';
 import { CircularPicture } from 'app/components/Image';
 import Pill from 'app/components/Pill';
 import Tooltip from 'app/components/Tooltip';
+import { GroupType, type Dateish } from 'app/models';
+import { useCurrentUser } from 'app/reducers/auth';
 import { resolveGroupLink, selectGroupEntities } from 'app/reducers/groups';
 import styles from 'app/routes/users/components/UserProfile/UserProfile.module.css';
 import { useAppDispatch, useAppSelector } from 'app/store/hooks';
-import { GroupType, type Dateish } from 'app/models';
+import { useIsCurrentUser } from '../../utils';
 import type { PublicGroup } from 'app/store/models/Group';
 import type Membership from 'app/store/models/Membership';
 import type { PastMembership } from 'app/store/models/Membership';
 import type { Optional } from 'utility-types';
-import { deleteMembershipHistory } from 'app/actions/GroupActions';
-import { useCurrentUser } from 'app/reducers/auth';
-import { useIsCurrentUser } from '../../utils';
-import { useEffect } from 'react';
 
 export const GroupMemberships = ({
   memberships,

--- a/app/routes/users/components/UserProfile/GroupMemberships.tsx
+++ b/app/routes/users/components/UserProfile/GroupMemberships.tsx
@@ -110,10 +110,7 @@ const GroupBadge = ({
 
   const params = useParams<{ username: string }>();
   const isCurrentUser = useIsCurrentUser(params.username);
-
-  useEffect(() => {
-    console.log(params, isCurrentUser);
-  }, [params, isCurrentUser]);
+  const currentUser = useCurrentUser();
 
   const abakusGroup = memberships[0].abakusGroup;
   if (!abakusGroup.showBadge) return null;
@@ -169,7 +166,7 @@ const GroupBadge = ({
           onConfirm={() =>
             dispatch(
               deleteMembershipHistory({
-                userId: user?.id,
+                userId: currentUser?.id,
                 groupId: abakusGroup.id,
               }),
             )

--- a/app/routes/users/components/UserProfile/UserProfile.module.css
+++ b/app/routes/users/components/UserProfile/UserProfile.module.css
@@ -90,11 +90,41 @@
   margin-right: var(--spacing-sm);
 }
 
+.badges {
+  position: relative;
+}
+
 .membershipBadge {
   &.inactive {
     filter: grayscale(100%);
     opacity: 0.7;
   }
+}
+
+.removeBadge {
+  position: absolute;
+  top: -3px;
+  right: -6px;
+  color: var(--secondary-font-color);
+  transition: opacity 0.2s ease-in-out;
+}
+
+.badges:hover .removeBadge {
+  animation: wiggle 1.5s ease-in-out;
+}
+
+@keyframes wiggle {
+  0% { transform: rotate(0deg); }
+  10% { transform: rotate(-10deg); }
+  20% { transform: rotate(10deg); }
+  30% { transform: rotate(-10deg); }
+  40% { transform: rotate(10deg); }
+  50% { transform: rotate(-5deg); }
+  60% { transform: rotate(5deg); }
+  70% { transform: rotate(-3deg); }
+  80% { transform: rotate(3deg); }
+  90% { transform: rotate(-2deg); }
+  100% { transform: rotate(0deg); }
 }
 
 .achievements {

--- a/app/routes/users/components/UserProfile/UserProfile.module.css
+++ b/app/routes/users/components/UserProfile/UserProfile.module.css
@@ -92,6 +92,7 @@
 
 .badges {
   position: relative;
+  display: inline-block;
 }
 
 .membershipBadge {
@@ -103,28 +104,23 @@
 
 .removeBadge {
   position: absolute;
-  top: -3px;
-  right: -6px;
-  color: var(--secondary-font-color);
-  transition: opacity 0.2s ease-in-out;
+  top: -2px;
+  right: -2px;
+  color: var(--color-red-6);
+  background-color: var(--color-absolute-white);
+  border-radius: 50%;
+  padding: 2px;
+  opacity: 0;
+  transition: opacity 0.25s ease-in-out;
+  cursor: pointer;
 }
 
-.badges:hover .removeBadge {
-  animation: wiggle 1.5s ease-in-out;
+.badgeContainer {
+  position: relative;
 }
 
-@keyframes wiggle {
-  0% { transform: rotate(0deg); }
-  10% { transform: rotate(-10deg); }
-  20% { transform: rotate(10deg); }
-  30% { transform: rotate(-10deg); }
-  40% { transform: rotate(10deg); }
-  50% { transform: rotate(-5deg); }
-  60% { transform: rotate(5deg); }
-  70% { transform: rotate(-3deg); }
-  80% { transform: rotate(3deg); }
-  90% { transform: rotate(-2deg); }
-  100% { transform: rotate(0deg); }
+.badgeContainer:hover .removeBadge {
+  opacity: 1;
 }
 
 .achievements {

--- a/app/routes/users/components/UserProfile/UserProfile.module.css
+++ b/app/routes/users/components/UserProfile/UserProfile.module.css
@@ -107,7 +107,7 @@
   top: -2px;
   right: -2px;
   color: var(--color-red-6);
-  background-color: var(--color-absolute-white);
+  background-color: var(--lego-card-color);
   border-radius: 50%;
   padding: 2px;
   opacity: 0;

--- a/app/routes/users/components/UserProfile/UserProfile.module.css
+++ b/app/routes/users/components/UserProfile/UserProfile.module.css
@@ -106,12 +106,12 @@
   position: absolute;
   top: -2px;
   right: -2px;
-  color: var(--color-red-6);
+  color: var(--danger-color);
   background-color: var(--lego-card-color);
   border-radius: 50%;
   padding: 2px;
   opacity: 0;
-  transition: opacity 0.25s ease-in-out;
+  transition: opacity var(--easing-md);
   cursor: pointer;
 }
 


### PR DESCRIPTION
# Description

I made it possible for users to remove inactive interest group from their profile. 

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
When pressing on the minus button it will trigger a confirmation modal.
        </td>
        <td>

![Screenshot 2025-02-17 at 15 57 36](https://github.com/user-attachments/assets/9cf572c2-212f-4cd4-bac0-9f4948e005dc)
        </td>
        <td>

![Screenshot 2025-02-17 at 16 07 39](https://github.com/user-attachments/assets/910f171b-d8f2-4344-b102-26d7ea40ee4d)
![Screenshot 2025-02-17 at 16 07 47](https://github.com/user-attachments/assets/877da66c-5ee3-44ed-b2ae-f82ef401c86e)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-1260
