### PR TITLE
FIX: Cypress create event test

### DIFF
--- a/cypress/e2e/create_event_spec.js
+++ b/cypress/e2e/create_event_spec.js
@@ -83,9 +83,9 @@ describe('Create event', () => {
     cy.get('._legoEditor_Toolbar_root').should('be.visible');
     //cy.focused().type('{enter}hello{uparrow}lol{enter}');
 
-    cy.get('._legoEditor_Toolbar_root button').first().click();
-    // Format text
     cy.focused().type('This text should be large');
+    // Format text
+    cy.get('._legoEditor_Toolbar_root button').first().click();
     cy.get('._legoEditor_root h1')
       .should('be.visible')
       .contains('This text should be large');


### PR DESCRIPTION
# Description

Simple fix for cypress testing of formatting of text in /events/create

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1295
