### PR TITLE
Add user count to PizzaAccordion

### DIFF
--- a/app/routes/meetings/components/MeetingDetail.module.css
+++ b/app/routes/meetings/components/MeetingDetail.module.css
@@ -46,3 +46,9 @@
 .pizzaList {
   list-style: inside;
 }
+
+.pizzaCount {
+  margin-left: var(--spacing-sm);
+  color: var(--secondary-font-color);
+  font-size: var(--font-size-sm);
+}

--- a/app/routes/meetings/components/PizzaAccordion.tsx
+++ b/app/routes/meetings/components/PizzaAccordion.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Icon } from '@webkom/lego-bricks';
+import { Accordion, Flex, Icon } from '@webkom/lego-bricks';
 import { ChevronRight, Pizza } from 'lucide-react';
 import { FlexRow } from 'app/components/FlexBox';
 import { MeetingInvitationStatus } from 'app/store/models/MeetingInvitation';
@@ -51,13 +51,21 @@ export const PizzaAccordion = ({ meeting, meetingInvitations }: Props) => {
       >
         {
           <div>
-            <h3>Skal ha pizza</h3>
+            <Flex alignItems="baseline">
+              <h3>Skal ha pizza</h3>
+              <span className={styles.pizzaCount}>({pizzaUsers.length})</span>
+            </Flex>
             <ul className={styles.pizzaList}>
               {pizzaUsers.map((user) => (
                 <li key={user}>{user}</li>
               ))}
             </ul>
-            <h3>Skal ikke ha pizza</h3>
+            <Flex alignItems="baseline">
+              <h3>Skal ikke ha pizza</h3>
+              <span className={styles.pizzaCount}>
+                ({notPizzaUsers.length})
+              </span>
+            </Flex>
             <ul className={styles.pizzaList}>
               {notPizzaUsers.map((user) => (
                 <li key={user}>{user}</li>


### PR DESCRIPTION
# Description

Show count for how many users want pizza and not in `PizzaAccordion`. Small change, but I want this. When the meeting report is long the reactions count is far away from the accordion.

# Result

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>

![Screenshot 2025-02-26 at 18 08 09](https://github.com/user-attachments/assets/47d6f51e-8c3d-48bb-9bc3-537a974daad2)
        </td>
        <td>

![Screenshot 2025-02-26 at 18 10 05](https://github.com/user-attachments/assets/eaec9e06-55c7-48cd-8492-869e8e14c422)
        </td>
    </tr>
        <td>

![Screenshot 2025-02-26 at 18 09 43](https://github.com/user-attachments/assets/b561a3e4-dbc7-466d-a6e2-7fc4f5be1e7c)
        </td>
        <td>

![Screenshot 2025-02-26 at 18 10 20](https://github.com/user-attachments/assets/1de8af03-24d1-47c5-aab4-9feaddfa6686)
        </td>
    </tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
