### PR TITLE
Add Accordion option for removing children when closed

### DIFF
--- a/app/routes/frontpage/components/LatestReadme.tsx
+++ b/app/routes/frontpage/components/LatestReadme.tsx
@@ -26,6 +26,7 @@ const LatestReadme = ({
       <Accordion
         defaultOpen={expandedInitially}
         disabled={!collapsible}
+        persistChildren
         triggerComponent={({ onClick, disabled, rotateClassName }) => (
           <div
             className={cx(styles.heading, !disabled && styles.pointer)}

--- a/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
+++ b/app/routes/surveys/components/Submissions/SubmissionsIndividual.tsx
@@ -20,7 +20,6 @@ const SubmissionItem = ({
   return (
     <li key={submission.id}>
       <Accordion
-        animated={false}
         triggerComponent={({ onClick, rotateClassName }) => (
           <div
             className={styles.answerTrigger}

--- a/app/routes/users/components/UserSettings/UserSettings.tsx
+++ b/app/routes/users/components/UserSettings/UserSettings.tsx
@@ -245,6 +245,7 @@ const UserSettings = () => {
       {isCurrentUser && (
         <Flex column gap="var(--spacing-md)">
           <Accordion
+            persistChildren
             triggerComponent={({ onClick, disabled, rotateClassName }) => (
               <div className={styles.advancedSettings} onClick={onClick}>
                 <Flex gap="var(--spacing-sm)" alignItems="center">

--- a/packages/lego-bricks/src/components/Accordion/index.tsx
+++ b/packages/lego-bricks/src/components/Accordion/index.tsx
@@ -36,6 +36,7 @@ export const Accordion = ({
   const [open, setOpen] = useState(defaultOpen);
   const [initialRender, setInitialRender] = useState(true);
   const [containerHeight, setContainerHeight] = useState(0);
+  const [isTransitioning, setTransitioning] = useState(false);
 
   // useCallback works with dynamically changing children unlike useRef
   const childrenWrapperRef = useCallback((node: HTMLDivElement) => {
@@ -54,6 +55,7 @@ export const Accordion = ({
     } else {
       setOpen(!open);
     }
+    setTransitioning(true);
   };
 
   // Ensures that the open flag is triggered after the initialRender flag is changed
@@ -68,7 +70,10 @@ export const Accordion = ({
   // The specific containerHeight is only needed to animate the opening
   const openHeight = initialRender || !animated ? 'initial' : containerHeight;
 
-  const renderChildren = !removeChildrenOnClose || open;
+  // Render children if they should always be rendered,
+  // if not keep them rendered as long as the accordion is not fully closed
+  const renderChildren =
+    !removeChildrenOnClose || open || (animated && isTransitioning);
 
   const trigger = (
     <TriggerComponent
@@ -94,6 +99,7 @@ export const Accordion = ({
         style={{
           height: open ? openHeight : 0,
         }}
+        onTransitionEnd={() => setTransitioning(false)}
       >
         <div ref={childrenWrapperRef}>{renderChildren && children}</div>
       </div>


### PR DESCRIPTION
# Description

Adding an option to remove the Accordion children from the DOM when it is closed.

This is an option that may improve performance, but it may impact the smoothness of the animation if they are combined.

Using the approach with `useCallback` and `ResizeObserver` also fixes issues where the content of an accordion in other ways may be changing, such as loading images.

# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-1166 and ABA-1264
