### PR TITLE
Filter quick links when searching

### DIFF
--- a/lego-webapp/components/Search/utils.tsx
+++ b/lego-webapp/components/Search/utils.tsx
@@ -221,13 +221,11 @@ const EXTERNAL_LINKS: Link[] = [
   },
 ];
 
-const sortFn = (a: Link, b: Link) => {
-  const aSortTitle =
-    a.sortTitle || (typeof a.title === 'string' ? a.title : a.key);
-  const bSortTitle =
-    b.sortTitle || (typeof b.title === 'string' ? b.title : b.key);
-  return aSortTitle.localeCompare(bSortTitle);
-};
+const getSortTitle = (link: Link) =>
+  link.sortTitle || (typeof link.title === 'string' ? link.title : link.key);
+
+const sortFn = (a: Link, b: Link) =>
+  getSortTitle(a).localeCompare(getSortTitle(b));
 
 const SORTED_REGULAR = LINKS.filter((link) => !link.admin).sort(sortFn);
 const SORTED_ADMIN = LINKS.filter((link) => link.admin).sort(sortFn);
@@ -235,6 +233,8 @@ type Options = {
   allowed: AllowedPages;
   loggedIn: boolean;
 };
+
+const SORTED_ALL = [...SORTED_REGULAR, ...EXTERNAL_LINKS, ...SORTED_ADMIN];
 
 /**
  * Finds the links that the user should be able to see.
@@ -266,6 +266,15 @@ export function getExternalLinks(options: Options): Array<NavigationLink> {
 }
 export function getAdminLinks(options: Options): Array<NavigationLink> {
   return retrieveAllowed(SORTED_ADMIN, options);
+}
+export function getAllLinksFiltered(
+  options: Options,
+  query: string,
+): Array<NavigationLink> {
+  const filteredLinks = SORTED_ALL.filter((link) =>
+    getSortTitle(link).toLowerCase().includes(query.toLowerCase()),
+  );
+  return retrieveAllowed(filteredLinks, options);
 }
 export const stripHtmlTags = (s: string): string => {
   return s.replace(/<(.|\n)*?>/g, '');


### PR DESCRIPTION
# Description

Finding pages in the menu is very hard because there are so many links, now the search also filters the links:)

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
Searching for "Utlån"
        </td>
        <td>
<img width="1098" alt="Screenshot 2025-03-05 at 21 56 59" src="https://github.com/user-attachments/assets/df496cb7-e19b-43ee-ba19-103b3279fcdf" />
        </td>
        <td>
<img width="1098" alt="Screenshot 2025-03-05 at 21 57 20" src="https://github.com/user-attachments/assets/a40105a1-5768-499a-83b5-42a0b7b68d02" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

It works:)

---

Resolves ABA-1329
