### PR TITLE
Add ShareButton component

### DIFF
--- a/lego-webapp/components/ShareButton/index.tsx
+++ b/lego-webapp/components/ShareButton/index.tsx
@@ -1,0 +1,43 @@
+import { Button, Flex, Icon } from '@webkom/lego-bricks';
+import { ShareIcon } from 'lucide-react';
+import { useAppDispatch } from 'lego-webapp/redux/hooks';
+import { addToast } from '~/redux/slices/toasts';
+
+type Props = {
+  title: string;
+  url: string;
+};
+
+const ShareButton: React.FC<Props> = ({ title, url }) => {
+  const dispatch = useAppDispatch();
+  const handleShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, url });
+      } catch (error) {
+        console.error('Kunne ikke dele:', error);
+      }
+    } else {
+      {
+        navigator.clipboard.writeText(url);
+      }
+      dispatch(
+        addToast({
+          message: 'Link er kopiert til utklippstavlen',
+          type: 'success',
+          dismissAfter: 10000,
+        }),
+      );
+    }
+  };
+
+  return (
+    <Button onPress={handleShare}>
+      <Flex justifyContent="center">
+        <Icon name="share" iconNode={<ShareIcon />} size={20} />
+      </Flex>
+    </Button>
+  );
+};
+
+export default ShareButton;

--- a/lego-webapp/components/ShareButton/index.tsx
+++ b/lego-webapp/components/ShareButton/index.tsx
@@ -11,12 +11,8 @@ type Props = {
 const ShareButton: React.FC<Props> = ({ title, url }) => {
   const dispatch = useAppDispatch();
   const handleShare = async () => {
-    if (navigator.share) {
-      try {
-        await navigator.share({ title, url });
-      } catch (error) {
-        console.error('Kunne ikke dele:', error);
-      }
+    if (navigator?.canShare?.({ title, url })) {
+      navigator.share({ title, url });
     } else {
       {
         navigator.clipboard.writeText(url);
@@ -25,7 +21,6 @@ const ShareButton: React.FC<Props> = ({ title, url }) => {
         addToast({
           message: 'Link er kopiert til utklippstavlen',
           type: 'success',
-          dismissAfter: 10000,
         }),
       );
     }
@@ -33,8 +28,9 @@ const ShareButton: React.FC<Props> = ({ title, url }) => {
 
   return (
     <Button onPress={handleShare}>
-      <Flex justifyContent="center">
-        <Icon name="share" iconNode={<ShareIcon />} size={20} />
+      <Flex justifyContent="center" gap="var(--spacing-sm)">
+        <Icon iconNode={<ShareIcon />} size={20} />
+        {title}
       </Flex>
     </Button>
   );

--- a/lego-webapp/components/ShareButton/index.tsx
+++ b/lego-webapp/components/ShareButton/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Icon } from '@webkom/lego-bricks';
-import { ShareIcon } from 'lucide-react';
+import { Share2, ShareIcon } from 'lucide-react';
 import { useAppDispatch } from 'lego-webapp/redux/hooks';
 import { addToast } from '~/redux/slices/toasts';
 

--- a/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
@@ -15,6 +15,7 @@ import DisplayContent from '~/components/DisplayContent';
 import InfoList from '~/components/InfoList';
 import { mazemapScript } from '~/components/MazemapEmbed';
 import PropertyHelmet from '~/components/PropertyHelmet';
+import ShareButton from '~/components/ShareButton';
 import Tag from '~/components/Tags/Tag';
 import TextWithIcon from '~/components/TextWithIcon';
 import {
@@ -303,6 +304,15 @@ const EventDetail = () => {
                   Oppdater matallergier / preferanser
                 </a>
               }
+            />
+          )}
+
+          <Line />
+
+          {loggedIn && (
+            <ShareButton
+              title={event?.title || 'Sjekk ut dette arrangementet!'}
+              url={`${appConfig?.webUrl}/events/${event?.id}`}
             />
           )}
 

--- a/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
@@ -309,12 +309,10 @@ const EventDetail = () => {
 
           <Line />
 
-          {loggedIn && (
-            <ShareButton
-              title={event?.title || 'Sjekk ut dette arrangementet!'}
-              url={`${appConfig?.webUrl}/events/${event?.id}`}
-            />
-          )}
+          <ShareButton
+            title={'Del arrangement'}
+            url={`${appConfig?.webUrl}/events/${event?.id}`}
+          />
 
           {(actionGrant.includes('edit') || actionGrant.includes('delete')) && (
             <Line />

--- a/lego-webapp/pages/joblistings/@joblistingIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/joblistings/@joblistingIdOrSlug/+Page.tsx
@@ -12,6 +12,7 @@ import DisplayContent from '~/components/DisplayContent';
 import InfoList from '~/components/InfoList';
 import { jobType, Year, Workplaces } from '~/components/JoblistingItem/Items';
 import PropertyHelmet from '~/components/PropertyHelmet';
+import ShareButton from '~/components/ShareButton';
 import Time from '~/components/Time';
 import YoutubeCover from '~/pages/pages/_components/YoutubeCover';
 import { fetchJoblisting } from '~/redux/actions/JoblistingActions';
@@ -186,6 +187,11 @@ const JoblistingDetail = () => {
               Søk her
             </LinkButton>
           )}
+
+          <ShareButton
+            title={'Del jobbannonse'}
+            url={`${appConfig?.webUrl}/joblistings/${joblisting?.id}`}
+          />
 
           {(joblisting.responsible || joblisting.contactMail) && (
             <div>

--- a/lego-webapp/pages/joblistings/@joblistingIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/joblistings/@joblistingIdOrSlug/+Page.tsx
@@ -188,11 +188,6 @@ const JoblistingDetail = () => {
             </LinkButton>
           )}
 
-          <ShareButton
-            title={'Del jobbannonse'}
-            url={`${appConfig?.webUrl}/joblistings/${joblisting?.id}`}
-          />
-
           {(joblisting.responsible || joblisting.contactMail) && (
             <div>
               <h3>Kontaktinfo</h3>
@@ -241,6 +236,11 @@ const JoblistingDetail = () => {
               </Flex>
             </div>
           )}
+
+          <ShareButton
+            title={'Del jobbannonse'}
+            url={`${appConfig?.webUrl}/joblistings/${joblisting?.id}`}
+          />
 
           {(canEdit || canDelete) && (
             <div>


### PR DESCRIPTION
# Description

Added a ShareButton component and implemented it in events, so people can share the link to different platforms or get it copied to clipboard.

# Result

 Description:
Added a sharebutton to events under "Food allergies". First after-photo in Safari. Second in Firefox as a link.

**Before**

<img width="366" alt="Screenshot 2025-03-05 at 21 58 15" src="https://github.com/user-attachments/assets/77320f32-69ca-40e5-8503-4306c267bd95" />

**After**

<img width="639" alt="Screenshot 2025-03-05 at 21 58 47" src="https://github.com/user-attachments/assets/12d49c39-54da-4912-b20c-e90ca24973ca" />

<img width="1282" alt="Screenshot 2025-03-05 at 21 41 27" src="https://github.com/user-attachments/assets/ecd4c375-d6a6-4bfd-b610-279319aa3628" />

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1177
