### PR TITLE
Fix Dockerfile not working without locally installed node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM node:20-alpine AS builder
 WORKDIR /app/
 COPY . /app
 
-COPY --from=setup /app/node_modules node_modules
+COPY --from=setup /app/node_modules /app/node_modules
 
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_ORG


### PR DESCRIPTION
# Description

I tested the Dockerfile with node_modules installed locally, making it work locally even though it copied the node_modules from the `setup`-step into the wrong directory.
