### PR TITLE
Fix docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY package.json yarn.lock ./
 COPY lego-webapp/package.json lego-webapp/package.json
 COPY packages packages
 
-RUN apk add curl
+RUN apk add curl # For Mazemap installation
 RUN yarn install
 
 COPY . /app
@@ -29,6 +29,8 @@ RUN yarn build
 FROM node:20-alpine
 
 WORKDIR /app/
+
+RUN apk add curl # For healthcheck
 
 ARG RELEASE
 ENV RELEASE=${RELEASE}

--- a/lego-webapp/server/index.ts
+++ b/lego-webapp/server/index.ts
@@ -12,8 +12,8 @@ async function startServer() {
   moment.locale('nb-NO');
   const app = express();
 
-  app.use(vike());
   app.get('/healthz', healthCheck);
+  app.use(vike());
 
   app.listen(port, () => {
     console.log(`Server listening on http://localhost:${port}`);


### PR DESCRIPTION
# Description

Healthcheck was failing, making it impossible to deploy... Appearently the docker image needs curl in order to do the check

Also I accidentally broke the /healthz endpoint a while ago

I'm not 100% sure it works, so I will try deploying to staging before merging