### PR TITLE
Add banner for Revue (Original PR used wrong path thus failed to merge)

### DIFF
--- a/lego-webapp/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
+++ b/lego-webapp/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
@@ -4,6 +4,7 @@ import moment from 'moment-timezone';
 import { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router';
+import Banner from '~/components/Banner';
 import Poll from '~/components/Poll';
 import RandomQuote from '~/components/RandomQuote';
 import { fetchData, fetchReadmes } from '~/redux/actions/FrontpageActions';
@@ -79,11 +80,11 @@ const AuthenticatedFrontpage = () => {
   return (
     <PageContainer card={false}>
       <Helmet title="Hjem" />
-      {/*<Banner
-        header="Abakus har opptak!"
-        subHeader="Trykk her for å søke på komité og revy"
-        link="https://opptak.abakus.no"
-      />*/}
+      <Banner
+        header="Billetter til Abakusrevyen ute nå!"
+        subHeader="Kjøp billetter her. Forestillinger 13.-14. mars"
+        link="https://byscenen.eventim-billetter.no/webshop/webticket/eventlist?production=99"
+      />
       <section className={styles.wrapper}>
         <CompactEvents className={styles.compactEvents} />
         <UpcomingRegistrationsSection />


### PR DESCRIPTION
# Description

Add banner

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Dark</td>
        <td>Light</td>
    </tr>
    <tr>
        <td>

Add Banner
        </td>
        <td>

![image](https://github.com/user-attachments/assets/e4f195f3-7cf9-48b0-9421-410e37082929)
        </td>
        <td>

![image](https://github.com/user-attachments/assets/8ac7af48-e9a0-4c7b-819f-19e88d69a766)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---
Previous PR for some reason used the path: 
app/routes/frontpage/components/AuthenticatedFrontpage.tsx
instead of: 
lego-webapp/app/routes/frontpage/components/AuthenticatedFrontpage.tsx
which made it unable to merge, sorry for the bother

