### PR TITLE
Fix css priority for attendee section skeleton

### DIFF
--- a/lego-webapp/components/UserGrid/UserGrid.module.css
+++ b/lego-webapp/components/UserGrid/UserGrid.module.css
@@ -6,7 +6,7 @@
   background-color: var(--additive-background);
 }
 
-.skeletonCell {
+div.skeletonCell {
   /* The same dimensions as the profile pictures  */
   width: 56px;
   height: 56px;


### PR DESCRIPTION
Same thing as #5420 
Before:
![image](https://github.com/user-attachments/assets/efdc9933-7f91-492f-8c94-5b4792e24a17)
After:
<img width="401" alt="Screenshot 2025-03-07 at 14 22 00" src="https://github.com/user-attachments/assets/e1ab659a-5f78-43f0-8e31-370d77966684" />
