### PR TITLE
Improve UX for banner admin page

### DIFF
--- a/lego-webapp/app/routes/hiddenAdmin/components/BannerEditor.tsx
+++ b/lego-webapp/app/routes/hiddenAdmin/components/BannerEditor.tsx
@@ -1,20 +1,21 @@
-import { LoadingPage, Page } from '@webkom/lego-bricks';
+import {
+  Button,
+  ConfirmModal,
+  Flex,
+  LoadingPage,
+  Page,
+} from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate, useParams } from 'react-router';
 import HTTPError from 'app/routes/errors';
 import { Color, COLORS } from '~/components/Banner';
-import {
-  TextInput,
-  Form,
-  LegoFinalForm,
-  CheckBox,
-  SelectInput,
-} from '~/components/Form';
+import { TextInput, Form, LegoFinalForm, SelectInput } from '~/components/Form';
 import { SubmitButton } from '~/components/Form/SubmitButton';
 import {
   createBanner,
+  deleteBanner,
   editBanner,
   fetchBannerById,
 } from '~/redux/actions/BannerActions';
@@ -57,6 +58,9 @@ const BannerEditor = () => {
       : editBanner(postData, bannerId);
     dispatch(action).then(() => navigate('/admin/banners'));
   };
+
+  const onDelete = () =>
+    dispatch(deleteBanner(bannerId!)).then(() => navigate('/admin/banners'));
 
   const colorToRepresentation: Record<Color, string> = {
     red: 'Rød',
@@ -113,25 +117,30 @@ const BannerEditor = () => {
             <Field
               placeholder="Rød"
               name="color"
-              label="Farge"
+              label="Stil"
               options={colorOptions}
               component={SelectInput.Field}
               required
               id="color"
             />
-            <Field
-              name="currentPrivate"
-              label="Vis på innlogget forside"
-              type="checkbox"
-              component={CheckBox.Field}
-            />
-            <Field
-              name="currentPublic"
-              label="Vis på offentlig forside"
-              type="checkbox"
-              component={CheckBox.Field}
-            />
-            <SubmitButton>{isNew ? 'Opprett' : 'Lagre endringer'}</SubmitButton>
+            <Flex gap="var(--spacing-md)">
+              <SubmitButton>
+                {isNew ? 'Opprett' : 'Lagre endringer'}
+              </SubmitButton>
+              {!isNew && (
+                <ConfirmModal
+                  title="Bekreft sletting av banner"
+                  message="Er du sikker på at du vil slette dette banneret?"
+                  onConfirm={onDelete}
+                >
+                  {({ openConfirmModal }) => (
+                    <Button onPress={openConfirmModal} danger>
+                      Slett
+                    </Button>
+                  )}
+                </ConfirmModal>
+              )}
+            </Flex>
           </Form>
         )}
       </LegoFinalForm>

--- a/lego-webapp/app/routes/hiddenAdmin/components/BannerOverview.module.css
+++ b/lego-webapp/app/routes/hiddenAdmin/components/BannerOverview.module.css
@@ -1,0 +1,23 @@
+.card {
+  padding: 0;
+}
+
+.cardSection {
+  padding: var(--spacing-lg);
+}
+
+.bannerContainer {
+  background-color: var(--lego-background-color);
+}
+
+.bannerContainer * {
+  margin: 0;
+}
+
+.card h4 {
+  text-align: center;
+}
+
+.editButton {
+  flex-shrink: 0;
+}

--- a/lego-webapp/app/routes/hiddenAdmin/components/BannerOverview.tsx
+++ b/lego-webapp/app/routes/hiddenAdmin/components/BannerOverview.tsx
@@ -1,26 +1,17 @@
-import {
-  Button,
-  ButtonGroup,
-  Card,
-  ConfirmModal,
-  Flex,
-  Icon,
-  LinkButton,
-  Page,
-} from '@webkom/lego-bricks';
+import { Card, Flex, LinkButton, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Globe, Lock } from 'lucide-react';
+import cx from 'classnames';
 import { Helmet } from 'react-helmet-async';
 import HTTPError from 'app/routes/errors';
+import Banner from '~/components/Banner';
 import { ContentSection, ContentMain } from '~/components/Content';
-import {
-  deleteBanner,
-  editBanner,
-  fetchAllBanners,
-} from '~/redux/actions/BannerActions';
+import ToggleSwitch from '~/components/Form/ToggleSwitch';
+import { editBanner, fetchAllBanners } from '~/redux/actions/BannerActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import { selectAllBanners } from '~/redux/slices/banner';
 import { guardLogin } from '~/utils/replaceUnlessLoggedIn';
+import styles from './BannerOverview.module.css';
+import type { Banner as BannerType } from '~/redux/models/Banner';
 
 const BannerOverview = () => {
   const dispatch = useAppDispatch();
@@ -42,71 +33,86 @@ const BannerOverview = () => {
       <Helmet title={'Bannere'} />
       <ContentSection>
         <ContentMain>
-          {allBanners.map((b) => (
-            <Card key={b.id}>
-              <Flex alignItems="center" justifyContent="space-between">
-                <Flex column>
-                  <h2>Tittel: {b.header}</h2>
-                  <h3>Undertittel: {b.subheader}</h3>
-                  <p>
-                    Lenke: <a href={b.link}>{b.link}</a>
-                  </p>
-                  <ButtonGroup>
-                    <LinkButton href={`/admin/banners/edit/${b.id}/`}>
-                      Rediger
-                    </LinkButton>
-                    <ConfirmModal
-                      title="Bekreft sletting av banner"
-                      message="Er du sikker på at du vil slette dette banneret?"
-                      onConfirm={() => dispatch(deleteBanner(b.id))}
-                    >
-                      {({ openConfirmModal }) => (
-                        <Button onPress={openConfirmModal} danger>
-                          Slett
-                        </Button>
-                      )}
-                    </ConfirmModal>
-                  </ButtonGroup>
-                </Flex>
-                <Flex>
-                  <Icon
-                    iconNode={
-                      <Globe
-                        color={b.currentPublic ? '#13a452' : 'gray'}
-                        onClick={() => {
-                          dispatch(
-                            editBanner(
-                              { currentPublic: !b.currentPublic },
-                              b.id,
-                            ),
-                          ).then(() => dispatch(fetchAllBanners()));
-                        }}
-                      />
-                    }
-                    size={25}
-                    color="green"
-                    style={{ cursor: 'pointer' }}
-                  />
-
-                  <Icon
-                    iconNode={
-                      <Lock color={b.currentPrivate ? '#13a452' : 'gray'} />
-                    }
-                    size={25}
-                    style={{ cursor: 'pointer' }}
-                    onClick={() => {
-                      dispatch(
-                        editBanner({ currentPrivate: !b.currentPrivate }, b.id),
-                      ).then(() => dispatch(fetchAllBanners()));
-                    }}
-                  />
-                </Flex>
-              </Flex>
-            </Card>
+          {allBanners.map((banner) => (
+            <BannerItem key={banner.id} banner={banner} />
           ))}
         </ContentMain>
       </ContentSection>
     </Page>
+  );
+};
+
+const BannerItem = ({ banner }: { banner: BannerType }) => {
+  const dispatch = useAppDispatch();
+
+  const togglePublic = () =>
+    dispatch(
+      editBanner({ currentPublic: !banner.currentPublic }, banner.id),
+    ).then(() => dispatch(fetchAllBanners()));
+
+  const togglePrivate = () =>
+    dispatch(
+      editBanner({ currentPrivate: !banner.currentPrivate }, banner.id),
+    ).then(() => dispatch(fetchAllBanners()));
+
+  return (
+    <Card hideOverflow className={styles.card}>
+      <div className={cx(styles.cardSection, styles.bannerContainer)}>
+        <Banner
+          header={banner.header}
+          subHeader={banner.subheader}
+          link={banner.link}
+          color={banner.color}
+        />
+      </div>
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        gap="var(--spacing-md)"
+        className={styles.cardSection}
+      >
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          gap="var(--spacing-md)"
+        >
+          <Flex
+            column
+            gap="var(--spacing-sm)"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <h4>Innlogget forside</h4>
+            <ToggleSwitch
+              value={banner.currentPrivate}
+              name="private"
+              checked={banner.currentPrivate}
+              onChange={togglePrivate}
+            />
+          </Flex>
+          <Flex
+            column
+            gap="var(--spacing-sm)"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <h4>Offentlig forside</h4>
+            <ToggleSwitch
+              value={banner.currentPublic}
+              name="public"
+              checked={banner.currentPublic}
+              onChange={togglePublic}
+            />
+          </Flex>
+        </Flex>
+        <LinkButton
+          href={`/admin/banners/edit/${banner.id}/`}
+          className={styles.editButton}
+        >
+          Rediger
+        </LinkButton>
+      </Flex>
+    </Card>
   );
 };
 


### PR DESCRIPTION
# Description

Display the banner and improve UX for selecting public/private banners

# Result

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
Complete overhaul of the design
        </td>
        <td>

![Screenshot 2025-03-07 at 19 10 47](https://github.com/user-attachments/assets/73bea691-cb1a-486e-81e0-d5aa3118d704)
        </td>
        <td>

![Screenshot 2025-03-07 at 19 10 05](https://github.com/user-attachments/assets/f211b902-c2a2-4e7e-964c-217b94957d9e)
        </td>
    </tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.

