### PR TITLE
Feat add feature flags

### DIFF
--- a/lego-webapp/components/Form/ObjectPermissions.tsx
+++ b/lego-webapp/components/Form/ObjectPermissions.tsx
@@ -71,7 +71,7 @@ const ObjectPermissions = ({
   ].filter(Boolean);
 };
 
-const toIds = (mapping) => mapping.value;
+export const toIds = (mapping) => mapping.value;
 
 export const normalizeObjectPermissions = ({
   requireAuth,

--- a/lego-webapp/components/errors/HTTPError.tsx
+++ b/lego-webapp/components/errors/HTTPError.tsx
@@ -7,10 +7,13 @@ import renderAbakus from './renderAbakus';
 const HTTPMapping = {
   '400': 'Noe gikk galt med forespørselen',
   '401': 'Du er ikke logget inn',
+  '402': 'Betaling påkrevd',
   '403': 'Denne siden har du ikke tilgang på',
   '404': 'Denne siden finnes ikke',
   '418': 'Jeg er en tekanne',
+  '428': 'Forutsetning påkrevd',
   '500': 'Noe gikk veldig galt, Webkom er på saken!',
+  '509': 'Båndbreddebegrensning nådd',
   '1337': 'Hackerman',
 };
 const fallbackStatus = 404;

--- a/lego-webapp/cypress/e2e/router_spec.js
+++ b/lego-webapp/cypress/e2e/router_spec.js
@@ -205,9 +205,7 @@ describe('Navigate throughout app', () => {
     openMenuAndSelect('Forum', '/forum');
     cy.contains('Forum');
 
-    // Lending
-    openMenuAndSelect('Utlån', '/lending');
-    cy.contains('Prinsessekjole');
+    // Lending is currently featureflagged and was removed from this test
   });
 
   it('should be able to log out', () => {

--- a/lego-webapp/pages/admin/banners/+Page.tsx
+++ b/lego-webapp/pages/admin/banners/+Page.tsx
@@ -106,7 +106,7 @@ const BannerItem = ({ banner }: { banner: BannerType }) => {
           </Flex>
         </Flex>
         <LinkButton
-          href={`/admin/banners/edit/${banner.id}/`}
+          href={`/admin/banners/${banner.id}/edit/`}
           className={styles.editButton}
         >
           Rediger

--- a/lego-webapp/pages/admin/banners/@bannerId/edit/+Page.tsx
+++ b/lego-webapp/pages/admin/banners/@bannerId/edit/+Page.tsx
@@ -1,0 +1,3 @@
+import BannerEditor from '../../BannerEditor';
+
+export default BannerEditor;

--- a/lego-webapp/pages/admin/banners/BannerEditor.tsx
+++ b/lego-webapp/pages/admin/banners/BannerEditor.tsx
@@ -86,7 +86,13 @@ const BannerEditor = () => {
       <Helmet title={title} />
       <LegoFinalForm
         onSubmit={onSubmit}
-        initialValues={banner}
+        initialValues={{
+          ...banner,
+          color: {
+            label: colorToRepresentation[banner?.color as Color],
+            value: banner?.color,
+          },
+        }}
         validate={validate}
       >
         {({ handleSubmit }) => (

--- a/lego-webapp/pages/admin/featureflags/+Page.tsx
+++ b/lego-webapp/pages/admin/featureflags/+Page.tsx
@@ -1,0 +1,72 @@
+import { ButtonGroup, Card, Flex, LinkButton, Page } from '@webkom/lego-bricks';
+import { usePreparedEffect } from '@webkom/react-prepare';
+import { Helmet } from 'react-helmet-async';
+import { ContentMain, ContentSection } from '~/components/Content';
+import ToggleSwitch from '~/components/Form/ToggleSwitch';
+import HTTPError from '~/components/errors/HTTPError';
+import {
+  editFeatureFlag,
+  fetchAdminAllFeatureFlags,
+} from '~/redux/actions/FeatureFlagActions';
+import { useAppDispatch, useAppSelector } from '~/redux/hooks';
+import { selectAllAdminFeatureFlags } from '~/redux/slices/featureFlags';
+import { guardLogin } from '~/utils/replaceUnlessLoggedIn';
+
+const FeatureFlagOverview = () => {
+  const dispatch = useAppDispatch();
+  usePreparedEffect(
+    'fetchAllFeatureFlags',
+    () => dispatch(fetchAdminAllFeatureFlags()),
+    [dispatch],
+  );
+  const allFlags = useAppSelector((state) => selectAllAdminFeatureFlags(state));
+  const sudoAdminAccess = useAppSelector((state) => state.allowed.sudo);
+  if (!sudoAdminAccess) return <HTTPError statusCode={402} />;
+
+  return (
+    <Page
+      title={'Feature flagg'}
+      back={sudoAdminAccess ? { href: '/sudo' } : { href: '/' }}
+      actionButtons={
+        <LinkButton href={`/admin/featureflags/new`}>Lag ny</LinkButton>
+      }
+    >
+      <Helmet title={'Feature flagg'} />
+      <ContentSection>
+        <ContentMain>
+          {allFlags.map((flag) => (
+            <Card key={flag.identifier}>
+              <Flex justifyContent="space-between">
+                <h2>{flag.identifier}</h2>
+                <ButtonGroup>
+                  <Flex
+                    column
+                    gap="var(--spacing-sm)"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    <h4>Aktiver</h4>
+                    <ToggleSwitch
+                      onChange={(isSelected) =>
+                        dispatch(
+                          editFeatureFlag({ isActive: isSelected }, flag.id),
+                        )
+                      }
+                      checked={flag.isActive}
+                    />
+                  </Flex>
+
+                  <LinkButton href={`/admin/featureflags/${flag.id}/edit/`}>
+                    Rediger
+                  </LinkButton>
+                </ButtonGroup>
+              </Flex>
+            </Card>
+          ))}
+        </ContentMain>
+      </ContentSection>
+    </Page>
+  );
+};
+
+export default guardLogin(FeatureFlagOverview);

--- a/lego-webapp/pages/admin/featureflags/@featureFlagId/+Page.tsx
+++ b/lego-webapp/pages/admin/featureflags/@featureFlagId/+Page.tsx
@@ -1,0 +1,3 @@
+import FeatureFlagEditor from '../FeatureFlagEditor';
+
+export default FeatureFlagEditor;

--- a/lego-webapp/pages/admin/featureflags/@featureFlagId/edit/+Page.tsx
+++ b/lego-webapp/pages/admin/featureflags/@featureFlagId/edit/+Page.tsx
@@ -1,0 +1,3 @@
+import FeatureFlagEditor from '../../FeatureFlagEditor';
+
+export default FeatureFlagEditor;

--- a/lego-webapp/pages/admin/featureflags/FeatureFlagEditor.tsx
+++ b/lego-webapp/pages/admin/featureflags/FeatureFlagEditor.tsx
@@ -1,0 +1,184 @@
+import { EntityId } from '@reduxjs/toolkit';
+import {
+  Button,
+  ConfirmModal,
+  Flex,
+  LoadingPage,
+  Page,
+} from '@webkom/lego-bricks';
+import { usePreparedEffect } from '@webkom/react-prepare';
+import { Field } from 'react-final-form';
+import { Helmet } from 'react-helmet-async';
+import { navigate } from 'vike/client/router';
+import {
+  CheckBox,
+  Form,
+  LegoFinalForm,
+  SelectInput,
+  SubmitButton,
+  TextInput,
+} from '~/components/Form';
+import { toIds } from '~/components/Form/ObjectPermissions';
+import HTTPError from '~/components/errors/HTTPError';
+import {
+  createFeatureFlag,
+  deleteFeatureFlag,
+  editFeatureFlag,
+  fetchAdminFeatureFlag,
+} from '~/redux/actions/FeatureFlagActions';
+import { useAppDispatch, useAppSelector } from '~/redux/hooks';
+import { CreateFeatureFlag, EditFeatureFlag } from '~/redux/models/FeatureFlag';
+import { selectAdminFeatureFlagById } from '~/redux/slices/featureFlags';
+import { guardLogin } from '~/utils/replaceUnlessLoggedIn';
+import { useParams } from '~/utils/useParams';
+import { createValidator, required } from '~/utils/validation';
+
+type FeatureFlagEditorParams = {
+  featureFlagId?: string;
+};
+
+type FormValues = {
+  identifier: string;
+  percentage?: number | null;
+  isActive: boolean;
+  allowedIdentifier?: string | null;
+  displayGroups?: { label: string; value: EntityId }[];
+};
+
+const FeatureFlagEditor = () => {
+  const { featureFlagId } = useParams<FeatureFlagEditorParams>();
+
+  const dispatch = useAppDispatch();
+
+  usePreparedEffect(
+    'fetchFeatureFlagForEditor',
+    () => featureFlagId && dispatch(fetchAdminFeatureFlag(featureFlagId)),
+    [featureFlagId],
+  );
+
+  const isNew = !featureFlagId;
+  const featureFlag = useAppSelector((state) =>
+    selectAdminFeatureFlagById(state, featureFlagId),
+  );
+
+  const sudoAdminAccess = useAppSelector((state) => state.allowed.sudo);
+  if (!sudoAdminAccess) return <HTTPError statusCode={509} />;
+
+  if (!isNew && !featureFlag) {
+    return <LoadingPage loading />;
+  }
+
+  const validate = createValidator({
+    identifier: [required()],
+  });
+
+  const onSubmit = (data: FormValues) => {
+    const postData: CreateFeatureFlag | EditFeatureFlag = {
+      ...data,
+      ...(data.displayGroups
+        ? { displayGroups: data.displayGroups.map(toIds) }
+        : {}),
+      ...(data.percentage && data.percentage !== undefined
+        ? { percentage: data.percentage }
+        : { percentage: null }),
+      ...(data.allowedIdentifier && data.allowedIdentifier !== undefined
+        ? { allowedIdentifier: data.allowedIdentifier }
+        : { allowedIdentifier: null }),
+    };
+
+    const action = isNew
+      ? createFeatureFlag(postData as CreateFeatureFlag)
+      : editFeatureFlag(postData, featureFlagId);
+
+    dispatch(action).then(() => navigate('/admin/featureflags'));
+  };
+
+  const onDelete = () =>
+    dispatch(deleteFeatureFlag(featureFlagId!)).then(() =>
+      navigate('/admin/featureflags'),
+    );
+
+  const title = isNew ? 'Nytt Flagg' : `Redigerer: ${featureFlag?.identifier}`;
+  return (
+    <Page title={title} back={{ href: '/admin/featureflags' }}>
+      <Helmet title={title} />
+      <LegoFinalForm<FormValues>
+        onSubmit={onSubmit}
+        validate={validate}
+        initialValues={
+          featureFlag
+            ? {
+                ...featureFlag,
+                displayGroups: featureFlag.displayGroups.map((g) => ({
+                  value: g.id,
+                  label: g.name,
+                })),
+              }
+            : undefined
+        }
+      >
+        {({ handleSubmit }) => (
+          <Form onSubmit={handleSubmit}>
+            <Field
+              placeholder="Feature"
+              name="identifier"
+              label="Nøkkel"
+              component={TextInput.Field}
+              id="identifier"
+              required
+            />
+            <Field
+              placeholder="50"
+              name="percentage"
+              label="Prosent (for A/B testing)"
+              component={TextInput.Field}
+              id="percentage"
+            />
+            <Field
+              placeholder="Sjekk feature flag rettigheter for disse routene"
+              name="allowedIdentifier"
+              label="Validerte routes "
+              component={TextInput.Field}
+              id="allowedIdentifier"
+            />
+            <Field
+              name="displayGroups"
+              filter={['users.abakusgroup']}
+              label="Grupper med rettighet"
+              placeholder="Skriv inn gruppene som skal se flagget"
+              component={SelectInput.AutocompleteField}
+              isMulti
+            />
+            <Field
+              name="isActive"
+              label="Aktiv"
+              type="checkbox"
+              component={CheckBox.Field}
+              id="isActive"
+            />
+            <Flex gap="var(--spacing-md)">
+              <SubmitButton>
+                {isNew ? 'Opprett' : 'Lagre endringer'}
+              </SubmitButton>
+              {!isNew && (
+                <ConfirmModal
+                  title="Bekreft sletting av flagg"
+                  message="Er du sikker på at du vil slette dette flagget?"
+                  onConfirm={onDelete}
+                >
+                  {({ openConfirmModal }) => (
+                    <Button onPress={openConfirmModal} danger>
+                      Slett
+                    </Button>
+                  )}
+                </ConfirmModal>
+              )}
+            </Flex>
+          </Form>
+        )}
+      </LegoFinalForm>
+    </Page>
+  );
+};
+
+export default guardLogin(FeatureFlagEditor);

--- a/lego-webapp/pages/admin/featureflags/new/+Page.tsx
+++ b/lego-webapp/pages/admin/featureflags/new/+Page.tsx
@@ -1,0 +1,3 @@
+import FeatureFlagEditor from '../FeatureFlagEditor';
+
+export default FeatureFlagEditor;

--- a/lego-webapp/pages/lending/+Page.tsx
+++ b/lego-webapp/pages/lending/+Page.tsx
@@ -12,9 +12,11 @@ import { FolderOpen } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import EmptyState from '~/components/EmptyState';
 import TextInput from '~/components/Form/TextInput';
+import HTTPError from '~/components/errors/HTTPError';
 import { fetchAllLendableObjects } from '~/redux/actions/LendableObjectActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import { selectAllLendableObjects } from '~/redux/slices/lendableObjects';
+import { useFeatureFlag } from '~/utils/useFeatureFlag';
 import useQuery from '~/utils/useQuery';
 import styles from './LendableObjectList.module.css';
 import type { ListLendableObject } from '~/redux/models/LendableObject';
@@ -62,6 +64,9 @@ const LendableObjectList = () => {
   const filteredLendableObjects = lendableObjects.filter((lendableObjects) =>
     lendableObjects.title.toLowerCase().includes(query.search.toLowerCase()),
   );
+  if (!useFeatureFlag('lending')) {
+    return <HTTPError />;
+  }
 
   const title = 'Utlån';
   return (

--- a/lego-webapp/pages/sudo/+Page.tsx
+++ b/lego-webapp/pages/sudo/+Page.tsx
@@ -1,4 +1,5 @@
-import { Page, Flex } from '@webkom/lego-bricks';
+import { Page, Flex, Card, Icon } from '@webkom/lego-bricks';
+import { Flag, Rss } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import a4bc35b6c0664b45 from '~/assets/26e7499bfb6390d9/a4bc35b6c0664b45.jpg';
 import acb2777779bbf024 from '~/assets/26e7499bfb6390d9/acb2777779bbf024.jpg';
@@ -11,6 +12,57 @@ import HTTPError from '~/components/errors/HTTPError';
 import { useAppSelector } from '~/redux/hooks';
 import { guardLogin } from '~/utils/replaceUnlessLoggedIn';
 import styles from './SudoAdmin.module.css';
+
+type PanelItem = {
+  link: string;
+  tag: string;
+  description: string;
+  iconNode: JSX.Element;
+};
+
+const links: PanelItem[] = [
+  {
+    link: '/admin/banners',
+    tag: 'Bannere',
+    description: 'Legg til og endre bannere som vises på forsiden',
+    iconNode: <Rss />,
+  },
+  {
+    link: '/admin/featureflags',
+    tag: 'Feature Flagg',
+    description:
+      'Legg til og endre feature flagg. Endre hva slags innhold som vises.',
+    iconNode: <Flag />,
+  },
+];
+
+const ControlPanelItem = ({ link, tag, description, iconNode }: PanelItem) => (
+  <a href={link}>
+    <Card>
+      <Icon iconNode={iconNode} size={20} />
+      <h3>{tag}</h3>
+      <p>{description}</p>
+    </Card>
+  </a>
+);
+const AdminControlPanel = () => {
+  return (
+    <div className={styles.controlPanel}>
+      <h2>Kontrollpanel</h2>
+      <Flex>
+        {links.map((l) => (
+          <ControlPanelItem
+            key={l.tag}
+            link={l.link}
+            tag={l.tag}
+            description={l.description}
+            iconNode={l.iconNode}
+          />
+        ))}
+      </Flex>
+    </div>
+  );
+};
 
 const SudoAdmin = () => {
   const sudoAdminAccess = useAppSelector((state) => state.allowed.sudo);
@@ -36,16 +88,8 @@ const SudoAdmin = () => {
               alt="An image was supposed to be here but is not"
               width={400}
             />
+            <AdminControlPanel />
           </Flex>
-          <h2>Handlinger:</h2>
-          <ul className={styles.list}>
-            <li>
-              <a href={'/admin/banners'}>Banners</a>
-            </li>
-            <li>
-              <a href={'#'}>FeatureToggle (Coming soon!)</a>
-            </li>
-          </ul>
         </ContentMain>
       </ContentSection>
     </Page>

--- a/lego-webapp/redux/actionTypes.ts
+++ b/lego-webapp/redux/actionTypes.ts
@@ -336,3 +336,11 @@ export const Banner = {
   EDIT: generateStatuses('Banner.EDIT'),
   DELETE: generateStatuses('Banner.DELETE'),
 };
+
+export const FeatureFlag = {
+  FETCH_ALL: generateStatuses('FeatureFlag.FETCH_ALL'),
+  FETCH: generateStatuses('FeatureFlag.FETCH'),
+  CREATE: generateStatuses('FeatureFlag.CREATE'),
+  EDIT: generateStatuses('FeatureFlag.EDIT'),
+  DELETE: generateStatuses('FeatureFlag.DELETE'),
+};

--- a/lego-webapp/redux/actions/FeatureFlagActions.ts
+++ b/lego-webapp/redux/actions/FeatureFlagActions.ts
@@ -1,0 +1,75 @@
+import { FeatureFlag as FeatureFlagAAT } from '~/redux/actionTypes';
+import {
+  AdminFeatureFlag,
+  CreateFeatureFlag,
+  EditFeatureFlag,
+  PublicFeatureFlag,
+} from '../models/FeatureFlag';
+import { featureFlagSchema } from '../schemas';
+import callAPI from './callAPI';
+import type { EntityId } from '@reduxjs/toolkit';
+
+export function fetchFeatureFlagByIdentifier(identifier: string) {
+  return callAPI<PublicFeatureFlag>({
+    types: FeatureFlagAAT.FETCH,
+    schema: featureFlagSchema,
+    endpoint: `/featureflags/${identifier}/`,
+  });
+}
+
+export function fetchAdminFeatureFlag(id: EntityId) {
+  return callAPI<AdminFeatureFlag>({
+    types: FeatureFlagAAT.FETCH,
+    schema: featureFlagSchema,
+    endpoint: `/featureflags-admin/${id}/`,
+  });
+}
+
+export function fetchAdminAllFeatureFlags() {
+  return callAPI<AdminFeatureFlag[]>({
+    types: FeatureFlagAAT.FETCH_ALL,
+    schema: [featureFlagSchema],
+    endpoint: `/featureflags-admin/`,
+  });
+}
+
+export function createFeatureFlag(featureFlag: CreateFeatureFlag) {
+  return callAPI<AdminFeatureFlag>({
+    types: FeatureFlagAAT.CREATE,
+    endpoint: '/featureflags-admin/',
+    method: 'POST',
+    schema: featureFlagSchema,
+    body: featureFlag,
+    meta: {
+      errorMessage: 'Opprettelse av flagg feilet',
+      successMessage: 'Opprettelse av flagg fullført',
+    },
+  });
+}
+
+export function editFeatureFlag(featureFlag: EditFeatureFlag, id: EntityId) {
+  return callAPI<AdminFeatureFlag>({
+    types: FeatureFlagAAT.EDIT,
+    endpoint: `/featureflags-admin/${id}/`,
+    method: 'PATCH',
+    schema: featureFlagSchema,
+    body: featureFlag,
+    meta: {
+      errorMessage: 'Endring av flagg feilet',
+      successMessage: 'Endring av flagg fullført',
+    },
+  });
+}
+
+export function deleteFeatureFlag(id: EntityId) {
+  return callAPI({
+    types: FeatureFlagAAT.DELETE,
+    endpoint: `/featureflags-admin/${id}/`,
+    method: 'DELETE',
+    meta: {
+      id: id,
+      errorMessage: 'Sletting av flagg feilet',
+      successMessage: 'Sletting av flagg fullført',
+    },
+  });
+}

--- a/lego-webapp/redux/models/FeatureFlag.ts
+++ b/lego-webapp/redux/models/FeatureFlag.ts
@@ -1,0 +1,45 @@
+import { EntityId } from '@reduxjs/toolkit';
+import { FieldGroup } from './Group';
+
+interface FeatureFlag {
+  id: EntityId;
+  identifier: string;
+  isActive: boolean;
+  percentage: number | null;
+  displayGroups: FieldGroup[];
+  allowedIdentifier: string | null;
+  canSeeFlag: boolean;
+}
+
+export type AdminFeatureFlag = Pick<
+  FeatureFlag,
+  | 'id'
+  | 'identifier'
+  | 'displayGroups'
+  | 'isActive'
+  | 'percentage'
+  | 'allowedIdentifier'
+  | 'canSeeFlag'
+>;
+
+export type PublicFeatureFlag = Pick<
+  FeatureFlag,
+  'id' | 'identifier' | 'canSeeFlag'
+>;
+
+export type CreateFeatureFlag = Pick<FeatureFlag, 'identifier' | 'isActive'> & {
+  displayGroups: EntityId[];
+  percentage?: number;
+  allowedIdentifier?: string;
+};
+
+export type EditFeatureFlag = Partial<
+  Pick<
+    FeatureFlag,
+    'identifier' | 'isActive' | 'percentage' | 'allowedIdentifier'
+  > & {
+    displayGroups: EntityId[];
+  }
+>;
+
+export type UnkownFeatureFlag = AdminFeatureFlag | PublicFeatureFlag;

--- a/lego-webapp/redux/models/LendingRequest.ts
+++ b/lego-webapp/redux/models/LendingRequest.ts
@@ -1,5 +1,4 @@
 import type { EntityId } from '@reduxjs/toolkit';
-import type ObjectPermissionsMixin from 'app/store/models/ObjectPermissionsMixin';
 
 enum LendingRequestStatus {
   Unapproved = 'unapproved',
@@ -30,7 +29,7 @@ export type ListLendingRequest = Pick<
   | 'endDate'
 >;
 
-export type AdminLendingRequest = ListLendingRequest & ObjectPermissionsMixin;
+export type AdminLendingRequest = ListLendingRequest;
 
 export type UnknownLendingRequest = ListLendingRequest | AdminLendingRequest;
 

--- a/lego-webapp/redux/models/entities.ts
+++ b/lego-webapp/redux/models/entities.ts
@@ -12,6 +12,7 @@ import type { UnknownEmailList } from '~/redux/models/EmailList';
 import type EmailUser from '~/redux/models/EmailUser';
 import type Emoji from '~/redux/models/Emoji';
 import type { UnknownEvent } from '~/redux/models/Event';
+import type { UnkownFeatureFlag } from '~/redux/models/FeatureFlag';
 import type Feed from '~/redux/models/Feed';
 import type AggregatedFeedActivity from '~/redux/models/FeedActivity';
 import type { UnknownForum, UnknownThread } from '~/redux/models/Forum';
@@ -50,6 +51,7 @@ export enum EntityType {
   EmailUsers = 'emailUsers',
   Emojis = 'emojis',
   Events = 'events',
+  FeatureFlag = 'featureFlags',
   FeedActivities = 'feedActivities',
   Feeds = 'feeds',
   Forums = 'forums',
@@ -93,6 +95,7 @@ export default interface Entities {
   [EntityType.EmailUsers]: Record<EntityId, EmailUser>;
   [EntityType.Emojis]: Record<EntityId, Emoji>;
   [EntityType.Events]: Record<EntityId, UnknownEvent>;
+  [EntityType.FeatureFlag]: Record<EntityId, UnkownFeatureFlag>;
   [EntityType.FeedActivities]: Record<EntityId, AggregatedFeedActivity>;
   [EntityType.Feeds]: Record<EntityId, Feed>;
   [EntityType.Forums]: Record<EntityId, UnknownForum>;

--- a/lego-webapp/redux/rootReducer.ts
+++ b/lego-webapp/redux/rootReducer.ts
@@ -12,6 +12,7 @@ import emailLists from '~/redux/slices/emailLists';
 import emailUsers from '~/redux/slices/emailUsers';
 import emojis from '~/redux/slices/emojis';
 import events from '~/redux/slices/events';
+import featureFlags from '~/redux/slices/featureFlags';
 import feedActivities from '~/redux/slices/feedActivities';
 import feeds from '~/redux/slices/feeds';
 import forums from '~/redux/slices/forums';
@@ -63,6 +64,7 @@ export const createRootReducer = () => {
     emailLists,
     emailUsers,
     events,
+    featureFlags,
     feedActivities,
     feeds,
     forums,

--- a/lego-webapp/redux/schemas.ts
+++ b/lego-webapp/redux/schemas.ts
@@ -167,3 +167,4 @@ export const forumSchema = new schema.Entity(EntityType.Forums, {
 });
 
 export const bannerSchema = new schema.Entity(EntityType.Banner);
+export const featureFlagSchema = new schema.Entity(EntityType.FeatureFlag);

--- a/lego-webapp/redux/slices/featureFlags.ts
+++ b/lego-webapp/redux/slices/featureFlags.ts
@@ -1,0 +1,43 @@
+import { createSelector, createSlice } from '@reduxjs/toolkit';
+import { FeatureFlag as FeatureFlagAAT } from '~/redux/actionTypes';
+import createLegoAdapter from '~/redux/legoAdapter/createLegoAdapter';
+import { EntityType } from '~/redux/models/entities';
+import { AdminFeatureFlag } from '../models/FeatureFlag';
+import type { RootState } from '~/redux/rootReducer';
+
+const legoAdapter = createLegoAdapter(EntityType.FeatureFlag);
+
+const featureFlagSlice = createSlice({
+  name: EntityType.FeatureFlag,
+  initialState: legoAdapter.getInitialState(),
+  reducers: {},
+  extraReducers: legoAdapter.buildReducers({
+    fetchActions: [FeatureFlagAAT.FETCH, FeatureFlagAAT.FETCH_ALL],
+    deleteActions: [FeatureFlagAAT.DELETE],
+  }),
+});
+
+export default featureFlagSlice.reducer;
+export const {
+  selectAllPaginated: selectAllFeatureFlags,
+  selectById: selectFeatureFlagById,
+  selectByField: selectFeatureFlagsByField,
+} = legoAdapter.getSelectors((state: RootState) => state.featureFlags);
+export const selectFeatureFlagByIdentifier =
+  selectFeatureFlagsByField('identifier').single;
+
+export const selectAllAdminFeatureFlags = createSelector(
+  selectAllFeatureFlags,
+  (featureFlags) => {
+    if (!featureFlags) return [];
+    return featureFlags as AdminFeatureFlag[];
+  },
+);
+
+export const selectAdminFeatureFlagById = createSelector(
+  selectFeatureFlagById,
+  (featureFlag) => {
+    if (!featureFlag) return null;
+    return featureFlag as AdminFeatureFlag;
+  },
+);

--- a/lego-webapp/utils/useFeatureFlag.ts
+++ b/lego-webapp/utils/useFeatureFlag.ts
@@ -1,0 +1,28 @@
+import { usePreparedEffect } from '@webkom/react-prepare';
+import { fetchFeatureFlagByIdentifier } from '~/redux/actions/FeatureFlagActions';
+import { useAppDispatch, useAppSelector } from '~/redux/hooks';
+import { selectFeatureFlagByIdentifier } from '~/redux/slices/featureFlags';
+
+/**
+ * Hook to check if a feature flag is enabled for the current user.
+ * @param identifier - The feature flag identifier.
+ * @returns {boolean} - Whether the feature flag is enabled (`true` or `false`).
+ */
+export const useFeatureFlag = (identifier: string): boolean => {
+  const dispatch = useAppDispatch();
+  const featureFlag = useAppSelector((state) =>
+    selectFeatureFlagByIdentifier(state, identifier),
+  );
+
+  usePreparedEffect(
+    'fetchFeatureFlagByIdentifier',
+    () => {
+      if (!featureFlag) {
+        dispatch(fetchFeatureFlagByIdentifier(identifier));
+      }
+    },
+    [dispatch, identifier, featureFlag],
+  );
+
+  return featureFlag?.canSeeFlag || false;
+};


### PR DESCRIPTION
# Description

This adds feature flags and i added one to lending.
Reloads is only required for the allowed part of this. The hook only part will still work. This is only due to fetchMeta not being called after editing so is really only a thing for admins. For regular users who did not refresh within the span of the activation, there is no way to force them to refetch meta either. The hook part will again still work. This is a minor edgecase.

Also improve design of sudo page

# Result

[Screencast_20250308_141059.webm](https://github.com/user-attachments/assets/2114fb1b-1e45-4240-b5e8-7d18a823d8d6)

![image](https://github.com/user-attachments/assets/5f26ba49-d791-4349-8448-cb32f541bc22)




If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.



- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves Resolves ABA-1345, ABA-1341
