### PR TITLE
Remove unnecessary variables.css imports

### DIFF
--- a/lego-webapp/components/Banner/Banner.module.css
+++ b/lego-webapp/components/Banner/Banner.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .link {
   display: block;
   margin: 0 var(--spacing-md);

--- a/lego-webapp/components/Chart/Chart.module.css
+++ b/lego-webapp/components/Chart/Chart.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .chartLabel {
   line-height: 1.3;
 

--- a/lego-webapp/components/CollapsibleDisplayContent/CollapsibleDisplayContent.module.css
+++ b/lego-webapp/components/CollapsibleDisplayContent/CollapsibleDisplayContent.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .collapse {
   position: relative;
   overflow: hidden;

--- a/lego-webapp/components/Comments/Comment.module.css
+++ b/lego-webapp/components/Comments/Comment.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .comment {
   padding: var(--spacing-md);
 }

--- a/lego-webapp/components/Comments/CommentTree.module.css
+++ b/lego-webapp/components/Comments/CommentTree.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .nested {
   margin-left: var(--spacing-xl);
 

--- a/lego-webapp/components/Content/ContentSection.module.css
+++ b/lego-webapp/components/Content/ContentSection.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 div.section {
   @media (--medium-viewport) {
     flex-direction: column;

--- a/lego-webapp/components/Content/ContentSidebar.module.css
+++ b/lego-webapp/components/Content/ContentSidebar.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .sidebar {
   flex: 1;
   padding: 0 0 0 var(--spacing-xl);

--- a/lego-webapp/components/DividerWithDots/DividerWithDots.module.css
+++ b/lego-webapp/components/DividerWithDots/DividerWithDots.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .visionLine {
   border-left: 3px solid var(--lego-red-color);
   display: flex;

--- a/lego-webapp/components/Dropdown/Dropdown.module.css
+++ b/lego-webapp/components/Dropdown/Dropdown.module.css
@@ -1,4 +1,3 @@
-@import url('../../styles/variables.css');
 @import url('../../styles/overlay.css');
 
 .content {

--- a/lego-webapp/components/ErrorBoundary/ErrorBoundary.module.css
+++ b/lego-webapp/components/ErrorBoundary/ErrorBoundary.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .container {
   width: 40%;
   margin: 0 auto;

--- a/lego-webapp/components/Feed/context.module.css
+++ b/lego-webapp/components/Feed/context.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .highlight {
   color: var(--lego-link-color);
 }

--- a/lego-webapp/components/Footer/Footer.module.css
+++ b/lego-webapp/components/Footer/Footer.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .footer {
   width: 100%;
   background-color: var(--lego-red-color);

--- a/lego-webapp/components/Form/CheckBox.module.css
+++ b/lego-webapp/components/Form/CheckBox.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .checkbox {
   --background: inherit;
   --border: var(--border-gray);

--- a/lego-webapp/components/Form/DatePicker.module.css
+++ b/lego-webapp/components/Form/DatePicker.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .calendar th,
 .calendar td {
   width: calc(100% / 7);

--- a/lego-webapp/components/Form/Field.module.css
+++ b/lego-webapp/components/Form/Field.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .field {
   width: 100%;
 }

--- a/lego-webapp/components/Form/Form.module.css
+++ b/lego-webapp/components/Form/Form.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .form {
   display: flex;
   flex-direction: column;

--- a/lego-webapp/components/Form/ImageUploadField.module.css
+++ b/lego-webapp/components/Form/ImageUploadField.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .base {
   position: relative;
   overflow: hidden;

--- a/lego-webapp/components/Form/Label.module.css
+++ b/lego-webapp/components/Form/Label.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .label {
   font-size: var(--font-size-lg);
   margin-bottom: var(--spacing-xs);

--- a/lego-webapp/components/Form/RadioButton.module.css
+++ b/lego-webapp/components/Form/RadioButton.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .radioButton {
   --border-hover: var(--color-gray-4);
   --border-active: var(--lego-red-color);

--- a/lego-webapp/components/Gallery/Gallery.module.css
+++ b/lego-webapp/components/Gallery/Gallery.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .galleryContainer {
   width: 100%;
 }

--- a/lego-webapp/components/Header/Header.module.css
+++ b/lego-webapp/components/Header/Header.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .themeChange {
   padding: var(--spacing-sm) var(--spacing-md);
   line-height: 1.3;

--- a/lego-webapp/components/Header/Navbar/Navbar.module.css
+++ b/lego-webapp/components/Header/Navbar/Navbar.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .navigation {
   display: flex;
   flex-direction: row;

--- a/lego-webapp/components/HeaderNotifications/HeaderNotifications.module.css
+++ b/lego-webapp/components/HeaderNotifications/HeaderNotifications.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .notifications {
   display: flex;
   justify-content: center;

--- a/lego-webapp/components/JoblistingItem/JoblistingItem.module.css
+++ b/lego-webapp/components/JoblistingItem/JoblistingItem.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .joblistingItem {
   display: flex;
   align-items: center;

--- a/lego-webapp/components/Poll/Poll.module.css
+++ b/lego-webapp/components/Poll/Poll.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .poll {
   background-color: var(--lego-card-color);
   width: 100%;

--- a/lego-webapp/components/Popover/Popover.module.css
+++ b/lego-webapp/components/Popover/Popover.module.css
@@ -1,4 +1,3 @@
-@import url('../../styles/variables.css');
 @import url('../../styles/overlay.css');
 
 .content {

--- a/lego-webapp/components/RandomQuote/RandomQuote.module.css
+++ b/lego-webapp/components/RandomQuote/RandomQuote.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .randomQuote {
   min-height: 155px;
 }

--- a/lego-webapp/components/Reactions/ReactionPicker.module.css
+++ b/lego-webapp/components/Reactions/ReactionPicker.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .reactionPicker {
   composes: popover from '../../styles/utilities.module.css';
   position: relative;

--- a/lego-webapp/components/Reactions/ReactionPickerFooter.module.css
+++ b/lego-webapp/components/Reactions/ReactionPickerFooter.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .reactionPickerFooter {
   width: 100%;
   height: 60px;

--- a/lego-webapp/components/Search/Search.module.css
+++ b/lego-webapp/components/Search/Search.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .wrapper {
   position: fixed;
   inset: 0;

--- a/lego-webapp/components/Search/SearchPageInput.module.css
+++ b/lego-webapp/components/Search/SearchPageInput.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .container {
   display: flex;
   justify-content: space-between;

--- a/lego-webapp/components/Search/SearchPageResults.module.css
+++ b/lego-webapp/components/Search/SearchPageResults.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .searchResult {
   padding-left: var(--spacing-md);
   border-left: 4px solid transparent;

--- a/lego-webapp/components/Table/Table.module.css
+++ b/lego-webapp/components/Table/Table.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .wrapper {
   overflow-x: auto;
   width: 100%;

--- a/lego-webapp/components/Toast/Toast.module.css
+++ b/lego-webapp/components/Toast/Toast.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 :root {
   --toast-background: var(--lego-font-color);
 }

--- a/lego-webapp/components/Upload/UploadImage.module.css
+++ b/lego-webapp/components/Upload/UploadImage.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .dropArea {
   border-radius: inherit;
   aspect-ratio: inherit;

--- a/lego-webapp/components/UserAttendance/AttendanceModalContent.module.css
+++ b/lego-webapp/components/UserAttendance/AttendanceModalContent.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .modalContainer {
   overflow: hidden;
   display: flex;

--- a/lego-webapp/components/UserAttendance/Registrations.module.css
+++ b/lego-webapp/components/UserAttendance/Registrations.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .summary {
   white-space: pre;
   color: var(--secondary-font-color);

--- a/lego-webapp/components/UserValidator/Validator.module.css
+++ b/lego-webapp/components/UserValidator/Validator.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .scannerButton {
   margin-bottom: var(--spacing-md);
 }

--- a/lego-webapp/pages/achievements/Overview.module.css
+++ b/lego-webapp/pages/achievements/Overview.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .listWrapper {
   display: flex;
   flex-wrap: wrap;

--- a/lego-webapp/pages/announcements/AnnouncementsList.module.css
+++ b/lego-webapp/pages/announcements/AnnouncementsList.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .formHeaders {
   font-size: var(--font-size-lg);
 }

--- a/lego-webapp/pages/articles/@articleIdOrSlug/ArticleDetail.module.css
+++ b/lego-webapp/pages/articles/@articleIdOrSlug/ArticleDetail.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .articleReactions {
   margin: var(--spacing-md) 0;
 }

--- a/lego-webapp/pages/articles/articles.module.css
+++ b/lego-webapp/pages/articles/articles.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .frontpage {
   margin-top: 20px;
 }

--- a/lego-webapp/pages/bdb/bdb.module.css
+++ b/lego-webapp/pages/bdb/bdb.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .deleteFile {
   display: flex;
   justify-content: space-between;

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .interestBox {
   width: 32%;
   min-width: 300px;

--- a/lego-webapp/pages/brand/BrandPage.module.css
+++ b/lego-webapp/pages/brand/BrandPage.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .colLeft {
   flex: 3;
 }

--- a/lego-webapp/pages/companies/@companyId/Company.module.css
+++ b/lego-webapp/pages/companies/@companyId/Company.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .companyInfo {
   min-width: 180px;
   min-height: 21px;

--- a/lego-webapp/pages/companies/CompaniesPage.module.css
+++ b/lego-webapp/pages/companies/CompaniesPage.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .picture {
   background-color: var(--color-white);
 }

--- a/lego-webapp/pages/events/@eventId/administrate/statistics/EventAttendeeStatistics.module.css
+++ b/lego-webapp/pages/events/@eventId/administrate/statistics/EventAttendeeStatistics.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../../styles/variables.css');
-
 .chartContainer {
   overflow: hidden;
   display: grid;

--- a/lego-webapp/pages/events/@eventIdOrSlug/EventDetail.module.css
+++ b/lego-webapp/pages/events/@eventIdOrSlug/EventDetail.module.css
@@ -1,4 +1,3 @@
-@import url('../../../styles/variables.css');
 @import url('../index/Event.module.css');
 
 .star svg {

--- a/lego-webapp/pages/events/@eventIdOrSlug/Stripe.module.css
+++ b/lego-webapp/pages/events/@eventIdOrSlug/Stripe.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .stripeButton {
   width: 100%;
 }

--- a/lego-webapp/pages/events/index/Event.module.css
+++ b/lego-webapp/pages/events/index/Event.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .form {
   gap: var(--spacing-md);
 }

--- a/lego-webapp/pages/events/index/EventList.module.css
+++ b/lego-webapp/pages/events/index/EventList.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .eventGroup {
   margin-bottom: var(--spacing-md);
 }

--- a/lego-webapp/pages/events/index/calendar/Calendar.module.css
+++ b/lego-webapp/pages/events/index/calendar/Calendar.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../styles/variables.css');
-
 :root {
   --calendar-border: 1px solid var(--border-gray);
 }

--- a/lego-webapp/pages/forum/ForumList.module.css
+++ b/lego-webapp/pages/forum/ForumList.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .listEntry {
   border-left: 8px solid var(--color-red-4);
   justify-content: space-between;

--- a/lego-webapp/pages/index/ArticleItem.module.css
+++ b/lego-webapp/pages/index/ArticleItem.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 div.body {
   display: flex;
   text-align: center;

--- a/lego-webapp/pages/index/AuthenticatedFrontpage.module.css
+++ b/lego-webapp/pages/index/AuthenticatedFrontpage.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .wrapper {
   display: grid;
   grid-template:

--- a/lego-webapp/pages/index/CompactEvents.module.css
+++ b/lego-webapp/pages/index/CompactEvents.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .compactEvents {
   display: flex;
   justify-content: space-between;

--- a/lego-webapp/pages/index/EventItem.module.css
+++ b/lego-webapp/pages/index/EventItem.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .link {
   color: var(--lego-font-color);
   width: 100%;

--- a/lego-webapp/pages/index/LatestReadme.module.css
+++ b/lego-webapp/pages/index/LatestReadme.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .latestReadme {
   flex: 1;
   position: relative;

--- a/lego-webapp/pages/index/Pinned.module.css
+++ b/lego-webapp/pages/index/Pinned.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .pinned {
   grid-area: pinned;
   width: 100%;

--- a/lego-webapp/pages/index/PublicFrontpage.module.css
+++ b/lego-webapp/pages/index/PublicFrontpage.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .wrapper {
   display: grid;
   grid-gap: var(--spacing-xl);

--- a/lego-webapp/pages/index/UpcomingRegistrations.module.css
+++ b/lego-webapp/pages/index/UpcomingRegistrations.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .eventItem {
   border-left: 4px solid transparent;
   padding: var(--spacing-sm) 0 var(--spacing-sm) var(--spacing-md);

--- a/lego-webapp/pages/interest-groups/InterestGroup.module.css
+++ b/lego-webapp/pages/interest-groups/InterestGroup.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .navigationItem {
   flex-grow: 1;
   color: var(--absolute-white);

--- a/lego-webapp/pages/joblistings/_components/JoblistingList.module.css
+++ b/lego-webapp/pages/joblistings/_components/JoblistingList.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .emptyState {
   max-width: 280px;
   text-align: center;

--- a/lego-webapp/pages/lending/LendableObjectList.module.css
+++ b/lego-webapp/pages/lending/LendableObjectList.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .lendableObjectsContainer {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/lego-webapp/pages/meetings/MeetingList.module.css
+++ b/lego-webapp/pages/meetings/MeetingList.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .meetingItem {
   padding-left: 20px;
   border-left: 4px solid transparent;

--- a/lego-webapp/pages/pages/_components/LandingPage.module.css
+++ b/lego-webapp/pages/pages/_components/LandingPage.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .pageContainer {
   position: relative;
   margin-top: -15px;

--- a/lego-webapp/pages/pages/_components/PageHierarchy.module.css
+++ b/lego-webapp/pages/pages/_components/PageHierarchy.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .sidebar {
   width: 15rem;
   display: flex;

--- a/lego-webapp/pages/pages/_components/subcomponents/DisplayVision/DisplayVision.module.css
+++ b/lego-webapp/pages/pages/_components/subcomponents/DisplayVision/DisplayVision.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../../styles/variables.css');
-
 .vision {
   display: flex;
   margin: 0 auto;

--- a/lego-webapp/pages/pages/_components/subcomponents/EmailItem/EmailItem.module.css
+++ b/lego-webapp/pages/pages/_components/subcomponents/EmailItem/EmailItem.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../../styles/variables.css');
-
 .container {
   display: flex;
   align-items: center;

--- a/lego-webapp/pages/pages/_components/subcomponents/Statistic/Statistic.module.css
+++ b/lego-webapp/pages/pages/_components/subcomponents/Statistic/Statistic.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../../styles/variables.css');
-
 .container {
   margin: 0 var(--spacing-md) var(--spacing-md);
   line-height: 1.3;

--- a/lego-webapp/pages/pages/_components/subcomponents/TextWithTitle/TextWithTitle.module.css
+++ b/lego-webapp/pages/pages/_components/subcomponents/TextWithTitle/TextWithTitle.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../../styles/variables.css');
-
 .container {
   flex-basis: calc(100% / 3);
   margin: 0 var(--spacing-sm);

--- a/lego-webapp/pages/pages/_components/subcomponents/Vision/Vision.module.css
+++ b/lego-webapp/pages/pages/_components/subcomponents/Vision/Vision.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../../styles/variables.css');
-
 .title {
   font-size: var(--font-size-lg);
   color: var(--lego-red-color);

--- a/lego-webapp/pages/pages/page/PageDetail.module.css
+++ b/lego-webapp/pages/pages/page/PageDetail.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .header {
   text-align: center;
   margin: 0 auto;

--- a/lego-webapp/pages/photos/@galleryId/index/picture/@pictureId/GalleryPictureModal.module.css
+++ b/lego-webapp/pages/photos/@galleryId/index/picture/@pictureId/GalleryPictureModal.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../../../styles/variables.css');
-
 .loadingIndicator {
   margin: 0.375rem;
 }

--- a/lego-webapp/pages/photos/Overview.module.css
+++ b/lego-webapp/pages/photos/Overview.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .gallery {
   width: 220px;
 }

--- a/lego-webapp/pages/photos/new/GalleryEditorActions.module.css
+++ b/lego-webapp/pages/photos/new/GalleryEditorActions.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .fixed {
   display: flex;
   align-items: center;

--- a/lego-webapp/pages/polls/@pollsId/PollEditor.module.css
+++ b/lego-webapp/pages/polls/@pollsId/PollEditor.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .optionField {
   display: flex;
   align-items: center;

--- a/lego-webapp/pages/polls/PollsList.module.css
+++ b/lego-webapp/pages/polls/PollsList.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .pollsList {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/lego-webapp/pages/quotes/Quotes.module.css
+++ b/lego-webapp/pages/quotes/Quotes.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .addQuote {
   max-width: 550px;
 }

--- a/lego-webapp/pages/surveys/components/surveys.module.css
+++ b/lego-webapp/pages/surveys/components/surveys.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .surveyItem {
   padding-left: 20px;
   border-left: 4px solid transparent;

--- a/lego-webapp/pages/tags/@tagId/TagDetail.module.css
+++ b/lego-webapp/pages/tags/@tagId/TagDetail.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .entity {
   flex: 1;
   min-width: 200px;

--- a/lego-webapp/pages/users/@username/_components/UserProfile.module.css
+++ b/lego-webapp/pages/users/@username/_components/UserProfile.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../styles/variables.css');
-
 .header {
   align-items: flex-start;
   justify-content: space-between;

--- a/lego-webapp/pages/users/@username/settings/profile/UserSettings.module.css
+++ b/lego-webapp/pages/users/@username/settings/profile/UserSettings.module.css
@@ -1,5 +1,3 @@
-@import url('../../../../../styles/variables.css');
-
 .right {
   flex: 1;
 }

--- a/lego-webapp/pages/users/registration/RegistrationPage.module.css
+++ b/lego-webapp/pages/users/registration/RegistrationPage.module.css
@@ -1,5 +1,3 @@
-@import url('../../../styles/variables.css');
-
 .programmeList {
   list-style: disc;
   list-style-position: inside;

--- a/lego-webapp/styles/README.md
+++ b/lego-webapp/styles/README.md
@@ -22,8 +22,6 @@ from CSS Modules:
 Variables are stored in `variables.css` and should be used in other CSS files:
 
 ```css
-@import 'styles/variables.css';
-
 .myClassName {
   background: var(--background-color);
 }

--- a/lego-webapp/styles/overlay.css
+++ b/lego-webapp/styles/overlay.css
@@ -1,5 +1,3 @@
-@import url('styles/variables.css');
-
 .content {
   composes: popover from 'styles/utilities.module.css';
   background: var(--lego-card-color);


### PR DESCRIPTION
# Description

All the variables are imported in `global.css`, so they are available everywhere. The imports simply duplicated css into all the output css files. 

# Result

Smaller css bundles

# Testing

- [x] I have thoroughly tested my changes.

Things look the same, tested in dev and build.
