### PR TITLE
Add BannerPreview to editor and redesign banners

### DIFF
--- a/lego-webapp/components/Banner/Banner.module.css
+++ b/lego-webapp/components/Banner/Banner.module.css
@@ -1,5 +1,3 @@
-@import url('../../styles/variables.css');
-
 .link {
   display: block;
   margin: 0 var(--spacing-md);
@@ -12,6 +10,7 @@
   animation-duration: 4s;
   animation-iteration-count: infinite;
   animation-delay: 5s;
+  transition: var(--easing-fast);
 }
 
 .subHeader {
@@ -22,31 +21,43 @@
   margin: 0;
 }
 
-.red {
-  background-color: var(--color-red-5);
-  color: var(--color-absolute-white);
+div.red {
+  color: var(--color-red-7);
+  background-color: var(--color-background-color);
+  border: 3px solid var(--color-red-7);
+
+  &:hover {
+    background-color: var(--color-red-7);
+    color: var(--color-white);
+  }
 }
 
-.gray {
+div.gray {
   background-color: var(--color-gray-4);
   color: var(--color-white);
 }
 
-.white {
+div.white {
   color: var(--color-black);
 }
 
-.lightBlue {
+div.lightBlue {
   background-color: var(--color-blue-5);
   color: var(--color-white);
 }
 
-.itdageneBlue {
-  background-color: #0778bc;
-  color: var(--color-white);
+div.itdageneBlue {
+  background-color: var(--color-background-color);
+  color: #0778bc;
+  border: 3px solid #0778bc;
+
+  &:hover {
+    background-color: #0778bc;
+    color: var(--color-white);
+  }
 }
 
-.buddyweek2024 {
+div.buddyweek2024 {
   border: 5px dashed var(--lego-red-color);
 }
 

--- a/lego-webapp/components/Banner/Banner.module.css
+++ b/lego-webapp/components/Banner/Banner.module.css
@@ -23,7 +23,7 @@
 
 div.red {
   color: var(--color-red-7);
-  background-color: var(--color-background-color);
+  background-color: var(--lego-background-color);
   border: 3px solid var(--color-red-7);
 
   &:hover {

--- a/lego-webapp/components/Banner/Banner.module.css
+++ b/lego-webapp/components/Banner/Banner.module.css
@@ -23,7 +23,7 @@
 
 div.red {
   color: var(--color-red-7);
-  background-color: var(--lego-background-color);
+  background-color: transparent;
   border: 3px solid var(--color-red-7);
 
   &:hover {
@@ -47,7 +47,7 @@ div.lightBlue {
 }
 
 div.itdageneBlue {
-  background-color: var(--color-background-color);
+  background-color: transparent;
   color: #0778bc;
   border: 3px solid #0778bc;
 

--- a/lego-webapp/pages/admin/banners/BannerEditor.tsx
+++ b/lego-webapp/pages/admin/banners/BannerEditor.tsx
@@ -6,10 +6,11 @@ import {
   Page,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Field } from 'react-final-form';
+import cx from 'classnames';
+import { Field, useFormState } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { navigate } from 'vike/client/router';
-import { Color, COLORS } from '~/components/Banner';
+import Banner, { Color, COLORS } from '~/components/Banner';
 import { TextInput, Form, LegoFinalForm, SelectInput } from '~/components/Form';
 import { SubmitButton } from '~/components/Form/SubmitButton';
 import HTTPError from '~/components/errors/HTTPError';
@@ -25,10 +26,21 @@ import { selectBannerById } from '~/redux/slices/banner';
 import { guardLogin } from '~/utils/replaceUnlessLoggedIn';
 import { useParams } from '~/utils/useParams';
 import { createValidator, required } from '~/utils/validation';
+import styles from './BannerOverview.module.css';
+
+const colorToRepresentation: Record<Color, string> = {
+  red: 'Rød',
+  white: 'Hvit',
+  gray: 'Grå',
+  lightBlue: 'Lyseblå',
+  itdageneBlue: 'IT-dagene Blå',
+  buddyweek2024: 'Fadderuke',
+};
 
 type BannerEditorParams = {
   bannerId?: string;
 };
+
 const BannerEditor = () => {
   const { bannerId } = useParams<BannerEditorParams>();
 
@@ -61,15 +73,6 @@ const BannerEditor = () => {
   const onDelete = () =>
     dispatch(deleteBanner(bannerId!)).then(() => navigate('/admin/banners'));
 
-  const colorToRepresentation: Record<Color, string> = {
-    red: 'Rød',
-    white: 'Hvit',
-    gray: 'Grå',
-    lightBlue: 'Lyseblå',
-    itdageneBlue: 'IT-dagene Blå',
-    buddyweek2024: 'Fadderuke',
-  };
-
   const colorOptions = (Object.keys(COLORS) as Color[]).sort().map((color) => ({
     value: color,
     label: colorToRepresentation[color],
@@ -97,6 +100,7 @@ const BannerEditor = () => {
       >
         {({ handleSubmit }) => (
           <Form onSubmit={handleSubmit}>
+            <BannerPreview />
             <Field
               placeholder="Revyen har opptak!"
               name="header"
@@ -150,6 +154,27 @@ const BannerEditor = () => {
         )}
       </LegoFinalForm>
     </Page>
+  );
+};
+
+const BannerPreview = () => {
+  const { values } = useFormState();
+
+  return (
+    <div
+      className={cx(
+        styles.cardSection,
+        styles.bannerContainer,
+        styles.bannerPreview,
+      )}
+    >
+      <Banner
+        header={values.header ?? 'Tittel'}
+        subHeader={values.subheader}
+        link={values.link ?? 'https://abakus.no'}
+        color={values.color.value}
+      />
+    </div>
   );
 };
 

--- a/lego-webapp/pages/admin/banners/BannerOverview.module.css
+++ b/lego-webapp/pages/admin/banners/BannerOverview.module.css
@@ -21,3 +21,7 @@
 .editButton {
   flex-shrink: 0;
 }
+
+.bannerPreview {
+  border-radius: var(--border-radius-lg);
+}

--- a/lego-webapp/pages/sudo/+Page.tsx
+++ b/lego-webapp/pages/sudo/+Page.tsx
@@ -36,28 +36,23 @@ const links: PanelItem[] = [
   },
 ];
 
-const ControlPanelItem = ({ link, tag, description, iconNode }: PanelItem) => (
-  <a href={link}>
-    <Card>
-      <Icon iconNode={iconNode} size={20} />
-      <h3>{tag}</h3>
-      <p>{description}</p>
+const ControlPanelItem = ({ link }: { link: PanelItem }) => (
+  <a href={link.link} className={styles.controlPanelItem}>
+    <Card isHoverable>
+      <Icon iconNode={link.iconNode} size={20} />
+      <h3>{link.tag}</h3>
+      <p>{link.description}</p>
     </Card>
   </a>
 );
+
 const AdminControlPanel = () => {
   return (
     <div className={styles.controlPanel}>
       <h2>Kontrollpanel</h2>
-      <Flex>
-        {links.map((l) => (
-          <ControlPanelItem
-            key={l.tag}
-            link={l.link}
-            tag={l.tag}
-            description={l.description}
-            iconNode={l.iconNode}
-          />
+      <Flex gap="var(--spacing-md)">
+        {links.map((link) => (
+          <ControlPanelItem key={link.tag} link={link} />
         ))}
       </Flex>
     </div>

--- a/lego-webapp/pages/sudo/SudoAdmin.module.css
+++ b/lego-webapp/pages/sudo/SudoAdmin.module.css
@@ -1,3 +1,11 @@
 .list {
   list-style-type: disc;
 }
+
+.controlPanelItem {
+  color: var(--lego-font-color);
+}
+
+.controlPanelItem h3 {
+  color: var(--lego-link-color);
+}


### PR DESCRIPTION
# Description

Add a preview of the banner to the `BannerEditor`.
Dome banner design suggestions, the ones there before look bad.
Also fix bug where css is not applied correctly (after Vite/Vike)


# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            `BannerPreview`
        </td>
        <td>

![Screenshot 2025-03-10 at 10 47 28](https://github.com/user-attachments/assets/d79aa4dd-9bbd-4ecd-a389-262d416f99f2)
        </td>
        <td>

![Screenshot 2025-03-10 at 10 46 49](https://github.com/user-attachments/assets/26b4d70d-b4a1-456e-b79c-40af106ab9ab)
        </td>
    </tr>
	<tr>
		<td>
			Banner redesigns
		</td>
		<td>

![Screenshot 2025-03-10 at 10 51 42](https://github.com/user-attachments/assets/f06d9a8b-600a-44a2-88cc-9a63bde95f17)

![Screenshot 2025-03-10 at 10 51 05](https://github.com/user-attachments/assets/354f0a2d-1e78-4a6c-9151-19d8e8015e23)
		</td>
		<td>

![Screenshot 2025-03-10 at 10 49 24](https://github.com/user-attachments/assets/98dbdfb7-4abb-44a7-8812-421135e3e1e9)

![Screenshot 2025-03-10 at 10 50 14](https://github.com/user-attachments/assets/967b0932-a1ed-428a-bd68-effe8b955e97)
		</td>
	</tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.

