### PR TITLE
Add lending admin page

### DIFF
--- a/lego-webapp/pages/lending/+Page.tsx
+++ b/lego-webapp/pages/lending/+Page.tsx
@@ -6,23 +6,19 @@ import {
   filterSidebar,
   FilterSection,
   LinkButton,
-  Flex,
   Button,
-  Icon,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty } from 'lodash';
-import { FolderOpen, MoveRight } from 'lucide-react';
+import { FolderOpen } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import EmptyState from '~/components/EmptyState';
 import TextInput from '~/components/Form/TextInput';
-import Time from '~/components/Time';
 import HTTPError from '~/components/errors/HTTPError';
-import LendingStatusTag from '~/pages/lending/LendingStatusTag';
+import LendingRequestCard from '~/pages/lending/LendingRequestCard';
 import { fetchAllLendableObjects } from '~/redux/actions/LendableObjectActions';
 import { fetchLendingRequests } from '~/redux/actions/LendingRequestActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
-import { TransformedLendingRequest } from '~/redux/models/LendingRequest';
 import { EntityType } from '~/redux/models/entities';
 import { selectAllLendableObjects } from '~/redux/slices/lendableObjects';
 import { selectTransformedLendingRequests } from '~/redux/slices/lendingRequests';
@@ -48,39 +44,6 @@ const LendableObject = ({
         <div className={styles.lendableObjectFooter}>
           <h4>{lendableObject.title}</h4>
         </div>
-      </Card>
-    </a>
-  );
-};
-
-const LendingRequest = ({
-  lendingRequest,
-}: {
-  lendingRequest: TransformedLendingRequest;
-}) => {
-  return (
-    <a
-      href={`/lending/${lendingRequest.lendableObject.id}/request/${lendingRequest.id}`}
-    >
-      <Card isHoverable hideOverflow className={styles.lendingRequestCard}>
-        <Image
-          className={styles.lendingRequestImage}
-          height={80}
-          width={80}
-          src={lendingRequest.lendableObject.image || '/icon-192x192.png'}
-          alt={`${lendingRequest.lendableObject.title}`}
-        />
-        <Flex justifyContent="space-between" width="100%">
-          <Flex column gap="var(--spacing-sm)">
-            <h4>{lendingRequest.lendableObject.title}</h4>
-            <Flex alignItems="center" gap={8}>
-              <Time time={lendingRequest.startDate} format="DD. MMM" />
-              <Icon iconNode={<MoveRight />} size={19} />
-              <Time time={lendingRequest.endDate} format="DD. MMM" />
-            </Flex>
-          </Flex>
-          <LendingStatusTag lendingRequestStatus={lendingRequest.status} />
-        </Flex>
       </Card>
     </a>
   );
@@ -127,8 +90,12 @@ const LendableObjectList = () => {
     selectTransformedLendingRequests(state, { pagination: requestsPagination }),
   );
 
-  const actionGrant = useAppSelector(
+  const objectsActionGrant = useAppSelector(
     (state) => state.lendableObjects.actionGrant,
+  );
+
+  const requestsActionGrant = useAppSelector(
+    (state) => state.lendingRequests.actionGrant,
   );
 
   const fetchingObjects = useAppSelector(
@@ -151,8 +118,11 @@ const LendableObjectList = () => {
       title={title}
       actionButtons={
         <>
-          {actionGrant.includes('create') && (
+          {objectsActionGrant.includes('create') && (
             <LinkButton href="/lending/new">Nytt utlånsobjekt</LinkButton>
+          )}
+          {requestsActionGrant.includes('admin') && (
+            <LinkButton href="/lending/admin">Administrator</LinkButton>
           )}
         </>
       }
@@ -177,7 +147,7 @@ const LendableObjectList = () => {
             {lendingRequests.length ? (
               <div className={styles.lendingRequestsContainer}>
                 {lendingRequests.map((lendingRequest) => (
-                  <LendingRequest
+                  <LendingRequestCard
                     key={lendingRequest.id}
                     lendingRequest={lendingRequest}
                   />

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
@@ -39,6 +39,7 @@ import { selectUserById } from '~/redux/slices/users';
 import { useFeatureFlag } from '~/utils/useFeatureFlag';
 import { useParams } from '~/utils/useParams';
 import styles from './LendingRequestDetail.module.css';
+import useQuery from '~/utils/useQuery';
 
 type Params = {
   lendingRequestId: string;
@@ -46,6 +47,10 @@ type Params = {
 };
 
 const LendingRequest = () => {
+  const { query, setQueryValue } = useQuery({
+    fromAdmin: '',
+  });
+
   const dispatch = useAppDispatch();
   const [fetching, setFetching] = useState(false);
 
@@ -88,7 +93,11 @@ const LendingRequest = () => {
   const title = `Forespørsel ${lendableObject?.title ? ` - ${lendableObject.title}` : ''}`;
 
   return (
-    <Page title={title} back={{ href: '/lending' }} skeleton={fetching}>
+    <Page
+      title={title}
+      back={{ href: query.fromAdmin ? '/lending/admin' : '/lending' }}
+      skeleton={fetching}
+    >
       <Helmet title={title} />
       {lendingRequest && (
         <ContentSection>

--- a/lego-webapp/pages/lending/LendableObjectList.module.css
+++ b/lego-webapp/pages/lending/LendableObjectList.module.css
@@ -46,6 +46,10 @@ img.lendableObjectImage {
   flex-direction: row;
   align-items: center;
   gap: var(--spacing-md);
+
+  @media (--small-viewport) {
+    flex-direction: column;
+  }
 }
 
 img.lendingRequestImage {
@@ -58,6 +62,15 @@ img.lendingRequestImage {
 .divider {
   border-bottom: 2px solid var(--border-gray);
   margin: var(--spacing-md) 0;
+}
+
+.tagContainer {
+  margin-left: auto;
+  width: 100%;
+}
+
+.tagContainer > div {
+  width: 100%;
 }
 
 .statusTag {

--- a/lego-webapp/pages/lending/LendingRequestCard.tsx
+++ b/lego-webapp/pages/lending/LendingRequestCard.tsx
@@ -20,25 +20,29 @@ const LendingRequestCard = ({
         `}
     >
       <Card isHoverable hideOverflow className={styles.lendingRequestCard}>
-        <Image
-          className={styles.lendingRequestImage}
-          height={80}
-          width={80}
-          src={lendingRequest.lendableObject.image || '/icon-192x192.png'}
-          alt={`
+        <Flex width="100%" gap="var(--spacing-md)">
+          <Image
+            className={styles.lendingRequestImage}
+            height={80}
+            width={80}
+            src={lendingRequest.lendableObject.image || '/icon-192x192.png'}
+            alt={`
       }${lendingRequest.lendableObject.title}`}
-        />
-        <Flex justifyContent="space-between" width="100%">
-          <Flex column gap="var(--spacing-sm)">
-            <h4>{lendingRequest.lendableObject.title}</h4>
-            <Flex alignItems="center" gap={8}>
-              <Time time={lendingRequest.startDate} format="DD. MMM" />
-              <Icon iconNode={<MoveRight />} size={19} />
-              <Time time={lendingRequest.endDate} format="DD. MMM" />
+          />
+          <Flex>
+            <Flex column gap="var(--spacing-sm)" justifyContent="center">
+              <h4>{lendingRequest.lendableObject.title}</h4>
+              <Flex alignItems="center" gap={8}>
+                <Time time={lendingRequest.startDate} format="DD. MMM" />
+                <Icon iconNode={<MoveRight />} size={19} />
+                <Time time={lendingRequest.endDate} format="DD. MMM" />
+              </Flex>
             </Flex>
           </Flex>
-          <LendingStatusTag lendingRequestStatus={lendingRequest.status} />
         </Flex>
+        <div className={styles.tagContainer}>
+          <LendingStatusTag lendingRequestStatus={lendingRequest.status} />
+        </div>
       </Card>
     </a>
   );

--- a/lego-webapp/pages/lending/LendingRequestCard.tsx
+++ b/lego-webapp/pages/lending/LendingRequestCard.tsx
@@ -1,0 +1,47 @@
+import { Card, Flex, Icon, Image } from '@webkom/lego-bricks';
+import { MoveRight } from 'lucide-react';
+import Time from '~/components/Time';
+import LendingStatusTag from '~/pages/lending/LendingStatusTag';
+import { TransformedLendingRequest } from '~/redux/models/LendingRequest';
+import styles from './LendableObjectList.module.css';
+
+const LendingRequestCard = ({
+  lendingRequest,
+  isFromAdmin,
+}: {
+  lendingRequest: TransformedLendingRequest;
+  isFromAdmin?: boolean;
+}) => {
+  return (
+    <a
+      href={`/lending/${lendingRequest.lendableObject.id}/request/${lendingRequest.id} ${
+        isFromAdmin ? '?fromAdmin=true' : ''
+      }
+        `}
+    >
+      <Card isHoverable hideOverflow className={styles.lendingRequestCard}>
+        <Image
+          className={styles.lendingRequestImage}
+          height={80}
+          width={80}
+          src={lendingRequest.lendableObject.image || '/icon-192x192.png'}
+          alt={`
+      }${lendingRequest.lendableObject.title}`}
+        />
+        <Flex justifyContent="space-between" width="100%">
+          <Flex column gap="var(--spacing-sm)">
+            <h4>{lendingRequest.lendableObject.title}</h4>
+            <Flex alignItems="center" gap={8}>
+              <Time time={lendingRequest.startDate} format="DD. MMM" />
+              <Icon iconNode={<MoveRight />} size={19} />
+              <Time time={lendingRequest.endDate} format="DD. MMM" />
+            </Flex>
+          </Flex>
+          <LendingStatusTag lendingRequestStatus={lendingRequest.status} />
+        </Flex>
+      </Card>
+    </a>
+  );
+};
+
+export default LendingRequestCard;

--- a/lego-webapp/pages/lending/admin/+Page.tsx
+++ b/lego-webapp/pages/lending/admin/+Page.tsx
@@ -1,0 +1,124 @@
+import {
+  LoadingIndicator,
+  Page,
+  filterSidebar,
+  FilterSection,
+  LinkButton,
+  Button,
+} from '@webkom/lego-bricks';
+import { usePreparedEffect } from '@webkom/react-prepare';
+import { isEmpty } from 'lodash';
+import { FolderOpen } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
+import EmptyState from '~/components/EmptyState';
+import TextInput from '~/components/Form/TextInput';
+import HTTPError from '~/components/errors/HTTPError';
+import LendingRequestCard from '~/pages/lending/LendingRequestCard';
+import { fetchLendingRequestsAdmin } from '~/redux/actions/LendingRequestActions';
+import { useAppDispatch, useAppSelector } from '~/redux/hooks';
+import { EntityType } from '~/redux/models/entities';
+import { selectTransformedLendingRequests } from '~/redux/slices/lendingRequests';
+import { selectPaginationNext } from '~/redux/slices/selectors';
+import { useFeatureFlag } from '~/utils/useFeatureFlag';
+import useQuery from '~/utils/useQuery';
+import styles from '../LendableObjectList.module.css';
+
+const LendingAdmin = () => {
+  const { query, setQueryValue } = useQuery({
+    search: '',
+  });
+
+  const dispatch = useAppDispatch();
+
+  usePreparedEffect(
+    'fetchAdminLendingRequests',
+    () => dispatch(fetchLendingRequestsAdmin({})),
+    [],
+  );
+
+  const { pagination: requestsPagination } = useAppSelector((state) =>
+    selectPaginationNext({
+      endpoint: '/lending/requests/admin/',
+      entity: EntityType.LendingRequests,
+      query,
+    })(state),
+  );
+
+  const fetchMoreLendingRequests = () => {
+    return dispatch(
+      fetchLendingRequestsAdmin({
+        next: true,
+      }),
+    );
+  };
+
+  const lendingRequests = useAppSelector((state) =>
+    selectTransformedLendingRequests(state, { pagination: requestsPagination }),
+  );
+
+  const actionGrant = useAppSelector(
+    (state) => state.lendableObjects.actionGrant,
+  );
+
+  if (!useFeatureFlag('lending')) {
+    return <HTTPError />;
+  }
+
+  const title = 'Utlån - Admin';
+  return (
+    <Page
+      title={title}
+      back={{ href: '/lending' }}
+      actionButtons={
+        <>
+          {actionGrant.includes('create') && (
+            <LinkButton href="/lending/new">Nytt utlånsobjekt</LinkButton>
+          )}
+        </>
+      }
+      sidebar={filterSidebar({
+        children: (
+          <FilterSection title="Søk">
+            <TextInput
+              prefix="search"
+              placeholder="Grill, soundboks..."
+              value={query.search}
+              onChange={(e) => setQueryValue('search')(e.target.value)}
+            />
+          </FilterSection>
+        ),
+      })}
+    >
+      <Helmet title={title} />
+      <h3>Utlånsforespørsler</h3>
+      <LoadingIndicator loading={requestsPagination.fetching}>
+        {lendingRequests.length ? (
+          <div className={styles.lendingRequestsContainer}>
+            {lendingRequests.map((lendingRequest) => (
+              <LendingRequestCard
+                key={lendingRequest.id}
+                lendingRequest={lendingRequest}
+                isFromAdmin
+              />
+            ))}
+          </div>
+        ) : (
+          <EmptyState
+            iconNode={<FolderOpen />}
+            body={<span>Ingen utlånsforespørsler</span>}
+          />
+        )}
+        {requestsPagination.hasMore && (
+          <Button
+            onPress={fetchMoreLendingRequests}
+            isPending={!isEmpty(lendingRequests) && requestsPagination.fetching}
+          >
+            Last inn mer
+          </Button>
+        )}
+      </LoadingIndicator>
+    </Page>
+  );
+};
+
+export default LendingAdmin;

--- a/lego-webapp/redux/actions/LendingRequestActions.ts
+++ b/lego-webapp/redux/actions/LendingRequestActions.ts
@@ -23,13 +23,16 @@ export const fetchLendingRequests = ({ next = false }) =>
     propagateError: true,
   });
 
-export const fetchLendingRequestsAdmin = () =>
+export const fetchLendingRequestsAdmin = ({ next = false }) =>
   callAPI<AdminLendingRequest[]>({
     types: LendingRequests.FETCH_ADMIN,
     endpoint: '/lending/requests/admin/',
     schema: [lendingRequestSchema],
     meta: {
       errorMessage: 'Henting av utlånsforespørsler feilet',
+    },
+    pagination: {
+      fetchNext: next,
     },
     propagateError: true,
   });

--- a/lego-webapp/redux/slices/lendingRequests.ts
+++ b/lego-webapp/redux/slices/lendingRequests.ts
@@ -14,7 +14,7 @@ const lendingRequestSlice = createSlice({
   initialState: legoAdapter.getInitialState(),
   reducers: {},
   extraReducers: legoAdapter.buildReducers({
-    fetchActions: [LendingRequests.FETCH],
+    fetchActions: [LendingRequests.FETCH, LendingRequests.FETCH_ADMIN],
   }),
 });
 
@@ -28,6 +28,7 @@ export const selectTransformedLendingRequests = createSelector(
   selectAllLendingRequests,
   selectAllLendableObjects,
   (lendingRequests, lendableObjects) => {
+    console.log(lendingRequests);
     return lendingRequests.map((lendingRequest) => {
       const lendableObject = lendableObjects.find(
         (lendableObject) => lendableObject.id === lendingRequest.lendableObject,


### PR DESCRIPTION
# Description

Adds admin page  where administrators can see all lending requests for objects they manage. 

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/user-attachments/assets/a69ad1c4-75a2-450f-a240-a09b567dc51c

# Testing

- [x] I have thoroughly tested my changes.

Verify that the admin system and navigation works.

Resolves [ABA-1322](https://linear.app/abakus-webkom/issue/ABA-1322/frontend-admin-page-for-viewing-new-lending-requests)
