### PR TITLE
Render MazemapEmbed once per page

### DIFF
--- a/lego-webapp/components/MazemapEmbed/MazemapAccordion.tsx
+++ b/lego-webapp/components/MazemapEmbed/MazemapAccordion.tsx
@@ -1,8 +1,9 @@
 import { Accordion, Flex, Icon } from '@webkom/lego-bricks';
 import { ChevronRight } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
 import mazemapLogo from '~/assets/mazemap.svg';
 import MazemapLink from '~/components/MazemapEmbed/MazemapLink';
-import { MazemapEmbed } from '~/components/MazemapEmbed/index';
+import { MazemapEmbed, mazemapScript } from '~/components/MazemapEmbed/index';
 import styles from './MazemapAccordion.module.css';
 import type { ComponentProps } from 'react';
 
@@ -14,6 +15,7 @@ export const MazemapAccordion = ({ defaultOpen = false, ...props }: Props) => {
   return (
     <>
       <Flex column className={styles.mazemapAccordion}>
+        <Helmet title="Mazemap">{mazemapScript}</Helmet>
         <Accordion
           persistChildren
           defaultOpen={defaultOpen}

--- a/lego-webapp/components/MazemapEmbed/MazemapAccordion.tsx
+++ b/lego-webapp/components/MazemapEmbed/MazemapAccordion.tsx
@@ -15,6 +15,7 @@ export const MazemapAccordion = ({ defaultOpen = false, ...props }: Props) => {
     <>
       <Flex column className={styles.mazemapAccordion}>
         <Accordion
+          persistChildren
           defaultOpen={defaultOpen}
           triggerComponent={({ onClick, rotateClassName }) => (
             <Flex

--- a/lego-webapp/components/MazemapEmbed/index.tsx
+++ b/lego-webapp/components/MazemapEmbed/index.tsx
@@ -170,15 +170,6 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
 
   return (
     <Flex column gap="var(--spacing-sm)">
-      <Helmet
-        title="Mazemap"
-        script={[
-          {
-            type: 'text/javascript',
-            src: 'https://api.mazemap.com/js/v2.2.1/mazemap.min.js',
-          },
-        ]}
-      />
       <div
         style={{
           height: props.height || 400,

--- a/lego-webapp/components/Search/mazemapAutocomplete.tsx
+++ b/lego-webapp/components/Search/mazemapAutocomplete.tsx
@@ -1,5 +1,7 @@
 import { debounce } from 'lodash';
 import { useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { mazemapScript } from '~/components/MazemapEmbed';
 import { useWaitForGlobal } from '~/utils/useWaitForGlobal';
 import { stripHtmlTags } from './utils';
 import type { ComponentType } from 'react';
@@ -84,12 +86,15 @@ const withMazemapAutocomplete = <P,>({
     const { options, onSearch, fetching } = useMazemapAutocomplete();
 
     return (
+      <>
+        <Helmet title="Mazemap Search">{mazemapScript}</Helmet>
       <WrappedComponent
         {...props}
         options={options}
         onSearch={onSearch}
         fetching={fetching}
       />
+      </>
     );
   };
   const displayName =

--- a/lego-webapp/components/Search/mazemapAutocomplete.tsx
+++ b/lego-webapp/components/Search/mazemapAutocomplete.tsx
@@ -19,12 +19,12 @@ type SelectOption = {
 };
 
 const mapRoomAndBuildingToSelectOption = (
+  value: number,
   poiName: string,
   buildingName: string,
-  value: number,
 ): SelectOption => {
   return {
-    label: stripHtmlTags(poiName + ', ' + buildingName),
+    label: [poiName, buildingName].filter(Boolean).join(', '),
     value: value,
   };
 };
@@ -61,9 +61,9 @@ export const useMazemapAutocomplete = () => {
           setOptions(
             results.results.features.map((result) =>
               mapRoomAndBuildingToSelectOption(
+                result.properties.poiId,
                 result.properties.dispPoiNames[0],
                 result.properties.dispBldNames[0],
-                result.properties.poiId,
               ),
             ),
           );
@@ -88,12 +88,12 @@ const withMazemapAutocomplete = <P,>({
     return (
       <>
         <Helmet title="Mazemap Search">{mazemapScript}</Helmet>
-      <WrappedComponent
-        {...props}
-        options={options}
-        onSearch={onSearch}
-        fetching={fetching}
-      />
+        <WrappedComponent
+          {...props}
+          options={options}
+          onSearch={onSearch}
+          fetching={fetching}
+        />
       </>
     );
   };

--- a/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
@@ -13,7 +13,6 @@ import {
 } from '~/components/Content';
 import DisplayContent from '~/components/DisplayContent';
 import InfoList from '~/components/InfoList';
-import { mazemapScript } from '~/components/MazemapEmbed';
 import PropertyHelmet from '~/components/PropertyHelmet';
 import Tag from '~/components/Tags/Tag';
 import TextWithIcon from '~/components/TextWithIcon';
@@ -195,7 +194,6 @@ const EventDetail = () => {
             rel="canonical"
             href={`${appConfig?.webUrl}/events/${event.id}`}
           />
-          {mazemapScript}
         </PropertyHelmet>
       )}
 

--- a/lego-webapp/pages/events/src/EventEditor/index.tsx
+++ b/lego-webapp/pages/events/src/EventEditor/index.tsx
@@ -10,11 +10,9 @@ import arrayMutators from 'final-form-arrays';
 import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
 import { Field } from 'react-final-form';
-import { Helmet } from 'react-helmet-async';
 import { navigate } from 'vike/client/router';
 import { Form, CheckBox, LegoFinalForm } from '~/components/Form';
 import { SubmitButton } from '~/components/Form/SubmitButton';
-import { mazemapScript } from '~/components/MazemapEmbed';
 import {
   transformEvent,
   transformEventStatusType,
@@ -342,8 +340,6 @@ const EventEditor = () => {
         href: isEditPage ? `/events/${event?.slug}` : '/events',
       }}
     >
-      <Helmet title={title}>´{mazemapScript}</Helmet>
-
       <TypedLegoForm
         onSubmit={onSubmit}
         initialValues={initialValues}

--- a/lego-webapp/pages/meetings/@meetingId/MeetingDetail.tsx
+++ b/lego-webapp/pages/meetings/@meetingId/MeetingDetail.tsx
@@ -27,7 +27,6 @@ import Dropdown from '~/components/Dropdown';
 import { ProfilePicture } from '~/components/Image';
 import InfoList from '~/components/InfoList';
 import LegoReactions from '~/components/LegoReactions';
-import { mazemapScript } from '~/components/MazemapEmbed';
 import { MazemapAccordion } from '~/components/MazemapEmbed/MazemapAccordion';
 import Time, { FromToTime } from '~/components/Time';
 import Tooltip from '~/components/Tooltip';
@@ -199,7 +198,7 @@ const MeetingDetails = () => {
         href: '/meetings',
       }}
     >
-      <Helmet title={meeting.title}>{mazemapScript}</Helmet>
+      <Helmet title={meeting.title}></Helmet>
 
       <ContentSection>
         <ContentMain>

--- a/lego-webapp/pages/meetings/MeetingEditor.tsx
+++ b/lego-webapp/pages/meetings/MeetingEditor.tsx
@@ -12,7 +12,6 @@ import { Trash2 } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState } from 'react';
 import { Field, FormSpy } from 'react-final-form';
-import { Helmet } from 'react-helmet-async';
 import { navigate } from 'vike/client/router';
 import Dropdown from '~/components/Dropdown';
 import {
@@ -29,7 +28,6 @@ import {
 import LegoFinalForm from '~/components/Form/LegoFinalForm';
 import SubmissionError from '~/components/Form/SubmissionError';
 import { SubmitButton } from '~/components/Form/SubmitButton';
-import { mazemapScript } from '~/components/MazemapEmbed';
 import MazemapLink from '~/components/MazemapEmbed/MazemapLink';
 import Attendance from '~/components/UserAttendance/Attendance';
 import { fetchMemberships } from '~/redux/actions/GroupActions';
@@ -315,7 +313,6 @@ const MeetingEditor = () => {
         href: `/meetings/${isEditPage ? meetingId : ''}`,
       }}
     >
-      <Helmet title={title}>{mazemapScript}</Helmet>
       <LegoFinalForm
         onSubmit={onSubmit}
         initialValues={initialValues}


### PR DESCRIPTION
# Description

Now the mazemap should load a maximum of once per page.
I thought of complicating this, then I saw persistchildren existed, rendering children on page load.
@eikhr already made mazemap.min.js @ 3,51MB preload, so downloading the rest at 0,5-1MB to have instant load of mazemap is worth it IMO. 
Otherwise we would need to refactor and wait to load the script until map is opened to have any real data saving effect anyways. Also, that big main js file would be cached in browser after loading any map so we'd be saving less than 1MB most of the time 🤷

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td >Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Loads before open, and stays loaded when re-opening (if people do that)
        </td>
        <td>         <video width='20px' height='400px' src=https://github.com/user-attachments/assets/ff21ff01-4b28-4622-8bc0-93350dca55cc />        </td>
        <td>
<video height='400px' src=https://github.com/user-attachments/assets/3f61d0bb-363c-49eb-99ba-ffbc9d33d092 />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.