### PR TITLE
Throttle theme changes instead of debouncing

### DIFF
--- a/lego-webapp/components/Header/ToggleTheme.tsx
+++ b/lego-webapp/components/Header/ToggleTheme.tsx
@@ -1,11 +1,6 @@
 import { Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { debounce } from 'lodash';
 import { MoonStar, Sun } from 'lucide-react';
-import { useCallback } from 'react';
-import { updateUserTheme } from '~/redux/actions/UserActions';
-import { useAppDispatch } from '~/redux/hooks';
-import { useCurrentUser, useIsLoggedIn } from '~/redux/slices/auth';
 import { applySelectedTheme, getTheme, useTheme } from '~/utils/themeUtils';
 import styles from './toggleTheme.module.css';
 import type { ReactNode, MouseEvent } from 'react';
@@ -19,29 +14,14 @@ type Props = {
 };
 
 const ToggleTheme = ({ className, children, isButton = true }: Props) => {
-  const dispatch = useAppDispatch();
-  const loggedIn = useIsLoggedIn();
-  const username = useCurrentUser()?.username;
   const icon = useIcon();
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedUpdateUserTheme = useCallback(
-    debounce((username, newTheme) => {
-      dispatch(updateUserTheme(username, newTheme));
-    }, 2000),
-    [dispatch],
-  );
-
-  const handleThemeChange = useCallback(
-    (e: MouseEvent) => {
-      e.preventDefault();
-      const currentTheme = getTheme();
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      applySelectedTheme(newTheme);
-      loggedIn && username && debouncedUpdateUserTheme(username, newTheme);
-    },
-    [loggedIn, username, debouncedUpdateUserTheme],
-  );
+  const handleThemeChange = (e: MouseEvent) => {
+    e.preventDefault();
+    const currentTheme = getTheme();
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    applySelectedTheme(newTheme);
+  };
 
   const Component = isButton ? 'button' : 'div';
   return (

--- a/lego-webapp/components/Header/index.tsx
+++ b/lego-webapp/components/Header/index.tsx
@@ -174,7 +174,9 @@ const Header = () => {
         ? getTheme() !== getOSTheme()
         : getTheme() !== currentUser.selectedTheme)
     ) {
-      applySelectedTheme(currentUser.selectedTheme || 'light');
+      applySelectedTheme(currentUser.selectedTheme || 'light', {
+        updateUserTheme: false,
+      });
     }
   }, [loggedIn, currentUser]);
 

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
@@ -47,7 +47,7 @@ type Params = {
 };
 
 const LendingRequest = () => {
-  const { query, setQueryValue } = useQuery({
+  const { query } = useQuery({
     fromAdmin: '',
   });
 

--- a/lego-webapp/utils/themeUtils.tsx
+++ b/lego-webapp/utils/themeUtils.tsx
@@ -1,16 +1,40 @@
-import { createContext, useEffect } from 'react';
+import { throttle } from 'lodash';
+import { createContext, useCallback, useEffect } from 'react';
+import { updateUserTheme } from '~/redux/actions/UserActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
+import { useCurrentUser, useIsLoggedIn } from '~/redux/slices/auth';
 import { setTheme } from '~/redux/slices/theme';
 
-export const applySelectedTheme = (theme: 'light' | 'dark' | 'auto') => {
-  if (!import.meta.env.SSR) {
-    document.documentElement.setAttribute(
-      'data-theme',
-      theme === 'auto' ? getOSTheme() : theme,
-    );
-    window.dispatchEvent(new Event('themeChange'));
-    localStorage.setItem('theme', theme);
-  }
+type ThemeChangeEventDetail = {
+  updateUserTheme?: boolean;
+};
+
+type ApplySelectedThemeOptions = {
+  updateUserTheme?: boolean;
+};
+
+export const applySelectedTheme = (
+  theme: 'light' | 'dark' | 'auto',
+  options: ApplySelectedThemeOptions = {
+    updateUserTheme: true,
+  },
+) => {
+  if (import.meta.env.SSR) return;
+
+  document.documentElement.setAttribute(
+    'data-theme',
+    theme === 'auto' ? getOSTheme() : theme,
+  );
+
+  window.dispatchEvent(
+    new CustomEvent<ThemeChangeEventDetail>('themeChange', {
+      detail: {
+        updateUserTheme: options.updateUserTheme,
+      },
+    }),
+  );
+
+  localStorage.setItem('theme', theme);
 };
 
 export const getTheme = (): 'dark' | 'light' =>
@@ -23,20 +47,46 @@ export const ThemeContext = createContext<'dark' | 'light'>(getTheme());
 
 export const ThemeContextListener = () => {
   const dispatch = useAppDispatch();
+  const username = useCurrentUser()?.username;
+  const loggedIn = useIsLoggedIn();
+
+  // Throttle ensures instant feedback first time user changes theme,
+  // but also ensures user cant spam the server with requests
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const throttledUpdateUserTheme = useCallback(
+    throttle(
+      (username, theme) => dispatch(updateUserTheme(username, theme)),
+      2000,
+    ),
+    [dispatch],
+  );
 
   useEffect(() => {
-    // Configure listener to synchronize state
-    const handleThemeChange = () => dispatch(setTheme(getTheme()));
+    
+    const handleThemeChange = (event?: Event) => {
+      const currentTheme = getTheme();
+      dispatch(setTheme(currentTheme)); // Synchronize local state
+
+      if (
+        (event as CustomEvent<ThemeChangeEventDetail> | undefined)?.detail
+          ?.updateUserTheme &&
+        loggedIn &&
+        username
+      )
+        throttledUpdateUserTheme(username, currentTheme); // Synchronize server state
+    };
+
     handleThemeChange();
     window.addEventListener('themeChange', handleThemeChange);
 
-    // Optimistically upadte theme from localStorage
+    // Optimistically update theme from localStorage
     const cachedTheme =
       localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
-    applySelectedTheme(cachedTheme);
+    applySelectedTheme(cachedTheme, { updateUserTheme: false });
 
     return () => window.removeEventListener('themeChange', handleThemeChange);
-  }, [dispatch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, loggedIn, username]);
 
   return <></>;
 };

--- a/lego-webapp/utils/themeUtils.tsx
+++ b/lego-webapp/utils/themeUtils.tsx
@@ -62,7 +62,6 @@ export const ThemeContextListener = () => {
   );
 
   useEffect(() => {
-    
     const handleThemeChange = (event?: Event) => {
       const currentTheme = getTheme();
       dispatch(setTheme(currentTheme)); // Synchronize local state


### PR DESCRIPTION
# Description

Currently the implementation of theme changing uses debounce to prevent spamming the server. This results in slow feedback (toast) for the user. Using throttling instead it sends a request instantly but does not allow further updates until after a delay. 

This way it is still kind of possible to spam the server (only 2s between each request), if we want to eliminate that too I did try out a custom function which combines the functionality of throttling and debounce (instant feedback on first click, then debounce rest of calls), its okay, but i might prefer the user feedback with just throttle.

Also moved more logic to themeUtils, both to make this PR work and its more clean imo. 

The custom event allows updates to the theme to not send a API request to the backend and only be used for syncing local state.

Also anyone know if there is a reason for why there is no `Theme` `enum` with `dark` and `light`? A lot of "magic" strings. If not I could make that. 

# Result

*Before (with debounce):*

https://github.com/user-attachments/assets/a3d775dd-8e7f-4447-a8a0-8c65d5564642

*After (with throttlling):*

https://github.com/user-attachments/assets/ae897ee5-3c74-45ce-9934-24f52a36b859


# Testing

- [ I have thoroughly spammed the theme change button probably 100000000 times] I have thoroughly tested my changes.

---

Resolves ABA-1362
