### PR TITLE
Fix modal height

### DIFF
--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webkom/lego-bricks",
-  "version": "1.3.6",
+  "version": "1.3.8",
   "description": "Component library for lego and other Abakus projects",
   "author": "webkom",
   "license": "MIT",

--- a/packages/lego-bricks/src/components/Modal/Modal.module.css
+++ b/packages/lego-bricks/src/components/Modal/Modal.module.css
@@ -13,7 +13,7 @@
   top: 0;
   left: 0;
   width: 100vw;
-  height: var(--visual-viewport-height);
+  height: 100vh;
   background: rgba(var(--rgb-min), var(--rgb-min), var(--rgb-min), 10%);
   backdrop-filter: blur(3px);
   display: flex;
@@ -55,7 +55,7 @@ html[data-theme='dark'] .overlay {
    * which moves the modal content out of the top of the screen if it 
    * is too tall
   */
-  max-height: calc(var(--visual-viewport-height) - 100px);
+  max-height: calc(100vh - 100px);
   padding: var(--spacing-xl);
   background: var(--color-white);
   outline: none;


### PR DESCRIPTION
# Description

This has annoyed me for quite some time...
Previously, when zooming in using two finger pinch, the modal height would shrink. This has now been fixed in `lego-bricks`.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/fced5bdc-d561-45fd-85c4-75d799c53145) | ![image](https://github.com/user-attachments/assets/943f461c-3764-424e-a15b-375cb27d8723) |


# Testing

- [x] I have thoroughly tested my changes.

Resolves [ABA-1365](https://linear.app/abakus-webkom/issue/ABA-1365/incorrect-modal-height-on-zoom)
