### PR TITLE
Add company description to events with checkbox

### DIFF
--- a/lego-webapp/app/models.ts
+++ b/lego-webapp/app/models.ts
@@ -270,6 +270,7 @@ export type Event = EventBase & {
   documentType?: 'event';
   responsibleUsers: EntityId[];
   isForeignLanguage: boolean;
+  showCompanyDescription: boolean;
 };
 
 type EventTransformPool = EventPoolBase & {
@@ -288,6 +289,7 @@ export type TransformEvent = EventBase & {
   responsibleUsers: PublicUser[];
   isForeignLanguage: boolean;
   date: [Dateish, Dateish];
+  showCompanyDescription: boolean;
 };
 
 export type Workplace = {

--- a/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
@@ -212,7 +212,12 @@ const EventDetail = () => {
               ))}
             </Flex>
           )}
-          {event?.showCompanyDescription && event.company && (<>{event.company?.description}</>)}
+          <Flex column>
+            <h3>Om bedriften</h3>
+            {event?.showCompanyDescription && event.company && (
+              <>{event.company?.description}</>
+            )}
+          </Flex>
         </ContentMain>
 
         <ContentSidebar>

--- a/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
@@ -212,6 +212,7 @@ const EventDetail = () => {
               ))}
             </Flex>
           )}
+          {event?.showCompanyDescription && event.company && (<>{event.company?.description}</>)}
         </ContentMain>
 
         <ContentSidebar>

--- a/lego-webapp/pages/events/src/EventEditor/EditorSection/Descriptions.tsx
+++ b/lego-webapp/pages/events/src/EventEditor/EditorSection/Descriptions.tsx
@@ -1,11 +1,10 @@
 import { Flex } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
-import { EditorField, TextEditor } from '~/components/Form';
+import { CheckBox, EditorField, TextEditor } from '~/components/Form';
 import Tag from '~/components/Tags/Tag';
 import styles from '../EventEditor.module.css';
 import type { EditingEvent } from '~/pages/events/utils';
 import type { UploadArgs } from '~/redux/actions/FileActions';
-import ToggleSwitch from '~/components/Form/ToggleSwitch';
 
 type Props = {
   uploadFile: (uploadArgs: UploadArgs) => void;
@@ -34,7 +33,7 @@ const Descriptions: React.FC<Props> = ({ uploadFile, values }) => {
       <Field
         label="Vis bedriftsbeskrivelse på arrangement"
         name="showCompanyDescription"
-        component={ToggleSwitch.Field}
+        component={CheckBox.Field}
         type="checkbox"
       />
       {values.tags?.length > 0 && (

--- a/lego-webapp/pages/events/src/EventEditor/EditorSection/Descriptions.tsx
+++ b/lego-webapp/pages/events/src/EventEditor/EditorSection/Descriptions.tsx
@@ -5,6 +5,7 @@ import Tag from '~/components/Tags/Tag';
 import styles from '../EventEditor.module.css';
 import type { EditingEvent } from '~/pages/events/utils';
 import type { UploadArgs } from '~/redux/actions/FileActions';
+import ToggleSwitch from '~/components/Form/ToggleSwitch';
 
 type Props = {
   uploadFile: (uploadArgs: UploadArgs) => void;
@@ -29,6 +30,12 @@ const Descriptions: React.FC<Props> = ({ uploadFile, values }) => {
         className={styles.descriptionEditor}
         uploadFile={uploadFile}
         required
+      />
+      <Field
+        label="Vis bedriftsbeskrivelse på arrangement"
+        name="showCompanyDescription"
+        component={ToggleSwitch.Field}
+        type="checkbox"
       />
       {values.tags?.length > 0 && (
         <Flex className={styles.tagRow}>

--- a/lego-webapp/pages/events/utils.ts
+++ b/lego-webapp/pages/events/utils.ts
@@ -259,6 +259,7 @@ export const transformEvent = (data: TransformEvent) => ({
     (data.hasFeedbackQuestion && data.feedbackDescription) || '',
   feedbackRequired: data.hasFeedbackQuestion && data.feedbackRequired,
   isForeignLanguage: data.isForeignLanguage,
+  showCompanyDescription: data.showCompanyDescription,
 });
 export const paymentPending = 'pending';
 export const paymentSuccess = 'succeeded';

--- a/lego-webapp/redux/models/Event.ts
+++ b/lego-webapp/redux/models/Event.ts
@@ -80,6 +80,7 @@ export interface CompleteEvent {
   isForeignLanguage: boolean;
   unregistered: EntityId[];
   userReg?: ReadRegistration;
+  showCompanyDescription: boolean;
 
   // for survey
   attendedCount: number;
@@ -136,6 +137,7 @@ export type ListEvent = Pick<
   | 'responsibleUsers'
   | 'actionGrant'
   | 'userReg'
+  | 'showCompanyDescription'
 > &
   ObjectPermissionsMixin;
 
@@ -189,6 +191,7 @@ export type DetailedEvent = Pick<
   | 'isForeignLanguage'
   | 'actionGrant'
   | 'isAdmitted'
+  | 'showCompanyDescription'
 > &
   ObjectPermissionsMixin;
 


### PR DESCRIPTION
# Description

Added a checkbox to let people easily add company descriptions to event descriptions.

# Result

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Added a checkbox in the event editor which enables/disables an extra box with a description of the company related to the event.
        </td>
        <td>
            <img width="929" alt="Skjermbilde 2025-03-19 kl  21 24 05" src="https://github.com/user-attachments/assets/304d0f9a-5f5a-490a-9728-3a90e2ab948f" />
            <img width="1096" alt="Skjermbilde 2025-03-19 kl  21 25 01" src="https://github.com/user-attachments/assets/a4f9da96-460e-4b06-aee9-4bff2d6bc5f5" />
        </td>
        <td>
            <img width="928" alt="Skjermbilde 2025-03-19 kl  21 14 46" src="https://github.com/user-attachments/assets/c2473937-1533-49ad-bcf4-3d212645cf07" />
            <img width="925" alt="Skjermbilde 2025-03-19 kl  21 14 30" src="https://github.com/user-attachments/assets/f0a40a92-3302-45f3-9777-0c2d92e0b7c2" />
        </td>
    </tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-1364
