### PR TITLE
Fix Page-component styling in lego-webapp

### DIFF
--- a/packages/lego-bricks/src/components/Layout/Page/PageContainer.module.css
+++ b/packages/lego-bricks/src/components/Layout/Page/PageContainer.module.css
@@ -1,4 +1,4 @@
-.container {
+div.container {
   position: relative;
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -11,7 +11,7 @@
   padding-top: 20px;
 }
 
-.card {
+div.card {
   background: var(--lego-card-color);
   box-shadow: var(--shadow-sm);
   border-radius: var(--border-radius-lg);


### PR DESCRIPTION
# Description

It broke because of the new pnpm setup... Same issue as with the Vike migration, but it now happens with `lego-bricks` as well because it is now imported directly from the non-compiled typescript code.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.


OK, now I can't reproduce the issue... But I'm 100% sure it was wrong, and this fixed it in dev:)

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Sidebar position
        </td>
        <td>

        </td>
        <td>
![Screenshot 2025-03-20 at 09 54 59](https://github.com/user-attachments/assets/cee994ec-8ae1-4928-9857-d41f6c614a67)
        </td>
    </tr>
    <tr>
        <td>
            Cover image position
        </td>
        <td>

        </td>
        <td>
![Screenshot 2025-03-20 at 09 55 38](https://github.com/user-attachments/assets/8a105237-3291-47d4-80dc-fa96597b6a41)
        </td>
    </tr>
</table>
