### PR TITLE
Fix event description showing "om bedriften" even when not toggled

### DIFF
--- a/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
@@ -212,12 +212,12 @@ const EventDetail = () => {
               ))}
             </Flex>
           )}
-          <Flex column>
-            <h3>Om bedriften</h3>
-            {event?.showCompanyDescription && event.company && (
+          {event?.showCompanyDescription && event.company && (
+            <Flex column>
+              <h3>Om bedriften</h3>
               <>{event.company?.description}</>
-            )}
-          </Flex>
+            </Flex>
+          )}
         </ContentMain>
 
         <ContentSidebar>


### PR DESCRIPTION
# Description

Fix event description showing "om bedriften" even when not toggled 

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

Fix event description showing "om bedriften" even when not toggled 

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Fix event description showing "om bedriften" even when not toggled 

---

Resolves ... (either GitHub issue or Linear task)
