### PR TITLE
Fix events page scrolling to top on fetch more

### DIFF
--- a/packages/lego-bricks/src/components/Tabs/Tab.tsx
+++ b/packages/lego-bricks/src/components/Tabs/Tab.tsx
@@ -20,6 +20,9 @@ export const Tab = ({ active, disabled, onPress, href, children }: Props) => {
       {href ? (
         <Link
           href={href}
+          routerOptions={{
+            keepScrollPosition: true,
+          }}
           isDisabled={disabled}
           onPress={onPress}
           className={className}

--- a/packages/lego-bricks/src/components/Tabs/TabContainer.tsx
+++ b/packages/lego-bricks/src/components/Tabs/TabContainer.tsx
@@ -58,7 +58,7 @@ export const TabContainer = ({ className, lineColor, children }: Props) => {
       });
     }
     checkScroll();
-  }, [children, location.pathname]);
+  }, [location.pathname]);
 
   useEffect(() => {
     const element = tabListRef.current;


### PR DESCRIPTION
# Description

Whenever you pressed the "fetch more" button on the events page, it scrolled up to the navigation tabs. I fixed it:)

---

Resolves ABA-1351
