### PR TITLE
Allow recheck trophies from sudo

### DIFF
--- a/lego-webapp/components/errors/HTTPError.tsx
+++ b/lego-webapp/components/errors/HTTPError.tsx
@@ -12,6 +12,7 @@ const HTTPMapping = {
   '404': 'Denne siden finnes ikke',
   '418': 'Jeg er en tekanne',
   '428': 'Forutsetning påkrevd',
+  '450': 'Blokkert av Windows foreldrekontroll',
   '500': 'Noe gikk veldig galt, Webkom er på saken!',
   '509': 'Båndbreddebegrensning nådd',
   '1337': 'Hackerman',

--- a/lego-webapp/pages/sudo/+Page.tsx
+++ b/lego-webapp/pages/sudo/+Page.tsx
@@ -1,5 +1,5 @@
 import { Page, Flex, Card, Icon } from '@webkom/lego-bricks';
-import { Flag, Rss } from 'lucide-react';
+import { Flag, Rss, Trophy } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import a4bc35b6c0664b45 from '~/assets/26e7499bfb6390d9/a4bc35b6c0664b45.jpg';
 import acb2777779bbf024 from '~/assets/26e7499bfb6390d9/acb2777779bbf024.jpg';
@@ -34,6 +34,12 @@ const links: PanelItem[] = [
       'Legg til og endre feature flagg. Endre hva slags innhold som vises.',
     iconNode: <Flag />,
   },
+  {
+    link: '/sudo/achievements',
+    tag: 'Achievements',
+    description: 'Administrer trofe-systemet.',
+    iconNode: <Trophy />,
+  },
 ];
 
 const ControlPanelItem = ({ link }: { link: PanelItem }) => (
@@ -48,14 +54,17 @@ const ControlPanelItem = ({ link }: { link: PanelItem }) => (
 
 const AdminControlPanel = () => {
   return (
-    <div className={styles.controlPanel}>
+    <Flex
+      className={styles.controlPanel}
+      gap="var(--spacing-md)"
+      column
+      width={'100%'}
+    >
       <h2>Kontrollpanel</h2>
-      <Flex gap="var(--spacing-md)">
-        {links.map((link) => (
-          <ControlPanelItem key={link.tag} link={link} />
-        ))}
-      </Flex>
-    </div>
+      {links.map((link) => (
+        <ControlPanelItem key={link.tag} link={link} />
+      ))}
+    </Flex>
   );
 };
 

--- a/lego-webapp/pages/sudo/achievements/+Page.tsx
+++ b/lego-webapp/pages/sudo/achievements/+Page.tsx
@@ -1,0 +1,58 @@
+import { Card, ConfirmModal, Flex, Page } from '@webkom/lego-bricks';
+import { Helmet } from 'react-helmet-async';
+import ContentMain from '~/components/Content/ContentMain';
+import HTTPError from '~/components/errors/HTTPError';
+import { triggerAchievementRecheck } from '~/redux/actions/AchievementActions';
+import { useAppDispatch, useAppSelector } from '~/redux/hooks';
+import styles from './SudoAchievements.module.css';
+
+const SudoAchievements = () => {
+  const dispatch = useAppDispatch();
+  const sudoAdminAccess = useAppSelector((state) => state.allowed.sudo);
+  if (!sudoAdminAccess) return <HTTPError statusCode={450} />;
+
+  return (
+    <Page
+      title={
+        <Flex alignItems="center" gap="var(--spacing-sm)">
+          Sudo Trofeer
+        </Flex>
+      }
+      back={{ href: '/sudo' }}
+    >
+      <Helmet title={'Sudo Trofeer'} />
+
+      <ContentMain>
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          column
+          width={'100%'}
+          gap="var(--spacing-md)"
+        >
+          <ConfirmModal
+            title="Bekreft resjekking av trofeer"
+            message="Er du sikker på at du vil sjekke alle trofeer på nytt?"
+            onConfirm={() => dispatch(triggerAchievementRecheck())}
+          >
+            {({ openConfirmModal }) => (
+              <Card
+                isHoverable
+                onClick={() => openConfirmModal()}
+                className={styles.sudoTrophyCard}
+              >
+                <h2>Valider alle trofeer</h2>
+                Obs! Dette kan være noe krevende for serveren. Ikke spam.
+              </Card>
+            )}
+          </ConfirmModal>
+          <Card isHoverable className={styles.sudoTrophyCard}>
+            <h2>Tildel trofeer</h2>
+            Coming later...
+          </Card>
+        </Flex>
+      </ContentMain>
+    </Page>
+  );
+};
+export default SudoAchievements;

--- a/lego-webapp/pages/sudo/achievements/SudoAchievements.module.css
+++ b/lego-webapp/pages/sudo/achievements/SudoAchievements.module.css
@@ -1,0 +1,4 @@
+.sudoTrophyCard {
+  width: 100%;
+  cursor: pointer;
+}

--- a/lego-webapp/redux/actionTypes.ts
+++ b/lego-webapp/redux/actionTypes.ts
@@ -330,6 +330,7 @@ export const Thread = {
 
 export const Achievement = {
   CREATE: generateStatuses('Achievement.CREATE'),
+  RECHECK: generateStatuses('Achievement.RECHECK'),
 };
 
 export const Banner = {

--- a/lego-webapp/redux/actions/AchievementActions.ts
+++ b/lego-webapp/redux/actions/AchievementActions.ts
@@ -32,7 +32,6 @@ export function postGettingWood() {
     method: 'POST',
     types: Achievement.CREATE,
     meta: {
-      errorMessage: 'Oppretting av trofé feilet.',
       successMessage: 'Trofe oppnådd: "Skaffe tre"',
     },
   });
@@ -45,8 +44,18 @@ export function postKeypress({ code }: { code: number[] }) {
     body: { code },
     types: Achievement.CREATE,
     meta: {
-      errorMessage: 'Oppretting av trofe feilet.',
       successMessage: 'Trofe oppnådd: "Powermode activated!"',
+    },
+  });
+}
+
+export function triggerAchievementRecheck() {
+  return callAPI({
+    endpoint: `/achievements/recheck_all/`,
+    types: Achievement.RECHECK,
+    meta: {
+      errorMessage: 'Sjekking av trofeer feilet.',
+      successMessage: 'Sjekking af trofeer fullført.',
     },
   });
 }


### PR DESCRIPTION
# Description

Allow recheck trophies from the sudo panel

![image](https://github.com/user-attachments/assets/1186ff1c-3b2e-4d19-96f6-50ae0ea050fa)

![image](https://github.com/user-attachments/assets/1268b540-8459-4ab6-88ba-521ebbab53e6)


![image](https://github.com/user-attachments/assets/ac911cad-275d-4018-a6f5-c634a4e02c4e)


# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.


- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1386
