### PR TITLE
Add support for diff using <ins> and <del> tags in lego-editor

### DIFF
--- a/packages/lego-editor/src/Editor.module.css
+++ b/packages/lego-editor/src/Editor.module.css
@@ -135,4 +135,14 @@
       -moz-outline-radius: 3px;
     }
   }
+
+  ins {
+    background-color: var(--color-green-3);
+    text-decoration: inherit;
+  }
+
+  del {
+    background-color: var(--color-red-2);
+    text-decoration: inherit;
+  }
 }

--- a/packages/lego-editor/src/extensions/diff.ts
+++ b/packages/lego-editor/src/extensions/diff.ts
@@ -1,0 +1,36 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+
+export const Diff = Node.create({
+  name: 'diff',
+
+  group: 'inline',
+
+  content: 'inline*',
+
+  inline: true,
+
+  addAttributes() {
+    return {
+      type: {
+        default: 'ins',
+        parseHTML: (element) => element.tagName.toLowerCase(),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'ins',
+      },
+      {
+        tag: 'del',
+      },
+    ];
+  },
+
+  renderHTML({ node }) {
+    const { type, ...attributes } = node.attrs;
+    return [type, mergeAttributes(this.options.HTMLAttributes, attributes), 0];
+  },
+});

--- a/packages/lego-editor/src/extensions/strike.ts
+++ b/packages/lego-editor/src/extensions/strike.ts
@@ -1,0 +1,135 @@
+import {
+  Mark,
+  markInputRule,
+  markPasteRule,
+  mergeAttributes,
+} from '@tiptap/core';
+
+/**
+ * Copied from https://github.com/ueberdosis/tiptap/blob/develop/packages/extension-strike/src/strike.ts
+ * Modified to work with diffs using <del> tags.
+ */
+
+export interface StrikeOptions {
+  /**
+   * HTML attributes to add to the strike element.
+   * @default {}
+   * @example { class: 'foo' }
+   */
+  HTMLAttributes: Record<string, unknown>;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    strike: {
+      /**
+       * Set a strike mark
+       * @example editor.commands.setStrike()
+       */
+      setStrike: () => ReturnType;
+      /**
+       * Toggle a strike mark
+       * @example editor.commands.toggleStrike()
+       */
+      toggleStrike: () => ReturnType;
+      /**
+       * Unset a strike mark
+       * @example editor.commands.unsetStrike()
+       */
+      unsetStrike: () => ReturnType;
+    };
+  }
+}
+
+/**
+ * Matches a strike to a ~~strike~~ on input.
+ */
+export const inputRegex = /(?:^|\s)(~~(?!\s+~~)((?:[^~]+))~~(?!\s+~~))$/;
+
+/**
+ * Matches a strike to a ~~strike~~ on paste.
+ */
+export const pasteRegex = /(?:^|\s)(~~(?!\s+~~)((?:[^~]+))~~(?!\s+~~))/g;
+
+/**
+ * This extension allows you to create strike text.
+ * @see https://www.tiptap.dev/api/marks/strike
+ */
+export const Strike = Mark.create<StrikeOptions>({
+  name: 'strike',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 's',
+      },
+      {
+        tag: 'strike',
+      },
+      {
+        style: 'text-decoration',
+        consuming: false,
+        getAttrs: (style) =>
+          (style as string).includes('line-through') ? {} : false,
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      's',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      setStrike:
+        () =>
+        ({ commands }) => {
+          return commands.setMark(this.name);
+        },
+      toggleStrike:
+        () =>
+        ({ commands }) => {
+          return commands.toggleMark(this.name);
+        },
+      unsetStrike:
+        () =>
+        ({ commands }) => {
+          return commands.unsetMark(this.name);
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-s': () => this.editor.commands.toggleStrike(),
+    };
+  },
+
+  addInputRules() {
+    return [
+      markInputRule({
+        find: inputRegex,
+        type: this.type,
+      }),
+    ];
+  },
+
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: pasteRegex,
+        type: this.type,
+      }),
+    ];
+  },
+});

--- a/packages/lego-editor/src/index.tsx
+++ b/packages/lego-editor/src/index.tsx
@@ -12,6 +12,8 @@ import cx from 'classnames';
 import { Figure } from './extensions/figure';
 import { ImageWithFileKey } from './extensions/image.ts';
 import { Link } from '@tiptap/extension-link';
+import { Diff } from './extensions/diff.ts';
+import { Strike } from './extensions/strike.ts';
 
 export type ImageUploadFn = (
   file: File,
@@ -28,7 +30,9 @@ type Props = {
 };
 
 const extensions = [
-  StarterKit.configure({ orderedList: {} }),
+  StarterKit.configure({ orderedList: {}, strike: false }),
+  Diff,
+  Strike,
   Underline,
   ImageWithFileKey,
   Figure,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,24 +15,15 @@ catalogs:
     classnames:
       specifier: ^2.5.1
       version: 2.5.1
-    eslint:
-      specifier: ^9.20.1
-      version: 9.21.0
     lucide-react:
       specifier: ^0.483.0
       version: 0.483.0
     react:
       specifier: ^18.3.1
       version: 18.3.1
-    react-aria-components:
-      specifier: ^1.7.1
-      version: 1.7.1
     react-dom:
       specifier: ^18.3.1
       version: 18.3.1
-    typescript:
-      specifier: ^5.6.3
-      version: 5.6.3
     vite:
       specifier: ^6.2.3
       version: 6.2.3
@@ -7623,7 +7614,7 @@ snapshots:
   '@eslint/config-array@0.19.2':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7649,7 +7640,7 @@ snapshots:
   '@eslint/eslintrc@3.3.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -10267,7 +10258,7 @@ snapshots:
       '@typescript-eslint/types': 8.25.0
       '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.25.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       eslint: 9.21.0
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -10299,7 +10290,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.6.3)
       '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.6.3)
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       eslint: 9.21.0
       ts-api-utils: 2.0.1(typescript@5.6.3)
       typescript: 5.6.3
@@ -10314,7 +10305,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.25.0
       '@typescript-eslint/visitor-keys': 8.25.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -11104,6 +11095,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -11739,7 +11734,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -12192,7 +12187,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -12213,7 +12208,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -14513,7 +14508,7 @@ snapshots:
   vite-node@2.1.9(@types/node@22.7.7):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 1.1.2
       vite: 5.4.12(@types/node@22.7.7)
@@ -14565,7 +14560,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.1.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.17
       pathe: 1.1.2


### PR DESCRIPTION
# Description

Forgot about this feature in #5471 . Meeting repot diff now works again:)

# Result

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Meeting report diff
        </td>
        <td>

![Screenshot 2025-03-26 at 14 42 34](https://github.com/user-attachments/assets/2898fa65-f9fb-46a1-9099-5b93e9fdd869)
        </td>
        <td>

![Screenshot 2025-03-26 at 14 42 20](https://github.com/user-attachments/assets/48f89c11-c118-40b5-a3fc-d3553af1cf53)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-1380
