### PR TITLE
Improve visibility of thursday button

### DIFF
--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -242,6 +242,7 @@ type CompanyInterestFormEntity = {
   companyPresentationComment: string;
   companyType: string;
   officeInTrondheim: boolean;
+  wantsThursdayEvent: boolean;
 };
 
 const requiredIfEventType = (eventType: string) =>
@@ -367,6 +368,7 @@ const CompanyInterestForm = ({ language }: Props) => {
     })),
     participantRange: (participantRange && participantRange[0]) || null,
     officeInTrondheim: companyInterest?.officeInTrondheim || false,
+    wantsThursdayEvent: companyInterest?.wantsThursdayEvent || false,
     semesters: edit
       ? semesters
           .map((semester) => ({
@@ -403,6 +405,7 @@ const CompanyInterestForm = ({ language }: Props) => {
       contactPerson: data.contactPerson,
       mail: data.mail,
       phone: data.phone,
+      wantsThursdayEvent: data.wantsThursdayEvent,
       officeInTrondheim: data.officeInTrondheim,
       semesters: data.semesters
         .filter((semester) => semester.checked)
@@ -592,11 +595,21 @@ const CompanyInterestForm = ({ language }: Props) => {
                     ))}
                   </MultiSelectGroup>
                 </Flex>
-                <Flex column className={styles.interestBox}>
+                <Flex
+                  column
+                  className={styles.interestBox}
+                  gap="var(--spacing-md)"
+                >
                   <Field
                     name="officeInTrondheim"
                     component={ToggleSwitch.Field}
                     label={FORM_LABELS.officeInTrondheim[language]}
+                  />
+                  <Field
+                    name="wantsThursdayEvent"
+                    component={ToggleSwitch.Field}
+                    label={FORM_LABELS.wantsThursdayEvent[language]}
+                    description={FORM_LABELS.wantsThursdayEventInfo[language]}
                   />
                 </Flex>
                 <Flex column className={styles.interestBox}>

--- a/lego-webapp/pages/bdb/company-interest/Translations.ts
+++ b/lego-webapp/pages/bdb/company-interest/Translations.ts
@@ -133,10 +133,6 @@ export const OTHER_OFFERS = {
     norwegian: 'Profilering på sosiale medier',
     english: 'Profiling on social media',
   },
-  thursday_event: {
-    norwegian: 'Ønsker arrangement torsdag',
-    english: 'Wish event thursday',
-  },
 };
 
 export const COMPANY_TYPES: Record<
@@ -235,6 +231,16 @@ export const FORM_LABELS = {
   officeInTrondheim: {
     norwegian: 'Har dere kontorer i Trondheim egnet for besøk?',
     english: 'Do you have offices in Trondheim suited for visiting?',
+  },
+  wantsThursdayEvent: {
+    norwegian: 'Ønsker dere arrangement på torsdag?',
+    english: 'Would you like to have the event on Thursday?',
+  },
+  wantsThursdayEventInfo: {
+    norwegian:
+      'Torsdags-arrangementer er av de mest populære blant studentene, og vi ser ofte høyere påmelding og større engasjement disse dagene.',
+    english:
+      'Thursday events are among the most popular with students, and we often see higher attendance and greater engagement on these days.',
   },
   contactPerson: {
     header: {

--- a/lego-webapp/pages/bdb/company-interest/Translations.ts
+++ b/lego-webapp/pages/bdb/company-interest/Translations.ts
@@ -238,9 +238,9 @@ export const FORM_LABELS = {
   },
   wantsThursdayEventInfo: {
     norwegian:
-      'Torsdags-arrangementer er av de mest populære blant studentene, og vi ser ofte høyere påmelding og større engasjement disse dagene.',
+      'Torsdags-arrangementer er av de mest populære blant studentene, og vi ser ofte høyere påmelding og større engasjement på torsdager.',
     english:
-      'Thursday events are among the most popular with students, and we often see higher attendance and greater engagement on these days.',
+      'Thursday events are among the most popular with students, and we often see higher attendance and greater engagement on thursdays.',
   },
   contactPerson: {
     header: {

--- a/lego-webapp/redux/models/CompanyInterest.ts
+++ b/lego-webapp/redux/models/CompanyInterest.ts
@@ -26,6 +26,7 @@ interface CompleteCompanyInterest {
   semesters: EntityId[];
   createdAt: Dateish;
   officeInTrondheim: boolean;
+  wantsThursdayEvent: boolean;
   events: CompanyInterestEventType[];
   companyCourseThemes: string[];
   otherOffers: string[];
@@ -70,6 +71,7 @@ export type DetailedCompanyInterest = Pick<
   | 'companyToCompanyComment'
   | 'companyPresentationComment'
   | 'officeInTrondheim'
+  | 'wantsThursdayEvent'
 >;
 
 export type ListCompanyInterest = Pick<

--- a/lego-webapp/redux/slices/companyInterest.ts
+++ b/lego-webapp/redux/slices/companyInterest.ts
@@ -33,6 +33,7 @@ export type CompanyInterestEntity = {
   semesters: CompanySemester[];
   companyType: CompanyInterestCompanyType;
   officeInTrondheim: boolean;
+  wantsThursdayEvent: boolean;
 };
 
 const legoAdapter = createLegoAdapter(EntityType.CompanyInterests);


### PR DESCRIPTION
# Description

Makes the thursday button more visible.

Backend PR: https://github.com/webkom/lego/pull/3807

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

## The vision

![image](https://github.com/user-attachments/assets/6a10f3c7-15f5-4c6a-9ace-8cdfa2956106)

## The result

![image](https://github.com/user-attachments/assets/c3cb2587-30b9-4a40-b90f-57430a5425d8)

# Testing

- [X] I have thoroughly tested my changes.

Works for new events. Old events also get migrated properly.

---

Resolves ... (either GitHub issue or Linear task)
