### PR TITLE
Rename event achievements and last gala achievement

### DIFF
--- a/lego-webapp/utils/achievementConstants.ts
+++ b/lego-webapp/utils/achievementConstants.ts
@@ -48,42 +48,42 @@ export const AchievementsInfo: Record<
 > = {
   event_count: [
     {
-      name: 'Arrangement:\nBronse',
+      name: 'Nykommer',
       description: 'Deltatt på 10 arrangementer',
       rarity: 0,
       hidden: false,
       image: trofe_sjeldenhetsgrad_1,
     },
     {
-      name: 'Arrangement:\nSølv',
+      name: 'Sosial sommerfugl',
       description: 'Deltatt på 25 arrangementer',
       rarity: 1,
       hidden: false,
       image: trofe_sjeldenhetsgrad_2,
     },
     {
-      name: 'Arrangement:\nGull',
+      name: 'Arrangementsjunkie',
       description: 'Deltatt på 50 arrangementer',
       rarity: 2,
       hidden: false,
       image: trofe_sjeldenhetsgrad_3,
     },
     {
-      name: 'Arrangement:\nPlatinum',
+      name: 'Oppmøtemeister',
       description: 'Deltatt på 100 arrangementer',
       rarity: 3,
       hidden: false,
       image: trofe_sjeldenhetsgrad_4,
     },
     {
-      name: 'Arrangement:\nDiamant',
+      name: 'Hater FOMO',
       description: 'Deltatt på 150 arrangementer',
       rarity: 4,
       hidden: false,
       image: trofe_sjeldenhetsgrad_5,
     },
     {
-      name: 'Arrangement:\nLegende',
+      name: 'Sosial legende',
       description: 'Deltatt på 200 arrangementer',
       rarity: 6,
       hidden: false,
@@ -92,21 +92,21 @@ export const AchievementsInfo: Record<
   ],
   event_rank: [
     {
-      name: 'Arrangement:\nMester',
+      name: 'Arrangementsridderen',
       description: '3. plass - flest arrangementer',
       rarity: 5,
       hidden: false,
       image: trofe_sjeldenhetsgrad_10,
     },
     {
-      name: 'Arrangement:\nStormester',
+      name: 'Arrangementsmonarken',
       description: '2. plass - flest arrangementer',
       rarity: 5,
       hidden: false,
       image: trofe_sjeldenhetsgrad_10,
     },
     {
-      name: 'Arrangement:\nFyrtårn',
+      name: 'Høye eksellense\nav arrangementer',
       description: '1. plass - flest arrangementer',
       rarity: 6,
       hidden: false,
@@ -294,7 +294,7 @@ export const AchievementsInfo: Record<
       image: trofe_sjeldenhetsgrad_5,
     },
     {
-      name: 'Ordensmedlem',
+      name: 'Galladiator',
       description: 'Deltatt på 15 gallaer',
       rarity: 5,
       hidden: false,


### PR DESCRIPTION
# Description

Changed a few achievement names. They are easily viewable in the diff.

# Testing

- [x] I have thoroughly tested my changes.

Looked at most of the changed achievements (especially the ones with a long name) in local instance of lego-webapp

---

Resolves [ABA-1394](https://linear.app/abakus-webkom/issue/ABA-1394)
