### PR TITLE
Prevent ToggleButton from submitting form

### DIFF
--- a/lego-webapp/components/Form/ToggleSwitch.tsx
+++ b/lego-webapp/components/Form/ToggleSwitch.tsx
@@ -36,6 +36,7 @@ const ToggleSwitch = ({
       <input type="hidden" name={name} value={isSelected ? 'true' : 'false'} />
       <ToggleButton
         {...props}
+        type="button"
         id={id}
         isSelected={isSelected}
         onChange={onChange}


### PR DESCRIPTION
# Description

IDK why, but it somehow the ToggleButtom becomes a type="submit" button when used in forms. Overriding it fixes the behaviour.

# Result

It no longer submits forms when toggling the button.

# Testing

- [x] I have thoroughly tested my changes.

I have tried it in the Joblisting form which used to have the bug.

---

Resolves ABA-1331
