### PR TITLE
Remove notification setting string for removed comment notification

### DIFF
--- a/lego-webapp/pages/users/@username/settings/notifications/+Page.tsx
+++ b/lego-webapp/pages/users/@username/settings/notifications/+Page.tsx
@@ -29,7 +29,6 @@ const notificationTypeTraslations = {
   restricted_mail_sent:
     'Engangs-e-poster som sendes til bestemte grupper (begrenset e-post)',
   company_interest_created: 'Ny bedriftsinteresse',
-  comment: 'Ny kommentar',
   comment_reply: 'Svar på kommentar',
   announcement: 'Kunngjøring/Viktig melding',
   survey_created: 'Ny spørreundersøkelse',


### PR DESCRIPTION
# Description

With https://github.com/webkom/lego/pull/3791 notifications for new comments are no longer a thing, so we don't need this string in the frontend anymore
