### PR TITLE
Define consent domain strings in one place

### DIFF
--- a/lego-webapp/pages/events/@eventId/administrate/attendees/RegistrationTables.tsx
+++ b/lego-webapp/pages/events/@eventId/administrate/attendees/RegistrationTables.tsx
@@ -11,6 +11,7 @@ import {
   getConsent,
   unregistrationIsClosed,
 } from '~/pages/events/utils';
+import { consentDomainStrings } from '~/pages/users/@username/_components/PhotoConsents';
 import { Presence } from '~/redux/models/Registration';
 import { isNotNullish } from '~/utils';
 import { WEBKOM_GROUP_ID } from '~/utils/constants';
@@ -116,14 +117,10 @@ export const getRegistrationInfo = (registration) => {
   return registrationInfo;
 };
 
-const consentMessage = (photoConsent) =>
+const consentMessage = (photoConsent: PhotoConsent) =>
   `Brukeren godkjenner ${
     photoConsent?.isConsenting ? ' ' : 'IKKE '
-  } at bilder publiseres på ${
-    photoConsent?.domain === PhotoConsentDomain.WEBSITE
-      ? 'abakus.no'
-      : 'sosiale medier'
-  }`;
+  } at bilder publiseres på ${consentDomainStrings[photoConsent?.domain]}`;
 
 const ConsentIcons = ({
   LEGACY_photoConsent,

--- a/lego-webapp/pages/users/@username/_components/PhotoConsents.tsx
+++ b/lego-webapp/pages/users/@username/_components/PhotoConsents.tsx
@@ -10,9 +10,15 @@ import {
 } from '~/pages/users/@username/_components/ProfileSection';
 import { updatePhotoConsent } from '~/redux/actions/UserActions';
 import { useAppDispatch } from '~/redux/hooks';
+import { capitalize } from '~/utils';
 import styles from './PhotoConsents.module.css';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { PhotoConsent } from 'app/models';
+
+export const consentDomainStrings = {
+  [PhotoConsentDomain.WEBSITE]: 'abakus.no',
+  [PhotoConsentDomain.SOCIAL_MEDIA]: 'sosiale medier',
+};
 
 const ConsentManager = ({
   consent,
@@ -33,15 +39,12 @@ const ConsentManager = ({
         ? 'Du ga samtykket den '
         : 'Du trakk samtykket den '
       : 'Du har ikke tatt stilling til samtykket.';
-  const presentableDomain =
-    consent.domain === PhotoConsentDomain.WEBSITE
-      ? 'Abakus.no'
-      : 'Sosiale medier';
+  const consentDomainString = consentDomainStrings[consent.domain];
   return (
-    <InfoField name={presentableDomain}>
+    <InfoField name={capitalize(consentDomainString)}>
       <h5>
-        Jeg godtar at Abakus kan legge ut bilder av meg på {presentableDomain} i
-        perioden {toReadableSemester(consent)}:
+        Jeg godtar at Abakus kan legge ut bilder av meg på {consentDomainString}{' '}
+        i perioden {toReadableSemester(consent)}:
       </h5>
       <div className={styles.statusContainer}>
         {consentStatus}
@@ -54,11 +57,11 @@ const ConsentManager = ({
       <ButtonGroup>
         <ConfirmModal
           closeOnConfirm={true}
-          title={`Trekke bildesamtykke på ${presentableDomain}`}
+          title={`Trekke bildesamtykke på ${consentDomainString}`}
           message={
             <>
               Er du sikker på at du vil trekke bildesamtykket ditt for
-              {toReadableSemester(consent)} på {presentableDomain}? Dersom du
+              {toReadableSemester(consent)} på {consentDomainString}? Dersom du
               ønsker å fjerne noen spesifikke bilder, kan du i stedet sende en
               e-post til <a href="mailto:pr@abakus.no">pr@abakus.no</a> med
               informasjon om hvilke bilder du vil fjerne.

--- a/lego-webapp/utils/index.ts
+++ b/lego-webapp/utils/index.ts
@@ -53,6 +53,9 @@ export function generateTreeStructure<
   }, []);
 }
 
+export const capitalize = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+
 export const isTruthy = <T>(x: T | null | undefined | false | '' | 0): x is T =>
   Boolean(x);
 


### PR DESCRIPTION
# Description

Resolves the last remaining point of ABA-16, defining the strings for photo consent domains, "abakus.no" and "sosiale media", in a single constant.

# Testing

- [x] I have thoroughly tested my changes.

I have verified that all the usages of the strings still work.

---

Resolves ABA-16
