### PR TITLE
Use css grid for profile page layout

### DIFF
--- a/lego-webapp/pages/users/@username/+Page.tsx
+++ b/lego-webapp/pages/users/@username/+Page.tsx
@@ -173,14 +173,18 @@ const UserProfile = () => {
     >
       <Helmet title={`${firstName} ${lastName}`} />
 
-      <Flex wrap className={styles.header}>
+      <div className={styles.pageGrid}>
         <Flex
           column
           alignItems="center"
           gap="var(--spacing-sm)"
-          className={styles.sidebar}
+          className={styles.profilePicture}
         >
-          <Flex alignItems="center" justifyContent="center">
+          <Flex
+            alignItems="center"
+            justifyContent="center"
+            className={cx(hasFrame && styles.frameMargin)}
+          >
             {hasFrame && (
               <Image alt="Gullramme" className={styles.frame} src={frame} />
             )}
@@ -188,7 +192,7 @@ const UserProfile = () => {
           </Flex>
           {isCurrentUser && (
             <DialogTrigger>
-              <Button className={cx(hasFrame && styles.frameMargin)}>
+              <Button>
                 <Icon iconNode={<QrCode />} size={19} />
                 Vis ABA-ID
               </Button>
@@ -204,7 +208,7 @@ const UserProfile = () => {
         <Flex
           alignItems="center"
           column
-          className={cx(styles.rightContent, styles.leftMarginContent)}
+          className={cx(styles.rightContent, styles.header)}
         >
           <GroupMemberships
             memberships={memberships}
@@ -215,9 +219,7 @@ const UserProfile = () => {
             <Achievements achievements={user.achievements} />
           )}
         </Flex>
-      </Flex>
 
-      <Flex wrap className={styles.content}>
         <div className={styles.info}>
           <UserInfo user={user} />
 
@@ -261,7 +263,7 @@ const UserProfile = () => {
               <GSuiteInfo emailAddress={user.emailAddress} />
             )}
         </div>
-        <div className={cx(styles.rightContent, styles.leftMarginContent)}>
+        <div className={styles.events}>
           {isCurrentUser && (
             <div className={styles.bottomMargin}>
               <h3>Dine kommende arrangementer</h3>
@@ -289,7 +291,7 @@ const UserProfile = () => {
             </div>
           )}
         </div>
-      </Flex>
+      </div>
     </Page>
   );
 };

--- a/lego-webapp/pages/users/@username/_components/UserProfile.module.css
+++ b/lego-webapp/pages/users/@username/_components/UserProfile.module.css
@@ -1,28 +1,43 @@
 @import url('styles/custom-media.css');
 
-.header {
-  align-items: flex-start;
-  justify-content: space-between;
+.pageGrid {
+  display: grid;
+  grid-template-areas:
+    'profile-picture header'
+    'info header'
+    'info events';
+  grid-template-columns: 348.53px 1fr; /* The width of the info cards below */
+  gap: var(--spacing-md) var(--spacing-lg);
 
   @media (--medium-viewport) {
-    justify-content: space-around;
-    gap: var(--spacing-md);
+    grid-template-areas:
+      'profile-picture'
+      'header'
+      'info'
+      'events';
+    grid-template-columns: 1fr;
   }
 }
 
-.content {
-  display: flex;
-  flex-direction: row;
-  padding-top: var(--spacing-md);
+.profilePicture {
+  grid-area: profile-picture;
+}
+
+.header {
+  grid-area: header;
+}
+
+.info {
+  grid-area: info;
+}
+
+.events {
+  grid-area: events;
 }
 
 .frameMargin {
-  margin-top: var(--spacing-xl);
-}
-
-.sidebar {
-  min-width: 348.53px; /* The width of the info cards below */
-  position: relative;
+  margin-top: var(--spacing-lg);
+  margin-bottom: var(--spacing-xl);
 }
 
 img.frame {
@@ -33,27 +48,16 @@ img.frame {
   position: absolute;
 }
 
-.leftMarginContent {
-  padding-left: var(--spacing-lg);
-}
-
 .rightContent {
-  flex: 2;
-  min-width: 320px;
-  width: 100%;
+  align-items: flex-start;
 
   @media (--medium-viewport) {
-    padding-left: 0;
     align-items: center;
 
     div {
       justify-content: center;
     }
   }
-}
-
-.info {
-  flex: 1;
 }
 
 .infoCard {


### PR DESCRIPTION
# Description

I got annoyed by the increasing spacing between the profile picture and info boxes caused by the space taken up by achievements to the right of it.
![Screenshot 2025-03-26 at 22 00 40](https://github.com/user-attachments/assets/0222c08f-7ccf-4aa8-8e9a-491bb8e5c74f)
Doing the layout using css grid allows it to take up all the available space while still allowing the correct layout on both desktop and mobile:)

# Result

The spacing between profile picture and info boxes is now independent of each other, allowing all available space to be utilized.
Mobile should be unaffected.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            My profile page
        </td>
        <td>

![Screenshot 2025-03-26 at 22 04 14](https://github.com/user-attachments/assets/5ebb1b27-dc98-4105-9975-2dce125cb39e)
        </td>
        <td>

![Screenshot 2025-03-26 at 22 04 27](https://github.com/user-attachments/assets/174155f2-7244-4959-9307-a4ec6734c8c0)
        </td>
    </tr>
    <tr>
        <td>
            My profile page (mobile)
        </td>
        <td>

![Screenshot 2025-03-26 at 22 06 03](https://github.com/user-attachments/assets/2389dc8f-0854-4980-9563-d30d19f61aab)
        </td>
        <td>

![Screenshot 2025-03-26 at 22 05 54](https://github.com/user-attachments/assets/b025c0fb-c090-439d-86f3-3e61e17f1bb9)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

