### PR TITLE
Fix eventcount in userprofiles

### DIFF
--- a/lego-webapp/pages/users/@username/+Page.tsx
+++ b/lego-webapp/pages/users/@username/+Page.tsx
@@ -274,9 +274,7 @@ const UserProfile = () => {
               <h3>
                 Dine tidligere arrangementer (
                 {!previousEventsPagination.fetching
-                  ? previousEvents === undefined
-                    ? 0
-                    : previousEvents.length
+                  ? (sortedPreviousEvents?.length ?? 0)
                   : '...'}
                 )
               </h3>


### PR DESCRIPTION
# Description

Fixed a mismatch between the listed events and the event count displayed in user profiles and in shell.

# Result

No visual changes

![image](https://github.com/user-attachments/assets/4bf0e7c7-7e81-40b1-bab7-2694f6328d95)
- The number of events listed now correctly matches the displayed count.

# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ABA-1399
