### PR TITLE
Fix and refactor timeline styling

### DIFF
--- a/lego-webapp/components/Feed/activity.module.css
+++ b/lego-webapp/components/Feed/activity.module.css
@@ -1,28 +1,9 @@
-.header {
-  display: flex;
-  align-items: center;
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-bottom: 1.5px solid var(--border-gray);
-  word-break: break-word;
-  white-space: pre-line;
-}
-
-.activityHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-direction: row;
-  padding: var(--spacing-sm) var(--spacing-md);
-}
-
-.activityHeaderItem {
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-}
-
 .activityContent {
   padding: 0 var(--spacing-md);
+}
+
+.activityFooter {
+  margin-left: var(--spacing-sm);
 }
 
 .time {

--- a/lego-webapp/components/Feed/activity.tsx
+++ b/lego-webapp/components/Feed/activity.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@webkom/lego-bricks';
+import { BaseCard, CardContent, CardFooter, Flex } from '@webkom/lego-bricks';
 import Linkify from 'linkify-react';
 import { LinkTag } from '~/components/Feed/Tag';
 import { ProfilePicture } from '~/components/Image';
@@ -20,13 +20,8 @@ const AggregatedActivityItem = <Verb extends FeedActivityVerb>({
   const { Header, Content } = activityRenderer;
 
   return (
-    <Card
-      style={{
-        padding: '0',
-        margin: 'var(--spacing-sm) 0 var(--spacing-md) 0',
-      }}
-    >
-      <div className={styles.header}>
+    <BaseCard>
+      <CardContent>
         <Linkify
           options={{
             rel: 'noopener noreferrer',
@@ -44,22 +39,24 @@ const AggregatedActivityItem = <Verb extends FeedActivityVerb>({
         >
           <Header aggregatedActivity={aggregatedActivity} tag={LinkTag} />
         </Linkify>
-      </div>
-      {aggregatedActivity.activities.map((activity, i) => (
-        <div key={i}>
-          <ActivityHeader
-            aggregatedActivity={aggregatedActivity}
-            activity={activity}
-          />
-          <div className={styles.activityContent}>
-            <Content
+      </CardContent>
+      <CardFooter variant="border">
+        {aggregatedActivity.activities.map((activity, i) => (
+          <div key={activity.activityId}>
+            <ActivityFooter
               aggregatedActivity={aggregatedActivity}
               activity={activity}
             />
+            <div className={styles.activityContent}>
+              <Content
+                aggregatedActivity={aggregatedActivity}
+                activity={activity}
+              />
+            </div>
           </div>
-        </div>
-      ))}
-    </Card>
+        ))}
+      </CardFooter>
+    </BaseCard>
   );
 };
 
@@ -68,30 +65,26 @@ type ActivityHeaderProps = {
   activity: FeedActivity;
 };
 
-const ActivityHeader = ({
+const ActivityFooter = ({
   aggregatedActivity,
   activity,
 }: ActivityHeaderProps) => {
   const actor = aggregatedActivity.context[activity.actor];
   if (actor.contentType !== 'users.user') return null;
   return (
-    <div className={styles.activityHeader}>
-      <div className={styles.activityHeaderItem}>
-        <ProfilePicture
-          size={40}
-          user={actor}
-          style={{
-            marginRight: 25,
-          }}
-        />
-        <a href={`/users/${actor.username}/`}>
-          {actor.firstName} {actor.lastName}
-        </a>
-      </div>
+    <Flex
+      alignItems="center"
+      gap="var(--spacing-sm)"
+      className={styles.activityFooter}
+    >
+      <ProfilePicture size={40} user={actor} />
+      <a href={`/users/${actor.username}/`}>
+        {actor.firstName} {actor.lastName}
+      </a>
       <i className={styles.time}>
         <Time time={activity.time} wordsAgo />
       </i>
-    </div>
+    </Flex>
   );
 };
 

--- a/lego-webapp/components/Feed/index.tsx
+++ b/lego-webapp/components/Feed/index.tsx
@@ -1,7 +1,7 @@
+import { Flex } from '@webkom/lego-bricks';
 import { Frown } from 'lucide-react';
 import EmptyState from '~/components/EmptyState';
 import ErrorBoundary from '~/components/ErrorBoundary';
-import ActivityRenderer from '~/components/Feed/ActivityRenderer';
 import { useAppSelector } from '~/redux/hooks';
 import { FeedActivityVerb } from '~/redux/models/FeedActivity';
 import { selectFeedActivitiesByFeedId } from '~/redux/slices/feeds';
@@ -17,6 +17,7 @@ import RegistrationBumpRenderer from './renders/registrationBump';
 import RestrictedMailSentRenderer from './renders/restrictedMail';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { ReactNode } from 'react';
+import type ActivityRenderer from '~/components/Feed/ActivityRenderer';
 
 export const activityRenderers = {
   [FeedActivityVerb.Comment]: CommentRenderer,
@@ -44,7 +45,9 @@ const Feed = ({ feedId }: Props): ReactNode => {
   );
 
   return (
-    <div
+    <Flex
+      column
+      gap="var(--spacing-md)"
       style={{
         width: '100%',
       }}
@@ -67,7 +70,7 @@ const Feed = ({ feedId }: Props): ReactNode => {
           body="Ingen aktiviteter i feeden ..."
         />
       )}
-    </div>
+    </Flex>
   );
 };
 

--- a/lego-webapp/pages/sudo/achievements/+Page.tsx
+++ b/lego-webapp/pages/sudo/achievements/+Page.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, ConfirmModal, Flex, Page } from '@webkom/lego-bricks';
+import { Button, ConfirmModal, Flex, Page } from '@webkom/lego-bricks';
 import { Helmet } from 'react-helmet-async';
 import ContentMain from '~/components/Content/ContentMain';
 import HTTPError from '~/components/errors/HTTPError';

--- a/packages/lego-bricks/src/components/Card/BaseCard.tsx
+++ b/packages/lego-bricks/src/components/Card/BaseCard.tsx
@@ -39,13 +39,18 @@ export const CardContent = ({
 
 export const CardFooter = ({
   children,
+  variant = 'background',
   className,
   ...flexProps
 }: {
   children: ReactNode;
+  variant: 'background' | 'border';
   className?: string;
 } & ComponentProps<typeof Flex>) => (
-  <Flex className={cx(styles.footer, className)} {...flexProps}>
+  <Flex
+    className={cx(styles.footer, styles[variant], className)}
+    {...flexProps}
+  >
     {children}
   </Flex>
 );

--- a/packages/lego-bricks/src/components/Card/Card.module.css
+++ b/packages/lego-bricks/src/components/Card/Card.module.css
@@ -121,6 +121,13 @@ html[data-theme='dark'] .danger a:hover {
 }
 
 .footer {
-  background-color: var(--additive-background);
   padding: var(--spacing-sm);
+
+  &.background {
+    background-color: var(--additive-background);
+  }
+
+  &.border {
+    border-top: 1px solid var(--border-gray);
+  }
 }


### PR DESCRIPTION
# Description

Timeline styling broke at some point, likely because of changes to the `Card`-component. I fix.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Timeline
        </td>
        <td>

![Screenshot 2025-03-31 at 15 03 56](https://github.com/user-attachments/assets/55f4cede-3562-4663-9058-824184e6bc48)
        </td>
        <td>
            
![Screenshot 2025-03-31 at 15 04 51](https://github.com/user-attachments/assets/58104f7c-79c7-4948-b26b-a6de51c333e9)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Looked at it:)
