### PR TITLE
Use new behavior in datepicker test

### DIFF
--- a/lego-webapp/cypress/e2e/home_page_spec.ts
+++ b/lego-webapp/cypress/e2e/home_page_spec.ts
@@ -66,7 +66,7 @@ describe('The Home Page and Login', () => {
     cy.contains('h2', 'Deloitte AS');
     cy.contains('h2', 'Mesan');
     cy.contains('h2', 'Sikkerhet og Sårbarhet').should('not.exist');
-    cy.get('ion-icon[name="chevron-down-outline"]').click();
+    cy.get(t('frontpage-show-more')).click();
     cy.contains('h2', 'Sikkerhet og Sårbarhet');
     cy.contains('a', 'Artikkel med youtube cover');
   });

--- a/lego-webapp/cypress/support/utils.ts
+++ b/lego-webapp/cypress/support/utils.ts
@@ -105,15 +105,14 @@ export const setDatePickerDate = (
   field(name).click();
 
   if (isNextMonth) {
-    cy.get('ion-icon[name="arrow-forward-outline"]')
-      .first()
-      .should('not.be.disabled')
+    cy.get('button:not(:disabled)[class*="prevOrNextMonth"]')
+      .contains(new RegExp('^' + date + '$', 'g'))
+      .click();
+  } else {
+    cy.get('button:not(:disabled):not([class*="prevOrNextMonth"])')
+      .contains(new RegExp('^' + date + '$', 'g'))
       .click();
   }
-
-  cy.get('button:not(:disabled):not([class*="prevOrNextMonth"])')
-    .contains(new RegExp('^' + date + '$', 'g'))
-    .click();
 
   field(name).click();
 };

--- a/lego-webapp/cypress/support/utils.ts
+++ b/lego-webapp/cypress/support/utils.ts
@@ -105,11 +105,11 @@ export const setDatePickerDate = (
   field(name).click();
 
   if (isNextMonth) {
-    cy.get('button:not(:disabled)[class*="prevOrNextMonth"]')
+    cy.get(`button:not(:disabled)${c('prevOrNextMonth')}`)
       .contains(new RegExp('^' + date + '$', 'g'))
       .click();
   } else {
-    cy.get('button:not(:disabled):not([class*="prevOrNextMonth"])')
+    cy.get(`button:not(:disabled):not(${c('prevOrNextMonth')})`)
       .contains(new RegExp('^' + date + '$', 'g'))
       .click();
   }

--- a/lego-webapp/pages/index/AuthenticatedFrontpage.tsx
+++ b/lego-webapp/pages/index/AuthenticatedFrontpage.tsx
@@ -1,5 +1,6 @@
 import { Flex, Icon, PageContainer } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -305,13 +306,13 @@ const ShowMoreButton = ({
   const events = useAppSelector(selectAllEvents<FrontpageEvent>);
 
   return (
-    <div className={styles.showMore}>
+    <div className={styles.showMore} data-test-id="frontpage-show-more">
       {events.length > eventsToShow && (
-        <Icon onPress={showMore} name="chevron-down-outline" size={30} />
+        <Icon onPress={showMore} iconNode={<ChevronDown />} size={30} />
       )}
 
       {events.length < eventsToShow && (
-        <Icon onPress={scrollToTop} name="chevron-up-outline" size={30} />
+        <Icon onPress={scrollToTop} iconNode={<ChevronUp />} size={30} />
       )}
     </div>
   );


### PR DESCRIPTION
# Description

New datepicker displays two months instead of one, which means running tests on the end of a month makes it pick the wrong date.

# Testing

- [x] I have thoroughly tested my changes.
 - [x] "Create event" test should no longer fail on the final day of a month
 - [x] "Home Page" test should no longer fail on loading icon 
---

Resolves ... (either GitHub issue or Linear task)
