### PR TITLE
Fix issue with image file-key when editing with lego-editor

### DIFF
--- a/packages/lego-editor/src/extensions/image.ts
+++ b/packages/lego-editor/src/extensions/image.ts
@@ -19,16 +19,15 @@ export const ImageWithFileKey = Image.extend({
       ...this.parent?.(),
       fileKey: {
         default: null,
-        parseHTML: (element) =>
-          element.querySelector('img')?.getAttribute('data-file-key'),
+        parseHTML: (element) => element?.getAttribute('data-file-key'),
       },
     };
   },
-  renderHTML({ HTMLAttributes }) {
+  renderHTML({ HTMLAttributes: { fileKey, ...HTMLAttributes } }) {
     return [
       'img',
       mergeAttributes(HTMLAttributes, {
-        ['data-file-key']: HTMLAttributes.fileKey,
+        ['data-file-key']: fileKey,
       }),
     ];
   },


### PR DESCRIPTION
# Description

Editing editor-content with images didn't work because of a mistake with parsing the `data-file-key` needed by the backend.
This fixes the parsing, so that it is preserved when editing content containing images.

# Testing

- [x] I have thoroughly tested my changes.

Tested editing events in dev mode, and verified that the `data-file-key` is correct after editing the event.
