### PR TITLE
Add minimum size for icons

### DIFF
--- a/packages/lego-bricks/src/components/Icon/Icon.module.css
+++ b/packages/lego-bricks/src/components/Icon/Icon.module.css
@@ -21,6 +21,8 @@
   display: flex;
   width: fit-content;
   height: fit-content;
+  min-width: 0.5em;
+  min-height: 0.5em;
   padding: 0.375rem;
   cursor: pointer;
   border-radius: 50%;


### PR DESCRIPTION
# Description

Examined cypress and found 3 reasons for why ionicons are not rendered:

a: The ionicons.js endpoint is down (or returns 500)
b:  The ionicons.js is blocked by cors (which also returns 500, and the reason why it does not show in dev)
c:  The ionicons.svg endpoint is down (or returns 500)

In case a and b, a clickable icon receives a width/height of 0px, which causes cypress to fail if it interacts with it.

Even though we are phasing ion out, buttons should not depend on a visual endpoint to be interactable.

# Result

Added min-width and min-height to `.clickable`. Uses a small `em` to be relative to the `size`-property

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.
# Testing

- [x] I have thoroughly tested my changes.

Made sure the `min` is only applied when it is `clickable`

---

