### PR TITLE
Improve image support in lego-editor

### DIFF
--- a/lego-webapp/components/Search/utils.tsx
+++ b/lego-webapp/components/Search/utils.tsx
@@ -188,7 +188,7 @@ const LINKS: Array<Link> = [
     key: 'email',
     title: 'E-post',
     icon: <MailSearch />,
-    url: '/admin/email',
+    url: '/admin/email/lists',
   },
   {
     admin: true,

--- a/packages/lego-editor/src/Editor.module.css
+++ b/packages/lego-editor/src/Editor.module.css
@@ -114,6 +114,10 @@
     overflow: hidden;
     background: var(--additive-background);
 
+    &:global(.ProseMirror-selectednode) {
+      outline: 2px solid var(--color-blue-6);
+    }
+
     figcaption {
       text-align: center;
       padding: var(--spacing-xs);
@@ -134,7 +138,6 @@
 
     &:global(.ProseMirror-selectednode) {
       outline: 2px solid var(--color-blue-6);
-      -moz-outline-radius: 3px;
     }
   }
 

--- a/packages/lego-editor/src/Editor.module.css
+++ b/packages/lego-editor/src/Editor.module.css
@@ -126,6 +126,8 @@
   }
 
   img {
+    margin: auto;
+    display: block;
     max-width: 100%;
     max-height: 40em;
     border-radius: var(--border-radius-md);

--- a/packages/lego-editor/src/components/ImageMenu.module.css
+++ b/packages/lego-editor/src/components/ImageMenu.module.css
@@ -1,0 +1,5 @@
+.root {
+  background-color: var(--color-gray-2);
+  border: 1px solid var(--color-gray-3);
+  border-radius: var(--spacing-sm);
+}

--- a/packages/lego-editor/src/components/ImageMenu.tsx
+++ b/packages/lego-editor/src/components/ImageMenu.tsx
@@ -1,0 +1,36 @@
+import { Editor } from '@tiptap/react';
+import styles from './ImageMenu.module.css';
+import { GalleryThumbnails, Trash } from 'lucide-react';
+import { ToolbarButton } from './Toolbar';
+
+type Props = {
+  editor: Editor | null;
+};
+
+export const ImageMenu = ({ editor }: Props) => {
+  const isImage = editor?.isActive('image');
+  const isFigure = editor?.isActive('figure');
+  if (!editor || !(isImage || isFigure)) return null;
+
+  return (
+    <div className={styles.root}>
+      <ToolbarButton
+        onClick={() =>
+          isImage
+            ? editor.chain().focus().imageToFigure().run()
+            : editor.chain().focus().figureToImage().run()
+        }
+        active={isFigure}
+        aria-label="Toggle caption"
+      >
+        <GalleryThumbnails size={18} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor?.chain().focus().clearNodes().run()}
+        aria-label="Remove image"
+      >
+        <Trash size={18} color="var(--color-red-6)" />
+      </ToolbarButton>
+    </div>
+  );
+};

--- a/packages/lego-editor/src/components/Toolbar.tsx
+++ b/packages/lego-editor/src/components/Toolbar.tsx
@@ -30,7 +30,7 @@ type ButtonProps = {
   children: ReactNode;
 };
 
-const ToolbarButton = ({
+export const ToolbarButton = ({
   onClick,
   disabled,
   active,

--- a/packages/lego-editor/src/index.tsx
+++ b/packages/lego-editor/src/index.tsx
@@ -1,6 +1,10 @@
 import './declaration.d.ts';
 import './global.css';
-import { useEditor, EditorContent as TipTapEditorContent } from '@tiptap/react';
+import {
+  useEditor,
+  EditorContent as TipTapEditorContent,
+  BubbleMenu,
+} from '@tiptap/react';
 import { generateHTML, generateJSON } from '@tiptap/html';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
@@ -9,11 +13,12 @@ import Toolbar from './components/Toolbar';
 import styles from './Editor.module.css';
 import { useEffect, useState } from 'react';
 import cx from 'classnames';
-import { Figure } from './extensions/figure';
+import { Figure } from './extensions/figure.tsx';
 import { ImageWithFileKey } from './extensions/image.ts';
 import { Link } from '@tiptap/extension-link';
 import { Diff } from './extensions/diff.ts';
 import { Strike } from './extensions/strike.ts';
+import { ImageMenu } from './components/ImageMenu.tsx';
 
 export type ImageUploadFn = (
   file: File,
@@ -89,6 +94,9 @@ export const Editor = ({
   return (
     <div className={cx(styles.container, className)} data-test-id="lego-editor">
       <Toolbar editor={editor} disabled={disabled} imageUpload={imageUpload} />
+      <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }}>
+        <ImageMenu editor={editor} />
+      </BubbleMenu>
       <TipTapEditorContent
         editor={editor}
         className={styles.content}


### PR DESCRIPTION
# Description

Since the new editor was released, we have received a few complains about the missing caption-feature on images. This PR re-adds it as an optional toggle on images, via a bubble-menu (see below).

It also centers images on the page, which generally looks better:)

# Result

Image when selected in lego-editor:
![Screenshot 2025-04-01 at 15 03 27](https://github.com/user-attachments/assets/2255a418-45ac-4239-be21-2006771708db)

After clicking the caption button:
![Screenshot 2025-04-01 at 15 03 58](https://github.com/user-attachments/assets/3a624b54-e43f-4d1d-aded-71aab81d9ede)


- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Article with images
        </td>
        <td>
            
![Screenshot 2025-04-01 at 14 46 33](https://github.com/user-attachments/assets/4aa79a46-5c9b-4047-8f34-476f24f09678)
        </td>
        <td>

![Screenshot 2025-04-01 at 14 46 03](https://github.com/user-attachments/assets/c660ec19-c63b-4afc-bb36-93c45b8ff9df)
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

I have tested both in lego-editor dev and in lego-webapp on staging. So I'm pretty sure it works:)

---

Resolves ABA-1407