### PR TITLE
Add tooltips to lego-editor toolbar buttons

### DIFF
--- a/lego-webapp/components/Comments/Comment.tsx
+++ b/lego-webapp/components/Comments/Comment.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Icon } from '@webkom/lego-bricks';
+import { Button, Flex, Icon, Tooltip } from '@webkom/lego-bricks';
 import { Reply, Trash2 } from 'lucide-react';
 import moment from 'moment';
 import { useState } from 'react';
@@ -7,7 +7,6 @@ import DisplayContent from '~/components/DisplayContent';
 import { ProfilePicture } from '~/components/Image';
 import { Tag } from '~/components/Tags';
 import Time from '~/components/Time';
-import Tooltip from '~/components/Tooltip';
 import { deleteComment } from '~/redux/actions/CommentActions';
 import { useAppDispatch } from '~/redux/hooks';
 import { useCurrentUser } from '~/redux/slices/auth';

--- a/lego-webapp/components/EventItem/index.tsx
+++ b/lego-webapp/components/EventItem/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, Icon, Image } from '@webkom/lego-bricks';
+import { Flex, Icon, Image, Tooltip } from '@webkom/lego-bricks';
 import {
   Calendar,
   CalendarClock,
@@ -11,7 +11,6 @@ import moment from 'moment-timezone';
 import Pill from '~/components/Pill';
 import Tag from '~/components/Tags/Tag';
 import Time from '~/components/Time';
-import Tooltip from '~/components/Tooltip';
 import { colorForEventType } from '~/pages/events/utils';
 import { EventStatusType } from '~/redux/models/Event';
 import { eventAttendanceAbsolute } from '~/utils/eventStatus';

--- a/lego-webapp/components/Form/Label.tsx
+++ b/lego-webapp/components/Form/Label.tsx
@@ -1,7 +1,6 @@
-import { Flex, Icon } from '@webkom/lego-bricks';
+import { Flex, Icon, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { HelpCircle } from 'lucide-react';
-import Tooltip from '~/components/Tooltip';
 import styles from './Label.module.css';
 import type { HTMLProps, ReactNode } from 'react';
 

--- a/lego-webapp/components/GroupMember/index.tsx
+++ b/lego-webapp/components/GroupMember/index.tsx
@@ -1,8 +1,7 @@
-import { Flex } from '@webkom/lego-bricks';
+import { Flex, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import React from 'react';
 import { ProfilePicture } from '~/components/Image';
-import Tooltip from '~/components/Tooltip';
 import { ROLES, type RoleType } from '~/utils/constants';
 import styles from './GroupMember.module.css';
 import type { PublicUser } from '~/redux/models/User';

--- a/lego-webapp/components/LoginForm/RegisterForm.tsx
+++ b/lego-webapp/components/LoginForm/RegisterForm.tsx
@@ -1,4 +1,4 @@
-import { Button, ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
+import { Button, ConfirmModal, Flex, Icon, Tooltip } from '@webkom/lego-bricks';
 import { useEffect, useState } from 'react';
 import { Field } from 'react-final-form';
 import {
@@ -9,7 +9,6 @@ import {
   SubmissionError,
   LegoFinalForm,
 } from '~/components/Form';
-import Tooltip from '~/components/Tooltip';
 import { sendRegistrationEmail } from '~/redux/actions/UserActions';
 import { useAppDispatch } from '~/redux/hooks';
 import { spyValues } from '~/utils/formSpyUtils';

--- a/lego-webapp/components/PhotoUploadStatus/index.tsx
+++ b/lego-webapp/components/PhotoUploadStatus/index.tsx
@@ -1,7 +1,6 @@
-import { Card, Flex, Icon, Image } from '@webkom/lego-bricks';
+import { Card, Flex, Icon, Image, Tooltip } from '@webkom/lego-bricks';
 import { X } from 'lucide-react';
 import { connect } from 'react-redux';
-import Tooltip from '~/components/Tooltip';
 import {
   selectGalleryPictureById,
   initialUploadStatus,

--- a/lego-webapp/components/Poll/index.tsx
+++ b/lego-webapp/components/Poll/index.tsx
@@ -1,4 +1,11 @@
-import { Accordion, Button, Flex, Icon, Skeleton } from '@webkom/lego-bricks';
+import {
+  Accordion,
+  Button,
+  Flex,
+  Icon,
+  Skeleton,
+  Tooltip,
+} from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { sortBy } from 'lodash-es';
 import {
@@ -10,7 +17,6 @@ import {
 } from 'lucide-react';
 import moment from 'moment-timezone';
 import EmptyState from '~/components/EmptyState';
-import Tooltip from '~/components/Tooltip';
 import { votePoll } from '~/redux/actions/PollActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import styles from './Poll.module.css';

--- a/lego-webapp/components/Reactions/Reaction.tsx
+++ b/lego-webapp/components/Reactions/Reaction.tsx
@@ -1,8 +1,7 @@
-import { Flex } from '@webkom/lego-bricks';
+import { Flex, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { useState } from 'react';
 import Emoji from '~/components/Emoji';
-import Tooltip from '~/components/Tooltip';
 import { addReaction, deleteReaction } from '~/redux/actions/ReactionActions';
 import { useAppDispatch } from '~/redux/hooks';
 import { useCurrentUser, useIsLoggedIn } from '~/redux/slices/auth';

--- a/lego-webapp/components/TextWithIcon/index.tsx
+++ b/lego-webapp/components/TextWithIcon/index.tsx
@@ -1,6 +1,5 @@
-import { Flex, Icon } from '@webkom/lego-bricks';
+import { Flex, Icon, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import Tooltip from '../Tooltip';
 import styles from './TextWithIcon.module.css';
 import type { ReactElement, ReactNode } from 'react';
 

--- a/lego-webapp/components/UserAttendance/AttendanceStatus.tsx
+++ b/lego-webapp/components/UserAttendance/AttendanceStatus.tsx
@@ -1,5 +1,4 @@
-import { Button, Flex, Skeleton } from '@webkom/lego-bricks';
-import Tooltip from '~/components/Tooltip';
+import { Button, Flex, Skeleton, Tooltip } from '@webkom/lego-bricks';
 import styles from './AttendanceStatus.module.css';
 import type { AttendanceModalPool } from './AttendanceModalContent';
 

--- a/lego-webapp/components/UserAttendance/RegisteredSummary.tsx
+++ b/lego-webapp/components/UserAttendance/RegisteredSummary.tsx
@@ -1,5 +1,4 @@
-import { Flex, Skeleton } from '@webkom/lego-bricks';
-import Tooltip from '~/components/Tooltip';
+import { Flex, Skeleton, Tooltip } from '@webkom/lego-bricks';
 import styles from './Registrations.module.css';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { PublicUser } from '~/redux/models/User';

--- a/lego-webapp/components/UserGrid/index.tsx
+++ b/lego-webapp/components/UserGrid/index.tsx
@@ -1,7 +1,6 @@
-import { Skeleton } from '@webkom/lego-bricks';
+import { Skeleton, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { ProfilePicture } from '~/components/Image';
-import Tooltip from '~/components/Tooltip';
 import styles from './UserGrid.module.css';
 import type { PublicUser } from '~/redux/models/User';
 

--- a/lego-webapp/package.json
+++ b/lego-webapp/package.json
@@ -79,7 +79,6 @@
     "react-swipeable": "^7.0.2",
     "react-tagcloud": "^2.3.3",
     "react-textarea-autosize": "^8.5.7",
-    "react-tiny-popover": "^8.1.6",
     "react-treeview": "^0.4.7",
     "react-turnstile": "^1.1.4",
     "react-youtube": "^10.1.0",

--- a/lego-webapp/pages/achievements/+Page.tsx
+++ b/lego-webapp/pages/achievements/+Page.tsx
@@ -1,10 +1,9 @@
-import { Card, Flex, Icon } from '@webkom/lego-bricks';
+import { Card, Flex, Icon, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { Ghost } from 'lucide-react';
 import { useEffect } from 'react';
 import { navigate } from 'vike/client/router';
 import { ContentMain } from '~/components/Content';
-import Tooltip from '~/components/Tooltip';
 import { postKeypress } from '~/redux/actions/AchievementActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import { CurrentUser, Rarity } from '~/redux/models/User';

--- a/lego-webapp/pages/announcements/AnnouncementsCreate.tsx
+++ b/lego-webapp/pages/announcements/AnnouncementsCreate.tsx
@@ -1,4 +1,10 @@
-import { ButtonGroup, Card, Flex, useLocation } from '@webkom/lego-bricks';
+import {
+  ButtonGroup,
+  Card,
+  Flex,
+  useLocation,
+  Tooltip,
+} from '@webkom/lego-bricks';
 import { isEmpty } from 'lodash-es';
 import { Field } from 'react-final-form';
 import {
@@ -10,7 +16,6 @@ import {
   RowSection,
 } from '~/components/Form';
 import { SubmitButton } from '~/components/Form/SubmitButton';
-import Tooltip from '~/components/Tooltip';
 import {
   createAnnouncement,
   sendAnnouncement,

--- a/lego-webapp/pages/bdb/(overview)/company-interest/+Page.tsx
+++ b/lego-webapp/pages/bdb/(overview)/company-interest/+Page.tsx
@@ -4,6 +4,7 @@ import {
   Flex,
   Icon,
   LinkButton,
+  Tooltip,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { FileDown, Trash2 } from 'lucide-react';
@@ -11,7 +12,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { ContentMain } from '~/components/Content';
 import SelectInput from '~/components/Form/SelectInput';
 import Table, { type ColumnProps } from '~/components/Table';
-import Tooltip from '~/components/Tooltip';
 import {
   getClosestCompanySemester,
   getCompanySemesterBySlug,

--- a/lego-webapp/pages/bdb/@companyId/+Page.tsx
+++ b/lego-webapp/pages/bdb/@companyId/+Page.tsx
@@ -7,6 +7,7 @@ import {
   Page,
   LinkButton,
   PageCover,
+  Tooltip,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { isEmpty } from 'lodash-es';
@@ -28,7 +29,6 @@ import joblistingStyles from '~/components/JoblistingItem/JoblistingItem.module.
 import Table from '~/components/Table';
 import TextWithIcon from '~/components/TextWithIcon';
 import Time from '~/components/Time';
-import Tooltip from '~/components/Tooltip';
 import FileUpload from '~/components/Upload/FileUpload';
 import UserLink from '~/components/UserLink';
 import SemesterStatus from '~/pages/bdb/SemesterStatus';

--- a/lego-webapp/pages/events/@eventId/administrate/+Layout.tsx
+++ b/lego-webapp/pages/events/@eventId/administrate/+Layout.tsx
@@ -1,9 +1,8 @@
-import { Page } from '@webkom/lego-bricks';
+import { Page, Tooltip } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { PropsWithChildren } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { NavigationTab } from '~/components/NavigationTab/NavigationTab';
-import Tooltip from '~/components/Tooltip';
 import { canSeeAllergies } from '~/pages/events/@eventId/administrate/allergies/+Page';
 import { fetchAdministrate } from '~/redux/actions/EventActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';

--- a/lego-webapp/pages/events/@eventId/administrate/attendees/AttendeeElements.tsx
+++ b/lego-webapp/pages/events/@eventId/administrate/attendees/AttendeeElements.tsx
@@ -3,6 +3,7 @@ import {
   Flex,
   Icon,
   LoadingIndicator,
+  Tooltip,
 } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import {
@@ -14,7 +15,6 @@ import {
   X,
 } from 'lucide-react';
 import { Button } from 'react-aria-components';
-import Tooltip from '~/components/Tooltip';
 import {
   unregister,
   updatePayment,

--- a/lego-webapp/pages/events/@eventId/administrate/attendees/RegistrationTables.tsx
+++ b/lego-webapp/pages/events/@eventId/administrate/attendees/RegistrationTables.tsx
@@ -1,10 +1,9 @@
-import { Flex } from '@webkom/lego-bricks';
+import { Flex, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { Check, Monitor, MonitorOff, Smartphone, X } from 'lucide-react';
 import { PhotoConsentDomain } from 'app/models';
 import Table from '~/components/Table';
 import Time from '~/components/Time';
-import Tooltip from '~/components/Tooltip';
 import {
   getEventSemesterFromStartTime,
   allConsentsAnswered,

--- a/lego-webapp/pages/events/@eventIdOrSlug/InterestedButton.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/InterestedButton.tsx
@@ -1,6 +1,5 @@
-import { Icon } from '@webkom/lego-bricks';
+import { Icon, Tooltip } from '@webkom/lego-bricks';
 import { Star } from 'lucide-react';
-import Tooltip from '~/components/Tooltip';
 import styles from '~/pages/events/@eventIdOrSlug/EventDetail.module.css';
 import { follow, unfollow } from '~/redux/actions/EventActions';
 import { useAppDispatch } from '~/redux/hooks';

--- a/lego-webapp/pages/events/@eventIdOrSlug/JoinEventForm.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/JoinEventForm.tsx
@@ -7,6 +7,7 @@ import {
   LoadingIndicator,
   ProgressBar,
   Skeleton,
+  Tooltip,
 } from '@webkom/lego-bricks';
 import { sumBy } from 'lodash-es';
 import { CircleHelp, UserMinus } from 'lucide-react';
@@ -20,7 +21,6 @@ import {
   SubmissionError,
   LegoFinalForm,
 } from '~/components/Form';
-import Tooltip from '~/components/Tooltip';
 import {
   paymentSuccess,
   paymentManual,

--- a/lego-webapp/pages/events/@eventIdOrSlug/infoLists.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/infoLists.tsx
@@ -1,8 +1,8 @@
+import { Tooltip } from '@webkom/lego-bricks';
 import { CircleHelp } from 'lucide-react';
 import moment from 'moment-timezone';
 import TextWithIcon from '~/components/TextWithIcon';
 import { FormatTime } from '~/components/Time';
-import Tooltip from '~/components/Tooltip';
 import {
   penaltyHours,
   registrationCloseTime,

--- a/lego-webapp/pages/events/src/EventEditor/EditorSection/Details.tsx
+++ b/lego-webapp/pages/events/src/EventEditor/EditorSection/Details.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@webkom/lego-bricks';
+import { Flex, Tooltip } from '@webkom/lego-bricks';
 import { Field } from 'react-final-form';
 import {
   RowSection,
@@ -9,7 +9,6 @@ import {
 } from '~/components/Form';
 import { Label } from '~/components/Form/Label';
 import MazemapLink from '~/components/MazemapEmbed/MazemapLink';
-import Tooltip from '~/components/Tooltip';
 import { EventTypeConfig } from '~/pages/events/utils';
 import styles from '../EventEditor.module.css';
 import type { EditingEvent } from '~/pages/events/utils';

--- a/lego-webapp/pages/index/CompactEvents.tsx
+++ b/lego-webapp/pages/index/CompactEvents.tsx
@@ -1,10 +1,9 @@
-import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
+import { Flex, Icon, Skeleton, Tooltip } from '@webkom/lego-bricks';
 import { Pin } from 'lucide-react';
 import moment from 'moment-timezone';
 import Circle from '~/components/Circle';
 import EmptyState from '~/components/EmptyState';
 import Time from '~/components/Time';
-import Tooltip from '~/components/Tooltip';
 import { eventListDefaultQuery } from '~/pages/events/index/+Layout';
 import { colorForEventType } from '~/pages/events/utils';
 import { useAppSelector } from '~/redux/hooks';

--- a/lego-webapp/pages/interest-groups/InterestGroupMemberModal.tsx
+++ b/lego-webapp/pages/interest-groups/InterestGroupMemberModal.tsx
@@ -1,9 +1,8 @@
-import { Flex, Icon, Modal } from '@webkom/lego-bricks';
+import { Flex, Icon, Modal, Tooltip } from '@webkom/lego-bricks';
 import { sortBy } from 'lodash-es';
 import { useState } from 'react';
 import TextInput from '~/components/Form/TextInput';
 import { ProfilePicture } from '~/components/Image';
-import Tooltip from '~/components/Tooltip';
 import shared from '~/components/UserAttendance/AttendanceModalContent.module.css';
 import styles from './InterestGroupMemberList.module.css';
 import type { PublicUser } from '~/redux/models/User';

--- a/lego-webapp/pages/meetings/@meetingId/MeetingDetail.tsx
+++ b/lego-webapp/pages/meetings/@meetingId/MeetingDetail.tsx
@@ -7,6 +7,7 @@ import {
   LoadingPage,
   Modal,
   Page,
+  Tooltip,
 } from '@webkom/lego-bricks';
 import { isEmpty } from 'lodash-es';
 import { ListRestart, Pencil } from 'lucide-react';
@@ -30,7 +31,6 @@ import LegoReactions from '~/components/LegoReactions';
 import { mazemapScript } from '~/components/MazemapEmbed';
 import { MazemapAccordion } from '~/components/MazemapEmbed/MazemapAccordion';
 import Time, { FromToTime } from '~/components/Time';
-import Tooltip from '~/components/Tooltip';
 import Attendance from '~/components/UserAttendance/Attendance';
 import { PizzaAccordion } from '~/pages/meetings/@meetingId/PizzaAccordion';
 import { setInvitationStatus } from '~/redux/actions/MeetingActions';

--- a/lego-webapp/pages/meetings/MeetingEditor.tsx
+++ b/lego-webapp/pages/meetings/MeetingEditor.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   LoadingPage,
   Page,
+  Tooltip,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { unionBy } from 'lodash-es';
@@ -31,7 +32,6 @@ import SubmissionError from '~/components/Form/SubmissionError';
 import { SubmitButton } from '~/components/Form/SubmitButton';
 import { mazemapScript } from '~/components/MazemapEmbed';
 import MazemapLink from '~/components/MazemapEmbed/MazemapLink';
-import Tooltip from '~/components/Tooltip';
 import Attendance from '~/components/UserAttendance/Attendance';
 import { fetchMemberships } from '~/redux/actions/GroupActions';
 import {

--- a/lego-webapp/pages/polls/PollEditor.tsx
+++ b/lego-webapp/pages/polls/PollEditor.tsx
@@ -1,4 +1,10 @@
-import { Button, ButtonGroup, ConfirmModal, Icon } from '@webkom/lego-bricks';
+import {
+  Button,
+  ButtonGroup,
+  ConfirmModal,
+  Icon,
+  Tooltip,
+} from '@webkom/lego-bricks';
 import arrayMutators from 'final-form-arrays';
 import { Plus, Trash2 } from 'lucide-react';
 import { Field } from 'react-final-form';
@@ -14,7 +20,6 @@ import {
   TextArea,
   TextInput,
 } from '~/components/Form';
-import Tooltip from '~/components/Tooltip';
 import styles from '~/pages/polls/@pollsId/PollEditor.module.css';
 import { createPoll, deletePoll, editPoll } from '~/redux/actions/PollActions';
 import { useAppDispatch } from '~/redux/hooks';

--- a/lego-webapp/pages/surveys/@surveyId/(wrapper)/submissions/summary/+Page.tsx
+++ b/lego-webapp/pages/surveys/@surveyId/(wrapper)/submissions/summary/+Page.tsx
@@ -1,7 +1,6 @@
-import { Flex, Icon, Skeleton } from '@webkom/lego-bricks';
+import { Flex, Icon, Skeleton, Tooltip } from '@webkom/lego-bricks';
 import { ReactNode, useContext } from 'react';
 import EmptyState from '~/components/EmptyState';
-import Tooltip from '~/components/Tooltip';
 import { SurveysRouteContext } from '~/pages/surveys/@surveyId/(wrapper)/SurveysRouteContext';
 import {
   hideAnswer,

--- a/lego-webapp/pages/users/@username/_components/Achievements.tsx
+++ b/lego-webapp/pages/users/@username/_components/Achievements.tsx
@@ -4,10 +4,10 @@ import {
   CardFooter,
   Flex,
   LinkButton,
+  Tooltip,
 } from '@webkom/lego-bricks';
 import moment from 'moment-timezone';
 import { useState, useMemo } from 'react';
-import Tooltip from '~/components/Tooltip';
 import { TitleWithRarity } from '~/pages/achievements/+Page';
 import AchievementsInfo from '~/utils/achievementConstants';
 import styles from './UserProfile.module.css';

--- a/lego-webapp/pages/users/@username/_components/AchievementsBox.tsx
+++ b/lego-webapp/pages/users/@username/_components/AchievementsBox.tsx
@@ -1,10 +1,9 @@
-import { Button, Flex } from '@webkom/lego-bricks';
+import { Button, Flex, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { Trophy } from 'lucide-react';
 import moment from 'moment-timezone';
 import { useState, useMemo } from 'react';
 import { navigate } from 'vike/client/router';
-import Tooltip from '~/components/Tooltip';
 import AchievementsInfo, { rarityMap } from '~/utils/achievementConstants';
 import styles from './UserProfile.module.css';
 import type { Achievement } from '~/redux/models/User';

--- a/lego-webapp/pages/users/@username/_components/EmailLists.tsx
+++ b/lego-webapp/pages/users/@username/_components/EmailLists.tsx
@@ -1,5 +1,5 @@
+import { Tooltip } from '@webkom/lego-bricks';
 import { useMemo } from 'react';
-import Tooltip from '~/components/Tooltip';
 import {
   InfoField,
   ProfileSection,

--- a/lego-webapp/pages/users/@username/_components/GroupMemberships.tsx
+++ b/lego-webapp/pages/users/@username/_components/GroupMemberships.tsx
@@ -1,4 +1,4 @@
-import { ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
+import { ConfirmModal, Flex, Icon, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { groupBy, orderBy } from 'lodash-es';
 import { CircleMinus } from 'lucide-react';
@@ -6,7 +6,6 @@ import moment from 'moment-timezone';
 import { GroupType, type Dateish } from 'app/models';
 import { CircularPicture } from '~/components/Image';
 import Pill from '~/components/Pill';
-import Tooltip from '~/components/Tooltip';
 import styles from '~/pages/users/@username/_components/UserProfile.module.css';
 import { deleteMembershipHistory } from '~/redux/actions/GroupActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';

--- a/lego-webapp/pages/users/@username/settings/oauth2/+Page.tsx
+++ b/lego-webapp/pages/users/@username/settings/oauth2/+Page.tsx
@@ -4,6 +4,7 @@ import {
   Flex,
   Icon,
   LinkButton,
+  Tooltip,
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { keys } from 'lodash-es';
@@ -13,7 +14,6 @@ import { ContentMain } from '~/components/Content';
 import EmptyState from '~/components/EmptyState';
 import Table from '~/components/Table';
 import Time from '~/components/Time';
-import Tooltip from '~/components/Tooltip';
 import {
   deleteOAuth2Grant,
   fetchOAuth2Applications,

--- a/packages/lego-bricks/package.json
+++ b/packages/lego-bricks/package.json
@@ -56,7 +56,8 @@
     "lucide-react": "catalog:",
     "react-aria-components": "catalog:",
     "react-cropper": "^2.3.3",
-    "react-dropzone": "^14.3.8"
+    "react-dropzone": "^14.3.8",
+    "react-tiny-popover": "^8.1.6"
   },
   "peerDependencies": {
     "react": "catalog:",

--- a/packages/lego-bricks/src/components/Tooltip/Tooltip.module.css
+++ b/packages/lego-bricks/src/components/Tooltip/Tooltip.module.css
@@ -13,7 +13,7 @@
   font-size: var(--font-size-md);
   font-weight: normal;
 
-  /* A small "border" added to the box-shadow 
+  /* A small "border" added to the box-shadow
   in case of sub-pixels rendering in the browser
   or rounding errors when positioning the arrow
   causing a small space between content and arrow */

--- a/packages/lego-bricks/src/components/Tooltip/index.tsx
+++ b/packages/lego-bricks/src/components/Tooltip/index.tsx
@@ -15,7 +15,7 @@ type Props = {
   disabled?: boolean;
 };
 
-const Tooltip = ({
+export const Tooltip = ({
   children,
   content,
   className,
@@ -57,5 +57,3 @@ const Tooltip = ({
     </div>
   );
 };
-
-export default Tooltip;

--- a/packages/lego-bricks/src/components/Tooltip/index.tsx
+++ b/packages/lego-bricks/src/components/Tooltip/index.tsx
@@ -34,6 +34,14 @@ export const Tooltip = ({
       onClick={onClick}
       onMouseEnter={() => setHovered(!disabled && !!content && true)}
       onMouseLeave={() => setHovered(false)}
+      // Support keyboard navigation if onClick (for accessibility)
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (onClick && (e.key === 'Enter' || e.key === ' ')) {
+          onClick();
+        }
+      }}
     >
       <Popover
         isOpen={hovered}

--- a/packages/lego-bricks/src/index.ts
+++ b/packages/lego-bricks/src/index.ts
@@ -11,6 +11,7 @@ export { Button, LinkButton } from './components/Button';
 export { ButtonGroup } from './components/Button/ButtonGroup';
 export { TabContainer } from './components/Tabs/TabContainer';
 export { Tab } from './components/Tabs/Tab';
+export { Tooltip } from './components/Tooltip';
 export {
   Page,
   PageContainer,

--- a/packages/lego-editor/src/components/ImageMenu.tsx
+++ b/packages/lego-editor/src/components/ImageMenu.tsx
@@ -2,6 +2,7 @@ import { Editor } from '@tiptap/react';
 import styles from './ImageMenu.module.css';
 import { GalleryThumbnails, Trash } from 'lucide-react';
 import { ToolbarButton } from './Toolbar';
+import { Flex } from '@webkom/lego-bricks';
 
 type Props = {
   editor: Editor | null;
@@ -13,7 +14,7 @@ export const ImageMenu = ({ editor }: Props) => {
   if (!editor || !(isImage || isFigure)) return null;
 
   return (
-    <div className={styles.root}>
+    <Flex className={styles.root}>
       <ToolbarButton
         onClick={() =>
           isImage
@@ -21,16 +22,16 @@ export const ImageMenu = ({ editor }: Props) => {
             : editor.chain().focus().figureToImage().run()
         }
         active={isFigure}
-        aria-label="Toggle caption"
+        tooltip={isImage ? 'Legg til bildetekst' : 'Fjern bildetekst'}
       >
         <GalleryThumbnails size={18} />
       </ToolbarButton>
       <ToolbarButton
         onClick={() => editor?.chain().focus().clearNodes().run()}
-        aria-label="Remove image"
+        tooltip="Slett bilde"
       >
         <Trash size={18} color="var(--color-red-6)" />
       </ToolbarButton>
-    </div>
+    </Flex>
   );
 };

--- a/packages/lego-editor/src/components/Toolbar.tsx
+++ b/packages/lego-editor/src/components/Toolbar.tsx
@@ -22,11 +22,13 @@ import {
 } from 'lucide-react';
 import { ImageUploadModal } from './ImageUploadModal';
 import { ImageUploadFn } from '../index';
+import { Flex, Tooltip } from '@webkom/lego-bricks';
 
 type ButtonProps = {
   onClick: MouseEventHandler;
   disabled?: boolean;
   active?: boolean;
+  tooltip?: string;
   children: ReactNode;
 };
 
@@ -34,10 +36,11 @@ export const ToolbarButton = ({
   onClick,
   disabled,
   active,
+  tooltip,
   children,
   ...props
 }: ButtonProps & HTMLProps<HTMLButtonElement>) => {
-  return (
+  const node = (
     <button
       {...props}
       className={cx(
@@ -50,6 +53,13 @@ export const ToolbarButton = ({
     >
       {children}
     </button>
+  );
+  return tooltip ? (
+    <Tooltip content={tooltip} positions={['top']}>
+      {node}
+    </Tooltip>
+  ) : (
+    node
   );
 };
 
@@ -72,6 +82,7 @@ const ImageUploadButton = ({
         onClick={() => setImageUploadModalOpen(true)}
         disabled={disabled}
         active={editor.isActive('image')}
+        tooltip="Legg til bilde"
         aria-label="Image"
       >
         <Image size={18} />
@@ -107,7 +118,7 @@ const ToolbarLinkButton = ({ editor, disabled }: ToolbarLinkButtonProps) => {
           editor.chain().focus().unsetLink().run();
           return;
         } else {
-          const url = window.prompt('Enter the URL');
+          const url = window.prompt('Velg URL');
           if (!url) return;
           editor
             .chain()
@@ -118,6 +129,7 @@ const ToolbarLinkButton = ({ editor, disabled }: ToolbarLinkButtonProps) => {
       }}
       disabled={disabled}
       active={editor.isActive('link')}
+      tooltip={editor.isActive('link') ? 'Fjern lenke' : 'Legg til lenke'}
     >
       <Link size={18} />
     </ToolbarButton>
@@ -136,11 +148,12 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
   }
 
   return (
-    <div className={styles.root} data-test-id="lego-editor-toolbar">
+    <Flex className={styles.root} data-test-id="lego-editor-toolbar">
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
         disabled={disabled}
         active={editor.isActive('heading', { level: 1 })}
+        tooltip="Overskrift 1"
       >
         <Heading1 size={18} />
       </ToolbarButton>
@@ -148,6 +161,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
         disabled={disabled}
         active={editor.isActive('heading', { level: 2 })}
+        tooltip="Overskrift 2"
       >
         <Heading2 size={18} />
       </ToolbarButton>
@@ -155,6 +169,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
         disabled={disabled}
         active={editor.isActive('heading', { level: 3 })}
+        tooltip="Overskrift 3"
       >
         <Heading3 size={18} />
       </ToolbarButton>
@@ -162,6 +177,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleHeading({ level: 4 }).run()}
         disabled={disabled}
         active={editor.isActive('heading', { level: 4 })}
+        tooltip="Overskrift 4"
       >
         <Heading4 size={18} />
       </ToolbarButton>
@@ -169,6 +185,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleBold().run()}
         disabled={disabled}
         active={editor.isActive('bold')}
+        tooltip="Fet skrift"
       >
         <Bold size={18} />
       </ToolbarButton>
@@ -176,6 +193,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleItalic().run()}
         disabled={disabled}
         active={editor.isActive('italic')}
+        tooltip="Kursiv"
       >
         <Italic size={18} />
       </ToolbarButton>
@@ -183,6 +201,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleUnderline().run()}
         disabled={disabled}
         active={editor.isActive('underline')}
+        tooltip="Understrek"
       >
         <Underline size={18} />
       </ToolbarButton>
@@ -190,6 +209,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleStrike().run()}
         disabled={disabled}
         active={editor.isActive('strike')}
+        tooltip="Gjennomstreking"
       >
         <Strikethrough size={18} />
       </ToolbarButton>
@@ -197,6 +217,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleCode().run()}
         disabled={disabled}
         active={editor.isActive('code')}
+        tooltip="Inline kode"
       >
         <Code size={18} />
       </ToolbarButton>
@@ -204,6 +225,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleCodeBlock().run()}
         disabled={disabled}
         active={editor.isActive('codeBlock')}
+        tooltip="Kodeblokk"
       >
         <Code2 size={18} />
       </ToolbarButton>
@@ -211,6 +233,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleBulletList().run()}
         disabled={disabled}
         active={editor.isActive('bulletList')}
+        tooltip="Punktliste"
       >
         <List size={18} />
       </ToolbarButton>
@@ -218,18 +241,21 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
         disabled={disabled}
         active={editor.isActive('orderedList')}
+        tooltip="Nummerert liste"
       >
         <ListOrdered size={18} />
       </ToolbarButton>
       <ToolbarButton
         onClick={() => editor.chain().focus().sinkListItem('listItem').run()}
         disabled={disabled || !editor.can().sinkListItem('listItem')}
+        tooltip="Legg til innrykk"
       >
         <Indent size={18} />
       </ToolbarButton>
       <ToolbarButton
         onClick={() => editor.chain().focus().liftListItem('listItem').run()}
         disabled={disabled || !editor.can().liftListItem('listItem')}
+        tooltip="Fjern innrykk"
       >
         <Outdent size={18} />
       </ToolbarButton>
@@ -239,7 +265,7 @@ const Toolbar = ({ editor, disabled, imageUpload }: Props): ReactNode => {
         disabled={disabled}
         imageUpload={imageUpload}
       />
-    </div>
+    </Flex>
   );
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,9 +218,6 @@ importers:
       react-textarea-autosize:
         specifier: ^8.5.7
         version: 8.5.7(@types/react@18.3.18)(react@18.3.1)
-      react-tiny-popover:
-        specifier: ^8.1.6
-        version: 8.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-treeview:
         specifier: ^0.4.7
         version: 0.4.7(react@18.3.1)
@@ -378,6 +375,9 @@ importers:
       react-dropzone:
         specifier: ^14.3.8
         version: 14.3.8(react@18.3.1)
+      react-tiny-popover:
+        specifier: ^8.1.6
+        version: 8.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@cfaester/enzyme-adapter-react-18':
         specifier: ^0.8.0


### PR DESCRIPTION
# NB! Builds on #5525 

# Description

Some of the toolbar buttons are not entirely self-explanatory based on the icons used. This adds tooltips to explain them further.
I also moved `<Tooltip>` into `lego-bricks` in order to be able to use it in `lego-editor`. This also required adding support for keyboard interaction with the Tooltip component, in the case that it uses `onClick` because of stricter linting in `lego-bricks`:)

# Result

- [x] Changes look good on both light and dark theme.
- [ ] Changes look good with different viewports (mobile, tablet, etc.).
  - Our tooltips don't work great on mobile, but that's not directly related to this PR
- [x] Changes look good with slower Internet connections.

Looks like this in toolbar:
![Screenshot 2025-04-01 at 16 31 02](https://github.com/user-attachments/assets/54ce281e-ff94-4823-98db-74c8121adf03)

And like this in image menu:
![Screenshot 2025-04-01 at 16 33 15](https://github.com/user-attachments/assets/cc7fbdbb-7a08-4e51-84e9-a9d78349fe89)

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1408