### PR TITLE
Add filters to lending admin

### DIFF
--- a/lego-webapp/redux/actions/LendingRequestActions.ts
+++ b/lego-webapp/redux/actions/LendingRequestActions.ts
@@ -23,11 +23,12 @@ export const fetchLendingRequests = ({ next = false }) =>
     propagateError: true,
   });
 
-export const fetchLendingRequestsAdmin = ({ next = false }) =>
+export const fetchLendingRequestsAdmin = ({ query, next = false }) =>
   callAPI<AdminLendingRequest[]>({
     types: LendingRequests.FETCH_ADMIN,
     endpoint: '/lending/requests/admin/',
     schema: [lendingRequestSchema],
+    query,
     meta: {
       errorMessage: 'Henting av utlånsforespørsler feilet',
     },

--- a/lego-webapp/redux/models/LendingRequest.ts
+++ b/lego-webapp/redux/models/LendingRequest.ts
@@ -4,10 +4,10 @@ import type { ActionGrant, Dateish } from 'app/models';
 
 export enum LendingRequestStatus {
   Unapproved = 'unapproved',
+  ChangesRequested = 'changes_requested',
   Approved = 'approved',
   Denied = 'denied',
   Cancelled = 'cancelled',
-  ChangesRequested = 'changes_requested',
 }
 
 interface LendingRequest {


### PR DESCRIPTION
# Description

Adds status filtering to the lending admin page. 

[Backend](https://github.com/webkom/lego/pull/3819)

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/user-attachments/assets/e83b5ab5-9626-4678-ad36-98bad9bd4c57

# Testing

- [x] I have thoroughly tested my changes.

Resolves [ABA-1352](https://linear.app/abakus-webkom/issue/ABA-1352/add-filtering-to-admin-panel-in-lending-system)
