### PR TITLE
Fix dependency installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 > For all the alternative ways to run the project, you will need to run `pnpm build` to compile [lego-bricks](#lego-bricks) the first time you run the project. After this, it will build automatically when changed.
 
 ```bash
-$ pnpm # Install dependencies
+$ pnpm i # Install dependencies
 $ pnpm build # Compile LEGO-BRICKS - only required the first time you run the project
 $ pnpm dev:staging # Start webserver with development backend
 ```


### PR DESCRIPTION
# Description

In the previous version of the README (ever since swapping out yarn for pnpm) there was a mistake in the command for installing dependencies. This command was just `pnpm` instead of `pnpm i` or `pnpm install`. This is likely because with yarn you could installing using simply `yarn`.

# Result

In this PR I have updated the command in `README.md` to reflect the correct usage of the pnpm installation command `pnpm i`.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
           Quick start section of README.md
        </td>
        <td>
<img width="306" alt="Screenshot 2025-04-03 at 13 44 49" src="https://github.com/user-attachments/assets/a67f0c8e-75c0-4d03-9004-8b5d9545fd00" />
        </td>
        <td>
<img width="306" alt="Screenshot 2025-04-03 at 13 45 13" src="https://github.com/user-attachments/assets/4333056d-8d39-4964-8a85-f2d08896c791" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tried running `pnpm`, noted how it didn't install depenencies. After updating the README, I tried running the new command `pnpm i`, and verified that it now runs the installation of dependencies using pnpm.