### PR TITLE
Add lending timeline

### DIFF
--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
@@ -43,7 +43,7 @@ import {
   AdminLendingRequest,
   TimelineEntry,
 } from '~/redux/models/LendingRequest';
-import { PublicUser, PublicUserWithGroups } from '~/redux/models/User';
+import { PublicUserWithGroups } from '~/redux/models/User';
 import { selectLendableObjectById } from '~/redux/slices/lendableObjects';
 import { selectLendingRequestById } from '~/redux/slices/lendingRequests';
 import { selectUserById } from '~/redux/slices/users';
@@ -267,6 +267,7 @@ const TimeLineEntry = ({
         {!isLast && <div className={styles.timelineLine} />}
       </Flex>
       <Flex
+        className={styles.timelineEntry}
         alignItems="center"
         gap="var(--spacing-sm)"
         width="100%"

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
@@ -25,6 +25,7 @@ import {
   TextInput,
 } from '~/components/Form';
 import { ProfilePicture } from '~/components/Image';
+import { Tag } from '~/components/Tags';
 import Time from '~/components/Time';
 import HTTPError from '~/components/errors/HTTPError';
 import LendingStatusTag, { statusMap } from '~/pages/lending/LendingStatusTag';
@@ -42,7 +43,7 @@ import {
   AdminLendingRequest,
   TimelineEntry,
 } from '~/redux/models/LendingRequest';
-import { PublicUserWithGroups } from '~/redux/models/User';
+import { PublicUser, PublicUserWithGroups } from '~/redux/models/User';
 import { selectLendableObjectById } from '~/redux/slices/lendableObjects';
 import { selectLendingRequestById } from '~/redux/slices/lendingRequests';
 import { selectUserById } from '~/redux/slices/users';
@@ -124,7 +125,7 @@ const LendingRequest = () => {
             <p>{lendingRequest.text}</p>
             <h3>Tidslinje</h3>
             <Flex column>
-              {lendingRequest.timelineEntries.map(
+              {lendingRequest.timelineEntries?.map(
                 (entry: TimelineEntry, index) => (
                   <TimeLineEntry
                     entry={entry}
@@ -255,21 +256,13 @@ const TimeLineEntry = ({
   isLast: boolean;
 }) => {
   return (
-    <Flex
-      alignItems="flex-start"
-      gap="var(--spacing-sm)"
-      key={entry.createdAt as string}
-    >
-      <Flex
-        column
-        alignItems="center"
-        style={{
-          color: statusMap[entry.status]?.color,
-        }}
-      >
-        <Icon
+    <Flex alignItems="flex-start" gap="var(--spacing-sm)">
+      <Flex column alignItems="center">
+        <Tag
+          className={styles.timelineTag}
           iconNode={statusMap[entry.status]?.icon || <MessageCircleIcon />}
-          size={24}
+          tag=""
+          color={statusMap[entry.status]?.color || 'blue'}
         />
         {!isLast && <div className={styles.timelineLine} />}
       </Flex>
@@ -280,17 +273,14 @@ const TimeLineEntry = ({
         justifyContent="space-between"
       >
         <Flex alignItems="center" gap="var(--spacing-sm)">
-          <a href={`/users/${entry.createdBy?.username}`}>
+          <a href={`/users/${entry.createdBy.username}`}>
             <Flex gap="var(--spacing-sm)" alignItems="center">
-              <ProfilePicture user={entry.createdBy} size={24} />
-              <h4>{entry.createdBy?.fullName}</h4>
+              <ProfilePicture user={entry.createdBy} size={32} />
+              <h4>{entry.createdBy.fullName}</h4>
             </Flex>
           </a>
-          <span className={styles.entryStatus}>
-            {entry.isSystem
-              ? `${statusMap[entry.status]?.doneText}.`
-              : entry.message}
-          </span>
+
+          <span className={styles.timelineMessage}>{`${entry.message}.`}</span>
         </Flex>
         <Time
           className={styles.timelineTime}

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/LendingRequestDetail.module.css
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/LendingRequestDetail.module.css
@@ -1,3 +1,5 @@
+@import url('styles/custom-media.css');
+
 .buttonWrapper,
 .buttonWrapper button {
   width: 100%;
@@ -11,14 +13,27 @@
   width: 100%;
 }
 
-.timelineTime, .timelineMessage {
+.timelineTime,
+.timelineMessage {
   color: var(--secondary-font-color);
 }
 
 .timelineLine {
   width: 1px;
-  height: var(--spacing-xl);
+  height: 2rem;
   background-color: var(--lego-font-color);
+
+  @media (--small-viewport) {
+    height: 4rem;
+  }
+}
+
+.timelineEntry {
+  @media (--small-viewport) {
+    flex-direction: column-reverse;
+    align-items: flex-start;
+    padding-top: var(--spacing-xs);
+  }
 }
 
 .timelineTag {

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/LendingRequestDetail.module.css
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/LendingRequestDetail.module.css
@@ -6,3 +6,17 @@
 .requestingUser h4 {
   color: var(--lego-font-color);
 }
+
+.commentField {
+  width: 100%;
+}
+
+.timelineTime .timelineMessage {
+  color: var(--secondary-font-color);
+}
+
+.timelineLine {
+  width: 1px;
+  height: var(--spacing-xl);
+  background-color: var(--lego-font-color);
+}

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/LendingRequestDetail.module.css
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/LendingRequestDetail.module.css
@@ -11,7 +11,7 @@
   width: 100%;
 }
 
-.timelineTime .timelineMessage {
+.timelineTime, .timelineMessage {
   color: var(--secondary-font-color);
 }
 
@@ -19,4 +19,12 @@
   width: 1px;
   height: var(--spacing-xl);
   background-color: var(--lego-font-color);
+}
+
+.timelineTag {
+  border-radius: 100%;
+  height: 32px;
+  width: 32px;
+  padding: 0;
+  justify-content: center;
 }

--- a/lego-webapp/pages/lending/LendingStatusTag.tsx
+++ b/lego-webapp/pages/lending/LendingStatusTag.tsx
@@ -15,43 +15,43 @@ export const statusMap: Record<
   {
     tag: string;
     buttonText: string;
-    doneText?: string;
     icon: ReactNode;
     color: TagColors;
   }
 > = {
+  [LendingRequestStatus.Created]: {
+    tag: 'Ny forespørsel',
+    buttonText: 'Opprett forespørsel',
+    icon: <CircleDashed className={styles.rotate} />,
+    color: 'blue',
+  },
   [LendingRequestStatus.Unapproved]: {
     tag: 'Venter på godkjenning',
     buttonText: 'Fjern godkjenning',
-    doneText: 'fjernet godkjenning',
     icon: <CircleDashed className={styles.rotate} />,
     color: 'orange',
   },
   [LendingRequestStatus.Approved]: {
     tag: 'Godkjent',
     buttonText: 'Godkjenn',
-    doneText: 'godkjente forespørselen',
     icon: <CircleCheckBig />,
     color: 'green',
   },
   [LendingRequestStatus.Denied]: {
     tag: 'Avslått',
     buttonText: 'Avslå',
-    doneText: 'avslo forespørselen',
     icon: <CircleX />,
     color: 'red',
   },
   [LendingRequestStatus.Cancelled]: {
     tag: 'Kansellert',
     buttonText: 'Kanseller forespørsel',
-    doneText: 'kansellerte forespørselen',
     icon: <CircleX />,
     color: 'red',
   },
   [LendingRequestStatus.ChangesRequested]: {
     tag: 'Endringer forespurt',
     buttonText: 'Forespør endringer',
-    doneText: 'forespurte endringer',
     icon: <CircleAlert />,
     color: 'orange',
   },

--- a/lego-webapp/pages/lending/LendingStatusTag.tsx
+++ b/lego-webapp/pages/lending/LendingStatusTag.tsx
@@ -15,6 +15,7 @@ export const statusMap: Record<
   {
     tag: string;
     buttonText: string;
+    doneText?: string;
     icon: ReactNode;
     color: TagColors;
   }
@@ -22,30 +23,35 @@ export const statusMap: Record<
   [LendingRequestStatus.Unapproved]: {
     tag: 'Venter på godkjenning',
     buttonText: 'Fjern godkjenning',
+    doneText: 'fjernet godkjenning',
     icon: <CircleDashed className={styles.rotate} />,
     color: 'orange',
   },
   [LendingRequestStatus.Approved]: {
     tag: 'Godkjent',
     buttonText: 'Godkjenn',
+    doneText: 'godkjente forespørselen',
     icon: <CircleCheckBig />,
     color: 'green',
   },
   [LendingRequestStatus.Denied]: {
     tag: 'Avslått',
     buttonText: 'Avslå',
+    doneText: 'avslo forespørselen',
     icon: <CircleX />,
     color: 'red',
   },
   [LendingRequestStatus.Cancelled]: {
     tag: 'Kansellert',
     buttonText: 'Kanseller forespørsel',
+    doneText: 'kansellerte forespørselen',
     icon: <CircleX />,
     color: 'red',
   },
   [LendingRequestStatus.ChangesRequested]: {
     tag: 'Endringer forespurt',
     buttonText: 'Forespør endringer',
+    doneText: 'forespurte endringer',
     icon: <CircleAlert />,
     color: 'orange',
   },

--- a/lego-webapp/redux/actions/LendingRequestActions.ts
+++ b/lego-webapp/redux/actions/LendingRequestActions.ts
@@ -1,6 +1,7 @@
 import {
   AdminLendingRequest,
   CreateLendingRequest,
+  DetailLendingRequest,
   EditLendingRequest,
   ListLendingRequest,
 } from '~/redux/models/LendingRequest';
@@ -58,6 +59,22 @@ export const editLendingRequest = (data: EditLendingRequest) =>
     meta: {
       errorMessage: 'Endring av utlånsforespørsel feilet',
       successMessage: 'Endring av utlånsforespørsel fullført',
+    },
+  });
+
+export const commentOnLendingRequest = (data: {
+  message: string;
+  lending_request: EntityId;
+}) =>
+  callAPI<DetailLendingRequest>({
+    types: LendingRequests.EDIT,
+    endpoint: `/lending/timelineentries/`,
+    method: 'POST',
+    schema: lendingRequestSchema,
+    body: data,
+    meta: {
+      errorMessage: 'Kommentering av utlånsforespørsel feilet',
+      successMessage: 'Kommentering av utlånsforespørsel fullført',
     },
   });
 

--- a/lego-webapp/redux/models/LendingRequest.ts
+++ b/lego-webapp/redux/models/LendingRequest.ts
@@ -1,7 +1,7 @@
 import { ListLendableObject } from '~/redux/models/LendableObject';
-import type { EntityId } from '@reduxjs/toolkit';
-import type { ActionGrant, Dateish, User } from 'app/models';
 import { PublicUser } from '~/redux/models/User';
+import type { EntityId } from '@reduxjs/toolkit';
+import type { ActionGrant, Dateish } from 'app/models';
 
 export enum LendingRequestStatus {
   Created = 'created',

--- a/lego-webapp/redux/models/LendingRequest.ts
+++ b/lego-webapp/redux/models/LendingRequest.ts
@@ -1,8 +1,10 @@
 import { ListLendableObject } from '~/redux/models/LendableObject';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { ActionGrant, Dateish, User } from 'app/models';
+import { PublicUser } from '~/redux/models/User';
 
 export enum LendingRequestStatus {
+  Created = 'created',
   Unapproved = 'unapproved',
   Approved = 'approved',
   Denied = 'denied',
@@ -14,6 +16,7 @@ interface LendingRequest {
   id: EntityId;
   createdBy: EntityId;
   updatedBy: EntityId;
+  createdAt: Dateish;
   lendableObject: EntityId;
   status: LendingRequestStatus;
   startDate: Dateish;
@@ -39,6 +42,7 @@ export type DetailLendingRequest = Pick<
   LendingRequest,
   | 'id'
   | 'createdBy'
+  | 'createdAt'
   | 'updatedBy'
   | 'lendableObject'
   | 'status'
@@ -66,7 +70,7 @@ export type EditLendingRequest = Required<Pick<LendingRequest, 'id'>> &
 
 export type TimelineEntry = {
   id: EntityId;
-  createdBy: User;
+  createdBy: PublicUser;
   createdAt: Dateish;
   message: string;
   isSystem: boolean;

--- a/lego-webapp/redux/models/LendingRequest.ts
+++ b/lego-webapp/redux/models/LendingRequest.ts
@@ -1,6 +1,6 @@
 import { ListLendableObject } from '~/redux/models/LendableObject';
 import type { EntityId } from '@reduxjs/toolkit';
-import type { ActionGrant, Dateish } from 'app/models';
+import type { ActionGrant, Dateish, User } from 'app/models';
 
 export enum LendingRequestStatus {
   Unapproved = 'unapproved',
@@ -20,6 +20,7 @@ interface LendingRequest {
   endDate: Dateish;
   text: string;
   actionGrant: ActionGrant;
+  timelineEntries: TimelineEntry[];
 }
 
 export type ListLendingRequest = Pick<
@@ -31,6 +32,7 @@ export type ListLendingRequest = Pick<
   | 'startDate'
   | 'endDate'
   | 'actionGrant'
+  | 'timelineEntries'
 >;
 
 export type DetailLendingRequest = Pick<
@@ -44,6 +46,7 @@ export type DetailLendingRequest = Pick<
   | 'endDate'
   | 'text'
   | 'actionGrant'
+  | 'timelineEntries'
 >;
 
 export type AdminLendingRequest = DetailLendingRequest;
@@ -60,3 +63,12 @@ export type CreateLendingRequest = Pick<
 >;
 export type EditLendingRequest = Required<Pick<LendingRequest, 'id'>> &
   Partial<Pick<LendingRequest, 'status' | 'startDate' | 'endDate'>>;
+
+export type TimelineEntry = {
+  id: EntityId;
+  createdBy: User;
+  createdAt: Dateish;
+  message: string;
+  isSystem: boolean;
+  status: LendingRequestStatus;
+};


### PR DESCRIPTION
# Description

Adds a timeline to the lending detail page. The timeline contains system actions automatically generated by the backend as well as submitted comments on the request.

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/user-attachments/assets/2fe2d628-3b5f-4fbc-aee5-3c94d21e62e4

# Testing

- [x] I have thoroughly tested my changes.

Create a new lending request and verify that a creation entry is present in the timeline. Verify that commenting on the request works and that submitting actions also creates timeline entries.  

---

Resolves [ABA-1398](https://linear.app/abakus-webkom/issue/ABA-1398/add-timeline-objects-to-frontend-and-replace-comments)
