### PR TITLE
Add support for new notification websocket message

### DIFF
--- a/lego-webapp/components/HeaderNotifications/index.tsx
+++ b/lego-webapp/components/HeaderNotifications/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '~/redux/actions/NotificationsFeedActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import { selectFeedActivitiesByFeedId } from '~/redux/slices/feeds';
+import { selectUnreadNotificationsCount } from '~/redux/slices/notificationsFeed';
 import Dropdown from '../Dropdown';
 import { getActivityRenderer } from '../Feed';
 import styles from './HeaderNotifications.module.css';
@@ -90,7 +91,7 @@ const HeaderNotificationsContent = () => {
 
 const NotificationsDropdown = () => {
   const dispatch = useAppDispatch();
-  const notificationsData = useAppSelector((state) => state.notificationsFeed);
+  const unreadCount = useAppSelector(selectUnreadNotificationsCount);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
 
   usePreparedEffect(
@@ -102,8 +103,6 @@ const NotificationsDropdown = () => {
       ]),
     [],
   );
-
-  const { unreadCount } = notificationsData;
 
   return (
     <Dropdown

--- a/lego-webapp/redux/slices/feedActivities.ts
+++ b/lego-webapp/redux/slices/feedActivities.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { type AnyAction, createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { Feed } from '~/redux/actionTypes';
 import createLegoAdapter from '~/redux/legoAdapter/createLegoAdapter';
@@ -14,6 +14,11 @@ const feedActivitiesSlice = createSlice({
   reducers: {},
   extraReducers: legoAdapter.buildReducers({
     fetchActions: [Feed.FETCH],
+    extraCases: (addCase) => {
+      addCase('SOCKET_NEW_NOTIFICATION', (state, action: AnyAction) => {
+        legoAdapter.upsertOne(state, action.payload);
+      });
+    },
   }),
 });
 

--- a/lego-webapp/redux/slices/feeds.ts
+++ b/lego-webapp/redux/slices/feeds.ts
@@ -35,6 +35,18 @@ const feedsSlice = createSlice({
           ),
         });
       });
+      addCase('SOCKET_NEW_NOTIFICATION', (state, action: AnyAction) => {
+        legoAdapter.upsertOne(state, {
+          id: 'notifications',
+          type: 'notifications',
+          activities: union(
+            state.entities.notifications
+              ? state.entities.notifications.activities || []
+              : [],
+            [action.payload.id],
+          ),
+        });
+      });
     },
   }),
 });

--- a/lego-webapp/redux/slices/notificationsFeed.ts
+++ b/lego-webapp/redux/slices/notificationsFeed.ts
@@ -1,25 +1,32 @@
-import { produce } from 'immer';
+import { createSlice } from '@reduxjs/toolkit';
 import { NotificationsFeed } from '~/redux/actionTypes';
-import type { Reducer } from '@reduxjs/toolkit';
+import { RootState } from '~/redux/rootReducer';
 
 const initialState = {
   unreadCount: 0,
   unseenCount: 0,
 };
-type State = typeof initialState;
-const notificationsFeed: Reducer<State> = produce((newState, action) => {
-  switch (action.type) {
-    case NotificationsFeed.FETCH_DATA.SUCCESS:
-      newState.unreadCount = action.payload.unreadCount;
-      newState.unseenCount = action.payload.unseenCount;
-      break;
+const notificationsFeed = createSlice({
+  name: 'notificationsFeed',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(NotificationsFeed.FETCH_DATA.SUCCESS, (state, action) => {
+      state.unreadCount = action.payload.unreadCount;
+      state.unseenCount = action.payload.unseenCount;
+    });
+    builder.addCase(NotificationsFeed.MARK_ALL.SUCCESS, () => initialState);
+    builder.addCase(NotificationsFeed.MARK_ALL.BEGIN, () => initialState);
+    builder.addCase('SOCKET_NEW_NOTIFICATION', (state) => {
+      state.unreadCount += 1;
+      state.unseenCount += 1;
+    });
+  },
+});
 
-    case NotificationsFeed.MARK_ALL.SUCCESS:
-    case NotificationsFeed.MARK_ALL.BEGIN: // Optimistically marking all as read first to avoid flickering
-      return initialState;
+export default notificationsFeed.reducer;
 
-    default:
-      break;
-  }
-}, initialState);
-export default notificationsFeed;
+export const selectUnreadNotificationsCount = (state: RootState) =>
+  state.notificationsFeed.unreadCount;
+export const selectUnseenNotificationsCount = (state: RootState) =>
+  state.notificationsFeed.unseenCount;


### PR DESCRIPTION
# Description

Related backend pr: https://github.com/webkom/lego/pull/3825

Updates the redux state with the newly received notification when receiving the new websocket message implemented in the related backend PR. This makes the notification thing in the header update live when receiving notifications.

# Result

https://github.com/user-attachments/assets/7e149374-53ba-44bc-bb20-945519c901ef

# Testing

- [x] I have thoroughly tested my changes.

As shown in the video, I have tested that the notifications appear correctly when the websocket message is received.

---

Resolves ABA-1420
