### PR TITLE
Display penalty notification in feed

### DIFF
--- a/lego-webapp/components/Feed/activity.module.css
+++ b/lego-webapp/components/Feed/activity.module.css
@@ -9,3 +9,7 @@
 .time {
   color: var(--secondary-font-color);
 }
+
+.redText {
+  color: var(--lego-red-color);
+}

--- a/lego-webapp/components/Feed/index.tsx
+++ b/lego-webapp/components/Feed/index.tsx
@@ -13,12 +13,12 @@ import CommentReplyRenderer from './renders/comment_reply';
 import EventRegisterRenderer from './renders/event_register';
 import GroupJoinRenderer from './renders/group';
 import MeetingInvitationRenderer from './renders/meetingInvitation';
+import PenaltyRenderer from './renders/penaltyNotification';
 import RegistrationBumpRenderer from './renders/registrationBump';
 import RestrictedMailSentRenderer from './renders/restrictedMail';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { ReactNode } from 'react';
 import type ActivityRenderer from '~/components/Feed/ActivityRenderer';
-import PenaltyRenderer from './renders/penaltyNotification';
 
 export const activityRenderers = {
   [FeedActivityVerb.Comment]: CommentRenderer,

--- a/lego-webapp/components/Feed/index.tsx
+++ b/lego-webapp/components/Feed/index.tsx
@@ -18,6 +18,7 @@ import RestrictedMailSentRenderer from './renders/restrictedMail';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { ReactNode } from 'react';
 import type ActivityRenderer from '~/components/Feed/ActivityRenderer';
+import PenaltyRenderer from './renders/penaltyNotification';
 
 export const activityRenderers = {
   [FeedActivityVerb.Comment]: CommentRenderer,
@@ -29,6 +30,7 @@ export const activityRenderers = {
   [FeedActivityVerb.Announcement]: AnnouncementRenderer,
   [FeedActivityVerb.GroupJoin]: GroupJoinRenderer,
   [FeedActivityVerb.EventRegister]: EventRegisterRenderer,
+  [FeedActivityVerb.Penalty]: PenaltyRenderer,
 };
 
 export const getActivityRenderer = <Verb extends FeedActivityVerb>(

--- a/lego-webapp/components/Feed/renders/penaltyNotification.tsx
+++ b/lego-webapp/components/Feed/renders/penaltyNotification.tsx
@@ -1,13 +1,11 @@
 import { Icon } from '@webkom/lego-bricks';
-import AggregatedFeedActivity, {
-  FeedActivityVerb,
-} from '~/redux/models/FeedActivity';
-import type ActivityRenderer from '~/components/Feed/ActivityRenderer';
-import styles from '../activity.module.css';
 import { CircleAlert } from 'lucide-react';
+import { FeedActivityVerb } from '~/redux/models/FeedActivity';
+import styles from '../activity.module.css';
+import type ActivityRenderer from '~/components/Feed/ActivityRenderer';
 
 const PenaltyRenderer: ActivityRenderer<FeedActivityVerb.Penalty> = {
-  Header: ({ aggregatedActivity, tag: Tag }) => {
+  Header: ({ aggregatedActivity }) => {
     const latestActivity = aggregatedActivity.lastActivity;
 
     return (

--- a/lego-webapp/components/Feed/renders/penaltyNotification.tsx
+++ b/lego-webapp/components/Feed/renders/penaltyNotification.tsx
@@ -1,0 +1,35 @@
+import { Icon } from '@webkom/lego-bricks';
+import AggregatedFeedActivity, {
+  FeedActivityVerb,
+} from '~/redux/models/FeedActivity';
+import type ActivityRenderer from '~/components/Feed/ActivityRenderer';
+import styles from '../activity.module.css';
+import { CircleAlert } from 'lucide-react';
+
+const PenaltyRenderer: ActivityRenderer<FeedActivityVerb.Penalty> = {
+  Header: ({ aggregatedActivity, tag: Tag }) => {
+    const latestActivity = aggregatedActivity.lastActivity;
+
+    return (
+      <p>
+        <b>
+          Du har fått{' '}
+          <span className={styles.redText}>
+            {latestActivity.extraContext.weight} prikk
+            {Number(latestActivity.extraContext.weight) > 1 ? 'er' : ''}
+          </span>
+          :{' '}
+        </b>
+        <br />
+        {latestActivity.extraContext.reason}
+      </p>
+    );
+  },
+  Content: () => null,
+  Icon: () => <Icon iconNode={<CircleAlert />} />,
+  getNotificationUrl: () => {
+    return `/users/me`;
+  },
+};
+
+export default PenaltyRenderer;

--- a/lego-webapp/components/HeaderNotifications/index.tsx
+++ b/lego-webapp/components/HeaderNotifications/index.tsx
@@ -61,6 +61,7 @@ const HeaderNotificationsContent = () => {
   const notifications = useAppSelector((state) =>
     selectFeedActivitiesByFeedId(state, 'notifications'),
   );
+  console.log(notifications);
   const fetchingNotifications = useAppSelector(
     (state) => state.feedActivities.fetching,
   );

--- a/lego-webapp/components/HeaderNotifications/index.tsx
+++ b/lego-webapp/components/HeaderNotifications/index.tsx
@@ -61,7 +61,6 @@ const HeaderNotificationsContent = () => {
   const notifications = useAppSelector((state) =>
     selectFeedActivitiesByFeedId(state, 'notifications'),
   );
-  console.log(notifications);
   const fetchingNotifications = useAppSelector(
     (state) => state.feedActivities.fetching,
   );

--- a/lego-webapp/pages/users/@username/settings/notifications/+Page.tsx
+++ b/lego-webapp/pages/users/@username/settings/notifications/+Page.tsx
@@ -16,7 +16,7 @@ import {
 } from '~/redux/slices/notificationSettings';
 import styles from './UserSettingsNotifications.module.css';
 
-const notificationTypeTraslations = {
+const notificationTypeTranslations = {
   weekly_mail: 'Ukesmail',
   event_bump: 'Rykker opp fra venteliste på arrangement',
   event_admin_registration: 'Adminregistrering',
@@ -132,7 +132,7 @@ const UserSettingsNotifications = () => {
             return (
               <tr key={key}>
                 <td>
-                  {notificationTypeTraslations[notificationType] ||
+                  {notificationTypeTranslations[notificationType] ||
                     notificationType.replace(/_/g, ' ')}
                 </td>
                 {alternatives.channels.map((channel, key) => (

--- a/lego-webapp/redux/models/FeedActivity.ts
+++ b/lego-webapp/redux/models/FeedActivity.ts
@@ -21,6 +21,7 @@ export enum FeedActivityVerb {
   Announcement = 'announcement',
   GroupJoin = 'group_join',
   EventRegister = 'event_register',
+  Penalty = 'penalty',
 }
 
 export type FeedActivityVerbAttr = {
@@ -33,6 +34,7 @@ export type FeedActivityVerbAttr = {
   [FeedActivityVerb.Announcement]: FeedAttrAnnouncement;
   [FeedActivityVerb.GroupJoin]: FeedAttrGroup;
   [FeedActivityVerb.EventRegister]: FeedAttrEvent;
+  [FeedActivityVerb.Penalty]: UnknownFeedAttr;
 };
 
 export interface FeedActivity {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ catalogs:
       specifier: ^5.6.3
       version: 5.6.3
     vite:
-      specifier: ^6.2.5
+      specifier: ^6.2.3
       version: 6.2.5
     vitest:
       specifier: ^3.0.9


### PR DESCRIPTION
# Description

Made penalty notifications visible in notification feed.

# Result

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Made penalty notification display, with penalty weight and reason.
        </td>
        <td>
            <img width="593" alt="Skjermbilde 2025-04-09 kl  19 43 12" src="https://github.com/user-attachments/assets/ccd53fa6-c81e-414b-8f02-336a1076c2a4" />
        </td>
        <td>
            <img width="593" alt="Skjermbilde 2025-04-09 kl  19 42 37" src="https://github.com/user-attachments/assets/12457ccd-124f-4da0-b45e-d787deaa35aa" />
        </td>
    </tr>
</table>

# Testing

- [X] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1424
