### PR TITLE
Fix custom media query variables in lego-bricks

### DIFF
--- a/packages/lego-bricks/src/components/Card/Card.module.css
+++ b/packages/lego-bricks/src/components/Card/Card.module.css
@@ -1,3 +1,5 @@
+@import '../../custom-media.css';
+
 .baseCard {
   background: var(--lego-card-color);
   border-radius: var(--border-radius-lg);
@@ -13,7 +15,7 @@
 .withIcon {
   gap: var(--spacing-md);
 
-  @media (max-width: 35em) {
+  @media (--small-viewport) {
     flex-direction: column;
     gap: var(--spacing-sm);
   }

--- a/packages/lego-bricks/src/components/Layout/Flex.module.css
+++ b/packages/lego-bricks/src/components/Layout/Flex.module.css
@@ -1,4 +1,4 @@
-/* stylelint-disable selector-class-pattern */
+@import '../../custom-media.css';
 
 .flex {
   display: flex;

--- a/packages/lego-bricks/src/components/Layout/Page/Page.module.css
+++ b/packages/lego-bricks/src/components/Layout/Page/Page.module.css
@@ -1,8 +1,10 @@
+@import '../../../custom-media.css';
+
 .content {
   width: 100%;
   padding: var(--spacing-xl);
 
-  @media (max-width: 45em) {
+  @media (--medium-viewport) {
     padding: 1rem;
   }
 

--- a/packages/lego-bricks/src/components/Layout/Page/PageContainer.module.css
+++ b/packages/lego-bricks/src/components/Layout/Page/PageContainer.module.css
@@ -1,3 +1,5 @@
+@import '../../../custom-media.css';
+
 div.container {
   position: relative;
   display: grid;
@@ -20,7 +22,7 @@ div.card {
 }
 
 .sidebar {
-  @media (max-width: 45em) {
+  @media (--medium-viewport) {
     display: none;
   }
 }

--- a/packages/lego-bricks/src/components/Layout/Page/Sidebar.module.css
+++ b/packages/lego-bricks/src/components/Layout/Page/Sidebar.module.css
@@ -1,3 +1,5 @@
+@import '../../../custom-media.css';
+
 .sidebar {
   position: relative;
   max-width: calc(var(--lego-max-width) / 4);
@@ -10,7 +12,7 @@
 .sidebarTrigger.mobileOnly {
   display: none;
 
-  @media (max-width: 45em) {
+  @media (--medium-viewport) {
     display: inline;
   }
 }

--- a/packages/lego-bricks/src/custom-media.css
+++ b/packages/lego-bricks/src/custom-media.css
@@ -1,0 +1,1 @@
+@import '../../../lego-webapp/styles/custom-media.css';

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,5 +12,5 @@ catalog:
   react-dom: ^18.3.1
   react: ^18.3.1
   typescript: ^5.6.3
-  vite: ^6.2.3
+  vite: ^6.2.5
   vitest: ^3.0.9


### PR DESCRIPTION
# Description

Custom media query variables allow us to write `@media (--medium-viewport)` instead of `@media (max-width: 45em)`, this fixes them in `lego-bricks`.

It is kind of hacky, but I import the media query definition from `lego-webapp` into `lego-bricks` using the file path `'../../../lego-webapp/styles/custom-media.css'`. This is the same way we import global variables so I think it's ok.

# Result

No visual changes, just defines all media query values in one place.

# Testing

- [x] I have thoroughly tested my changes.

They all still work after building.

---

Resolves ABA-965