### PR TITLE
Improve timeline design

### DIFF
--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
@@ -130,6 +130,7 @@ const LendingRequest = () => {
                   <TimeLineEntry
                     entry={entry}
                     key={entry.id}
+                    isFirst={index === 0}
                     isLast={index === lendingRequest.timelineEntries.length - 1}
                   />
                 ),
@@ -251,20 +252,25 @@ const CommentForm = ({ lendingRequestId }: { lendingRequestId: EntityId }) => {
 const TimeLineEntry = ({
   entry,
   isLast,
+  isFirst,
 }: {
   entry: TimelineEntry;
   isLast: boolean;
+  isFirst: boolean;
 }) => {
   return (
     <div className={styles.timelineContainer}>
       <Flex column alignItems="center" className={styles.timelineTagContainer}>
+        {!isFirst && !entry.isSystem && (
+          <div className={styles.timelineLineStart} />
+        )}
         <Tag
           className={styles.timelineTag}
           iconNode={statusMap[entry.status]?.icon || <MessageCircleIcon />}
           tag=""
           color={statusMap[entry.status]?.color || 'blue'}
         />
-        {!isLast && <div className={styles.timelineLine} />}
+        {!isLast && <div className={styles.timelineLineEnd} />}
       </Flex>
       <a href={`/users/${entry.createdBy.username}`}>
         <div
@@ -278,14 +284,14 @@ const TimeLineEntry = ({
           <h4 className={styles.timelineUsername}>
             {entry.createdBy.fullName}
           </h4>
-          <span
-            className={styles.timelineText}
-          >{`${entry.isSystem ? statusMap[entry.status].timelineText : entry.message}`}</span>
           <Time
             className={styles.timelineTime}
             time={entry.createdAt}
             format="DD. MMM HH:mm"
           />
+          <span
+            className={styles.timelineText}
+          >{`${entry.isSystem ? statusMap[entry.status].timelineText : entry.message}`}</span>
         </div>
       </a>
     </div>

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/LendingRequestDetail.module.css
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/LendingRequestDetail.module.css
@@ -19,16 +19,24 @@
   column-gap: var(--spacing-md);
 }
 
-.timelineContainer time,
-.timelineContainer span {
+.timelineContainer time {
   color: var(--secondary-font-color);
 }
 
-.timelineLine {
+.timelineLineStart,
+.timelineLineEnd {
+  background-color: var(--lego-font-color);
   width: 1px;
+}
+
+.timelineLineStart {
+  height: var(--spacing-md);
+  flex-shrink: 0;
+}
+
+.timelineLineEnd {
   height: 100%;
   padding: var(--spacing-md) 0;
-  background-color: var(--lego-font-color);
 
   @media (--mobile-device) {
     padding: var(--spacing-lg) 0;
@@ -41,16 +49,7 @@
   display: grid;
   column-gap: var(--spacing-md);
   align-items: center;
-}
-
-.timelineEntrySystemContainer {
-  grid-template-columns: 32px auto 1fr auto;
-
-  @media (--mobile-device) {
-    grid-template-columns: 32px auto 1fr;
-    row-gap: var(--spacing-sm);
-    padding-bottom: var(--spacing-lg);
-  }
+  grid-template-columns: 32px auto auto;
 }
 
 .timelineEntryMessageContainer {
@@ -58,30 +57,28 @@
   border-radius: var(--border-radius-lg);
   border: 1.5px solid var(--border-gray);
   box-shadow: var(--shadow-sm);
-
   padding: var(--spacing-md);
-  grid-template-columns: 32px auto auto;
+}
+
+.timelineText {
+  grid-column-start: 2;
+  grid-column-end: 4;
+}
+
+.timelineEntrySystemContainer > .timelineText {
+  color: var(--secondary-font-color);
 }
 
 .timelineEntryMessageContainer > .timelineText {
-  grid-row-start: 2;
-  grid-row-end: 3;
-  grid-column-start: 1;
-  grid-column-end: 4;
-  margin-top: var(--spacing-sm);
+  color: var(--lego-font-color);
+}
+
+.timelineTime {
+  text-align: end;
 }
 
 .timelineEntrySystemContainer > .timelineTime {
-  text-align: start;
-  @media (--mobile-device) {
-    order: -1;
-    grid-column-start: 1;
-    grid-column-end: 4;
-  }
-}
-
-.timelineEntryMessageContainer > .timelineTime {
-  text-align: end;
+  padding-right: var(--spacing-md);
 }
 
 .timelineTagContainer {


### PR DESCRIPTION
# Description

Improves the lending timeline design on small screens with long names, and aligns the timeline event icon with the user's profile picture.  

# Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

| Before | After |
| -- | -- |
| ![Screenshot From 2025-04-20 17-51-29](https://github.com/user-attachments/assets/b57f50e9-2ac8-458a-9a5f-d331a52bbf36) | ![Screenshot From 2025-04-20 17-50-27](https://github.com/user-attachments/assets/fc6fa669-a9b5-4b7d-b118-72904ea3fd8e) |


# Testing

- [x] I have thoroughly tested my changes.

Verify that the timeline looks good on small screens with long names.
