### PR TITLE
STYLE: Design update to countdown banner

### DIFF
--- a/lego-webapp/components/Countdown/Countdown.module.css
+++ b/lego-webapp/components/Countdown/Countdown.module.css
@@ -4,3 +4,28 @@
   font-weight: bold;
   margin: var(--spacing-sm) 0;
 }
+
+.unitContainer {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xs);
+}
+
+.unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--color-event-black);
+}
+
+.value {
+  font-family: monospace;
+  font-size: var(--font-size-xl);
+}
+
+.label {
+  font-family: monospace;
+  font-size: var(--font-size-sm);
+  color: var(--color-event-black);
+}

--- a/lego-webapp/components/Countdown/index.tsx
+++ b/lego-webapp/components/Countdown/index.tsx
@@ -3,7 +3,6 @@ import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
 import { Dateish } from 'app/models';
 import styles from './Countdown.module.css';
-import { sendContactMessage } from '~/redux/actions/ContactActions';
 
 type CountdownProps = {
   endDate?: Dateish | string;
@@ -18,12 +17,13 @@ const Countdown = ({
   className,
   timezone = 'Europe/Oslo',
 }: CountdownProps) => {
-  const [timeRemaining, setTimeRemaining] = useState('');
+  const [timeRemaining, setTimeRemaining] = useState<
+    { value: string; label: string }[]
+  >([]);
   const [countdownEnded, setCountdownEnded] = useState(false);
   const [isValidDate, setIsValidDate] = useState(false);
 
   useEffect(() => {
-    setTimeRemaining('');
     setCountdownEnded(false);
 
     if (!endDate) return;
@@ -32,7 +32,6 @@ const Countdown = ({
 
     if (!parsedEndDate.isValid()) {
       console.error('Invalid countdown end date:', endDate);
-      setTimeRemaining('Ugyldig dato');
       setIsValidDate(false);
       return;
     }
@@ -46,12 +45,8 @@ const Countdown = ({
 
         if (diff <= 0) {
           setCountdownEnded(true);
-          setTimeRemaining('');
           return;
         }
-
-        const formatUnit = (value: number, unit1: string, unitN: string) =>
-          value > 0 ? `${value} ${value === 1 ? unit1 : unitN}` : '';
 
         const duration = moment.duration(diff);
         const daysLeft = Math.floor(duration.asDays());
@@ -60,18 +55,21 @@ const Countdown = ({
         const secondsLeft = duration.seconds();
 
         const units = [
-          formatUnit(daysLeft, 'dag', 'dager'),
-          formatUnit(hoursLeft, 'time', 'timer'),
-          formatUnit(minutesLeft, 'minutt', 'minutter'),
+          {
+            value: String(daysLeft).padStart(2, '0'),
+            label: daysLeft === 1 ? 'dag' : 'dager',
+          },
+          {
+            value: String(hoursLeft).padStart(2, '0'),
+            label: hoursLeft === 1 ? 'time' : 'timer',
+          },
+          { value: String(minutesLeft).padStart(2, '0'), label: 'min' },
+          { value: String(secondsLeft).padStart(2, '0'), label: 'sek' },
         ];
 
-        const seconds = `${secondsLeft} ${secondsLeft === 1 ? 'sekund' : 'sekunder'}`;
-        units.push(seconds);
-
-        setTimeRemaining(units.join(', '));
+        setTimeRemaining(units);
       } catch (error) {
         console.error('Error updating countdown:', error);
-        setTimeRemaining('Feil med nedtelling');
       }
     };
 
@@ -85,7 +83,18 @@ const Countdown = ({
 
   return (
     <div className={cx(styles.countdown, className)}>
-      {countdownEnded ? endMessage : timeRemaining}
+      {countdownEnded ? (
+        endMessage
+      ) : (
+        <div className={styles.unitContainer}>
+          {timeRemaining.map((unit, index) => (
+            <div key={index} className={styles.unit}>
+              <div className={styles.value}>{unit.value}</div>
+              <div className={styles.label}>{unit.label}</div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/lego-webapp/components/Countdown/index.tsx
+++ b/lego-webapp/components/Countdown/index.tsx
@@ -3,6 +3,7 @@ import moment from 'moment-timezone';
 import { useEffect, useState } from 'react';
 import { Dateish } from 'app/models';
 import styles from './Countdown.module.css';
+import { sendContactMessage } from '~/redux/actions/ContactActions';
 
 type CountdownProps = {
   endDate?: Dateish | string;
@@ -62,8 +63,10 @@ const Countdown = ({
           formatUnit(daysLeft, 'dag', 'dager'),
           formatUnit(hoursLeft, 'time', 'timer'),
           formatUnit(minutesLeft, 'minutt', 'minutter'),
-          formatUnit(secondsLeft, 'sekund', 'sekunder'),
-        ].filter(Boolean);
+        ];
+
+        const seconds = `${secondsLeft} ${secondsLeft === 1 ? 'sekund' : 'sekunder'}`;
+        units.push(seconds);
 
         setTimeRemaining(units.join(', '));
       } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ catalogs:
       specifier: ^5.6.3
       version: 5.6.3
     vite:
-      specifier: ^6.2.3
+      specifier: ^6.2.5
       version: 6.2.5
     vitest:
       specifier: ^3.0.9


### PR DESCRIPTION
# Description
Design update to countdown: Now time unit is under the time. Beware the time is in monospace to keep the characters the same width so the time dont move when seconds tick (I dont know if this is good, but it looks better I think). All time units will still appear even if it hits 0. Like if there are no days or hours, it still shows 00 : 00 : xx : xx

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>

https://github.com/user-attachments/assets/680ee948-26c2-4875-81ee-73e3bbf5437c 

</td>
        <td>

https://github.com/user-attachments/assets/cf58d264-6ca3-40bf-926a-9b141525a69a

</td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1453
