### PR TITLE
Style update: lending mobile

### DIFF
--- a/lego-webapp/pages/lending/LendableObjectList.module.css
+++ b/lego-webapp/pages/lending/LendableObjectList.module.css
@@ -4,14 +4,10 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-auto-rows: 1fr;
-  gap: var(--spacing-xl);
-
-  @media (width <= 60em) {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  gap: var(--spacing-md);
 
   @media (--small-viewport) {
-    grid-template-columns: repeat(1, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 


### PR DESCRIPTION
# Description

Small style update for lending index page for small (mobile) viewports. Change to smaller gap between cards and two columns on smaller viewports instead to one. Felt it was a little awkward to scroll one by one card - would take a long time to find your lending object.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Change gap size (less) and 2 fr instead of 1 fr (mobile)
        </td>
        <td>

https://github.com/user-attachments/assets/15ac20ba-00c0-4b7d-a6c6-b17eac7cbf22

</td>
<td>
  

https://github.com/user-attachments/assets/754d202c-59fe-4580-98ce-829decaf5fa6


</td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.


Resolves ABA-1455
