### PR TITLE
STYLE: Cleaner lending index page

### DIFF
--- a/lego-webapp/pages/lending/+Page.tsx
+++ b/lego-webapp/pages/lending/+Page.tsx
@@ -147,11 +147,11 @@ const LendableObjectList = () => {
       title={title}
       actionButtons={
         <>
-          {objectsActionGrant.includes('create') && (
-            <LinkButton href="/lending/new">Nytt utlånsobjekt</LinkButton>
-          )}
           {canSeeLendingRequests && requestsActionGrant.includes('admin') && (
             <LinkButton href="/lending/admin">Administrator</LinkButton>
+          )}
+          {objectsActionGrant.includes('create') && (
+            <LinkButton href="/lending/new">Nytt utlånsobjekt</LinkButton>
           )}
         </>
       }
@@ -171,7 +171,6 @@ const LendableObjectList = () => {
       <Helmet title={title} />
       {canSeeLendingRequests && (
         <>
-          <h3>Dine utlånsforespørsler</h3>
           <LoadingIndicator loading={requestsPagination.fetching}>
             {lendingRequests.length ? (
               <div className={styles.lendingRequestsContainer}>
@@ -184,8 +183,9 @@ const LendableObjectList = () => {
               </div>
             ) : (
               <EmptyState
+                className={styles.lendingRequestEmpty}
                 iconNode={<FolderOpen />}
-                body={<span>Ingen utlånsforespørsler</span>}
+                body={<span>Du har ingen utlånsforespørsler</span>}
               />
             )}
             {requestsPagination.hasMore && (
@@ -202,7 +202,9 @@ const LendableObjectList = () => {
           <div className={styles.divider} />
         </>
       )}
-      <h3>Tilgjengelige utlånsobjekter</h3>
+      <div className={styles.lendingSubsection}>
+        <h3>Tilgjengelig Utstyr</h3>
+      </div>
       <LoadingIndicator loading={fetchingObjects}>
         {filteredLendableObjects.length ? (
           <div className={styles.lendableObjectsContainer}>

--- a/lego-webapp/pages/lending/+Page.tsx
+++ b/lego-webapp/pages/lending/+Page.tsx
@@ -151,7 +151,7 @@ const LendableObjectList = () => {
             <LinkButton href="/lending/admin">Administrator</LinkButton>
           )}
           {objectsActionGrant.includes('create') && (
-            <LinkButton href="/lending/new">Nytt utlånsobjekt</LinkButton>
+            <LinkButton href="/lending/new">Nytt Utstyr</LinkButton>
           )}
         </>
       }

--- a/lego-webapp/pages/lending/@lendableObjectId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/+Page.tsx
@@ -1,5 +1,5 @@
 import { Page, LinkButton, PageCover, Card } from '@webkom/lego-bricks';
-import { Warehouse } from 'lucide-react';
+import { Package } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import {
   ContentMain,
@@ -55,7 +55,7 @@ export const LendableObjectList = () => {
           </ContentMain>
           <ContentSidebar>
             <TextWithIcon
-              iconNode={<Warehouse />}
+              iconNode={<Package />}
               size={20}
               content={lendableObject.location}
             />

--- a/lego-webapp/pages/lending/LendableObjectList.module.css
+++ b/lego-webapp/pages/lending/LendableObjectList.module.css
@@ -8,6 +8,7 @@
 
   @media (--small-viewport) {
     grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-md);
   }
 }
 

--- a/lego-webapp/pages/lending/LendableObjectList.module.css
+++ b/lego-webapp/pages/lending/LendableObjectList.module.css
@@ -4,7 +4,7 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-auto-rows: 1fr;
-  gap: var(--spacing-md);
+  gap: var(--spacing-lg);
 
   @media (--small-viewport) {
     grid-template-columns: repeat(2, 1fr);
@@ -48,7 +48,7 @@ img.lendableObjectImage {
   p {
     display: flex;
     align-items: center;
-    font-size: var(--font-size-md);
+    font-size: var(--font-size-sm);
     line-height: var(--spacing-lg);
     margin: 0;
   }
@@ -58,6 +58,10 @@ img.lendableObjectImage {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+}
+
+.lendingRequestEmpty {
+  margin: var(--spacing-md) 0;
 }
 
 .lendingRequestCard {
@@ -109,4 +113,8 @@ img.lendingRequestImage {
 
 .statusTag .rotate {
   animation: spinner 5s linear infinite;
+}
+
+.lendingSubsection {
+  margin-bottom: var(--spacing-md);
 }


### PR DESCRIPTION
# Description

I think this makes the cleaner and not so cramped

1. Adding more spacing between cards (but not for mobile)
2. Reorder buttons
3. Bigger contrast between info and title the cards
4. Removed subsection "Dine forespørsler"
5. Subsections and buttons have more user friendly names

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
<td>

<img width="1164" alt="Screenshot 2025-05-07 at 22 34 33" src="https://github.com/user-attachments/assets/91e5ff4b-db3b-4d7e-973e-16932ee280c5" />

</td>


<td>

<img width="1151" alt="Screenshot 2025-05-07 at 22 34 26" src="https://github.com/user-attachments/assets/24b9909a-c4d7-4ba5-adbd-be32fb4f6652" />

</td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Resolves ABA-1459
