### PR TITLE
FIX: font difference mobile

### DIFF
--- a/lego-webapp/components/Countdown/Countdown.module.css
+++ b/lego-webapp/components/Countdown/Countdown.module.css
@@ -20,12 +20,17 @@
 }
 
 .value {
-  font-family: monospace;
   font-size: var(--font-size-xl);
 }
 
 .label {
-  font-family: monospace;
   font-size: var(--font-size-sm);
   color: var(--color-event-black);
+}
+
+.value,
+.label {
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 }


### PR DESCRIPTION
# Description

Countdown banner time font is different on mobile compared to laptops

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.


Resolves ABA-1460
