### PR TITLE
Add lending calendar

### DIFF
--- a/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.module.css
+++ b/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.module.css
@@ -1,0 +1,97 @@
+.calendar {
+    table-layout: fixed;
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.calendar th,
+.calendar td {
+    width: calc(100% / 7);
+    text-align: center;
+    font-size: var(--font-size-md);
+    transition: background var(--easing-blazingly-fast);
+}
+
+.calendarContainer {
+    margin-bottom: var(--spacing-md);
+}
+
+.today {
+    background-color: var(--color-gray-2);
+}
+
+.prevOrNextMonth {
+    opacity: 0.5;
+}
+
+.timeRangesContainer {
+    margin-top: var(--spacing-md);
+    padding: var(--spacing-sm);
+    border-radius: var(--border-radius);
+    background-color: var(--color-white);
+}
+
+.timeRangesList {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+.timeRangeItem {
+    padding: var(--spacing-xs) 0;
+    margin-bottom: var(--spacing-xs);
+    border-left: 3px solid var(--color-red-4);
+    padding-left: var(--spacing-sm);
+}
+
+.dayCell {
+    vertical-align: top;
+    padding: 0 !important;
+    border: 1px solid var(--color-gray-2);
+}
+
+.calendarDayWrapper {
+    height: 100%;
+    width: 100%;
+    padding: var(--spacing-sm);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.dayNumber {
+    font-weight: bold;
+    align-self: flex-start;
+    margin-bottom: var(--spacing-xs);
+}
+
+.inlineTimes {
+    font-size: var(--font-size-sm);
+    overflow-y: visible;
+    width: 100%;
+}
+
+.timeRange, .selectedTimeRange {
+    padding: 2px 4px;
+    margin-bottom: 2px;
+    white-space: normal;
+    word-break: break-word;
+    border-radius: 2px;
+}
+
+.timeRange {
+    background-color: var(--color-red-2);
+    border-left: 3px solid var(--color-red-4);
+}
+
+.selectedTimeRange {
+    background-color: var(--color-green-2);
+    border-left: 3px solid var(--color-green-4);
+}
+
+.calendarHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--spacing-sm);
+}

--- a/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.module.css
+++ b/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.module.css
@@ -1,97 +1,126 @@
 .calendar {
-    table-layout: fixed;
-    width: 100%;
-    border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
 }
 
 .calendar th,
 .calendar td {
-    width: calc(100% / 7);
-    text-align: center;
-    font-size: var(--font-size-md);
-    transition: background var(--easing-blazingly-fast);
+  width: calc(100% / 7);
+  text-align: center;
+  font-size: var(--font-size-md);
+  transition: background var(--easing-blazingly-fast);
 }
 
 .calendarContainer {
-    margin-bottom: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
 }
 
 .today {
-    background-color: var(--color-gray-2);
+  background-color: var(--color-gray-2);
 }
 
 .prevOrNextMonth {
-    opacity: 0.5;
+  opacity: 0.5;
 }
 
 .timeRangesContainer {
-    margin-top: var(--spacing-md);
-    padding: var(--spacing-sm);
-    border-radius: var(--border-radius);
-    background-color: var(--color-white);
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm);
+  border-radius: var(--border-radius-md);
+  background-color: var(--color-white);
 }
 
 .timeRangesList {
-    list-style-type: none;
-    padding: 0;
-    margin: 0;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
 }
 
 .timeRangeItem {
-    padding: var(--spacing-xs) 0;
-    margin-bottom: var(--spacing-xs);
-    border-left: 3px solid var(--color-red-4);
-    padding-left: var(--spacing-sm);
+  padding: var(--spacing-xs) 0;
+  margin-bottom: var(--spacing-xs);
+  border-left: 3px solid var(--color-red-4);
+  padding-left: var(--spacing-sm);
 }
 
 .dayCell {
-    vertical-align: top;
-    padding: 0 !important;
-    border: 1px solid var(--color-gray-2);
+  vertical-align: top;
+  padding: 0;
+  border: 1px solid var(--color-gray-2);
 }
 
 .calendarDayWrapper {
-    height: 100%;
-    width: 100%;
-    padding: var(--spacing-sm);
-    position: relative;
-    display: flex;
-    flex-direction: column;
+  height: 100%;
+  width: 100%;
+  padding: var(--spacing-sm);
+  position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .dayNumber {
-    font-weight: bold;
-    align-self: flex-start;
-    margin-bottom: var(--spacing-xs);
+  font-weight: bold;
+  align-self: flex-start;
+  margin-bottom: var(--spacing-xs);
 }
 
 .inlineTimes {
-    font-size: var(--font-size-sm);
-    overflow-y: visible;
-    width: 100%;
+  font-size: var(--font-size-sm);
+  overflow-y: visible;
+  width: 100%;
 }
 
-.timeRange, .selectedTimeRange {
-    padding: 2px 4px;
-    margin-bottom: 2px;
-    white-space: normal;
-    word-break: break-word;
-    border-radius: 2px;
+.timeRange,
+.selectedTimeRange {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin-bottom: var(--spacing-xs);
+  white-space: normal;
+  word-break: break-word;
+  border-radius: 2px;
+  min-height: 1.5rem;
 }
 
 .timeRange {
-    background-color: var(--color-red-2);
-    border-left: 3px solid var(--color-red-4);
+  background-color: var(--color-red-2);
+  border-left: 3px solid var(--color-red-4);
 }
 
 .selectedTimeRange {
-    background-color: var(--color-green-2);
-    border-left: 3px solid var(--color-green-4);
+  background-color: var(--color-green-2);
+  border-left: 3px solid var(--color-green-4);
 }
 
 .calendarHeader {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: var(--spacing-sm);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+}
+
+.calendarLegend {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) 0;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.legendColor {
+  width: 1rem;
+  height: 1rem;
+  border-radius: var(--border-radius-sm);
+}
+
+.selectedColor {
+  background-color: var(--color-green-2);
+  border: 2px solid var(--color-green-4);
+}
+
+.unavailableColor {
+  background-color: var(--color-red-2);
+  border: 2px solid var(--color-red-4);
 }

--- a/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.tsx
@@ -240,8 +240,8 @@ const LendingCalendar = ({
                             {selectedTimeRange && (
                               <div className={styles.selectedTimeRange}>
                                 {selectedTimeRange.fullDay
-                                  ? 'Valgt: Hele dagen'
-                                  : `Valgt: ${selectedTimeRange.start}-${selectedTimeRange.end}`}
+                                  ? ''
+                                  : `${selectedTimeRange.start}-${selectedTimeRange.end}`}
                               </div>
                             )}
 
@@ -252,9 +252,7 @@ const LendingCalendar = ({
                                 </div>
                               ))
                             ) : (
-                              <div className={styles.timeRange}>
-                                Utilgjengelig
-                              </div>
+                              <div className={styles.timeRange} />
                             )}
                           </div>
                         </div>
@@ -266,6 +264,26 @@ const LendingCalendar = ({
           )}
         </tbody>
       </table>
+      <Flex
+        justifyContent="center"
+        gap="var(--spacing-lg)"
+        className={styles.calendarLegend}
+      >
+        <Flex alignItems="center" gap="var(--spacing-xs)">
+          <div className={styles.legendItem}>
+            <div className={cx(styles.legendColor, styles.selectedColor)}></div>
+            <span>Valgt periode</span>
+          </div>
+        </Flex>
+        <Flex alignItems="center" gap="var(--spacing-xs)">
+          <div className={styles.legendItem}>
+            <div
+              className={cx(styles.legendColor, styles.unavailableColor)}
+            ></div>
+            <span>Utilgjengelig</span>
+          </div>
+        </Flex>
+      </Flex>
     </div>
   );
 };

--- a/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.tsx
@@ -1,0 +1,210 @@
+import { Button, Flex, Icon } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import moment, { Moment } from 'moment-timezone';
+import { useState } from 'react';
+import createMonthlyCalendar from '~/utils/createMonthlyCalendar';
+import styles from './LendingCalendar.module.css';
+import type { Dateish } from 'app/models';
+
+type LendingCalendarProps = {
+  unavailableRanges?: [Dateish, Dateish][];
+  selectedRange?: [Dateish, Dateish];
+};
+
+const LendingCalendar = ({
+  unavailableRanges = [],
+  selectedRange,
+}: LendingCalendarProps) => {
+  const [currentMonth, setCurrentMonth] = useState(moment());
+
+  const navigateMonth = (direction: 'prev' | 'next') => {
+    setCurrentMonth(
+      currentMonth.clone().add(direction === 'next' ? 1 : -1, 'month'),
+    );
+  };
+
+  const getUnavailableTimeRanges = (day: Moment) => {
+    const dayStart = day.clone().startOf('day');
+    const dayEnd = day.clone().endOf('day');
+    const timeRanges: { start: string; end: string; fullDay: boolean }[] = [];
+
+    for (const [start, end] of unavailableRanges) {
+      if (!start || !end) continue;
+
+      const startDate = moment(start);
+      const endDate = moment(end);
+
+      if (startDate.isSameOrBefore(dayEnd) && endDate.isSameOrAfter(dayStart)) {
+        const overlapStart = moment.max(startDate, dayStart);
+        const overlapEnd = moment.min(endDate, dayEnd);
+
+        timeRanges.push({
+          start: overlapStart.format('HH:mm'),
+          end: overlapEnd.format('HH:mm'),
+          fullDay: overlapStart.isSame(dayStart) && overlapEnd.isSame(dayEnd),
+        });
+      }
+    }
+
+    return timeRanges;
+  };
+
+  const getSelectedTimeRange = (day: Moment) => {
+    if (!selectedRange || !selectedRange[0] || !selectedRange[1]) return null;
+
+    const dayStart = day.clone().startOf('day');
+    const dayEnd = day.clone().endOf('day');
+
+    const startDate = moment(selectedRange[0]);
+    const endDate = moment(selectedRange[1]);
+
+    if (startDate.isSameOrBefore(dayEnd) && endDate.isSameOrAfter(dayStart)) {
+      const overlapStart = moment.max(startDate, dayStart);
+      const overlapEnd = moment.min(endDate, dayEnd);
+
+      return {
+        start: overlapStart.format('HH:mm'),
+        end: overlapEnd.format('HH:mm'),
+        fullDay: overlapStart.isSame(dayStart) && overlapEnd.isSame(dayEnd),
+      };
+    }
+
+    return null;
+  };
+
+  const isFullyUnavailable = (day: Moment) => {
+    const dayStart = day.clone().startOf('day');
+    const dayEnd = day.clone().endOf('day');
+
+    for (const [start, end] of unavailableRanges) {
+      if (!start || !end) continue;
+      const startDate = moment(start);
+      const endDate = moment(end);
+
+      if (startDate.isSameOrBefore(dayStart) && endDate.isSameOrAfter(dayEnd)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  const isInSelectedRange = (day: Moment) => {
+    if (!selectedRange || !selectedRange[0] || !selectedRange[1]) return false;
+    const [start, end] = selectedRange.map((d) => moment(d));
+    return day.isBetween(start, end, 'day', '[]');
+  };
+
+  const isSelectedEndpoint = (day: Moment) => {
+    if (!selectedRange || !selectedRange[0] || !selectedRange[1]) return false;
+    const [start, end] = selectedRange.map((d) => moment(d));
+    return day.isSame(start, 'day') || day.isSame(end, 'day');
+  };
+
+  return (
+    <div className={styles.calendarContainer}>
+      <div className={styles.calendarHeader}>
+        <h3>Tilgjengelighet</h3>
+        <Flex alignItems="center" gap="var(--spacing-sm)">
+          <Button
+            flat
+            onPress={() => navigateMonth('prev')}
+            aria-label="Forrige måned"
+          >
+            <Icon iconNode={<ArrowLeft />}></Icon>
+          </Button>
+          {currentMonth.format('MMMM YYYY')}
+          <Button
+            flat
+            onPress={() => navigateMonth('next')}
+            aria-label="Neste måned"
+          >
+            <Icon iconNode={<ArrowRight />}></Icon>
+          </Button>
+        </Flex>
+      </div>
+      <table className={styles.calendar}>
+        <thead>
+          <tr>
+            {['Ma', 'Ti', 'On', 'To', 'Fr', 'Lø', 'Sø'].map((d, i) => (
+              <th key={i}>{d}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from(
+            {
+              length: Math.ceil(createMonthlyCalendar(currentMonth).length / 7),
+            },
+            (_, i) => (
+              <tr key={i}>
+                {createMonthlyCalendar(currentMonth)
+                  .slice(i * 7, i * 7 + 7)
+                  .map((dateProps, j) => {
+                    const timeRanges = getUnavailableTimeRanges(dateProps.day);
+                    const selectedTimeRange = getSelectedTimeRange(
+                      dateProps.day,
+                    );
+                    const fully = isFullyUnavailable(dateProps.day);
+                    const hasRanges = timeRanges.length > 0;
+                    const inSelectedRange = isInSelectedRange(dateProps.day);
+                    const isEndpoint = isSelectedEndpoint(dateProps.day);
+
+                    return (
+                      <td
+                        key={j}
+                        className={cx(
+                          styles.dayCell,
+                          dateProps.day.isSame(moment(), 'day') && styles.today,
+                        )}
+                      >
+                        <div
+                          className={cx(
+                            styles.calendarDayWrapper,
+                            dateProps.prevOrNextMonth && styles.prevOrNextMonth,
+                            inSelectedRange && styles.inSelectedRange,
+                            isEndpoint && styles.selectedEndpoint,
+                          )}
+                        >
+                          <div className={styles.dayNumber}>
+                            {dateProps.day.date()}
+                          </div>
+
+                          <div className={styles.inlineTimes}>
+                            {selectedTimeRange && (
+                              <div className={styles.selectedTimeRange}>
+                                {selectedTimeRange.fullDay
+                                  ? 'Valgt: Hele dagen'
+                                  : `Valgt: ${selectedTimeRange.start}-${selectedTimeRange.end}`}
+                              </div>
+                            )}
+
+                            {hasRanges &&
+                              !fully &&
+                              timeRanges.map((range, idx) => (
+                                <div key={idx} className={styles.timeRange}>
+                                  {`${range.start}-${range.end}`}
+                                </div>
+                              ))}
+
+                            {fully && (
+                              <div className={styles.timeRange}>
+                                Utilgjengelig
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                    );
+                  })}
+              </tr>
+            ),
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default LendingCalendar;

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
@@ -51,6 +51,7 @@ import { useFeatureFlag } from '~/utils/useFeatureFlag';
 import { useParams } from '~/utils/useParams';
 import useQuery from '~/utils/useQuery';
 import styles from './LendingRequestDetail.module.css';
+import LendingCalendar from '~/pages/lending/@lendableObjectId/LendingCalendar';
 
 type Params = {
   lendingRequestId: string;
@@ -113,6 +114,14 @@ const LendingRequest = () => {
       {lendingRequest && (
         <ContentSection>
           <ContentMain>
+            <LendingCalendar
+              lendableObjectId={lendableObjectId}
+              selectedRange={
+                lendingRequest.startDate
+                  ? [lendingRequest.startDate, lendingRequest.endDate]
+                  : undefined
+              }
+            />
             <h3>Forespørrende bruker</h3>
             <RequestingUser user={createdByUser} />
             <h3>Periode</h3>

--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
@@ -28,6 +28,7 @@ import { ProfilePicture } from '~/components/Image';
 import { Tag } from '~/components/Tags';
 import Time from '~/components/Time';
 import HTTPError from '~/components/errors/HTTPError';
+import LendingCalendar from '~/pages/lending/@lendableObjectId/LendingCalendar';
 import LendingStatusTag, { statusMap } from '~/pages/lending/LendingStatusTag';
 import { useIsCurrentUser } from '~/pages/users/utils';
 import {
@@ -51,7 +52,6 @@ import { useFeatureFlag } from '~/utils/useFeatureFlag';
 import { useParams } from '~/utils/useParams';
 import useQuery from '~/utils/useQuery';
 import styles from './LendingRequestDetail.module.css';
-import LendingCalendar from '~/pages/lending/@lendableObjectId/LendingCalendar';
 
 type Params = {
   lendingRequestId: string;

--- a/lego-webapp/pages/lending/@lendableObjectId/request/new/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/new/+Page.tsx
@@ -1,4 +1,5 @@
-import { Page } from '@webkom/lego-bricks';
+import { Card, Flex, Page } from '@webkom/lego-bricks';
+import { useState } from 'react';
 import { Field } from 'react-final-form';
 import { Helmet } from 'react-helmet-async';
 import { navigate } from 'vike/client/router';
@@ -11,6 +12,7 @@ import {
   TextInput,
 } from '~/components/Form';
 import HTTPError from '~/components/errors/HTTPError';
+import LendingCalendar from '~/pages/lending/@lendableObjectId/LendingCalendar';
 import { createLendingRequest } from '~/redux/actions/LendingRequestActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import { CreateLendingRequest } from '~/redux/models/LendingRequest';
@@ -28,9 +30,13 @@ type FormValues = {
 
 type Props = {
   initialValues?: Partial<FormValues>;
+  onRangeChange?: (range: [Dateish, Dateish]) => void;
 };
 
-export const LendingRequestEditor = ({ initialValues }: Props) => {
+export const LendingRequestEditor = ({
+  initialValues,
+  onRangeChange,
+}: Props) => {
   const { lendableObjectId } = useParams<{ lendableObjectId: string }>();
 
   const dispatch = useAppDispatch();
@@ -62,7 +68,17 @@ export const LendingRequestEditor = ({ initialValues }: Props) => {
             placeholder="Legg til praktisk info..."
             component={TextInput.Field}
           />
-          <Field name="date" label="Dato" range component={DatePicker.Field} />
+          <Field
+            name="date"
+            label="Dato"
+            range
+            component={DatePicker.Field}
+            onChange={(value: [Dateish, Dateish]) => {
+              if (onRangeChange && value && value.length === 2) {
+                onRangeChange(value);
+              }
+            }}
+          />
 
           <SubmitButton>Send forespørsel</SubmitButton>
         </Form>
@@ -73,6 +89,7 @@ export const LendingRequestEditor = ({ initialValues }: Props) => {
 
 export default function LendingRequestCreate() {
   const { lendableObjectId } = useParams<{ lendableObjectId: string }>();
+  const [range, setRange] = useState<[Dateish, Dateish] | undefined>();
   const lendableObject = useAppSelector((state) =>
     selectLendableObjectById(state, lendableObjectId),
   );
@@ -81,7 +98,13 @@ export default function LendingRequestCreate() {
   return (
     <Page title={title} back={{ href: `/lending/` }}>
       <Helmet title={title} />
-      <LendingRequestEditor />
+      <LendingCalendar selectedRange={range} />
+      <Card>
+        <Flex column gap="var(--spacing-md)">
+          <h3>Ny forespørsel</h3>
+          <LendingRequestEditor onRangeChange={setRange} />
+        </Flex>
+      </Card>
     </Page>
   );
 }

--- a/lego-webapp/pages/lending/@lendableObjectId/request/new/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/new/+Page.tsx
@@ -98,7 +98,10 @@ export default function LendingRequestCreate() {
   return (
     <Page title={title} back={{ href: `/lending/` }}>
       <Helmet title={title} />
-      <LendingCalendar selectedRange={range} />
+      <LendingCalendar
+        selectedRange={range}
+        lendableObjectId={lendableObjectId}
+      />
       <Card>
         <Flex column gap="var(--spacing-md)">
           <h3>Ny forespørsel</h3>

--- a/lego-webapp/redux/actionTypes.ts
+++ b/lego-webapp/redux/actionTypes.ts
@@ -88,6 +88,7 @@ export const Joblistings = {
 
 export const LendableObjects = {
   FETCH: generateStatuses('LendableObject.FETCH_ALL'),
+  FETCH_AVAILABILITY: generateStatuses('LendableObject.FETCH_AVAILABILITY'),
   CREATE: generateStatuses('LendableObject.CREATE'),
   EDIT: generateStatuses('LendableObject.EDIT'),
   DELETE: generateStatuses('LendableObject.DELETE'),

--- a/lego-webapp/redux/actions/LendableObjectActions.ts
+++ b/lego-webapp/redux/actions/LendableObjectActions.ts
@@ -54,3 +54,22 @@ export const createLendableObject = (data: CreateLendableObject) =>
       errorMessage: 'Opprettelse av utlånsobjekt feilet',
     },
   });
+
+export const fetchLendableObjectAvailability = (
+  id: EntityId,
+  query: {
+    year?: number;
+    month?: number;
+  },
+) =>
+  callAPI<[string, string][]>({
+    types: LendableObjects.FETCH_AVAILABILITY,
+    endpoint: `/lending/objects/${id}/availability/`,
+    meta: {
+      errorMessage: 'Henting av utlånsobjekt feilet',
+      id,
+      query,
+    },
+    query,
+    propagateError: true,
+  });

--- a/lego-webapp/redux/models/LendableObject.ts
+++ b/lego-webapp/redux/models/LendableObject.ts
@@ -1,5 +1,5 @@
 import type { EntityId } from '@reduxjs/toolkit';
-import type { ActionGrant } from 'app/models';
+import type { ActionGrant, Dateish } from 'app/models';
 import type ObjectPermissionsMixin from '~/redux/models/ObjectPermissionsMixin';
 
 interface LendableObject {
@@ -10,11 +10,18 @@ interface LendableObject {
   location: string;
   canLend: boolean;
   actionGrant: ActionGrant;
+  availability?: [Dateish, Dateish][];
 }
 
 export type ListLendableObject = Pick<
   LendableObject,
-  'id' | 'title' | 'description' | 'image' | 'location' | 'canLend'
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'image'
+  | 'location'
+  | 'canLend'
+  | 'availability'
 > & { responsibleGroups: EntityId[] };
 
 export type DetailLendableObject = ListLendableObject &

--- a/lego-webapp/redux/slices/lendableObjects.ts
+++ b/lego-webapp/redux/slices/lendableObjects.ts
@@ -13,6 +13,17 @@ const lendableObjectsSlice = createSlice({
   extraReducers: legoAdapter.buildReducers({
     fetchActions: [LendableObjects.FETCH],
     deleteActions: [LendableObjects.DELETE],
+    extraCases: (addCase) => {
+      addCase(LendableObjects.FETCH_AVAILABILITY.SUCCESS, (state, action) => {
+        const id = action.meta.id;
+        legoAdapter.updateOne(state, {
+          id,
+          changes: {
+            availability: action.payload,
+          },
+        });
+      });
+    },
   }),
 });
 


### PR DESCRIPTION
# Description

Adds a calendar to show unavailable time slots given a lendable object, as well the time slots chosen for the current lending request. The calendar is added to both the new lending request and lending request detail pages. 

Next step will be to make the calendar function as the date and time picker for new lending requests.

[Backend PR](https://github.com/webkom/lego/pull/3836)

# Result

- [x] Changes look good on both light and dark theme.
- [ ] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

https://github.com/user-attachments/assets/9dd8f7ed-3d3a-45b8-bf9c-d5eca973b277

# Testing

- [x] I have thoroughly tested my changes.

Create and approve a lending request. Verify that the calendar displays unavailable and selected time slots correctly.

Resolves [ABA-1438](https://linear.app/abakus-webkom/issue/ABA-1438)
