### PR TITLE
Redirect url to account for slug change

### DIFF
--- a/lego-webapp/pages/+config.ts
+++ b/lego-webapp/pages/+config.ts
@@ -12,6 +12,9 @@ export default {
     '/admin/email': '/admin/email/lists',
     // Old emails used this url for some reason
     '/185f9aa436cf7f5da598.png': '/logo-dark.png',
+    '/pages/organisasjon/46-fondstyret/edit':
+      '/pages/organisasjon/46-fondet/edit', // backwards compat for renamed slug
+    '/pages/organisasjon/46-fondstyret': '/pages/organisasjon/46-fondet', // backwards compat for renamed slug
   },
 
   passToClient: ['storeInitialState'],


### PR DESCRIPTION
# Description

The current slug `/pages/organisasjon/46-fondstyret`, contains the old outdated spelling of Fondsstyret, and the page is not really about the board but rather the fund itself. We thus want to rename it to `/pages/organisasjon/46-fondet`. This change adds a redirect to ensure backwards compatability and no broken links.

# Result

No visual changes

# Testing

- [x] I have thoroughly tested my changes.

Tested locally with staging backend, seemed to work just fine.

---

Resolves ABA-1467
