### PR TITLE
feature: Add pinning on joblistings

### DIFF
--- a/lego-webapp/pages/joblistings/+Page.tsx
+++ b/lego-webapp/pages/joblistings/+Page.tsx
@@ -79,7 +79,9 @@ const sortJoblistings = (joblistings: ListJoblisting[], sortType: string) => {
     }
   })();
 
-  return joblistings.sort(sorter);
+  return joblistings
+    .slice()
+    .sort((a, b) => Number(b.isPinned) - Number(a.isPinned) || sorter(a, b));
 };
 
 const JoblistingsPage = () => {

--- a/lego-webapp/pages/joblistings/_components/JoblistingEditor.tsx
+++ b/lego-webapp/pages/joblistings/_components/JoblistingEditor.tsx
@@ -103,6 +103,7 @@ const JoblistingEditor = () => {
     const payload = {
       ...newJoblisting,
       id: joblistingId,
+      isPinned: newJoblisting.isPinned,
       fromYear: newJoblisting.fromYear?.value,
       toYear: newJoblisting.toYear?.value,
       visibleFrom: newJoblisting.visibleRange[0],
@@ -171,6 +172,7 @@ const JoblistingEditor = () => {
 
   const initialValues = {
     ...joblisting,
+    isPinned: joblisting?.isPinned ?? false,
     text: joblisting?.text || '<p></p>',
     description: joblisting?.description || '<p></p>',
     company: joblisting?.company
@@ -287,7 +289,14 @@ const JoblistingEditor = () => {
                 type="checkbox"
                 component={ToggleSwitch.Field}
               />
+              <Field
+                name="isPinned"
+                label="Fest til toppen"
+                type="checkbox"
+                component={ToggleSwitch.Field}
+              />
             </RowSection>
+
 
             <RowSection>
               <Field

--- a/lego-webapp/redux/models/Joblisting.ts
+++ b/lego-webapp/redux/models/Joblisting.ts
@@ -38,6 +38,7 @@ interface Joblisting {
   createdAt: Dateish;
   actionGrant?: ActionGrant;
   rollingRecruitment: boolean;
+  isPinned: boolean;
 }
 
 export type ListJoblisting = Pick<
@@ -53,6 +54,7 @@ export type ListJoblisting = Pick<
   | 'toYear'
   | 'createdAt'
   | 'rollingRecruitment'
+  | 'isPinned'
 >;
 
 export type DetailedJoblisting = Pick<
@@ -77,6 +79,7 @@ export type DetailedJoblisting = Pick<
   | 'createdAt'
   | 'actionGrant'
   | 'rollingRecruitment'
+  | 'isPinned'
 >;
 
 export type UnknownJoblisting = ListJoblisting | DetailedJoblisting;


### PR DESCRIPTION
# Description

Requested by Bedkom it is now possible to pin job-listings to the top of the page. This is done when creating or editing a job listing.

# Result

https://github.com/user-attachments/assets/9198a648-958c-4a64-a9c0-ea3f98cfe8a1


If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

# Testing

- [X] I have thoroughly tested my changes.

---

See also backend PR: 

Resolves ABA-1483
