### PR TITLE
Fix typo and update office hours in info section

### DIFF
--- a/lego-webapp/pages/pages/_components/LandingPage.tsx
+++ b/lego-webapp/pages/pages/_components/LandingPage.tsx
@@ -119,7 +119,7 @@ const LandingPage: PageRenderer<null> = () => {
         <div>
           <h3>Sosiale medier</h3>
           <p>
-            Har du lyst til å følge med på hva de forskjellige delene av abakus
+            Har du lyst til å følge med på hva de forskjellige delene av Abakus
             driver med? Følg oss på sosiale medier!
           </p>
           <Flex wrap gap="var(--spacing-md)">
@@ -227,7 +227,7 @@ const info = {
   officeAddress: 'Realfagsbygget A-blokka \nTredje etasje, rom A3.133',
   webkomOfficeAddress:
     'EL-bygget rom F-252 \nO.S. Bragstads plass 2F \nNTNU Gløshaugen',
-  officeHours: 'Hver tirsdag kl. 1315 - 1400 \npå Realfagsbygget',
+  officeHours: 'Hver onsdag kl. 1215 - 1300 \npå Realfagsbygget',
   organizationNo: '98 60 37 314 MVA',
 };
 const committeeEmails = [


### PR DESCRIPTION
# Description

Fixes a minor typo and updates the office hours in the Abakus info section.

# Result

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Changes
        </td>
        <td>
            
<img width="140" height="30" alt="Screenshot 2025-09-02 at 23 05 24" src="https://github.com/user-attachments/assets/400f37e4-c536-46d8-847d-2476f29a7a20" />
<img width="169" height="26" alt="Screenshot 2025-09-02 at 23 05 33" src="https://github.com/user-attachments/assets/d5ab1dd5-cf59-479b-a418-36dc5997d56f" />
        </td>
        <td>
            
<img width="148" height="45" alt="Screenshot 2025-09-02 at 23 06 08" src="https://github.com/user-attachments/assets/151aa4fe-b557-4c8b-a839-fdb23b74a96f" />
<img width="183" height="38" alt="Screenshot 2025-09-02 at 23 06 17" src="https://github.com/user-attachments/assets/e3d17bf3-afd4-4260-8353-e543246ffbf5" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.


---

Resolves ABA-1492
