### PR TITLE
Remove anonymous option for contact forms

### DIFF
--- a/lego-webapp/pages/contact/+Page.tsx
+++ b/lego-webapp/pages/contact/+Page.tsx
@@ -27,7 +27,8 @@ const Contact = () => {
               varslingsportal
             </a>
             . Da sikrer du at saken din blir behandlet best mulig, og du har
-            mulighet til å følge opp saken samtidig som du forblir <strong>anonym</strong>.
+            mulighet til å følge opp saken samtidig som du forblir{' '}
+            <strong>anonym</strong>.
             <br />
             Les mer i våre{' '}
             <a href="/pages/organisasjon/117-abakus-etiske-retningslinjer">
@@ -37,16 +38,16 @@ const Contact = () => {
           </span>
         </Card>
 
-      {loggedIn ? (
-        <ContactForm />
-      ) : (
-        <span>
-          <h3>Du er ikke innlogget</h3>
-          Du må være innlogget for å benytte dette skjemaet. Dersom du ikke har
-          abakus bruker se andre kontaktmuligheter under{' '}
-          <a href="/pages/info-om-abakus#contact">Om Abakus - Kontakt Oss</a>.
-        </span>
-      )}
+        {loggedIn ? (
+          <ContactForm />
+        ) : (
+          <span>
+            <h3>Du er ikke innlogget</h3>
+            Du må være innlogget for å benytte dette skjemaet. Dersom du ikke
+            har abakus bruker se andre kontaktmuligheter under{' '}
+            <a href="/pages/info-om-abakus#contact">Om Abakus - Kontakt Oss</a>.
+          </span>
+        )}
       </Flex>
     </Page>
   );

--- a/lego-webapp/pages/contact/ContactForm.tsx
+++ b/lego-webapp/pages/contact/ContactForm.tsx
@@ -29,7 +29,6 @@ const validate = createValidator({
 const REVUE_BOARD_GROUP_ID = 59;
 
 const ContactForm = () => {
-
   const committees = useAppSelector((state) =>
     selectGroupsByType(state, GroupType.Committee),
   );
@@ -78,11 +77,7 @@ const ContactForm = () => {
   }));
 
   return (
-    <LegoFinalForm
-      onSubmit={onSubmit}
-      validate={validate}
-      validateOnSubmitOnly
-    >
+    <LegoFinalForm onSubmit={onSubmit} validate={validate} validateOnSubmitOnly>
       {({ handleSubmit }) => (
         <Form onSubmit={handleSubmit}>
           <p>


### PR DESCRIPTION
# Description

Removes the option for sending anonymous contact forms.

This could be an issue if this is being linked outside of abakus.no intended for externals to use to contact abakus as it is now not possible to submit the contact form without being logged in. The path `abakus.no/contact` seems like a typical entry point for externals to contact abakus on if they dont know of other ways. 

If this contact form is only intented for abakus users anyways it should be okay. 

# Testing

- [X] I have thoroughly tested my changes.

---

See related backend pr: webkom/lego#3842

Resolves ABA-1496
