### PR TITLE
fix: Refactor Reactions to use react-aria

### DIFF
--- a/lego-webapp/components/Reactions/index.tsx
+++ b/lego-webapp/components/Reactions/index.tsx
@@ -1,14 +1,15 @@
-import { Flex, Icon } from '@webkom/lego-bricks';
+import { Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { SmilePlus } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
+import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components';
 import { fetchEmojis } from '~/redux/actions/EmojiActions';
-import { useAppDispatch } from '~/redux/hooks';
+import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import { useIsLoggedIn } from '~/redux/slices/auth';
 import reactionStyles from './Reaction.module.css';
 import ReactionPicker from './ReactionPicker';
 import styles from './index.module.css';
-import type { ReactNode, SyntheticEvent } from 'react';
+import type { ReactNode } from 'react';
 import type { EmojiWithReactionData } from '~/components/LegoReactions';
 import type { ContentTarget } from '~/utils/contentTarget';
 
@@ -25,83 +26,67 @@ type Props = {
  */
 const Reactions = ({ children, className, emojis, contentTarget }: Props) => {
   const [reactionPickerOpen, setReactionPickerOpen] = useState(false);
-  const [addEmojiHovered, setAddEmojiHovered] = useState(false);
-  const [fetchedEmojis, setFetchedEmojis] = useState(false);
-  const nodeRef = useRef<HTMLDivElement>(null);
 
   const loggedIn = useIsLoggedIn();
-
   const dispatch = useAppDispatch();
+  const hasFetchedAll = useAppSelector((state) => state.emojis.hasFetchedAll);
 
-  const toggleReactionPicker = useCallback(
-    (e: MouseEvent | SyntheticEvent) => {
-      if (!reactionPickerOpen && !fetchedEmojis) {
-        dispatch(fetchEmojis());
-      }
-
-      setReactionPickerOpen(!reactionPickerOpen);
-      setFetchedEmojis(true);
-      e.stopPropagation();
-    },
-    [dispatch, fetchedEmojis, reactionPickerOpen],
-  );
-
-  useEffect(() => {
-    const handleOutsideClick = (e: MouseEvent) => {
-      if (
-        nodeRef.current &&
-        e.target instanceof Node &&
-        nodeRef.current.contains(e.target)
-      ) {
-        return;
-      }
-      toggleReactionPicker(e);
-    };
-
-    if (reactionPickerOpen) {
-      document.addEventListener('click', handleOutsideClick, false);
-      return () =>
-        document.removeEventListener('click', handleOutsideClick, false);
-    }
-  }, [reactionPickerOpen, toggleReactionPicker]);
+  // Only fetch emojis if they haven't been fetched yet.
+  // This prioritizes performance and user experience
+  // at the cost of potentially stale data (until redux is refreshed).
+  const initialFetchEmojis = useCallback(() => {
+    if (!hasFetchedAll) dispatch(fetchEmojis());
+  }, [dispatch, hasFetchedAll]);
 
   return (
-    <div className={styles.reactionsContainer} ref={nodeRef}>
+    <div className={styles.reactionsContainer}>
       <div className={className ? className : styles.reactions}>
+        {/* Reactions */}
         {children}
+
+        {/* New reaction */}
         {loggedIn && (
-          <Flex
-            alignItems="center"
-            justifyContent="center"
-            className={cx(
-              reactionStyles.reaction,
-              styles.addReactionEmojiContainer,
-            )}
-            onClick={toggleReactionPicker}
-            onMouseEnter={() => setAddEmojiHovered(true)}
-            onMouseLeave={() => setAddEmojiHovered(false)}
+          <DialogTrigger
+            onOpenChange={(isOpen) => {
+              setReactionPickerOpen(isOpen);
+              initialFetchEmojis();
+            }}
           >
-            <Icon
-              size={18}
-              iconNode={
-                <SmilePlus
-                  color={
-                    addEmojiHovered || reactionPickerOpen
-                      ? 'var(--color-orange-6)'
-                      : 'var(--placeholder-color)'
+            <Button
+              className={cx(
+                reactionStyles.reaction,
+                styles.addReactionEmojiContainer,
+              )}
+            >
+              {({ isHovered }) => (
+                <Icon
+                  size={18}
+                  iconNode={
+                    <SmilePlus
+                      color={
+                        isHovered || reactionPickerOpen
+                          ? 'var(--color-orange-6)'
+                          : 'var(--placeholder-color)'
+                      }
+                    />
                   }
                 />
-              }
-            />
-          </Flex>
+              )}
+            </Button>
+
+            <Popover placement="top">
+              <Dialog>
+                <div className={styles.reactionPickerContent}>
+                  <ReactionPicker
+                    emojis={emojis}
+                    contentTarget={contentTarget}
+                  />
+                </div>
+              </Dialog>
+            </Popover>
+          </DialogTrigger>
         )}
       </div>
-
-      {reactionPickerOpen && (
-        <div className={styles.reactionPickerContainer}>
-          <ReactionPicker emojis={emojis} contentTarget={contentTarget} />
-        </div>
-      )}
     </div>
   );
 };

--- a/lego-webapp/redux/slices/emojis.ts
+++ b/lego-webapp/redux/slices/emojis.ts
@@ -10,10 +10,17 @@ const legoAdapter = createLegoAdapter(EntityType.Emojis, {
 
 const emojisSlice = createSlice({
   name: EntityType.Emojis,
-  initialState: legoAdapter.getInitialState(),
+  initialState: legoAdapter.getInitialState({
+    hasFetchedAll: false,
+  }),
   reducers: {},
   extraReducers: legoAdapter.buildReducers({
     fetchActions: [Emoji.FETCH, Emoji.FETCH_ALL],
+    extraCases: (addCase) => {
+      addCase(Emoji.FETCH_ALL.SUCCESS, (state) => {
+        state.hasFetchedAll = true;
+      });
+    },
   }),
 });
 


### PR DESCRIPTION
# Description

Refactored the `Reactions` component to use components from `react-aria-components` instead of the custom logic we had. This results in a more robust and proper solution for handling popovers.

Also added a state in redux indicating wheter emojis have previously been fetched. If they have it will not try to fetch them again. This prevents multiple instances of the reaction picker from fetching emojis again and displaying the loading indicator. This way the picker rarely loads. However the cost of this is that the emojis state might become stale at least until redux is refreshed.

# Result

- It prioritizes opening above the trigger component, but if there is not room it will open where there is
- It will never be cropped due to overflow as the popover now works like a `Dialog` existing entirely outside of the root
- It is not possible to have multiple pickers open 
- It is not possible to interact with other elements while the picker is open
- Uses built in functionality for detecting hover

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

**Before**

https://github.com/user-attachments/assets/d0fe01d3-754e-42ac-a5a7-c717bc045216

**After**

https://github.com/user-attachments/assets/03fe6217-c9a7-40b7-b334-7316f61a0f47


# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-1514
