### PR TITLE
FIX: Scroll to top when viewing photo

### DIFF
--- a/lego-webapp/pages/photos/@galleryId/index/+Layout.tsx
+++ b/lego-webapp/pages/photos/@galleryId/index/+Layout.tsx
@@ -8,8 +8,9 @@ import {
 } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import { ImageDown, ImagePlus, Images, Pencil } from 'lucide-react';
-import { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren, useState, useRef, useEffect } from 'react';
 import { navigate } from 'vike/client/router';
+import { usePageContext } from 'vike-react/usePageContext';
 import EmptyState from '~/components/EmptyState';
 import Gallery from '~/components/Gallery';
 import PropertyHelmet, {
@@ -77,6 +78,9 @@ const GalleryDetail = ({ children }: PropsWithChildren) => {
   const upload = query.upload === 'true';
   const [downloading, setDownloading] = useState(false);
 
+  const scrollRef = useRef(0);
+  const pageContext = usePageContext();
+
   const { galleryId } = useParams<{ galleryId: string }>();
   const gallery = useAppSelector((state) =>
     selectGalleryById<DetailedGallery>(state, galleryId),
@@ -99,6 +103,14 @@ const GalleryDetail = ({ children }: PropsWithChildren) => {
   const loggedIn = useIsLoggedIn();
 
   const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (pageContext.urlPathname === `/photos/${gallery.id}`) {
+      setTimeout(() => {
+        window.scrollTo(0, scrollRef.current);
+      }, 0);
+    }
+  }, [pageContext.urlPathname, gallery.id]);
 
   usePreparedEffect(
     'fetchGalleryDetail',
@@ -125,6 +137,7 @@ const GalleryDetail = ({ children }: PropsWithChildren) => {
   };
 
   const handleClick = (picture: GalleryListPicture) => {
+    scrollRef.current = window.scrollY;
     navigate(`/photos/${gallery.id}/picture/${picture.id}`);
   };
 


### PR DESCRIPTION
# Description

When you view a photo in gallery, you get jumped to the top of the page. This is because viewing a photo routes to a new "page", rather then it being an overlay model (making this a modal is the best solution).

*Current fix is not great*😝

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            Jumps to top of the page
        </td>
        <td>

https://github.com/user-attachments/assets/d2c3b334-b246-48ba-95ec-ebab466a9412

        </td>
        <td>

https://github.com/user-attachments/assets/f0d71236-2c39-4d31-9a62-766f01be5f8f

        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1511
