### PR TITLE
feature: update interest form for spring semester

### DIFF
--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -55,6 +55,7 @@ import {
   COLLABORATION_TYPES,
   COMPANY_TYPES,
   TOOLTIP,
+  COLLABORATION_DESCRIPTIONS,
 } from './Translations';
 import {
   interestText,
@@ -67,6 +68,7 @@ import {
   PARTICIPANT_RANGE_MAP,
   sortSemesterChronologically,
   PARTICIPANT_RANGE_TYPES,
+  collaborationDescriptionToString,
 } from './utils';
 import type { ReactNode } from 'react';
 import type { DetailedCompanyInterest } from '~/redux/models/CompanyInterest';
@@ -202,6 +204,11 @@ const CollaborationBox = ({
         label={COLLABORATION_TYPES[collaborationToString(key)][language]}
         type="checkbox"
         component={CheckBox.Field}
+        description={
+          COLLABORATION_DESCRIPTIONS[collaborationDescriptionToString(key)][
+            language
+          ]
+        }
       />
     ))}
   </Flex>
@@ -478,13 +485,13 @@ const CompanyInterestForm = ({ language }: Props) => {
       commentName: 'breakfastTalkComment',
       commentPlaceholder: interestText.breakfastTalkComment[language],
     },
-    {
-      name: 'bedex',
-      translated: EVENTS.bedex[language],
-      description: interestText.bedexDescription[language],
-      commentName: 'bedexComment',
-      commentPlaceholder: interestText.bedexComment[language],
-    },
+    // {
+    //   name: 'bedex',
+    //   translated: EVENTS.bedex[language],
+    //   description: interestText.bedexDescription[language],
+    //   commentName: 'bedexComment',
+    //   commentPlaceholder: interestText.bedexComment[language],
+    // },
     {
       name: 'other',
       translated: EVENTS.other[language],
@@ -505,6 +512,11 @@ const CompanyInterestForm = ({ language }: Props) => {
       description: interestText.companyToCompanyDescription[language],
       commentName: 'companyToCompanyComment',
       commentPlaceholder: interestText.companyToCompanyComment[language],
+    },
+    {
+      name: 'collaboration_revue',
+      translated: COLLABORATION_TYPES.collaboration_revue[language],
+      description: interestText.revueCollaboration[language],
     },
   ];
 

--- a/lego-webapp/pages/bdb/company-interest/Translations.ts
+++ b/lego-webapp/pages/bdb/company-interest/Translations.ts
@@ -21,10 +21,10 @@ export const EVENTS = {
   //   norwegian: 'Digital presentasjon',
   //   english: 'Digital presentation',
   // },
-  bedex: {
-    norwegian: 'Bedriftsekskursjon (BedEx)',
-    english: 'Company excursion (BedEx)',
-  },
+  // bedex: {
+  //   norwegian: 'Bedriftsekskursjon (BedEx)',
+  //   english: 'Company excursion (BedEx)',
+  // },
   other: {
     norwegian: 'Alternativt arrangement',
     english: 'Other event',
@@ -83,9 +83,9 @@ export const TOOLTIP = {
   },
   company_to_company: {
     norwegian:
-      'Bedrift-til-bedrift er et arrangement som arrangeres i samarbeid med to andre bedrifter. 3 grupper med studenter rullerer på å besøke bedriftene deres i ca. 40 minutter og ser hvordan dere har det i deres lokaler. Her kan dere presentere caser fra deres bedrift, ha escape room, konkurranser eller finne på noe annet gøy. Etter at alle gruppene har besøkt alle bedriftene, drar alle ut på felles mingling.',
+      'Bli med på et unikt arrangement hvor studentene roterer mellom bedriftenes Trondheimskontorer. Hver bedrift får ca. 40 minutter med hver gruppe av studenter. Opplegget kan inkludere en introduksjon til bedriften og spennende konkurranser. Til slutt samles alle for mingling, hvor dere kan knytte nye kontakter og dele erfaringer.',
     english:
-      'Company-to-company is an event organized in collaboration with two other companies. 3 groups of students rotate to visit their companies for approximately 40 minutes and have a look around your workspace. Here you can present cases from your company, have escape rooms, competitions or come up with something else fun. After all the groups have visited all the businesses, everyone goes out for joint mingling.',
+      'Join a unique event where students rotate between the offices of the companies in Trondheim. Each company gets approx. 40 minutes with each group of students. The program can include an introduction to the company and exciting competitions. Finally, everyone gathers for more socializing, where you can make new contacts and share experiences.',
   },
 };
 
@@ -170,10 +170,10 @@ export const COLLABORATION_TYPES = {
     norwegian: 'Samarbeid med TIHLDE linjeforening',
     english: 'Event in collaboration with TIHLDE',
   },
-  // collaboration_revue: {
-  //   norwegian: 'Samarbeid med Revyen',
-  //   english: 'Collaboration with the revue',
-  // },
+  collaboration_revue: {
+    norwegian: 'Samarbeid med Revyen',
+    english: 'Collaboration with the revue',
+  },
   // collaboration_anniversary: {
   //   english: "Collaboration with Abakus' anniversary committee*",
   //   norwegian: 'Samarbeid med Abakus sitt Jubileum*',
@@ -182,6 +182,27 @@ export const COLLABORATION_TYPES = {
   //   english: "Collaboration with the revue's anniversary committee*",
   //   norwegian: 'Samarbeid med Revyen sitt Jubileum*',
   // },
+};
+
+export const COLLABORATION_DESCRIPTIONS = {
+  collaboration_omega: {
+    norwegian: 'Samarbeid med Omega linjeforening',
+    english: 'Event in collaboration with Omega',
+  },
+  collaboration_online: {
+    norwegian: 'Samarbeid med Online linjeforening',
+    english: 'Event in collaboration with Online',
+  },
+  collaboration_tihlde: {
+    norwegian: 'Samarbeid med TIHLDE linjeforening',
+    english: 'Event in collaboration with TIHLDE',
+  },
+  collaboration_revue: {
+    norwegian:
+      'Hver vår er det premiere på Abakus sin egne revy. Ta med studentene på en hyggelig kveld hvor dere presenterer selskapet deres, før dere sammen drar og ser på årets revy!',
+    english:
+      'Every spring, Abakus puts on its own revue. Invite the students to a pleasant evening where you present your company, before heading together to watch this year’s revue!',
+  },
 };
 
 export const TARGET_GRADES = {

--- a/lego-webapp/pages/bdb/company-interest/utils.tsx
+++ b/lego-webapp/pages/bdb/company-interest/utils.tsx
@@ -7,6 +7,7 @@ import {
   SURVEY_OFFERS,
   OTHER_OFFERS,
   TARGET_GRADES,
+  COLLABORATION_DESCRIPTIONS,
 } from './Translations';
 import type CompanySemester from '~/redux/models/CompanySemester';
 
@@ -24,10 +25,13 @@ export const sortSemesterChronologically = (
 };
 
 export const PARTICIPANT_RANGE_TYPES = {
-  first: '10-30',
-  second: '30-60',
-  third: '60-100',
-  fourth: '100+',
+  first: '0-10',
+  second: '10-20',
+  third: '20-30',
+  fourth: '30-40',
+  fifth: '40-50',
+  sixth: '50-60',
+  seventh: '60+',
 };
 
 export const PARTICIPANT_RANGE_MAP = {
@@ -82,6 +86,11 @@ export const collaborationToString = (collab) =>
 export const targetGradeToString = (targetGrade) =>
   Object.keys(TARGET_GRADES)[
     Number(targetGrade.charAt(targetGrade.length - 2))
+  ];
+
+export const collaborationDescriptionToString = (collab) =>
+  Object.keys(COLLABORATION_DESCRIPTIONS)[
+    Number(collab.charAt(collab.length - 2))
   ];
 
 export const getCsvUrl = (


### PR DESCRIPTION
# Description

As requested by Bedkom the interest form has been changed accordingly:

- endre intervallene med antall deltakere til 0-10,10-20,20-30,30-40,40-50,50-60,60+
- endre semesteret til V26
- fjerne bedriftsekskusjon
- legge til revy bedpres og B2B
       - BtB
                  - Bli med på et unikt arrangement hvor studentene roterer mellom bedriftenes Trondheimskontorer. Hver bedrift                     får ca. 40 minutter med hver gruppe av studenter. Opplegget kan inkludere en introduksjon til bedriften og spennende konkurranser. Til slutt samles alle for mingling, hvor dere kan knytte nye kontakter og dele erfaringer.
        - revy-bedriftspresentasjon
                -Hver vår er det premiere på Abakus sin egne revy. Ta med studentene på en hyggelig kveld hvor dere presenterer selskapet deres, før dere sammen drar og ser på årets revy!

# Result
![Skjermbilde 2025-09-22 kl  11 17 26](https://github.com/user-attachments/assets/e1bbf466-a3e3-4bb8-88e3-32c9a39542cc)

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.

> [!CAUTION]
> Make sure your images do not contain any real user information.

---

Resolves ABA-1537