### PR TITLE
fix: aspectRatio for ImageUploadField

### DIFF
--- a/lego-webapp/components/Form/ImageUploadField.tsx
+++ b/lego-webapp/components/Form/ImageUploadField.tsx
@@ -37,7 +37,7 @@ const ImageUploadField = ({
       className={cx(styles.base, styles.coverImage, className && className)}
       style={{ aspectRatio, ...style }}
     >
-      <ImageUpload onSubmit={onSubmit} {...props} />
+      <ImageUpload aspectRatio={aspectRatio} onSubmit={onSubmit} {...props} />
     </div>
   );
 };

--- a/lego-webapp/pages/lending/LendableObjectEditor.module.css
+++ b/lego-webapp/pages/lending/LendableObjectEditor.module.css
@@ -1,0 +1,8 @@
+.thumbnail {
+  width: 250px;
+  flex-shrink: 0;
+}
+
+.detailsContainer {
+  flex: 1;
+}

--- a/lego-webapp/pages/lending/LendableObjectEditor.tsx
+++ b/lego-webapp/pages/lending/LendableObjectEditor.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/redux/actions/LendableObjectActions';
 import { useAppDispatch } from '~/redux/hooks';
 import { createValidator, required } from '~/utils/validation';
+import style from './LendableObjectEditor.module.css';
 import type { EntityId } from '@reduxjs/toolkit';
 import type {
   CreateLendableObject,
@@ -72,7 +73,7 @@ export const LendableObjectEditor = ({ initialValues }: Props) => {
       {({ handleSubmit }) => (
         <Form onSubmit={handleSubmit}>
           <Flex gap="var(--spacing-lg)">
-            <div style={{ width: '250px' }}>
+            <div className={style.thumbnail}>
               <Field
                 name="image"
                 component={ImageUploadField}
@@ -80,7 +81,11 @@ export const LendableObjectEditor = ({ initialValues }: Props) => {
                 img={initialValues?.image}
               />
             </div>
-            <Flex column style={{ flexGrow: '1' }} gap="var(--spacing-md)">
+            <Flex
+              column
+              className={style.detailsContainer}
+              gap="var(--spacing-md)"
+            >
               <Flex gap="var(--spacing-md)">
                 <Field
                   label="Navn"


### PR DESCRIPTION
# Description

A bug (that I made heh) made it so that the cropper when uploading an image wasn't forced to have the correct aspectRatio.

before:

<img width="568" height="836" alt="image" src="https://github.com/user-attachments/assets/51b858a4-4a2b-46c5-828e-a0800ada95c6" />


after:

<img width="569" height="821" alt="image" src="https://github.com/user-attachments/assets/aa39902f-e863-47de-a73a-0ace09fc1986" />

notice that in the after, the cropper is always square

