### PR TITLE
fix: change date format

### DIFF
--- a/lego-webapp/redux/slices/search.ts
+++ b/lego-webapp/redux/slices/search.ts
@@ -98,7 +98,7 @@ export const searchMapping: SearchMapping = {
   },
   'events.event': {
     label: (event) =>
-      `${event.title} (${moment(event.startTime).format('YYYY-MM-DD')})`,
+      `${event.title} (${moment(event.startTime).format('DD.MM.YYYY')})`,
     title: 'title',
     type: 'Arrangement',
     date: 'startTime',
@@ -172,7 +172,7 @@ export const searchMapping: SearchMapping = {
   },
   'meetings.meeting': {
     label: (meeting) =>
-      `${meeting.title} (${moment(meeting.startTime).format('YYYY-MM-DD')})`,
+      `${meeting.title} (${moment(meeting.startTime).format('DD.MM.YYYY')})`,
     title: 'title',
     type: 'Møte',
     date: 'startTime',


### PR DESCRIPTION
# Description

Fixed the date format when picking events or meetings to show: DD.MM.YYYY instead of YYYY-MM-DD.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
<td>
Change format
</td>
        <td>
<img width="902" height="740" alt="Skjermbilde fra 2025-10-11 01-08-44" src="https://github.com/user-attachments/assets/61e0063a-5921-4fa0-a13a-c62ce9a7c6b8" />
        </td>
        <td>
<img width="502" height="251" alt="t" src="https://github.com/user-attachments/assets/2c3b3f60-eda6-4704-b022-071d84faf75f" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1535