### PR TITLE
fix: Prevent menu from appearing over modal

### DIFF
--- a/packages/lego-bricks/src/components/Modal/Modal.module.css
+++ b/packages/lego-bricks/src/components/Modal/Modal.module.css
@@ -19,7 +19,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 90;
+  z-index: 302;
 
   &[data-entering] {
     animation: overlay-fade var(--easing-medium);


### PR DESCRIPTION
# Description

There was a small issue where the hamburger-menu would appear above the overlay, for example while viewing pictures in the album

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>before</td>
        <td>after</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            <img width="387" height="315" alt="Screenshot from 2025-10-19 18-24-46" src="https://github.com/user-attachments/assets/9100d946-8948-45ec-aa23-08524cc75843" />
        </td>
        <td>
            <img width="387" height="315" alt="Screenshot from 2025-10-19 18-25-05" src="https://github.com/user-attachments/assets/48b65cad-d30c-4ccc-8241-f6549f261e71" />
       </td>
    </tr>
</table>

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
