### PR TITLE
Fix spacing on mobile view in profile settings

### DIFF
--- a/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
+++ b/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
@@ -118,7 +118,7 @@ const UserSettings = () => {
         subscription={{}}
       >
         {({ handleSubmit }) => (
-          <Form onSubmit={handleSubmit}>
+          <Form onSubmit={handleSubmit} className={styles.settings}>
             <Flex gap="var(--spacing-xl)" className={styles.mobileColumn}>
               <Flex
                 column
@@ -129,8 +129,12 @@ const UserSettings = () => {
                 <UserImage user={user} />
                 <RemovePicture username={user.username} />
               </Flex>
-
-              <Flex column gap="var(--spacing-md)" className={styles.right}>
+              <Flex
+                column
+                gap="var(--spacing-md)"
+                className={styles.right}
+                basis={false}
+              >
                 <Field
                   placeholder="Brukernavn"
                   label="Brukernavn"
@@ -192,23 +196,32 @@ const UserSettings = () => {
               </Flex>
             </Flex>
 
-            <RowSection>
-              <Field
-                label="GitHub-brukernavn"
-                name="githubUsername"
-                prefixIconNode={<Icon iconNode={<Github />} />}
-                component={TextInput.Field}
-                parse={(value) => value}
-              />
+            <Flex
+              column
+              justifyContent="center"
+              alignItems="center"
+              gap="var(--spacing-sm)"
+              width={'100%'}
+              basis={false}
+            >
+              <RowSection className={styles.socialLinks}>
+                <Field
+                  label="GitHub-brukernavn"
+                  name="githubUsername"
+                  prefixIconNode={<Icon iconNode={<Github />} />}
+                  component={TextInput.Field}
+                  parse={(value) => value}
+                />
 
-              <Field
-                label="LinkedIn-ID"
-                name="linkedinId"
-                prefixIconNode={<Icon iconNode={<Linkedin />} />}
-                component={TextInput.Field}
-                parse={(value) => value}
-              />
-            </RowSection>
+                <Field
+                  label="LinkedIn-ID"
+                  name="linkedinId"
+                  prefixIconNode={<Icon iconNode={<Linkedin />} />}
+                  component={TextInput.Field}
+                  parse={(value) => value}
+                />
+              </RowSection>
+            </Flex>
 
             <MultiSelectGroup legend="Fargetema" name="selectedTheme">
               <Field

--- a/lego-webapp/pages/users/@username/settings/profile/UserSettings.module.css
+++ b/lego-webapp/pages/users/@username/settings/profile/UserSettings.module.css
@@ -13,3 +13,8 @@
     flex-direction: column;
   }
 }
+
+.socialLinks {
+  flex: 1;
+  width: 100%;
+}

--- a/packages/lego-bricks/src/components/Layout/Flex.module.css
+++ b/packages/lego-bricks/src/components/Layout/Flex.module.css
@@ -79,3 +79,7 @@
 .alignItems__stretch {
   align-items: stretch;
 }
+
+.basis__small .flex {
+  flex-basis: 0;
+}

--- a/packages/lego-bricks/src/components/Layout/Flex.tsx
+++ b/packages/lego-bricks/src/components/Layout/Flex.tsx
@@ -30,6 +30,7 @@ type Props<C extends ElementType> = {
   margin?: number | string;
   width?: number | string;
   gap?: number | string;
+  basis?: boolean;
 } & ComponentPropsWithRef<C>;
 
 /**
@@ -50,6 +51,7 @@ const Flex = <C extends ElementType = 'div'>({
   width,
   gap,
   style,
+  basis = true,
   ...htmlAttributes
 }: Props<C>) => (
   <Component
@@ -61,6 +63,7 @@ const Flex = <C extends ElementType = 'div'>({
       styles[`justifyContent__${justifyContent}`],
       styles[`alignItems__${alignItems}`],
       className,
+      !basis && styles[`basis__small`],
     )}
     style={{
       padding,


### PR DESCRIPTION
# Description
Add a new prop for option to get small spacing, to get rid of huge spacing on mobile views if many input fields next to each other

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before/after</td>
    </tr>
    <tr>
        <td>
            Fix the spacing between fields in the profile settings (old to the left, new to the right
        </td>
        <td>

https://github.com/user-attachments/assets/65fdd449-32e2-4ddc-b934-f313867833fa

</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1572
