### PR TITLE
Always visible toolbar

### DIFF
--- a/packages/lego-editor/src/Editor.module.css
+++ b/packages/lego-editor/src/Editor.module.css
@@ -14,6 +14,9 @@
     border-bottom-left-radius: var(--border-radius-md);
     padding: var(--spacing-sm);
     background: var(--color-white);
+    position: relative;
+    overflow-y: auto;
+    max-height: 75vh;
   }
 
   &:focus-within {


### PR DESCRIPTION
# Description

Solution for https://github.com/webkom/lego/issues/3837#issue-3227978348. Instead of making the toolbar sticky, I opted to make the content-box scrollable with a max-height. Now the toolbar does not get pushed outside your viewport. A sticky toolbar would also look kinda awkward🤷‍♂️


Btw, toolbar component code is very cool!

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
  <tr>
    <td width="25%">Description</td>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td>Always visible tooltip</td>
    <td>
      <video src="https://github.com/user-attachments/assets/fb175d4e-2c67-47f3-b0b5-2073ba893563" 
             width="320" 
             controls 
             muted 
             loop>
      </video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/63599617-b135-430e-8faa-7831d6c72dc0" 
             width="220" 
             controls 
             muted 
             loop>
      </video>
    </td>
  </tr>
</table>



# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ABA-1472
