### PR TITLE
chore: fix capitalization on 'ledelsen' with big L

### DIFF
--- a/lego-webapp/pages/articles/ArticleEditor.tsx
+++ b/lego-webapp/pages/articles/ArticleEditor.tsx
@@ -179,7 +179,7 @@ const ArticleEditor = () => {
               <Card severity="warning">
                 <Card.Header>Obs!</Card.Header>
                 <p>
-                  Du må ha godkjenning fra ledelsen for å feste til forsiden.
+                  Du må ha godkjenning fra Ledelsen for å feste til forsiden.
                 </p>
               </Card>
             )}

--- a/lego-webapp/pages/events/src/EventEditor/EditorSection/Header.tsx
+++ b/lego-webapp/pages/events/src/EventEditor/EditorSection/Header.tsx
@@ -67,7 +67,7 @@ const Header = ({
       {values.pinned && (
         <Card severity="warning">
           <Card.Header>Obs!</Card.Header>
-          <p>Du må ha godkjenning fra ledelsen for å feste til forsiden.</p>
+          <p>Du må ha godkjenning fra Ledelsen for å feste til forsiden.</p>
         </Card>
       )}
 


### PR DESCRIPTION
# Description

By internal spelling rules in Abakus, "Ledelsen" should be spelled with capital L. This is fixed here.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.


- [X] I have thoroughly tested my changes.


Resolves ABA-1603
