### PR TITLE
Prevent admin functionality on own lendingRequest

### DIFF
--- a/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/request/@lendingRequestId/+Page.tsx
@@ -176,31 +176,35 @@ const LendingRequest = () => {
               </Flex>
             )}
             {isAdmin && (
-              <>
+              <div>
                 <h3>Admin</h3>
-                <Flex
-                  column
-                  gap="var(--spacing-sm)"
-                  className={styles.buttonWrapper}
-                >
-                  <UpdateButton
-                    toStatus={
-                      lendingRequest.status === LendingRequestStatus.Approved
-                        ? LendingRequestStatus.Unapproved
-                        : LendingRequestStatus.Approved
-                    }
-                    lendingRequest={lendingRequest}
-                  />
-                  <UpdateButton
-                    toStatus={LendingRequestStatus.Denied}
-                    lendingRequest={lendingRequest}
-                  />
-                  <UpdateButton
-                    toStatus={LendingRequestStatus.ChangesRequested}
-                    lendingRequest={lendingRequest}
-                  />
-                </Flex>
-              </>
+                {isCurrentUser ? (
+                  <p>Du kan ikke administrere din egen forespørsel</p>
+                ) : (
+                  <Flex
+                    column
+                    gap="var(--spacing-sm)"
+                    className={styles.buttonWrapper}
+                  >
+                    <UpdateButton
+                      toStatus={
+                        lendingRequest.status === LendingRequestStatus.Approved
+                          ? LendingRequestStatus.Unapproved
+                          : LendingRequestStatus.Approved
+                      }
+                      lendingRequest={lendingRequest}
+                    />
+                    <UpdateButton
+                      toStatus={LendingRequestStatus.Denied}
+                      lendingRequest={lendingRequest}
+                    />
+                    <UpdateButton
+                      toStatus={LendingRequestStatus.ChangesRequested}
+                      lendingRequest={lendingRequest}
+                    />
+                  </Flex>
+                )}
+              </div>
             )}
           </ContentSidebar>
         </ContentSection>

--- a/lego-webapp/pages/lending/RequestInbox.module.css
+++ b/lego-webapp/pages/lending/RequestInbox.module.css
@@ -60,6 +60,9 @@ img.lendingRequestImage {
   width: 100%;
   font-size: var(--font-size-xs);
   padding: var(--spacing-xs) var(--spacing-md);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 @keyframes spinner {


### PR DESCRIPTION
# Description

A user should not have any admin functionality on their own requests. This should be fixed in backend too as currently only "approve" is not allowed on own requests.

Also just centering content of statuspill.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.


<img width="448" height="561" alt="Screenshot 2025-11-09 at 14 39 30" src="https://github.com/user-attachments/assets/d59a9f38-5a7c-494a-b702-186bf09529bb" />
