### PR TITLE
Fix menu toggle alignment on scroll

### DIFF
--- a/lego-webapp/components/Header/Header.module.css
+++ b/lego-webapp/components/Header/Header.module.css
@@ -98,6 +98,10 @@ html[data-theme='dark'] img.logoDarkMode {
 }
 
 .searchButton {
+  display: flex;
+  width: 24px;
+  align-items: center;
+  box-sizing: content-box;
   z-index: 301;
 }
 
@@ -105,6 +109,10 @@ html[data-theme='dark'] img.logoDarkMode {
   position: relative;
   width: 24px;
   height: 24px;
+}
+
+.searching {
+  position: fixed;
 }
 
 .menuIcon,

--- a/lego-webapp/components/Header/index.tsx
+++ b/lego-webapp/components/Header/index.tsx
@@ -225,7 +225,7 @@ const Header = () => {
               className={styles.searchButton}
               data-test-id="search-menu-icon"
             >
-              <div className={styles.iconWrapper}>
+              <div className={cx(styles.iconWrapper, searchOpen && styles.searching)}>
                 <Icon
                   iconNode={<Menu />}
                   size={24}


### PR DESCRIPTION
# Description 
This PR fixes an issue where the menu toggle (hamburger to close icon) becomes misaligned or barely visible when opening the menu after scrolling.  Since the header is not sticky, the toggle keeps its old position relative to the scrolled header, causing the close icon to appear almost off-screen or out of alignment with the search field.

This change adjusts the positioning so that when the menu is opened, the toggle correctly aligns with the fixed header/search field layout, regardless of scroll position.  Only minimal CSS adjustments were made to existing elements.

If this behaviour was intentional or part of the design, feel free to reject the PR, I simply assumed it was an unintended UX side effect.

Label: **bug-fix**

# Result

- [x] Changes look good on both light and dark theme.  
- [x] Changes look good with different viewports (desktop, tablet, mobile).  
- [x] Changes look good with slower Internet connections.  

> **Note:** No user data is included in the screenshots.

<table>
    <tr>
        <td width="25%"><strong>Description</strong></td>
        <td><strong>Before</strong></td>
        <td><strong>After</strong></td>
    </tr>
    <tr>
        <td>
            Menu toggle does not reposition when the menu is opened after scrolling,
            causing the close icon to appear misaligned or almost off-screen.
        </td>
        <td>
            <img width="1676" height="310" alt="image" src="https://github.com/user-attachments/assets/f473d6d7-574d-4ee7-a333-ea6aaa1308a4" />
        </td>
        <td>
            <img width="1660" height="253" alt="image" src="https://github.com/user-attachments/assets/04a7b6a5-5f06-4134-abb5-2cde743ee2d3" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

**Testing procedure:**
1. Scroll the page so that the header is partially out of view.  
2. Open the menu using the toggle.  
3. Observe that in the previous behaviour, the close icon appears in the old scroll position.  
4. With this fix applied, the toggle properly aligns with the fixed header/search field.  
5. Verified across multiple viewports, themes, and with throttled network.

---

Resolves https://github.com/webkom/lego/issues/3866