### PR TITLE
feature: add see all button on readme accordian

### DIFF
--- a/lego-webapp/pages/index/_components/authenticated/LatestReadme.module.css
+++ b/lego-webapp/pages/index/_components/authenticated/LatestReadme.module.css
@@ -40,3 +40,9 @@
     transform: scale(1.05);
   }
 }
+
+.seeAllButton {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--spacing-sm);
+}

--- a/lego-webapp/pages/index/_components/authenticated/LatestReadme.tsx
+++ b/lego-webapp/pages/index/_components/authenticated/LatestReadme.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Card, Flex, Icon, Image } from '@webkom/lego-bricks';
+import { Accordion, Card, Flex, Icon, Image, LinkButton } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { ChevronRight } from 'lucide-react';
 import { readmeIfy } from '~/components/ReadmeLogo';
@@ -50,6 +50,11 @@ const LatestReadme = ({
               <Image src={image} alt={`Forsidebildet til ${title}`} />
             </a>
           ))}
+        </div>
+        <div style={{ display: "flex", justifyContent: "center", marginTop: "var(--spacing-sm)"}}>
+          <LinkButton href="https://readme.abakus.no">
+            Se alle
+          </LinkButton>
         </div>
       </Accordion>
     </Card>

--- a/lego-webapp/pages/index/_components/authenticated/LatestReadme.tsx
+++ b/lego-webapp/pages/index/_components/authenticated/LatestReadme.tsx
@@ -1,4 +1,11 @@
-import { Accordion, Card, Flex, Icon, Image, LinkButton } from '@webkom/lego-bricks';
+import {
+  Accordion,
+  Card,
+  Flex,
+  Icon,
+  Image,
+  LinkButton,
+} from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { ChevronRight } from 'lucide-react';
 import { readmeIfy } from '~/components/ReadmeLogo';
@@ -52,9 +59,7 @@ const LatestReadme = ({
           ))}
         </div>
         <div className={styles.seeAllButton}>
-          <LinkButton href="https://readme.abakus.no">
-            Se alle
-          </LinkButton>
+          <LinkButton href="https://readme.abakus.no">Se alle</LinkButton>
         </div>
       </Accordion>
     </Card>

--- a/lego-webapp/pages/index/_components/authenticated/LatestReadme.tsx
+++ b/lego-webapp/pages/index/_components/authenticated/LatestReadme.tsx
@@ -51,7 +51,7 @@ const LatestReadme = ({
             </a>
           ))}
         </div>
-        <div style={{ display: "flex", justifyContent: "center", marginTop: "var(--spacing-sm)"}}>
+        <div className={styles.seeAllButton}>
           <LinkButton href="https://readme.abakus.no">
             Se alle
           </LinkButton>


### PR DESCRIPTION
# Description

Per now it is no direct link to readme webside from the readme accordion. Added a "Se alle" button. 

# Before:
![Skjermbilde 2025-11-14 kl  16 08 49](https://github.com/user-attachments/assets/70129ab1-9731-4797-bb34-cefc09b6fd45)


# After:
![Skjermbilde 2025-11-14 kl  16 09 05](https://github.com/user-attachments/assets/06820cbc-aec4-4508-87da-a7ec24a02c8a)


- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.


# Testing

- [X] I have thoroughly tested my changes.


Resolves ABA-1608
