### PR TITLE
Temporarily disable sourcemaps

### DIFF
--- a/lego-webapp/vite.config.ts
+++ b/lego-webapp/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     react(),
     sentryVitePlugin({
       sourcemaps: {
-        disable: false,
+        disable: true,
       },
     }),
     cjsInterop({
@@ -46,7 +46,7 @@ export default defineConfig({
 
   build: {
     target: 'es2022',
-    sourcemap: 'hidden',
+    sourcemap: false,
     cssCodeSplit: false,
     rollupOptions: {
       output: {


### PR DESCRIPTION
# Description

This will cause Sentry not to work as expected, and this should be turned on again when our local servers is up and running. This is to fix Javascript heap getting full and failing build...