### PR TITLE
bug-fix - Suggesting a usefulLinkGraphic img scaling-fix for Safari

### DIFF
--- a/lego-webapp/pages/index/PublicFrontpage.module.css
+++ b/lego-webapp/pages/index/PublicFrontpage.module.css
@@ -62,5 +62,7 @@ div.wrapper {
 .usefulLinkGraphic {
   margin: 0 auto;
   width: auto;
-  height: 40%;
+  height: auto;
+  max-height: 40vh;
+  object-fit: contain;
 }


### PR DESCRIPTION
# Description

Suggesting using something like this to fix the usefulLinkGraphic image scaling to work in Safari, not just Chrome..  


# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.


# Before and after screenshots:
<img width="883" height="889" alt="before" src="https://github.com/user-attachments/assets/3793ffcd-7c79-4b14-aae6-b64d4680ef90" />
<img width="882" height="908" alt="after" src="https://github.com/user-attachments/assets/941bedec-adaf-4b0b-9cb0-7df524ddd263" />


> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
        <td>
            ...
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Tested on Chrome, Safari and with small viewports. 

---

Resolves ... (either GitHub issue or Linear task)
