### PR TITLE
feature: make pinned article shake if wanted

### DIFF
--- a/lego-webapp/pages/articles/ArticleEditor.tsx
+++ b/lego-webapp/pages/articles/ArticleEditor.tsx
@@ -120,6 +120,7 @@ const ArticleEditor = () => {
       content: data.content,
       tags: (data.tags || []).map((tag) => tag.value.toLowerCase()),
       pinned: data.pinned,
+      wiggle: data.wiggle,
     };
 
     dispatch(
@@ -176,12 +177,21 @@ const ArticleEditor = () => {
               component={CheckBox.Field}
             />
             {values.pinned && (
-              <Card severity="warning">
-                <Card.Header>Obs!</Card.Header>
-                <p>
-                  Du må ha godkjenning fra Ledelsen for å feste til forsiden.
-                </p>
-              </Card>
+              <>
+                <Card severity="warning">
+                  <Card.Header>Obs!</Card.Header>
+                  <p>
+                    Du må ha godkjenning fra Ledelsen for å feste til forsiden.
+                  </p>
+                </Card>
+
+                <Field
+                  label="Wiggle på forsiden"
+                  name="wiggle"
+                  type="checkbox"
+                  component={CheckBox.Field}
+                />
+              </>
             )}
 
             <Field

--- a/lego-webapp/pages/index/AuthenticatedFrontpage.tsx
+++ b/lego-webapp/pages/index/AuthenticatedFrontpage.tsx
@@ -20,6 +20,7 @@ import {
   addArticleType,
   addEventType,
   selectPinned,
+  isArticle,
 } from '~/redux/slices/frontpage';
 import { selectPinnedPoll } from '~/redux/slices/polls';
 import { selectRandomQuote } from '~/redux/slices/quotes';
@@ -109,7 +110,12 @@ const AuthenticatedFrontpage = () => {
         <CompactEvents className={styles.compactEvents} />
         <UpcomingRegistrationsSection />
         <Events pinnedId={pinned?.id} numberToShow={eventsToShow} />
-        <Pinned item={pinned} url={itemUrl(pinned)} meta={renderMeta(pinned)} />
+        <Pinned
+          item={pinned}
+          url={itemUrl(pinned)}
+          meta={renderMeta(pinned)}
+          wiggle={pinned && isArticle(pinned) ? pinned.wiggle : false}
+        />
         <PollItem />
         <QuoteItem />
         {readMe}

--- a/lego-webapp/pages/index/Pinned.module.css
+++ b/lego-webapp/pages/index/Pinned.module.css
@@ -5,7 +5,20 @@
   width: 100%;
 }
 
-div.body {
+div.authenticatedBody {
+  padding: 0;
+  min-height: 260px;
+  animation-name: wiggle;
+  animation-duration: 5s;
+  animation-iteration-count: infinite;
+  animation-delay: 5s;
+
+  @media (--mobile-device) {
+    min-height: 180px;
+  }
+}
+
+div.publicBody {
   padding: 0;
   min-height: 260px;
 
@@ -48,4 +61,30 @@ div.body {
 
 .itemTitle > a {
   color: var(--lego-font-color);
+}
+
+@keyframes wiggle {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  5% {
+    transform: rotate(-1.5deg);
+  }
+
+  10% {
+    transform: rotate(0deg);
+  }
+
+  15% {
+    transform: rotate(1.5deg);
+  }
+
+  20% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(0deg);
+  }
 }

--- a/lego-webapp/pages/index/Pinned.tsx
+++ b/lego-webapp/pages/index/Pinned.tsx
@@ -1,4 +1,5 @@
 import { Card, Flex, Image } from '@webkom/lego-bricks';
+import cx from 'classnames';
 import { useAppSelector } from '~/redux/hooks';
 import { isEvent } from '~/redux/slices/frontpage';
 import utilStyles from '~/styles/utilities.module.css';
@@ -11,9 +12,10 @@ type Props = {
   url: string;
   meta: ReactElement<'span'> | null;
   style?: CSSProperties;
+  wiggle?: boolean;
 };
 
-const Pinned = ({ item, url, meta, style }: Props) => {
+const Pinned = ({ item, url, meta, style, wiggle }: Props) => {
   const fetching = useAppSelector(
     (state) =>
       state.frontpage.fetching ||
@@ -26,7 +28,11 @@ const Pinned = ({ item, url, meta, style }: Props) => {
         {fetching || item?.pinned ? 'Festet oppslag' : 'Oppslag'}
       </h3>
 
-      <Card skeleton={fetching && !item} hideOverflow className={styles.body}>
+      <Card
+        skeleton={fetching && !item}
+        hideOverflow
+        className={cx(styles.publicBody, wiggle && styles.authenticatedBody)}
+      >
         <a href={url} className={styles.innerLinks}>
           <Image
             className={styles.image}

--- a/lego-webapp/pages/index/PublicFrontpage.tsx
+++ b/lego-webapp/pages/index/PublicFrontpage.tsx
@@ -79,6 +79,7 @@ const PublicFrontpage = () => {
           item={pinned}
           url={itemUrl(pinned)}
           meta={renderMeta(pinned)}
+          wiggle={false}
         />
         <LatestReadme
           expandedInitially

--- a/lego-webapp/redux/models/Article.d.ts
+++ b/lego-webapp/redux/models/Article.d.ts
@@ -23,6 +23,7 @@ interface CompleteArticle {
   reactionsGrouped?: ReactionsGrouped[];
   youtubeUrl: string;
   actionGrant: ArticlePermissions[];
+  wiggle: boolean;
 }
 
 export type DetailedArticle = Pick<
@@ -46,6 +47,7 @@ export type DetailedArticle = Pick<
   | 'canViewGroups'
   | 'canEditGroups'
   | 'actionGrant'
+  | 'wiggle'
 >;
 
 export type AdminDetailedArticle = DetailedArticle & ObjectPermissionsMixin;
@@ -71,6 +73,7 @@ export type PublicArticle = Pick<
   | 'createdAt'
   | 'pinned'
   | 'actionGrant'
+  | 'wiggle'
 >;
 
 export type UnknownArticle = (


### PR DESCRIPTION
# Description

Should be an option to wiggle pinned article to get some attention to it on the front page, but only for authenticated users. 

# Result


https://github.com/user-attachments/assets/b0fd4bfe-bf28-482d-b688-a83b915ce599



- [X] Changes look good on both light and dark theme.
- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.

# Testing

- [X] I have thoroughly tested my changes..

---

Resolves ABA-1618
Related backend PR: 
