### PR TITLE
Remove photographers requirement from galleries

### DIFF
--- a/lego-webapp/pages/photos/new/+Page.tsx
+++ b/lego-webapp/pages/photos/new/+Page.tsx
@@ -117,7 +117,6 @@ const TypedLegoForm = LegoFinalForm<FormValues>;
 const validate = createValidator({
   title: [required('Du må gi albumet en tittel')],
   location: [required('Du må velge en lokasjon for albumet')],
-  photographers: [required('Du må velge minst én fotograf')],
 });
 
 const GalleryEditor = () => {
@@ -314,7 +313,6 @@ const GalleryEditor = () => {
               placeholder="Skriv inn navn på fotografer"
               component={SelectInput.AutocompleteField}
               isMulti
-              required
             />
             <Field
               name="event"


### PR DESCRIPTION
# Description

As requested from pr, the requirement for photographers on galleries is removed here. This will not cause any problems with the Gallery model in the backend since the photographers field is of type ManyToMany which is by default optional

# Result

before:
<img width="290" height="121" alt="image" src="https://github.com/user-attachments/assets/a4efc75e-9324-41b0-aee4-888d239fef2a" />


after:
<img width="258" height="80" alt="image" src="https://github.com/user-attachments/assets/856b6bed-f28a-4fc6-812c-29337a723ca3" />

