### PR TITLE
Changing trophy:tags intuitive

### DIFF
--- a/lego-webapp/pages/sudo/achievements/tags/+Page.tsx
+++ b/lego-webapp/pages/sudo/achievements/tags/+Page.tsx
@@ -48,7 +48,7 @@ export default function EventTagEditor() {
               isMulti
               tags
             />
-            <SubmitButton>Endre tags på arrangement</SubmitButton>
+            <SubmitButton>Endre tags</SubmitButton>
           </Form>
         )}
       </LegoFinalForm>

--- a/lego-webapp/redux/actions/EventActions.ts
+++ b/lego-webapp/redux/actions/EventActions.ts
@@ -119,7 +119,7 @@ export function editPartialEvent(
     body: { ...event, cover: event.cover || undefined },
     meta: {
       errorMessage: 'Endring av arrangement feilet',
-      successMessage: 'Endring av arrangement fullført'
+      successMessage: 'Endring av arrangement fullført',
     },
   });
 }


### PR DESCRIPTION
# Description

Small changes that making setting and changing trophy:tags more intuitive

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

# Before
https://github.com/user-attachments/assets/de62491a-06dc-40ba-bc9f-69dc61fc34ba

# After
https://github.com/user-attachments/assets/39297895-ac7a-43a2-aaa5-e6c8aa7a2483

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #5877 
