### PR TITLE
README REVAMP 

### DIFF
--- a/lego-webapp/.vscode/settings.json
+++ b/lego-webapp/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "js/ts.tsdk.path": "node_modules/typescript/lib"
-}

--- a/lego-webapp/.vscode/settings.json
+++ b/lego-webapp/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
@@ -62,3 +62,28 @@
 .label {
   color: var(--danger-color);
 }
+
+.readMe :global([class*="heading"]) {
+  font-size: var(--font-size-xl);
+}
+
+
+.readMe :global([class*="thumbnailContainer"]) {
+  padding-top: 5px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, min-content);
+  gap: var(--spacing-xs);
+  overflow: hidden;
+
+  @media (--mobile-device) {
+    gap: var(--spacing-xs);
+  }
+
+  @media (--small-viewport) {
+    gap: var(--spacing-xs);
+  }
+}
+.readMe{
+  padding-top: 25px;
+}

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
@@ -64,11 +64,12 @@
 }
 
 .readMe :global([class*='heading']) {
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-lg);
 }
 
 .readMe :global([class*='thumbnailContainer']) {
-  padding-top: 5px;
+  padding-top: 0px;
+  margin: 0px;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, min-content);

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
@@ -63,12 +63,11 @@
   color: var(--danger-color);
 }
 
-.readMe :global([class*="heading"]) {
+.readMe :global([class*='heading']) {
   font-size: var(--font-size-xl);
 }
 
-
-.readMe :global([class*="thumbnailContainer"]) {
+.readMe :global([class*='thumbnailContainer']) {
   padding-top: 5px;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -84,6 +83,6 @@
     gap: var(--spacing-xs);
   }
 }
-.readMe{
+.readMe {
   padding-top: 25px;
 }

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -75,6 +75,10 @@ import {
 import type { ReactNode } from 'react';
 import type { DetailedCompanyInterest } from '~/redux/models/CompanyInterest';
 import type CompanySemester from '~/redux/models/CompanySemester';
+import LatestReadme from '~/pages/index/LatestReadme';
+import { fetchReadmes } from '~/redux/actions/FrontpageActions'; 
+import { useEffect } from 'react';
+
 
 const SemesterBox = ({
   fields,
@@ -191,6 +195,12 @@ const OtherBox = ({
         }
       />
     ))}
+  </Flex>
+);
+
+const readMe = (
+  <Flex className={styles.readMe}>
+    <LatestReadme expandedInitially={false} />
   </Flex>
 );
 
@@ -538,6 +548,12 @@ const CompanyInterestForm = ({ language }: Props) => {
 
   const title = edit ? 'Bedriftsinteresse' : FORM_LABELS.mainHeading[language];
 
+  const dispatch1 = useAppDispatch();
+
+  useEffect(() => {
+    dispatch1(fetchReadmes(2));
+  }, [dispatch1]);
+
   return (
     <Page
       title={title}
@@ -747,6 +763,7 @@ const CompanyInterestForm = ({ language }: Props) => {
                       component={OtherBox}
                     />
                   </MultiSelectGroup>
+                  {readMe}
                 </Flex>
               </Flex>
               <div className={styles.topline} />

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -1,7 +1,6 @@
 import { Card, Flex, LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import arrayMutators from 'final-form-arrays';
-import { useEffect } from 'react';
 import { Field, FormSpy } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
@@ -354,9 +353,11 @@ const CompanyInterestForm = ({ language }: Props) => {
     [companyInterestId, edit],
   );
 
-  useEffect(() => {
-    dispatch(fetchReadmes(2));
-  }, [dispatch]);
+  usePreparedEffect(
+    'fetchReadmes',
+    () => dispatch(fetchReadmes(2)),
+    [dispatch],
+  );
 
   const allEvents = Object.keys(EVENTS);
   const allOtherOffers = Object.keys(OTHER_OFFERS);

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -1,6 +1,7 @@
 import { Card, Flex, LoadingIndicator, Page } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import arrayMutators from 'final-form-arrays';
+import { useEffect } from 'react';
 import { Field, FormSpy } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
@@ -22,6 +23,7 @@ import SubmissionError from '~/components/Form/SubmissionError';
 import { SubmitButton } from '~/components/Form/SubmitButton';
 import ToggleSwitch from '~/components/Form/ToggleSwitch';
 import { readmeIfy } from '~/components/ReadmeLogo';
+import LatestReadme from '~/pages/index/LatestReadme';
 import {
   fetchSemesters,
   fetchSemestersForInterestform,
@@ -31,6 +33,7 @@ import {
   fetchCompanyInterest,
   updateCompanyInterest,
 } from '~/redux/actions/CompanyInterestActions';
+import { fetchReadmes } from '~/redux/actions/FrontpageActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import { selectCompanyInterestById } from '~/redux/slices/companyInterest';
 import {
@@ -73,11 +76,9 @@ import {
   othersDescriptionToString,
 } from './utils';
 import type { ReactNode } from 'react';
+
 import type { DetailedCompanyInterest } from '~/redux/models/CompanyInterest';
 import type CompanySemester from '~/redux/models/CompanySemester';
-import LatestReadme from '~/pages/index/LatestReadme';
-import { fetchReadmes } from '~/redux/actions/FrontpageActions';
-import { useEffect } from 'react';
 
 const SemesterBox = ({
   fields,
@@ -353,6 +354,10 @@ const CompanyInterestForm = ({ language }: Props) => {
     [companyInterestId, edit],
   );
 
+  useEffect(() => {
+    dispatch(fetchReadmes(2));
+  }, [dispatch]);
+
   const allEvents = Object.keys(EVENTS);
   const allOtherOffers = Object.keys(OTHER_OFFERS);
   const allCollaborations = Object.keys(COLLABORATION_TYPES);
@@ -546,12 +551,6 @@ const CompanyInterestForm = ({ language }: Props) => {
   ];
 
   const title = edit ? 'Bedriftsinteresse' : FORM_LABELS.mainHeading[language];
-
-  const dispatch1 = useAppDispatch();
-
-  useEffect(() => {
-    dispatch1(fetchReadmes(2));
-  }, [dispatch1]);
 
   return (
     <Page

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -76,14 +76,9 @@ import type { ReactNode } from 'react';
 import type { DetailedCompanyInterest } from '~/redux/models/CompanyInterest';
 import type CompanySemester from '~/redux/models/CompanySemester';
 import LatestReadme from '~/pages/index/LatestReadme';
-<<<<<<< HEAD
 import { fetchReadmes } from '~/redux/actions/FrontpageActions'; 
 import { useEffect } from 'react';
 
-=======
-import { fetchReadmes } from '~/redux/actions/FrontpageActions';
-import { useEffect } from 'react';
->>>>>>> 8620cbd1c (added info window and latest readme front pages)
 
 const SemesterBox = ({
   fields,

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -76,9 +76,8 @@ import type { ReactNode } from 'react';
 import type { DetailedCompanyInterest } from '~/redux/models/CompanyInterest';
 import type CompanySemester from '~/redux/models/CompanySemester';
 import LatestReadme from '~/pages/index/LatestReadme';
-import { fetchReadmes } from '~/redux/actions/FrontpageActions'; 
+import { fetchReadmes } from '~/redux/actions/FrontpageActions';
 import { useEffect } from 'react';
-
 
 const SemesterBox = ({
   fields,

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -353,11 +353,9 @@ const CompanyInterestForm = ({ language }: Props) => {
     [companyInterestId, edit],
   );
 
-  usePreparedEffect(
-    'fetchReadmes',
-    () => dispatch(fetchReadmes(2)),
-    [dispatch],
-  );
+  usePreparedEffect('fetchReadmes', () => dispatch(fetchReadmes(2)), [
+    dispatch,
+  ]);
 
   const allEvents = Object.keys(EVENTS);
   const allOtherOffers = Object.keys(OTHER_OFFERS);

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -52,6 +52,7 @@ import {
   COMPANY_TYPES,
   EVENTS,
   FORM_LABELS,
+  OTHER_DESCRIPTIONS,
   OTHER_OFFERS,
   SURVEY_OFFERS,
   TARGET_GRADES,
@@ -69,6 +70,7 @@ import {
   sortSemesterChronologically,
   surveyOffersToString,
   targetGradeToString,
+  othersDescriptionToString,
 } from './utils';
 import type { ReactNode } from 'react';
 import type { DetailedCompanyInterest } from '~/redux/models/CompanyInterest';
@@ -184,6 +186,9 @@ const OtherBox = ({
         label={readmeIfy(OTHER_OFFERS[otherOffersToString(key)][language])}
         type="checkbox"
         component={CheckBox.Field}
+        description={
+          OTHER_DESCRIPTIONS[othersDescriptionToString(key)][language]
+        }
       />
     ))}
   </Flex>

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -76,9 +76,14 @@ import type { ReactNode } from 'react';
 import type { DetailedCompanyInterest } from '~/redux/models/CompanyInterest';
 import type CompanySemester from '~/redux/models/CompanySemester';
 import LatestReadme from '~/pages/index/LatestReadme';
+<<<<<<< HEAD
 import { fetchReadmes } from '~/redux/actions/FrontpageActions'; 
 import { useEffect } from 'react';
 
+=======
+import { fetchReadmes } from '~/redux/actions/FrontpageActions';
+import { useEffect } from 'react';
+>>>>>>> 8620cbd1c (added info window and latest readme front pages)
 
 const SemesterBox = ({
   fields,
@@ -200,7 +205,7 @@ const OtherBox = ({
 
 const readMe = (
   <Flex className={styles.readMe}>
-    <LatestReadme expandedInitially={false} />
+    <LatestReadme expandedInitially={true} />
   </Flex>
 );
 

--- a/lego-webapp/pages/bdb/company-interest/Translations.ts
+++ b/lego-webapp/pages/bdb/company-interest/Translations.ts
@@ -205,6 +205,19 @@ export const COLLABORATION_DESCRIPTIONS = {
   },
 };
 
+export const OTHER_DESCRIPTIONS = {
+  ad_readme: {
+    norwegian:
+      'readme er Gløshaugens største linjeforeningsmagasin, som kommer ut tre ganger i semesteret, og vi har et opplag på 500 eksemplarer hver utgave. Magasinet er gratis, distribueres på hele NTNUs campus Gløshaugen, og når ut til over 900 studenter innenfor datateknologi, cybersikkerhet, datakommunikasjon og informasjonsteknologi.',
+    english:
+      'readme er Gløshaugens største linjeforeningsmagasin, som kommer ut tre ganger i semesteret, og vi har et opplag på 500 eksemplarer hver utgave. Magasinet er gratis, distribueres på hele NTNUs campus Gløshaugen, og når ut til over 900 studenter innenfor datateknologi, cybersikkerhet, datakommunikasjon og informasjonsteknologi.',
+  },
+  prof_social_media: {
+    norwegian: '',
+    english: '',
+  },
+};
+
 export const TARGET_GRADES = {
   '1': {
     norwegian: '1. klasse',

--- a/lego-webapp/pages/bdb/company-interest/Translations.ts
+++ b/lego-webapp/pages/bdb/company-interest/Translations.ts
@@ -210,7 +210,7 @@ export const OTHER_DESCRIPTIONS = {
     norwegian:
       'readme er Gløshaugens største linjeforeningsmagasin, som kommer ut tre ganger i semesteret, og vi har et opplag på 500 eksemplarer hver utgave. Magasinet er gratis, distribueres på hele NTNUs campus Gløshaugen, og når ut til over 900 studenter innenfor datateknologi, cybersikkerhet, datakommunikasjon og informasjonsteknologi.',
     english:
-      'readme er Gløshaugens største linjeforeningsmagasin, som kommer ut tre ganger i semesteret, og vi har et opplag på 500 eksemplarer hver utgave. Magasinet er gratis, distribueres på hele NTNUs campus Gløshaugen, og når ut til over 900 studenter innenfor datateknologi, cybersikkerhet, datakommunikasjon og informasjonsteknologi.',
+      'readme is the largest student association magazine at Gløshaugen. It is published three times per semester, with a print run of 500 copies per issue. The magazine is free, distributed across NTNU’s Gløshaugen campus, and reaches more than 900 students in computer science, cyber security, data communications, and information technology',
   },
   prof_social_media: {
     norwegian: '',

--- a/lego-webapp/pages/bdb/company-interest/utils.tsx
+++ b/lego-webapp/pages/bdb/company-interest/utils.tsx
@@ -8,6 +8,7 @@ import {
   OTHER_OFFERS,
   TARGET_GRADES,
   COLLABORATION_DESCRIPTIONS,
+  OTHER_DESCRIPTIONS,
 } from './Translations';
 import type CompanySemester from '~/redux/models/CompanySemester';
 
@@ -85,6 +86,9 @@ export const otherOffersToString = (offer) =>
 
 export const collaborationToString = (collab) =>
   Object.keys(COLLABORATION_TYPES)[Number(collab.charAt(collab.length - 2))];
+
+export const othersDescriptionToString = (others) =>
+  Object.keys(OTHER_DESCRIPTIONS)[Number(others.charAt(others.length - 2))];
 
 export const targetGradeToString = (targetGrade) =>
   Object.keys(TARGET_GRADES)[

--- a/lego-webapp/pages/index/LatestReadme.tsx
+++ b/lego-webapp/pages/index/LatestReadme.tsx
@@ -20,7 +20,6 @@ const LatestReadme = ({
   displayCount = 4,
 }: Props) => {
   const readmes = useAppSelector((state) => state.readme);
-
   return (
     <Card className={styles.latestReadme} style={style}>
       <Accordion


### PR DESCRIPTION
# Description
Readme wanted to be more visible in the company interest forms, so i added the info window that shows upon hovering, as well as the latest readme front pages. This way, readme will catch the companies' eyes ;)

# Result
BEFORE:
<img width="291" height="107" alt="image" src="https://github.com/user-attachments/assets/89ce1f14-691d-4f93-a467-80fed9017270" />

AFTER:
<img width="279" height="296" alt="image" src="https://github.com/user-attachments/assets/f4528397-780d-4a78-bd86-0aac951c2526" />
<img width="648" height="498" alt="image" src="https://github.com/user-attachments/assets/c8f73b00-9c31-4eb8-af8f-7818e91c26b7" />



- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.


# Testing

- [x] I have thoroughly tested my changes.

---

Resolves ... (either GitHub issue or Linear task)
