### PR TITLE
new-feature Draft exchange system

### DIFF
--- a/lego-webapp/app/models.ts
+++ b/lego-webapp/app/models.ts
@@ -339,3 +339,22 @@ export type EventAdministrate = Omit<Event, 'createdBy' | 'comments'> & {
   createdBy: number;
   comments: number[];
 };
+
+export type Country = {
+  id: number;
+  name: string;
+};
+
+export type University = {
+  id: EntityId;
+  name: string;
+  country: string;
+}
+
+export type Exchange = {
+  id: number;
+  student: PublicUser;
+  university: University;
+  semester: 'vår' | 'høst';
+  year: number;
+};

--- a/lego-webapp/pages/users/@username/+Page.tsx
+++ b/lego-webapp/pages/users/@username/+Page.tsx
@@ -25,15 +25,17 @@ import { EmailLists } from '~/pages/users/@username/_components/EmailLists';
 import { GSuiteInfo } from '~/pages/users/@username/_components/GSuiteInfo';
 import { GroupTree } from '~/pages/users/@username/_components/GroupTree';
 import { Permissions } from '~/pages/users/@username/_components/Permissions';
-import { UserInfo } from '~/pages/users/@username/_components/UserInfo';
+import { Exchanges, ExchangesInfo, UserInfo } from '~/pages/users/@username/_components/UserInfo';
 import { useIsCurrentUser } from '~/pages/users/utils';
 import { fetchPrevious, fetchUpcoming } from '~/redux/actions/EventActions';
+// import { fetchExchanges } from '~/redux/actions/ExchangeActions';
 import { fetchAllWithType } from '~/redux/actions/GroupActions';
 import { fetchUser } from '~/redux/actions/UserActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
 import { EntityType } from '~/redux/models/entities';
 import { useCurrentUser } from '~/redux/slices/auth';
 import { selectAllEvents } from '~/redux/slices/events';
+import { selectAllExchanges } from '~/redux/slices/exchanges';
 import { selectGroupsByType, selectGroupEntities } from '~/redux/slices/groups';
 import { selectPaginationNext } from '~/redux/slices/selectors';
 import { selectUserByUsername } from '~/redux/slices/users';
@@ -48,6 +50,9 @@ import type { ExclusifyUnion } from 'app/types';
 import type { ListEvent } from '~/redux/models/Event';
 import type { PublicGroup } from '~/redux/models/Group';
 import type { CurrentUser, PublicUserWithGroups } from '~/redux/models/User';
+import { query } from 'express';
+import { selectEmojisByIds } from '~/redux/slices/emojis';
+import { useEffect } from 'react';
 
 const UserProfile = () => {
   const params = useParams<{ username: string }>();
@@ -106,6 +111,9 @@ const UserProfile = () => {
 
   const groupEntities = useAppSelector(selectGroupEntities);
 
+  const emojis = useAppSelector((state) =>
+    selectEmojisByIds(state, [':japan:'])
+  )
   const dispatch = useAppDispatch();
 
   usePreparedEffect(
@@ -137,6 +145,7 @@ const UserProfile = () => {
     abakusEmailLists = [],
     permissionsPerGroup = [],
     photoConsents,
+    exchanges = [],
   } = user;
 
   const allAbakusGroupsWithPerms = uniqBy(
@@ -232,6 +241,9 @@ const UserProfile = () => {
         <div className={styles.info}>
           <UserInfo user={user} />
 
+          {exchanges?.length > 0 &&
+            <ExchangesInfo exchanges={exchanges} />
+          }
           {showSettings && <Penalties userId={user.id} />}
 
           {showSettings && photoConsents && photoConsents.length > 0 && (

--- a/lego-webapp/pages/users/@username/_components/ExchangeField.tsx
+++ b/lego-webapp/pages/users/@username/_components/ExchangeField.tsx
@@ -1,0 +1,125 @@
+import { Button, ConfirmModal, Flex, Icon } from '@webkom/lego-bricks';
+import { debounce } from 'lodash-es';
+import { GraduationCap, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { Field } from 'react-final-form';
+import { FieldArray } from 'react-final-form-arrays';
+import type { University } from '~/app/models';
+import { SelectInput } from '~/components/Form';
+import { autocomplete } from '~/redux/actions/SearchActions';
+import { useAppDispatch, useAppSelector } from '~/redux/hooks';
+import { selectAutocompleteRedux } from '~/redux/slices/search';
+
+const ExchangeField = () => {
+    const [query, setQuery] = useState('');
+    const searchResults = useAppSelector(selectAutocompleteRedux);
+    const dispatch = useAppDispatch();
+
+    const currentYear = new Date().getFullYear();
+    const yearOptions = Array.from({ length: 10 }, (_, i) => ({
+        label: String(currentYear - 5 + i),
+        value: currentYear - 5 + i,
+    }));
+
+    const semesterOptions = [
+        { label: 'Vår', value: 'vår' },
+        { label: 'Høst', value: 'høst' },
+    ];
+
+    const onSearchUniversities = debounce((searchQuery: string) => {
+        setQuery(searchQuery);
+        if (searchQuery.length >= 2) {
+            dispatch(autocomplete(searchQuery, ['users.university']));
+        }
+    }, 300);
+
+    // Filter and map search results to university options
+    const universityOptions = searchResults
+        .filter((result) => result.contentType === 'users.university')
+        .map((result) => {
+            const uni = result as unknown as University;
+            return {
+                label: `${uni.name}, ${uni.country.name}`,
+                value: uni.id,
+            };
+        });
+
+    return (
+        <FieldArray name="exchanges">
+            {({ fields }) => (
+                <Flex column gap="var(--spacing-md)">
+                    <Flex alignItems="center" gap="var(--spacing-sm)">
+                        <Icon iconNode={<GraduationCap />} />
+                        <label>Utvekslingsopphold</label>
+                    </Flex>
+
+                    {fields.map((name, index) => (
+                        <Flex
+                            key={name}
+                            gap="var(--spacing-sm)"
+                            alignItems="flex-end"
+                            wrap
+                        >
+                            <div style={{ flex: '2 1 300px', minWidth: '200px' }}>
+                                <Field
+                                    name={`${name}.university`}
+                                    label={index === 0 ? 'Universitet' : undefined}
+                                    component={SelectInput.AutocompleteField}
+                                    onInputChange={onSearchUniversities}
+                                    options={universityOptions}
+                                    placeholder="Søk etter universitet..."
+                                    required
+                                />
+                            </div>
+
+                            <div style={{ flex: '1 1 120px', minWidth: '100px' }}>
+                                <Field
+                                    name={`${name}.semester`}
+                                    label={index === 0 ? 'Semester' : undefined}
+                                    component={SelectInput.Field}
+                                    options={semesterOptions}
+                                    placeholder="Velg semester"
+                                    required
+                                />
+                            </div>
+
+                            <div style={{ flex: '1 1 120px', minWidth: '100px' }}>
+                                <Field
+                                    name={`${name}.year`}
+                                    label={index === 0 ? 'År' : undefined}
+                                    component={SelectInput.Field}
+                                    options={yearOptions}
+                                    placeholder="Velg år"
+                                    required
+                                />
+                            </div>
+
+                            <ConfirmModal
+                                title="Fjern utveksling"
+                                message="Er du sikker på at du vil fjerne denne utvekslingen?"
+                                onConfirm={() => fields.remove(index)}
+                            >
+                                {({ openConfirmModal }) => (
+                                    <Button onPress={openConfirmModal} danger size="small">
+                                        <Trash2 size={16} />
+                                    </Button>
+                                )}
+                            </ConfirmModal>
+                        </Flex>
+                    ))}
+
+                    <Button
+                        onPress={() =>
+                            fields.push({ university: null, semester: null, year: null })
+                        }
+                        secondary
+                    >
+                        Legg til utveksling
+                    </Button>
+                </Flex>
+            )}
+        </FieldArray>
+    );
+};
+
+export default ExchangeField;

--- a/lego-webapp/pages/users/@username/_components/UserInfo.tsx
+++ b/lego-webapp/pages/users/@username/_components/UserInfo.tsx
@@ -1,10 +1,13 @@
 import { Flex, Icon } from '@webkom/lego-bricks';
+import Emoji from '~/components/Emoji';
+import Pill from '~/components/Pill';
 import {
   EmailInfoField,
   InfoField,
   ProfileSection,
 } from '~/pages/users/@username/_components/ProfileSection';
 import styles from '~/pages/users/@username/_components/UserProfile.module.css';
+import { Exchange } from '~/redux/models/Exchange';
 import type { CurrentUser, PublicUserWithGroups } from '~/redux/models/User';
 
 const GithubField = ({ githubUsername }: { githubUsername: string }) => (
@@ -55,3 +58,23 @@ export const UserInfo = ({ user }: Props) => (
     </Flex>
   </ProfileSection>
 );
+
+export const ExchangesInfo = ({ exchanges }: { exchanges: Exchange[] }) => (
+  // <ProfileSection title="Utvekslingsopphold">
+  //   {exchanges.map((exchange) => <ExchangePill key={exchange.id} exchange={exchange} />)}
+  // </ProfileSection >
+  <>
+    <h3>Utvekslingsopphold</h3>
+    <>  {exchanges.map((exchange) => <ExchangePill key={exchange.id} exchange={exchange} />)}
+    </>
+  </>
+);
+
+export const ExchangePill = ({ exchange }: { exchange: Exchange }) => (
+  <Flex gap="var(--spacing-sm">
+    <Pill color={exchange.semester == 'vår' ? 'var(--success-color)' : 'peru'}>{exchange.semester.slice(0, 1)}{exchange.year - 2000}</Pill>
+    <Pill key={exchange.id}>{exchange.university.name}</Pill>
+    <Pill key={exchange.id}><Emoji unicodeString={exchange.university.country.emoji.unicodeString} /></Pill>
+
+  </Flex>
+)

--- a/lego-webapp/pages/users/@username/_components/UserInfo.tsx
+++ b/lego-webapp/pages/users/@username/_components/UserInfo.tsx
@@ -74,7 +74,7 @@ export const ExchangePill = ({ exchange }: { exchange: Exchange }) => (
   <Flex gap="var(--spacing-sm">
     <Pill color={exchange.semester == 'vår' ? 'var(--success-color)' : 'peru'}>{exchange.semester.slice(0, 1)}{exchange.year - 2000}</Pill>
     <Pill key={exchange.id}>{exchange.university.name}</Pill>
-    <Pill key={exchange.id}><Emoji unicodeString={exchange.university.country.emoji.unicodeString} /></Pill>
+    {/* <Pill key={exchange.id}><Emoji unicodeString={exchange.university.country.emoji.unicodeString} /></Pill> */}
 
   </Flex>
 )

--- a/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
+++ b/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
@@ -14,6 +14,7 @@ import {
   SubmitButton,
   SubmissionError,
   RowSection,
+  MultiSelectGroup,
 } from '~/components/Form';
 import ToggleSwitch from '~/components/Form/ToggleSwitch';
 import { useIsCurrentUser } from '~/pages/users/utils';

--- a/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
+++ b/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
@@ -1,7 +1,9 @@
 import { Accordion, Flex, Icon, LoadingIndicator } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
+import arrayMutators from 'final-form-arrays';
 import { ChevronRight, Github, Linkedin, Mail } from 'lucide-react';
 import { Field } from 'react-final-form';
+
 import { ContentMain } from '~/components/Content';
 import {
   Form,
@@ -38,6 +40,7 @@ import ThemeSelector from './ThemeSelector';
 import UserImage from './UserImage';
 import styles from './UserSettings.module.css';
 import type { CurrentUser } from '~/redux/models/User';
+import ExchangeField from '../../_components/ExchangeField';
 
 type GenderKey = keyof typeof Gender;
 
@@ -53,6 +56,11 @@ type FormValues = {
   isAbakusMember: boolean;
   githubUsername?: string;
   linkedinId?: string;
+  exchanges: Array<{
+    university: { label: string; value: number };
+    semester: 'V' | 'H';
+    year: number;
+  }>;
 };
 
 const TypedLegoForm = LegoFinalForm<FormValues>;
@@ -95,7 +103,14 @@ const UserSettings = () => {
     const body = {
       ...values,
       gender: values.gender.value,
-    };
+      exchanges: values.exchanges
+        ?.filter((ex) => ex.university && ex.semester && ex.year)
+        .map((ex) => ({
+          university_id: ex.university!.value,
+          semester: ex.semester!,
+          year: ex.year!,
+        })) || [],
+    }
 
     dispatch(updateUser(body));
   };
@@ -114,6 +129,14 @@ const UserSettings = () => {
     isAbakusMember: user.isAbakusMember,
     githubUsername: user.githubUsername ?? '',
     linkedinId: user.linkedinId ?? '',
+    exchanges: user.exchanges?.map((exchange) => ({
+      university: {
+        label: `${exchange.university.name}, ${exchange.university.country.name}`,
+        value: exchange.university.id,
+      },
+      semester: exchange.semester,
+      year: exchange.year,
+    })) || [],
   };
 
   return (
@@ -124,6 +147,8 @@ const UserSettings = () => {
         validate={validate}
         keepDirtyOnReinitialize
         subscription={{}}
+        mutators={{ ...arrayMutators }}
+
       >
         {({ handleSubmit }) => (
           <Form onSubmit={handleSubmit} className={styles.settings}>
@@ -229,6 +254,31 @@ const UserSettings = () => {
                   parse={(value) => value}
                 />
               </RowSection>
+
+              <ExchangeField />
+              <MultiSelectGroup legend="Fargetema" name="selectedTheme">
+                <Field
+                  name="selectedTheme"
+                  label="Auto"
+                  value="auto"
+                  type="radio"
+                  component={RadioButton.Field}
+                />
+                <Field
+                  name="selectedTheme"
+                  label="Lyst"
+                  value="light"
+                  type="radio"
+                  component={RadioButton.Field}
+                />
+                <Field
+                  name="selectedTheme"
+                  label="Mørkt"
+                  value="dark"
+                  type="radio"
+                  component={RadioButton.Field}
+                />
+              </MultiSelectGroup>
             </Flex>
 
             <ThemeSelector />

--- a/lego-webapp/redux/actionTypes.ts
+++ b/lego-webapp/redux/actionTypes.ts
@@ -335,3 +335,7 @@ export const FeatureFlag = {
   EDIT: generateStatuses('FeatureFlag.EDIT'),
   DELETE: generateStatuses('FeatureFlag.DELETE'),
 };
+
+export const Exchange = {
+  FETCH_ALL: generateStatuses('Exchange.FETCH_ALL')
+}

--- a/lego-webapp/redux/actions/ExchangeActions.ts
+++ b/lego-webapp/redux/actions/ExchangeActions.ts
@@ -1,0 +1,19 @@
+import { Exchange } from '~/redux/actionTypes'
+import callAPI from '~/redux/actions/callAPI';
+import { exchangeSchema } from '~/redux/schemas';
+
+export function fetchExchanges({ query, next = false }) {
+    return callAPI({
+        types: Exchange.FETCH_ALL,
+        endpoint: '/exchanges/',
+        schema: [exchangeSchema],
+        query,
+        pagination: {
+            fetchNext: next,
+        },
+        meta: {
+            errorMessage: 'Henting av utvekslingsopphold feilet',
+        },
+        propagateError: true,
+    });
+}

--- a/lego-webapp/redux/models/Exchange.ts
+++ b/lego-webapp/redux/models/Exchange.ts
@@ -1,0 +1,13 @@
+import { EntityId } from "@reduxjs/toolkit";
+import { PublicUser } from "./User";
+
+export interface Exchange {
+    id: EntityId;
+    student: PublicUser;
+    university: {
+        name: string,
+        country: string
+    };
+    year: number;
+    semester: string;
+}

--- a/lego-webapp/redux/models/User.ts
+++ b/lego-webapp/redux/models/User.ts
@@ -3,6 +3,7 @@ import type { EntityId } from '@reduxjs/toolkit';
 import type {
   ActionGrant,
   Dateish,
+  Exchange,
   PhotoConsentDomain,
   Semester,
 } from 'app/models';
@@ -89,6 +90,7 @@ interface User {
   achievementsScore: number;
   achievementRank: number;
   commandSuggestions?: Array<string>;
+  exchanges: Exchange[];
 }
 
 // Used if the user tries to get themselves or has the EDIT permission.
@@ -128,6 +130,7 @@ export type CurrentUser = Pick<
   | 'achievementsScore'
   | 'achievementRank'
   | 'commandSuggestions'
+  | 'exchanges'
 >;
 
 export type PublicUser = Pick<

--- a/lego-webapp/redux/models/entities.ts
+++ b/lego-webapp/redux/models/entities.ts
@@ -12,6 +12,7 @@ import type { UnknownEmailList } from '~/redux/models/EmailList';
 import type EmailUser from '~/redux/models/EmailUser';
 import type Emoji from '~/redux/models/Emoji';
 import type { UnknownEvent } from '~/redux/models/Event';
+import type { Exchange } from '~/redux/models/Exchange';
 import type { UnkownFeatureFlag } from '~/redux/models/FeatureFlag';
 import type Feed from '~/redux/models/Feed';
 import type AggregatedFeedActivity from '~/redux/models/FeedActivity';
@@ -79,6 +80,7 @@ export enum EntityType {
   Tags = 'tags',
   Users = 'users',
   SystemStatus = 'systemStatus',
+  Exchanges = 'exchanges'
 }
 
 // Most fetch success redux actions are normalized such that payload.entities is a subset of this interface.
@@ -94,6 +96,7 @@ export default interface Entities {
   [EntityType.EmailUsers]: Record<EntityId, EmailUser>;
   [EntityType.Emojis]: Record<EntityId, Emoji>;
   [EntityType.Events]: Record<EntityId, UnknownEvent>;
+  [EntityType.Exchanges]: Record<EntityId, Exchange>
   [EntityType.FeatureFlag]: Record<EntityId, UnkownFeatureFlag>;
   [EntityType.FeedActivities]: Record<EntityId, AggregatedFeedActivity>;
   [EntityType.Feeds]: Record<EntityId, Feed>;

--- a/lego-webapp/redux/rootReducer.ts
+++ b/lego-webapp/redux/rootReducer.ts
@@ -12,6 +12,7 @@ import emailLists from '~/redux/slices/emailLists';
 import emailUsers from '~/redux/slices/emailUsers';
 import emojis from '~/redux/slices/emojis';
 import events from '~/redux/slices/events';
+import exchanges from '~/redux/slices/exchanges';
 import featureFlags from '~/redux/slices/featureFlags';
 import feedActivities from '~/redux/slices/feedActivities';
 import feeds from '~/redux/slices/feeds';
@@ -62,6 +63,7 @@ export const createRootReducer = () => {
     emailLists,
     emailUsers,
     events,
+    exchanges,
     featureFlags,
     feedActivities,
     feeds,

--- a/lego-webapp/redux/schemas.ts
+++ b/lego-webapp/redux/schemas.ts
@@ -162,3 +162,5 @@ export const followersEventSchema = new schema.Entity(
 
 export const bannerSchema = new schema.Entity(EntityType.Banner);
 export const featureFlagSchema = new schema.Entity(EntityType.FeatureFlag);
+
+export const exchangeSchema = new schema.Entity(EntityType.Exchanges);

--- a/lego-webapp/redux/slices/emojis.ts
+++ b/lego-webapp/redux/slices/emojis.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSelector, createSlice, EntityId } from '@reduxjs/toolkit';
 import { Emoji } from '~/redux/actionTypes';
 import createLegoAdapter from '~/redux/legoAdapter/createLegoAdapter';
 import { EntityType } from '~/redux/models/entities';
@@ -27,4 +27,9 @@ const emojisSlice = createSlice({
 export default emojisSlice.reducer;
 export const { selectAll: selectEmojis } = legoAdapter.getSelectors<RootState>(
   (state) => state.emojis,
+);
+export const selectEmojisByIds = createSelector(
+  selectEmojis,
+  (_: RootState, ids: EntityId[] = []) => ids,
+  (entities, ids) => ids.map((id) => entities[id]),
 );

--- a/lego-webapp/redux/slices/exchanges.ts
+++ b/lego-webapp/redux/slices/exchanges.ts
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { Exchange } from '~/redux/actionTypes';
+import createLegoAdapter from "../legoAdapter/createLegoAdapter";
+import { EntityType } from "../models/entities";
+
+import type { RootState } from '~/redux/rootReducer';
+
+
+const legoAdapter = createLegoAdapter(EntityType.Exchanges)
+
+const exchangesSlice = createSlice({
+    name: EntityType.Exchanges,
+    initialState: legoAdapter.getInitialState(),
+    reducers: {},
+    extraReducers: legoAdapter.buildReducers({
+        fetchActions: [Exchange.FETCH_ALL]
+    })
+})
+
+export default exchangesSlice.reducer;
+
+export const {
+    selectAll: selectAllExchanges,
+} = legoAdapter.getSelectors((state: RootState) => state.exchanges);

--- a/lego-webapp/redux/slices/search.ts
+++ b/lego-webapp/redux/slices/search.ts
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
 import { categoryOptions } from '~/pages/pages/page/+Page';
 import { Search } from '~/redux/actionTypes';
 import { resolveGroupLink } from '~/redux/slices/groups';
-import type { User, Event, Group, Meeting, Dateish } from 'app/models';
+import type { User, Event, Group, Meeting, Dateish, University } from 'app/models';
 import type { SearchArticle } from '~/redux/models/Article';
 import type { SearchCompany } from '~/redux/models/Company';
 import type { RootState } from '~/redux/rootReducer';
@@ -56,6 +56,7 @@ interface SearchMapping {
   'tags.tag': SearchResultMapping<Record<string, string>>;
   'users.abakusgroup': SearchResultMapping<Group>;
   'meetings.meeting': SearchResultMapping<Meeting>;
+  'universities.university': SearchResultMapping<University>;
 }
 
 export type RawSearchResult = object & {
@@ -182,6 +183,20 @@ export const searchMapping: SearchMapping = {
     path: '/meetings/',
     value: 'id',
     content: (item) => item['description'],
+  },
+  'users.university': {
+    label: (university) => {
+      const name = university.name || '';
+      const country = university.country?.name || '';
+      return country ? `${name}, ${country}` : name;
+    },
+    title: 'name',
+    type: 'Universitet',
+    icon: 'graduation-cap',
+    iconType: 'icon',
+    color: '#000000',
+    value: 'id',
+    content: (university) => university.country?.name,
   },
 };
 type State = typeof initialState;


### PR DESCRIPTION
# Description

Added tag on profile page showing which country and university at which the student has been on exchange.
In-progress: search through country/unis in database to easily add to your profile.
Planned: Optional visibility in central view of all exchanges, with links to relevant student and potentially "lesebrev" if they wrote one.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [ ] Changes look good on both light and dark theme. Nuh-uh
- [ ] Changes look good with different viewports (mobile, tablet, etc.). Nuh-uh
- [ ] Changes look good with slower Internet connections. Nuh-uh


<img width="394" height="311" alt="569202058-a0365260-d5cd-4e20-bd82-7cc36d015a98" src="https://github.com/user-attachments/assets/b9427dea-89f3-4260-a50a-4a1fe9c11a9e" />


<img width="364" height="319" alt="Screenshot 2026-03-25 at 17 54 26" src="https://github.com/user-attachments/assets/d771f53f-d443-4af1-bd4a-ba35f43d3892" />



# Testing

- [ ] I have thoroughly tested my changes. Nuh-uh.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves ... (either GitHub issue or Linear task)
