### PR TITLE
Fix mazemap crashing site

### DIFF
--- a/lego-webapp/components/MazemapEmbed/index.tsx
+++ b/lego-webapp/components/MazemapEmbed/index.tsx
@@ -185,7 +185,7 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
 
   if (webglError) {
     return (
-      <Flex gap={'5px'} justifyContent="center">
+      <Flex gap={'var(--spacing-xs)'} justifyContent="center">
         <p>Nettleseren støtter ikke WebGL.</p>
         <Tooltip content="Prøv å slå på grafikkakselerasjon i nettleserinnstillingene dine.">
           <Icon iconNode={<Info />} size={18} />

--- a/lego-webapp/components/MazemapEmbed/index.tsx
+++ b/lego-webapp/components/MazemapEmbed/index.tsx
@@ -1,5 +1,6 @@
-import { Flex } from '@webkom/lego-bricks';
+import { Flex, Icon, Tooltip } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { Info } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Keyboard } from '~/utils/constants';
 import { useWaitForGlobal } from '~/utils/useWaitForGlobal';
@@ -22,30 +23,40 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
   const Mazemap = useWaitForGlobal('Mazemap');
   const [blockScrollZoom, setBlockScrollZoom] = useState<boolean>(false);
   const [blockTouchMovement, setBlockTouchZoom] = useState<boolean>(false);
+  const [webglError, setWebglError] = useState<boolean>(false);
+
   //initialize map only once, mazemapPoi will probably not change
   useEffect(() => {
     if (!Mazemap) return;
-    const embeddedMazemap = new Mazemap.Map({
-      container: 'mazemap-embed',
-      campuses: 1,
-      center: {
-        lng: 10.4042965,
-        lat: 63.4154135,
-      },
-      zLevel: 3,
-      zoom: 16,
-      minZoom: 10,
-      maxZoom: 20,
-      zLevelControl: true,
-      scrollZoom: false,
-      doubleClickZoom: false,
-      dragRotate: false,
-      dragPan: false,
-      touchZoomRotate: false,
-      touchPitch: false,
-      //this is a horrible feature
-      pitchWithRotate: false,
-    });
+
+    let embeddedMazemap;
+
+    try {
+      embeddedMazemap = new Mazemap.Map({
+        container: 'mazemap-embed',
+        campuses: 1,
+        center: {
+          lng: 10.4042965,
+          lat: 63.4154135,
+        },
+        zLevel: 3,
+        zoom: 16,
+        minZoom: 10,
+        maxZoom: 20,
+        zLevelControl: true,
+        scrollZoom: false,
+        doubleClickZoom: false,
+        dragRotate: false,
+        dragPan: false,
+        touchZoomRotate: false,
+        touchPitch: false,
+        //this is a horrible feature
+        pitchWithRotate: false,
+      });
+    } catch {
+      setWebglError(true);
+      return;
+    }
 
     embeddedMazemap.dragPan._mousePan.enable();
 
@@ -150,6 +161,12 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
     return () => {
       window.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('keyup', onKeyUp);
+
+      try {
+        embeddedMazemap?.remove?.();
+      } catch {
+        //ignore
+      }
     };
   }, [Mazemap, mazemapPoi, isMac]);
 
@@ -166,27 +183,39 @@ export const MazemapEmbed = ({ mazemapPoi, ...props }: Props) => {
     );
   }
 
-  return (
-    <Flex column gap="var(--spacing-sm)">
-      <div
-        style={{
-          height: props.height || 400,
-          opacity: blockScrollZoom || blockTouchMovement ? 0.5 : 1,
-          touchAction: 'pan-x pan-y',
-        }}
-        id="mazemap-embed"
-        className={cx(styles.mazemapEmbed, props.className)}
-      >
-        {(blockScrollZoom || blockTouchMovement) && (
-          <span className={styles.blockingText}>
-            {blockScrollZoom
-              ? `Hold ${isMac ? '⌘' : 'ctrl'} for å zoome`
-              : 'Bruk to fingre for å flytte kartet'}
-          </span>
-        )}
-      </div>
-    </Flex>
-  );
+  if (webglError) {
+    return (
+      <Flex gap={'5px'} justifyContent="center">
+        <p>Nettleseren støtter ikke WebGL.</p>
+        <Tooltip content="Prøv å slå på grafikkakselerasjon i nettleserinnstillingene dine.">
+          <Icon iconNode={<Info />} size={18} />
+        </Tooltip>
+      </Flex>
+    );
+  }
+  {
+    return (
+      <Flex column gap="var(--spacing-sm)">
+        <div
+          style={{
+            height: props.height || 400,
+            opacity: blockScrollZoom || blockTouchMovement ? 0.5 : 1,
+            touchAction: 'pan-x pan-y',
+          }}
+          id="mazemap-embed"
+          className={cx(styles.mazemapEmbed, props.className)}
+        >
+          {(blockScrollZoom || blockTouchMovement) && (
+            <span className={styles.blockingText}>
+              {blockScrollZoom
+                ? `Hold ${isMac ? '⌘' : 'ctrl'} for å zoome`
+                : 'Bruk to fingre for å flytte kartet'}
+            </span>
+          )}
+        </div>
+      </Flex>
+    );
+  }
 };
 
 export const mazemapDeps = (

--- a/lego-webapp/cypress/e2e/create_meeting_spec.ts
+++ b/lego-webapp/cypress/e2e/create_meeting_spec.ts
@@ -50,14 +50,14 @@ describe('Create meeting', () => {
     fieldError('date').should('not.exist');
     fieldError('description').should('not.exist');
 
-    setDatePickerTime('date', '19', '30', false);
-    setDatePickerTime('date', '20', '00', true);
+    setDatePickerTime('date', '18', '30', false);
+    setDatePickerTime('date', '19', '00', true);
 
     fieldError('date').should('not.exist');
-    field('date').should('contain.value', '19:30');
-    field('date').should('contain.value', '20:00');
+    field('date').should('contain.value', '18:30');
+    field('date').should('contain.value', '19:00');
 
-    setDatePickerTime('date', '20', '30', true);
+    setDatePickerTime('date', '19', '30', true);
 
     fieldError('date').should('not.exist');
 
@@ -203,7 +203,7 @@ describe('Create meeting', () => {
     cy.get(t('Modal__closeButton')).click();
 
     setDatePickerTime('date', '17', '15', false);
-    setDatePickerTime('date', '20', '00', true);
+    setDatePickerTime('date', '19', '00', true);
     field('useMazemap').click();
     selectFromSelectField('mazemapPoi', 'Abakus, Realfagbygget', 'abakus');
     selectFromSelectField('users', 'bedkom bedkom (bedkom)', 'bedkom');
@@ -231,7 +231,7 @@ describe('Create meeting', () => {
       'be.visible',
     );
     cy.contains('div', 'Når')
-      .should('contain.text', '17:15 - 20:00')
+      .should('contain.text', '17:15 - 19:00')
       .should('be.visible');
     cy.contains('div', 'Sted')
       .should('contain.text', 'Abakus, Realfagbygget')


### PR DESCRIPTION
# Description

If the browser does not support WebGL, MazeMap will throw an error when initializing. The error is not handled and will therefore crash the site. 

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
    <tr>
        <td width="25%">Description</td>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
           Better error handling
        </td>
        <td>
<img width="788" height="270" alt="bilde" src="https://github.com/user-attachments/assets/354a8cf3-8990-4522-9f85-16d2eb4ea864" />
        </td>
        <td>
<img width="465" height="335" alt="bilde" src="https://github.com/user-attachments/assets/30845a86-77f3-4223-ab5b-5b2c22b1076e" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #5917 