### PR TITLE
Pin gallery to top of album page

### DIFF
--- a/lego-webapp/pages/photos/+Page.tsx
+++ b/lego-webapp/pages/photos/+Page.tsx
@@ -1,6 +1,6 @@
-import { LinkButton, Page } from '@webkom/lego-bricks';
+import { LinkButton, Page, Flex, Icon } from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
-import { Images } from 'lucide-react';
+import { Images, Pin } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
 import { navigate } from 'vike/client/router';
 import EmptyState from '~/components/EmptyState';
@@ -50,6 +50,17 @@ const Overview = () => {
           )
         }
         onClick={(gallery) => navigate(`/photos/${gallery.id}#list`)}
+        renderOverlay={(gallery) =>
+          gallery.isPinned && (
+            <Flex>
+              <Icon
+                className={styles.pinnedBadge}
+                iconNode={<Pin fill="currentColor" />}
+                size={18}
+              />
+            </Flex>
+          )
+        }
         renderBottom={(photo) => (
           <div className={styles.galleryInfo}>
             <h4 className={styles.galleryTitle}>{photo.title}</h4>

--- a/lego-webapp/pages/photos/Overview.module.css
+++ b/lego-webapp/pages/photos/Overview.module.css
@@ -78,3 +78,12 @@
 .toggleButton {
   cursor: pointer;
 }
+
+.pinnedBadge {
+  position: absolute;
+  top: var(--spacing-xs);
+  right: var(--spacing-xs);
+  color: var(--white);
+  padding: var(--spacing-xs);
+  rotate: 40deg;
+}

--- a/lego-webapp/pages/photos/new/+Page.tsx
+++ b/lego-webapp/pages/photos/new/+Page.tsx
@@ -110,6 +110,7 @@ export type FormValues = {
   event: (typeof searchMapping)['events.event'];
   description: string;
   publicMetadata: boolean;
+  isPinned: boolean;
 } & ObjectPermissionsMixin;
 
 const TypedLegoForm = LegoFinalForm<FormValues>;
@@ -178,6 +179,7 @@ const GalleryEditor = () => {
       ...normalizeObjectPermissions(data),
       // id: data.id,
       publicMetadata: data.publicMetadata,
+      isPinned: data.isPinned,
       title: data.title,
       description: data.description,
       takenAt: moment(data.takenAt).format('YYYY-MM-DD'),
@@ -333,6 +335,13 @@ const GalleryEditor = () => {
               label="Publiser metadata for deling på sosiale medier"
               description="Dette deler kun cover, tittel og beskrivelse"
               name="publicMetadata"
+              type="checkbox"
+              component={CheckBox.Field}
+            />
+            <Field
+              label="Fest album til toppen"
+              description="Albumet vises øverst på albumoversikten"
+              name="isPinned"
               type="checkbox"
               component={CheckBox.Field}
             />

--- a/lego-webapp/redux/models/Gallery.d.ts
+++ b/lego-webapp/redux/models/Gallery.d.ts
@@ -15,6 +15,7 @@ interface Gallery {
   takenAt: Dateish;
   createdAt: Dateish;
   pictureCount: number;
+  isPinned: boolean;
   event: PublicEvent;
   photographers: PublicUser[];
   publicMetadata: unknown;
@@ -31,6 +32,7 @@ export type ListGallery = Pick<
   | 'takenAt'
   | 'createdAt'
   | 'pictureCount'
+  | 'isPinned'
 >;
 
 export type AdminListGallery = ListGallery & ObjectPermissionsMixin;
@@ -45,6 +47,7 @@ export type DetailedGallery = Pick<
   | 'createdAt'
   | 'event'
   | 'photographers'
+  | 'isPinned'
   | 'cover'
   | 'publicMetadata'
   | 'pictures'

--- a/lego-webapp/redux/slices/galleries.ts
+++ b/lego-webapp/redux/slices/galleries.ts
@@ -6,7 +6,10 @@ import { EntityType } from '~/redux/models/entities';
 import type { RootState } from '~/redux/rootReducer';
 
 const legoAdapter = createLegoAdapter(EntityType.Galleries, {
-  sortComparer: (a, b) => moment(b.takenAt).diff(a.takenAt),
+  sortComparer: (a, b) => {
+    if (a.isPinned != b.isPinned) return a.isPinned ? -1 : 1;
+    return moment(b.takenAt).diff(a.takenAt);
+  },
 });
 const galleriesSlice = createSlice({
   name: EntityType.Galleries,


### PR DESCRIPTION
# Description

Possible to pin an album to the top of the gallery page

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

# Pinned galleried at the top
<img width="994" height="385" alt="Screenshot 2026-04-16 at 00 11 21" src="https://github.com/user-attachments/assets/585a2dfa-7b04-480e-95bc-05dbf6210daf" />

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Backend [PR](https://github.com/webkom/lego/pull/4119)
