### PR TITLE
**new-feature** Lending Calender Request link to Request page

### DIFF
--- a/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.module.css
+++ b/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.module.css
@@ -124,3 +124,11 @@
   background-color: var(--color-red-2);
   border: 2px solid var(--color-red-4);
 }
+
+.clickableRequestCell {
+  position: absolute;
+  display: block;
+  width: 100%;
+  inset: 0;
+  height: 100%;
+}

--- a/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.tsx
+++ b/lego-webapp/pages/lending/@lendableObjectId/LendingCalendar.tsx
@@ -24,6 +24,8 @@ type TimeRange = {
   start: string;
   end: string;
   fullDay: boolean;
+  id?: number;
+  canEditRequest?: boolean;
 };
 
 const LendingCalendar = ({
@@ -73,7 +75,12 @@ const LendingCalendar = ({
       return [];
     }
 
-    for (const [start, end] of lendableObject.availability) {
+    for (const [
+      start,
+      end,
+      id,
+      canEditRequest,
+    ] of lendableObject.availability) {
       if (!start || !end) continue;
 
       const startDate = moment(start);
@@ -89,6 +96,8 @@ const LendingCalendar = ({
           fullDay:
             overlapStart.format('HH:mm') === '00:00' &&
             overlapEnd.format('HH:mm') === '23:59',
+          id: id,
+          canEditRequest: canEditRequest,
         };
 
         const isSimilarToSelected =
@@ -216,6 +225,11 @@ const LendingCalendar = ({
                     const inSelectedRange = isInSelectedRange(dateProps.day);
                     const isEndpoint = isSelectedEndpoint(dateProps.day);
 
+                    // possibly several accepted timeranges
+                    const firstTimeRange = timeRanges[0];
+                    const requestId = firstTimeRange?.id;
+                    const canEdit = firstTimeRange?.canEditRequest;
+
                     return (
                       <td
                         key={j}
@@ -232,6 +246,13 @@ const LendingCalendar = ({
                             isEndpoint && styles.selectedEndpoint,
                           )}
                         >
+                          {canEdit && (
+                            <a
+                              href={`${lendableObjectId}/request/${requestId}/`}
+                              className={styles.clickableRequestCell}
+                            />
+                          )}
+
                           <div className={styles.dayNumber}>
                             {dateProps.day.date()}
                           </div>


### PR DESCRIPTION
# Description

Lending Calender for Lending Object now links to the relevant Lending Request to the corresponding cell if the user has permission to edit the request. Links to the first Request if there are several accepted Requests in the same time span.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

After:

[user_created_request.webm](https://github.com/user-attachments/assets/18e718cc-1754-4bc6-b1c9-7c1578c87ea4)

> Screen recorder KIS after one video

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves [webkom x bekk](https://github.com/orgs/webkom/projects/7/views/10?pane=issue&itemId=174112694&issue=webkom%7Clego-webapp%7C5930)

Depends on [backend pr](https://github.com/webkom/lego/compare/availability-pass-requestid-and-edit-boolean?expand=1)
