### PR TITLE
fix the randomization of polls

### DIFF
--- a/lego-webapp/components/Poll/index.tsx
+++ b/lego-webapp/components/Poll/index.tsx
@@ -7,7 +7,7 @@ import {
   Tooltip,
 } from '@webkom/lego-bricks';
 import cx from 'classnames';
-import { sortBy } from 'lodash-es';
+import { sortBy, shuffle } from 'lodash-es';
 import {
   ChartNoAxesColumn,
   ChevronDown,
@@ -185,11 +185,12 @@ type VoteOpenProps = {
 
 const VoteOpen = ({ details, poll, options }: VoteOpenProps) => {
   const dispatch = useAppDispatch();
+  const shuffledOptions = shuffle(options);
 
   return (
     <Flex column alignItems="center" className={styles.optionWrapper}>
       {details && <p className={styles.description}>{poll.description}</p>}
-      {options.map((option) => (
+      {shuffledOptions.map((option) => (
         <Flex key={option.id} width="90%">
           <Button
             className={styles.voteButton}


### PR DESCRIPTION
# Description

Previously, you could see the results of polls before voting. This was quite annoying! Therefore, I (with some help) decided to fix this personal day-ruining problem. 🤗🤗
The options are now randomly shuffled on the frontend, both on the front page and the poll page.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
    <tr>
        <td width="25%">Before Change</td>
        <td>After Change</td>
        <td>After Vote</td>
    </tr>
    <tr>
        <td>
            <img width="633" height="431" alt="image" src="https://github.com/user-attachments/assets/e7fc4b53-881b-43a3-b0a1-1f3dc6a3b914" />
        </td>
        <td>
<img width="672" height="459" alt="image" src="https://github.com/user-attachments/assets/cc32f170-516c-4a15-b56d-6ef3777f5c92" />
        </td>
        <td>
<img width="631" height="441" alt="image" src="https://github.com/user-attachments/assets/8d31f6ca-67f3-42ee-ad00-25c645d9ec36" />
        </td>
    </tr>
</table>

# Testing

- [x] I have thoroughly tested my changes.
