### PR TITLE
Fix types for restricted mail/announcements

### DIFF
--- a/lego-webapp/pages/admin/email/restricted/RestrictedMailEditor.tsx
+++ b/lego-webapp/pages/admin/email/restricted/RestrictedMailEditor.tsx
@@ -26,38 +26,39 @@ const validate = createValidator({
 const RestrictedMailEditor = () => {
   const { restrictedMailId } = useParams<{ restrictedMailId: string }>();
   const isNew = restrictedMailId === undefined;
-  const restrictedMail = useAppSelector<DetailedRestrictedMail | undefined>(
-    (state) => selectRestrictedMailById(state, restrictedMailId),
+  const restrictedMail = useAppSelector((state) =>
+    selectRestrictedMailById<DetailedRestrictedMail>(state, restrictedMailId),
   );
 
-  const initialValues = isNew
-    ? {}
-    : {
-        ...restrictedMail,
-        groups: (restrictedMail?.groups || []).map((groups) => ({
-          label: groups.name,
-          value: groups.id,
-        })),
-        meetings: (restrictedMail?.meetings || []).map((meeting) => ({
-          label: meeting.title,
-          value: meeting.id,
-        })),
-        events: (restrictedMail?.events || []).map((event) => ({
-          label: event.title,
-          value: event.id,
-        })),
-        // Raw Sauce
-        rawAddresses: (restrictedMail?.rawAddresses || []).map(
-          (rawAddresses) => ({
-            label: rawAddresses,
-            value: rawAddresses,
-          }),
-        ),
-        users: (restrictedMail?.users || []).map((user) => ({
-          label: user.fullName,
-          value: user.id,
-        })),
-      };
+  const initialValues =
+    isNew || !restrictedMail
+      ? {}
+      : {
+          ...restrictedMail,
+          groups: (restrictedMail?.groups || []).map((groups) => ({
+            label: groups.name,
+            value: groups.id,
+          })),
+          meetings: (restrictedMail?.meetings || []).map((meeting) => ({
+            label: meeting.title,
+            value: meeting.id,
+          })),
+          events: (restrictedMail?.events || []).map((event) => ({
+            label: event.title,
+            value: event.id,
+          })),
+          // Raw Sauce
+          rawAddresses: (restrictedMail?.rawAddresses || []).map(
+            (rawAddresses) => ({
+              label: rawAddresses,
+              value: rawAddresses,
+            }),
+          ),
+          users: (restrictedMail?.users || []).map((user) => ({
+            label: user.fullName,
+            value: user.id,
+          })),
+        };
 
   const dispatch = useAppDispatch();
 

--- a/lego-webapp/pages/announcements/AnnouncementsCreate.tsx
+++ b/lego-webapp/pages/announcements/AnnouncementsCreate.tsx
@@ -33,22 +33,10 @@ import {
 } from '~/utils/validation';
 import styles from './AnnouncementsList.module.css';
 import type { FormApi } from 'final-form';
-import type {
-  AutocompleteEvent,
-  SearchEvent,
-  UnknownEvent,
-} from '~/redux/models/Event';
-import type {
-  AutocompleteGroup,
-  SearchGroup,
-  UnknownGroup,
-} from '~/redux/models/Group';
-import type {
-  AutocompleteMeeting,
-  SearchMeeting,
-  UnknownMeeting,
-} from '~/redux/models/Meeting';
-import type { AutocompleteUser } from '~/redux/models/User';
+import type { UnknownEvent } from '~/redux/models/Event';
+import type { UnknownGroup } from '~/redux/models/Group';
+import type { UnknownMeeting } from '~/redux/models/Meeting';
+import type { SearchResult } from '~/redux/slices/search';
 
 export type AnnouncementCreateLocationState = {
   group?: UnknownGroup;
@@ -58,13 +46,13 @@ export type AnnouncementCreateLocationState = {
 
 export type FormValues = {
   message: string;
-  users?: AutocompleteUser[];
-  groups?: (AutocompleteGroup | SearchGroup)[];
-  events?: (AutocompleteEvent | SearchEvent)[];
+  users?: SearchResult[];
+  groups?: SearchResult[];
+  events?: SearchResult[];
   excludeWaitingList?: boolean;
-  meetings?: (AutocompleteMeeting | SearchMeeting)[];
-  meetingInvitationStatus?: MeetingInvitationStatus;
-  fromGroup?: AutocompleteGroup;
+  meetings?: SearchResult[];
+  meetingInvitationStatus?: { label: string; value: MeetingInvitationStatus };
+  fromGroup?: SearchResult;
   send: boolean;
 };
 

--- a/lego-webapp/redux/actions/AnnouncementsActions.ts
+++ b/lego-webapp/redux/actions/AnnouncementsActions.ts
@@ -2,11 +2,23 @@ import { Announcements } from '~/redux/actionTypes';
 import callAPI from '~/redux/actions/callAPI';
 import { announcementsSchema } from '~/redux/schemas';
 import type { EntityId } from '@reduxjs/toolkit';
-import type { FormValues as CreateAnnouncementFormValues } from '~/pages/announcements/AnnouncementsCreate';
 import type {
   DetailedAnnouncement,
   ListAnnouncement,
 } from '~/redux/models/Announcement';
+import type { MeetingInvitationStatus } from '~/redux/models/MeetingInvitation';
+
+export type CreateAnnouncementPayload = {
+  message: string;
+  users?: (string | undefined)[];
+  groups?: (string | undefined)[];
+  events?: (string | undefined)[];
+  meetings?: (string | undefined)[];
+  excludeWaitingList?: boolean;
+  meetingInvitationStatus?: MeetingInvitationStatus;
+  fromGroup?: string;
+  send: boolean;
+};
 
 export function fetchAll() {
   return callAPI<ListAnnouncement[]>({
@@ -20,7 +32,7 @@ export function fetchAll() {
   });
 }
 
-export function createAnnouncement(body: CreateAnnouncementFormValues) {
+export function createAnnouncement(body: CreateAnnouncementPayload) {
   return callAPI<DetailedAnnouncement>({
     types: Announcements.CREATE,
     endpoint: '/announcements/',


### PR DESCRIPTION
# Description

Fix types in restricted mail / announcements

# Testing

- [x] I have thoroughly tested my changes.

Cause: FormValues typed the autocomplete fields as raw entities, but the form
  holds the post-transformAutocompletes shape (SearchResult, with .value). The
  same type was re-imported by createAnnouncement for its body - but the API
  body is just IDs.

Fix:
  - FormValues: use SearchResult for autocomplete fields; option shape for
  meetingInvitationStatus.
  - createAnnouncement: new local CreateAnnouncementPayload type for the request
   body.

Errors fixed
  - initialValues (3× TS2322): SearchResult[] vs declared entity arrays - lines
  90, 98, 106.

  - .value access in onSubmit (5× TS2339, 1× TS2551): declared types have no
  .value - lines 124, 125, 126, 127, 128, 129.