### PR TITLE
change max-width of lego

### DIFF
--- a/lego-webapp/components/Footer/Footer.module.css
+++ b/lego-webapp/components/Footer/Footer.module.css
@@ -20,6 +20,7 @@
   padding: var(--spacing-md);
   margin-bottom: -1px; /* In case of glitchy render */
   background: url('../../assets/skyline.svg') bottom center no-repeat;
+  background-size: min(775px, 100%) auto;
 
   @media (--small-viewport) {
     justify-content: center;

--- a/lego-webapp/styles/custom-media.css
+++ b/lego-webapp/styles/custom-media.css
@@ -1,5 +1,5 @@
 @custom-media --small-viewport (max-width: 35em);
 @custom-media --medium-viewport (max-width: 45em);
 @custom-media --mobile-device (max-width: 992px);
-@custom-media --lego-max-width (max-width: 1100px);
+@custom-media --lego-max-width (max-width: 1280px);
 @custom-media --tall-viewport (min-height: 900px);

--- a/lego-webapp/styles/variables.css
+++ b/lego-webapp/styles/variables.css
@@ -26,7 +26,7 @@
   --danger-color: var(--color-red-6);
   --success-color: var(--color-green-6);
 
-  --lego-max-width: 1100px;
+  --lego-max-width: 1280px;
 
   --lego-header-height: 120px;
   --development-banner-height: 0px;

--- a/packages/lego-bricks/src/components/Layout/Page/PageCover.module.css
+++ b/packages/lego-bricks/src/components/Layout/Page/PageCover.module.css
@@ -2,7 +2,6 @@
   grid-area: cover;
   box-sizing: border-box;
   max-width: var(--lego-max-width);
-  max-height: 330px;
   aspect-ratio: 3.3;
   width: 100%;
   overflow: hidden;


### PR DESCRIPTION
# Description

Maybe my most controversial PR🙈

Bump --lego-max-width from 1100px → 1280px

1100px is starting to feel cramped on modern laptop screens. 1280px is a
common industry sweet spot (GitHub, Linear, etc.) and gives us more
breathing room without going full-bleed.

Changes:
- --lego-max-width: 1100px → 1280px (affects navbar, footer, and anything
composing the container utility)
- Scaled up the footer skyline SVG to match - it was designed at 1100px wide

Worth checking out on the branch to get a feel for it - some components may
look a bit wide with the extra space and could use follow-up tweaks.

---

### BEFORE
<img width="1510" height="825" alt="Screenshot 2026-05-14 at 18 15 09" src="https://github.com/user-attachments/assets/12ea9d5f-38f6-454b-b6d2-6a95cf594f59" />


### AFTER
<img width="1511" height="785" alt="Screenshot 2026-05-14 at 18 15 18" src="https://github.com/user-attachments/assets/2c182a1e-03c8-423d-8f49-67768e78baaf" />
