### PR TITLE
Refactor and optimize droneCI setup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ steps:
     environment:
       POSTGRES_USER: lego
       POSTGRES_HOST_AUTH_METHOD: trust
-    when:
+    when: &checks
       event: [push]
       branch:
         exclude: [build]
@@ -28,10 +28,7 @@ steps:
       MINIO_SECRET_KEY: lego-dev
     commands:
       - /usr/bin/docker-entrypoint.sh server /export
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
 
   - name: thumbor
     image: apsl/thumbor:latest
@@ -51,18 +48,12 @@ steps:
       LOADER: tc_aws.loaders.s3_loader
     links:
       - minio
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
 
   - name: redis
     image: redis
     detach: true
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
 
   - name: api
     image: registry.webkom.dev/webkom/lego:latest
@@ -111,19 +102,13 @@ steps:
       SEARCH_BACKEND: 'postgres'
       ELASTICSEARCH_HOST: 'ignored'
       CORS_ORIGIN_DOMAINS: 'frontend:3000'
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
 
   - name: legocypresshelper
     image: abakus/lego-cypress-helper:latest
     detach: true
     pull: true
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     environment:
       PG_HOST: postgres
       PG_USERNAME: lego
@@ -136,16 +121,9 @@ steps:
 
   - name: setup
     image: node:20-alpine
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
-      - postgres
-      - minio
-      - thumbor
-      - redis
-      - api
+      - clone
     volumes:
       - name: pnpm-store
         path: /drone/src/.pnpm-store
@@ -160,10 +138,7 @@ steps:
 
   - name: build
     image: node:20-alpine
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
       - setup
     commands:
@@ -173,10 +148,7 @@ steps:
 
   - name: test
     image: node:20-alpine
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
       - setup
     commands:
@@ -186,10 +158,7 @@ steps:
 
   - name: lint
     image: node:20-alpine
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
       - setup
     commands:
@@ -199,10 +168,7 @@ steps:
 
   - name: typescript
     image: node:20-slim
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
       - setup
     commands:
@@ -211,16 +177,27 @@ steps:
       - pnpm types
     failure: ignore
 
+  - name: audit
+    image: node:20-alpine
+    when: *checks
+    depends_on:
+      - clone
+    commands:
+      - npm i -g corepack
+      - corepack enable
+      - pnpm audit --prod
+    failure: ignore
+
   - name: install_cypress
     image: node:20-alpine
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
       - setup
+    volumes:
+      - name: cypress-cache
+        path: /cypress-cache
     environment:
-      CYPRESS_CACHE_FOLDER: /drone/src/.cypress_cache
+      CYPRESS_CACHE_FOLDER: /cypress-cache
     commands:
       - npm i -g corepack
       - corepack enable
@@ -229,10 +206,7 @@ steps:
   - name: frontend
     image: node:20-alpine
     detach: true
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
       - build
     environment:
@@ -249,20 +223,20 @@ steps:
     image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1
     shm_size: 512m
     ipc: host
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
       - legocypresshelper
       - install_cypress
       - frontend
+    volumes:
+      - name: cypress-cache
+        path: /cypress-cache
     environment:
       TZ: Europe/Oslo
       CYPRESS_API_BASE_URL: http://api:8000
       CYPRESS_RESET_DB_API: http://legocypresshelper:3030
       CYPRESS_BASE_URL: http://frontend:3000
-      CYPRESS_CACHE_FOLDER: /drone/src/.cypress_cache
+      CYPRESS_CACHE_FOLDER: /cypress-cache
       CYPRESS_RECORD_KEY:
         from_secret: cypress_record_key
     commands:
@@ -274,16 +248,16 @@ steps:
 
   - name: cypress_component
     image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1
-    when:
-      event: [push]
-      branch:
-        exclude: [build]
+    when: *checks
     depends_on:
       - install_cypress
       - build
+    volumes:
+      - name: cypress-cache
+        path: /cypress-cache
     environment:
       TZ: Europe/Oslo
-      CYPRESS_CACHE_FOLDER: /drone/src/.cypress_cache
+      CYPRESS_CACHE_FOLDER: /cypress-cache
     commands:
       - npm i -g corepack
       - corepack enable
@@ -353,10 +327,13 @@ volumes:
   - name: pnpm-store
     host:
       path: /tmp/drone-cache/pnpm
+  - name: cypress-cache
+    host:
+      path: /tmp/drone-cache/cypress
 
 image_pull_secrets:
   - dockerconfigjson
 
 ---
 kind: signature
-hmac: c7e50bfcec2b7a481bc69e26c282ffc48c24c4665cb22816b17d87e2ebc07ce9
+hmac: 390b7ff64d98cd699f30a2afcc2f472b38ea879241ae31fe5fdbfd1e126bc126


### PR DESCRIPTION
# Description

I would like inputs from the more experience regarding our droneCI. I done some research on how to make droneCI more effective. It has been a pain waiting for checks, and I feel like a lot of it is redundant or at least could have done in parallell. This is what I have attempted to implement:

1. Define check step and refer to it by the other tests. More of a refactor.
2. Decouple setup from the backend services (biggest speedup)
	- `pnpm install` has no reason to wait for postgres/api to spin up
	- `setup` -> build/test/lint/typescript/install_cypress now run in parallell with the slow api step (reset_db/migrate/load_fixtures/rebuild_index), instead of after it.
3. Persist the Cypress binary across builds
	- New host volume, mounted into the three Cypress steps so the 100MB binary download happens once
4. New non-gating `pnpm audit` step for security vulnerabilities 

All in all I dont think this is going to reduce a lot of time, but at least its faster😅

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #5970 