### PR TITLE
Fix: Check who can see allergies

### DIFF
--- a/lego-webapp/pages/events/@eventId/administrate/allergies/+Page.tsx
+++ b/lego-webapp/pages/events/@eventId/administrate/allergies/+Page.tsx
@@ -64,17 +64,19 @@ const Allergies = () => {
 
   const dispatch = useAppDispatch();
 
+  const canSee = canSeeAllergies(currentUser, event);
+
   usePreparedEffect(
     'fetchAllergies',
-    () => eventId && dispatch(fetchAllergies(eventId)),
-    [eventId],
+    () => eventId && canSee && dispatch(fetchAllergies(eventId)),
+    [eventId, canSee],
   );
 
   if (!event?.id) {
     return <LoadingIndicator loading={fetching} />;
   }
 
-  if (!canSeeAllergies(currentUser, event)) {
+  if (!canSee) {
     return <HTTPError statusCode={403} />;
   }
 


### PR DESCRIPTION
# Description

Proper check on users that can view allergies. Before people could navigate to the page even thought it was disabled by just navigating to the endpoint.

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

[Backend PR](https://github.com/webkom/lego/pull/4157)
