### PR TITLE
Fix apple wallet payment request

### DIFF
--- a/lego-webapp/pages/events/@eventIdOrSlug/JoinEventForm.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/JoinEventForm.tsx
@@ -155,13 +155,6 @@ const PaymentForm = ({
     }}
   >
     <h3>Betaling</h3>
-    <Card className={styles.warningBox} severity="warning">
-      <Card.Header>Advarsel</Card.Header>
-      <span>
-        Vi har for øyeblikket problemer med Stripe. Derfor fungerer ikke Apple
-        Pay akkurat nå.
-      </span>
-    </Card>
     <div className={styles.eventPrice} title="Special price for you my friend!">
       Du skal betale{' '}
       <b>{(event.price / 100).toFixed(2).replace('.', ',')} kr</b>

--- a/lego-webapp/pages/events/@eventIdOrSlug/StripeElement.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/StripeElement.tsx
@@ -14,6 +14,7 @@ import { payment } from '~/redux/actions/EventActions';
 import { useAppDispatch } from '~/redux/hooks';
 import { appConfig } from '~/utils/appConfig';
 import { useTheme } from '~/utils/themeUtils';
+import { confirmPaymentRequest } from './confirmPaymentRequest';
 import stripeStyles from './Stripe.module.css';
 import type {
   PaymentRequest,
@@ -222,51 +223,19 @@ const PaymentRequestForm = (props: PaymentRequestFormProps) => {
       return;
     }
 
-    const handlePaymentMethod = async ({
+    const handlePaymentMethod = ({
       paymentMethod,
       complete,
-    }: PaymentRequestPaymentMethodEvent) => {
-      if (!clientSecret) {
-        complete('fail');
-        setError(
-          'Betalingen er ikke klar enda. Vent et øyeblikk og prøv igjen.',
-        );
-        return;
-      }
-
-      const { error: confirmError } = await stripe.confirmCardPayment(
+    }: PaymentRequestPaymentMethodEvent) =>
+      confirmPaymentRequest({
+        stripe,
         clientSecret,
-        { payment_method: paymentMethod.id },
-        { handleActions: false },
-      );
-
-      if (confirmError) {
-        complete('fail');
-        setError(
-          confirmError.message ??
-            'Det oppsto en ukjent feil. Hvis problemet vedvarer, ta kontakt med Webkom.',
-        );
-        return;
-      }
-
-      // Dismiss the payment sheet before handling any required next actions
-      // (e.g. 3D Secure), as recommended by Stripe.
-      complete('success');
-      setLoading(true);
-
-      const { error } = await stripe.confirmCardPayment(clientSecret);
-
-      if (error) {
-        setError(
-          error.message ??
-            'Det oppsto en ukjent feil. Hvis problemet vedvarer, ta kontakt med Webkom.',
-        );
-      } else {
-        setSuccess();
-      }
-
-      setLoading(false);
-    };
+        paymentMethod,
+        complete,
+        setError,
+        setLoading,
+        setSuccess,
+      });
 
     paymentRequest.on('paymentmethod', handlePaymentMethod);
 

--- a/lego-webapp/pages/events/@eventIdOrSlug/StripeElement.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/StripeElement.tsx
@@ -9,13 +9,16 @@ import {
 } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { Button, Card, LoadingIndicator } from '@webkom/lego-bricks';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { payment } from '~/redux/actions/EventActions';
 import { useAppDispatch } from '~/redux/hooks';
 import { appConfig } from '~/utils/appConfig';
 import { useTheme } from '~/utils/themeUtils';
 import stripeStyles from './Stripe.module.css';
-import { confirmPaymentRequest } from './confirmPaymentRequest';
+import {
+  PAYMENT_NOT_READY_ERROR,
+  confirmPaymentRequest,
+} from './confirmPaymentRequest';
 import type {
   PaymentRequest,
   PaymentRequestPaymentMethodEvent,
@@ -97,24 +100,29 @@ const CardForm = (props: CardFormProps) => {
         setError(
           'Teknisk feil, skjemaet har ikke blitt startet riktig. Ta kontakt med Webkom om problemet vedvarer.',
         );
+        setLoading(false);
         return;
       }
-      const { error } = await stripe.confirmCardPayment(clientSecret, {
-        payment_method: {
-          card: card,
-          billing_details: {
-            email: currentUser.email,
-            name: currentUser.fullName,
+      try {
+        const { error } = await stripe.confirmCardPayment(clientSecret, {
+          payment_method: {
+            card: card,
+            billing_details: {
+              email: currentUser.email,
+              name: currentUser.fullName,
+            },
           },
-        },
-      });
+        });
 
-      if (error) {
-        setError(
-          error.message ?? 'Det skjedde en ukjent feil med betalingen din.',
-        );
-      } else {
-        setSuccess();
+        if (error) {
+          setError(
+            error.message ?? 'Det skjedde en ukjent feil med betalingen din.',
+          );
+        } else {
+          setSuccess();
+        }
+      } catch {
+        setError('Det skjedde en ukjent feil med betalingen din.');
       }
 
       setLoading(false);
@@ -175,8 +183,10 @@ const PaymentRequestForm = (props: PaymentRequestFormProps) => {
     null,
   );
   const [canMakePayment, setCanMakePayment] = useState(false);
+  const paymentRequested = useRef(false);
 
   const stripe = useStripe();
+  const dispatch = useAppDispatch();
 
   const {
     event,
@@ -213,6 +223,19 @@ const PaymentRequestForm = (props: PaymentRequestFormProps) => {
 
     setPaymentRequest(paymentReq);
   }, [paymentRequest, stripe, event, setCanPaymentRequest]);
+
+  // The card form requests the payment intent when it is submitted, but the
+  // wallet sheet confirms the moment the user authorises it – there is no
+  // submit step to hang it off. Request it as soon as we know a wallet is
+  // available, so the clientSecret is in place before the sheet can open.
+  useEffect(() => {
+    if (!canMakePayment || clientSecret || paymentRequested.current) {
+      return;
+    }
+
+    paymentRequested.current = true;
+    dispatch(payment(event.id));
+  }, [canMakePayment, clientSecret, dispatch, event.id]);
 
   // (Re)register the `paymentmethod` listener whenever its dependencies change,
   // so it always confirms with the current clientSecret. The handler *must*
@@ -258,6 +281,12 @@ const PaymentRequestForm = (props: PaymentRequestFormProps) => {
     >
       {canMakePayment && paymentRequest && (
         <PaymentRequestButtonElement
+          onClick={(e) => {
+            if (!clientSecret) {
+              e.preventDefault();
+              setError(PAYMENT_NOT_READY_ERROR);
+            }
+          }}
           className={stripeStyles.PaymentRequestButton}
           options={{
             style: {

--- a/lego-webapp/pages/events/@eventIdOrSlug/StripeElement.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/StripeElement.tsx
@@ -15,7 +15,10 @@ import { useAppDispatch } from '~/redux/hooks';
 import { appConfig } from '~/utils/appConfig';
 import { useTheme } from '~/utils/themeUtils';
 import stripeStyles from './Stripe.module.css';
-import type { PaymentMethod, PaymentRequest } from '@stripe/stripe-js';
+import type {
+  PaymentRequest,
+  PaymentRequestPaymentMethodEvent,
+} from '@stripe/stripe-js';
 import type { EventRegistrationPaymentStatus } from 'app/models';
 import type {
   AuthUserDetailedEvent,
@@ -45,16 +48,6 @@ type CardFormProps = SharedFormProps & {
 type PaymentRequestFormProps = SharedFormProps & {
   setCanPaymentRequest: (arg0: boolean) => void;
 };
-
-// See https://stripe.com/docs/js/appendix/payment_response#payment_response_object-complete
-// for the statuses
-type CompleteStatus =
-  | 'success'
-  | 'fail'
-  | 'invalid_payer_name'
-  | 'invalid_payer_phone'
-  | 'invalid_payer_email'
-  | 'invalid_shipping_address';
 
 function StripeElementStyle(fontColor) {
   return {
@@ -177,17 +170,10 @@ const CardForm = (props: CardFormProps) => {
 };
 
 const PaymentRequestForm = (props: PaymentRequestFormProps) => {
-  const [complete, setComplete] = useState<
-    ((status: CompleteStatus) => void) | null
-  >(null);
   const [paymentRequest, setPaymentRequest] = useState<PaymentRequest | null>(
     null,
   );
   const [canMakePayment, setCanMakePayment] = useState(false);
-  const [paymentStarted, setPaymentStarted] = useState(false);
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(
-    null,
-  );
 
   const stripe = useStripe();
 
@@ -201,27 +187,73 @@ const PaymentRequestForm = (props: PaymentRequestFormProps) => {
     setCanPaymentRequest,
   } = props;
 
-  const completePayment = useCallback(
-    async (clientSecret) => {
-      if (!complete || !paymentMethod || !stripe) {
+  // Create the PaymentRequest instance once Stripe and the event are ready.
+  useEffect(() => {
+    if (paymentRequest || !stripe || !event) {
+      return;
+    }
+
+    const paymentReq = stripe.paymentRequest({
+      currency: 'nok',
+      total: {
+        label: event.title,
+        amount: event.price,
+      },
+      requestPayerName: true,
+      requestPayerEmail: true,
+      requestPayerPhone: true,
+      country: 'NO',
+    });
+
+    paymentReq.canMakePayment().then((result) => {
+      setCanMakePayment(!!result);
+      setCanPaymentRequest(!!result);
+    });
+
+    setPaymentRequest(paymentReq);
+  }, [paymentRequest, stripe, event, setCanPaymentRequest]);
+
+  // (Re)register the `paymentmethod` listener whenever its dependencies change,
+  // so it always confirms with the current clientSecret. The handler *must*
+  // call `complete()` within 30s to dismiss the Apple Pay / Google Pay sheet –
+  // otherwise it spins forever.
+  useEffect(() => {
+    if (!paymentRequest || !stripe) {
+      return;
+    }
+
+    const handlePaymentMethod = async ({
+      paymentMethod,
+      complete,
+    }: PaymentRequestPaymentMethodEvent) => {
+      if (!clientSecret) {
+        complete('fail');
+        setError(
+          'Betalingen er ikke klar enda. Vent et øyeblikk og prøv igjen.',
+        );
         return;
       }
 
       const { error: confirmError } = await stripe.confirmCardPayment(
         clientSecret,
-        {
-          payment_method: paymentMethod.id,
-        },
+        { payment_method: paymentMethod.id },
         { handleActions: false },
       );
 
       if (confirmError) {
         complete('fail');
+        setError(
+          confirmError.message ??
+            'Det oppsto en ukjent feil. Hvis problemet vedvarer, ta kontakt med Webkom.',
+        );
         return;
       }
 
+      // Dismiss the payment sheet before handling any required next actions
+      // (e.g. 3D Secure), as recommended by Stripe.
       complete('success');
       setLoading(true);
+
       const { error } = await stripe.confirmCardPayment(clientSecret);
 
       if (error) {
@@ -234,83 +266,20 @@ const PaymentRequestForm = (props: PaymentRequestFormProps) => {
       }
 
       setLoading(false);
-    },
-    [stripe, complete, paymentMethod, setError, setSuccess, setLoading],
-  );
-
-  const completePaymentManual = useCallback(
-    async (status: CompleteStatus) => {
-      if (!complete) {
-        return;
-      }
-
-      complete(status);
-
-      if (status === 'success') {
-        setSuccess();
-      }
-    },
-    [complete, setSuccess],
-  );
-
-  useEffect(() => {
-    if (!paymentRequest && stripe && event) {
-      // Create a paymentRequest instance
-      const paymentReq = stripe.paymentRequest({
-        currency: 'nok',
-        total: {
-          label: event.title,
-          amount: event.price,
-        },
-        requestPayerName: true,
-        requestPayerEmail: true,
-        requestPayerPhone: true,
-        country: 'NO',
-      });
-      // Complete the payment
-      paymentReq.on('paymentmethod', async ({ paymentMethod, complete }) => {
-        setComplete(() => complete);
-        setPaymentMethod(paymentMethod);
-
-        if (clientSecret) {
-          completePayment(clientSecret);
-        }
-      });
-      // Render the Payment Request Button Element
-      paymentReq.canMakePayment().then((result) => {
-        setCanMakePayment(!!result);
-        setCanPaymentRequest(!!result);
-      });
-      setPaymentRequest(paymentReq);
-    }
-  }, [
-    paymentRequest,
-    clientSecret,
-    stripe,
-    event,
-    completePayment,
-    setCanPaymentRequest,
-  ]);
-
-  useEffect(() => {
-    if (clientSecret && completePayment && !paymentStarted) {
-      setPaymentStarted(true);
-      completePayment(clientSecret);
-    }
-  }, [clientSecret, completePayment, paymentStarted, completePaymentManual]);
-
-  useEffect(() => {
-    return () => {
-      completePaymentManual('fail');
     };
-  }, [completePaymentManual]);
+
+    paymentRequest.on('paymentmethod', handlePaymentMethod);
+
+    return () => {
+      paymentRequest.off('paymentmethod', handlePaymentMethod);
+    };
+  }, [paymentRequest, stripe, clientSecret, setError, setSuccess, setLoading]);
 
   useEffect(() => {
-    if (paymentError && setError && completePaymentManual) {
-      completePaymentManual('fail');
+    if (paymentError) {
       setError(paymentError);
     }
-  }, [paymentError, completePaymentManual, setError]);
+  }, [paymentError, setError]);
 
   return (
     <div
@@ -320,14 +289,6 @@ const PaymentRequestForm = (props: PaymentRequestFormProps) => {
     >
       {canMakePayment && paymentRequest && (
         <PaymentRequestButtonElement
-          onClick={(e) => {
-            if (paymentMethod) {
-              e.preventDefault();
-              setError(
-                'Det skjedde en feil under prosesseringen av betalingen. Vennligst refresh siden for å prøve igjen.',
-              );
-            }
-          }}
           className={stripeStyles.PaymentRequestButton}
           options={{
             style: {

--- a/lego-webapp/pages/events/@eventIdOrSlug/StripeElement.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/StripeElement.tsx
@@ -14,8 +14,8 @@ import { payment } from '~/redux/actions/EventActions';
 import { useAppDispatch } from '~/redux/hooks';
 import { appConfig } from '~/utils/appConfig';
 import { useTheme } from '~/utils/themeUtils';
-import { confirmPaymentRequest } from './confirmPaymentRequest';
 import stripeStyles from './Stripe.module.css';
+import { confirmPaymentRequest } from './confirmPaymentRequest';
 import type {
   PaymentRequest,
   PaymentRequestPaymentMethodEvent,

--- a/lego-webapp/pages/events/@eventIdOrSlug/__tests__/confirmPaymentRequest.spec.ts
+++ b/lego-webapp/pages/events/@eventIdOrSlug/__tests__/confirmPaymentRequest.spec.ts
@@ -4,12 +4,38 @@ import type { PaymentMethod, Stripe } from '@stripe/stripe-js';
 
 const paymentMethod = { id: 'pm_123' } as unknown as PaymentMethod;
 
-type ConfirmResult = { error?: { message?: string } };
+const GENERIC_ERROR =
+  'Det oppsto en ukjent feil. Hvis problemet vedvarer, ta kontakt med Webkom.';
 
-const setup = (confirmResults: ConfirmResult[]) => {
+// Shapes returned by stripe.confirmCardPayment, see
+// https://docs.stripe.com/js/payment_intents/confirm_card_payment
+const requiresAction = {
+  paymentIntent: { id: 'pi_123', status: 'requires_action' },
+};
+const succeeded = { paymentIntent: { id: 'pi_123', status: 'succeeded' } };
+const declined = {
+  error: {
+    type: 'card_error',
+    code: 'card_declined',
+    message: 'Your card was declined.',
+  },
+};
+const authenticationFailure = {
+  error: {
+    type: 'card_error',
+    code: 'payment_intent_authentication_failure',
+    message: 'We are unable to authenticate your payment method.',
+  },
+};
+
+type ConfirmOutcome = Record<string, unknown> | Error;
+
+const setup = (outcomes: ConfirmOutcome[]) => {
   const confirmCardPayment = vi.fn();
-  confirmResults.forEach((result) =>
-    confirmCardPayment.mockResolvedValueOnce(result),
+  outcomes.forEach((outcome) =>
+    outcome instanceof Error
+      ? confirmCardPayment.mockRejectedValueOnce(outcome)
+      : confirmCardPayment.mockResolvedValueOnce(outcome),
   );
   return {
     stripe: { confirmCardPayment } as unknown as Stripe,
@@ -23,7 +49,7 @@ const setup = (confirmResults: ConfirmResult[]) => {
 
 describe('confirmPaymentRequest', () => {
   it('dismisses the wallet sheet and finalises the payment on success', async () => {
-    const ctx = setup([{}, {}]); // both confirmation steps succeed
+    const ctx = setup([requiresAction, succeeded]);
 
     await confirmPaymentRequest({
       ...ctx,
@@ -48,7 +74,7 @@ describe('confirmPaymentRequest', () => {
   });
 
   it('fails the sheet and surfaces the error when confirmation is rejected', async () => {
-    const ctx = setup([{ error: { message: 'Card declined' } }]);
+    const ctx = setup([declined]);
 
     await confirmPaymentRequest({
       ...ctx,
@@ -57,14 +83,14 @@ describe('confirmPaymentRequest', () => {
     });
 
     expect(ctx.complete).toHaveBeenCalledWith('fail');
-    expect(ctx.setError).toHaveBeenCalledWith('Card declined');
+    expect(ctx.setError).toHaveBeenCalledWith('Your card was declined.');
     expect(ctx.setSuccess).not.toHaveBeenCalled();
     // Must not run the second confirmation after a failure.
     expect(ctx.confirmCardPayment).toHaveBeenCalledTimes(1);
   });
 
   it('still reports an error if a required next action fails after success', async () => {
-    const ctx = setup([{}, { error: { message: '3D Secure failed' } }]);
+    const ctx = setup([requiresAction, authenticationFailure]);
 
     await confirmPaymentRequest({
       ...ctx,
@@ -73,8 +99,42 @@ describe('confirmPaymentRequest', () => {
     });
 
     expect(ctx.complete).toHaveBeenCalledWith('success');
-    expect(ctx.setError).toHaveBeenCalledWith('3D Secure failed');
+    expect(ctx.setError).toHaveBeenCalledWith(
+      'We are unable to authenticate your payment method.',
+    );
     expect(ctx.setSuccess).not.toHaveBeenCalled();
+    expect(ctx.setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('fails the sheet when the first confirmation rejects', async () => {
+    const ctx = setup([new Error('Network error')]);
+
+    await confirmPaymentRequest({
+      ...ctx,
+      clientSecret: 'cs_test',
+      paymentMethod,
+    });
+
+    expect(ctx.complete).toHaveBeenCalledWith('fail');
+    expect(ctx.setError).toHaveBeenCalledWith(GENERIC_ERROR);
+    expect(ctx.setSuccess).not.toHaveBeenCalled();
+    expect(ctx.confirmCardPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the sheet dismissed when the next action rejects', async () => {
+    const ctx = setup([requiresAction, new Error('Network error')]);
+
+    await confirmPaymentRequest({
+      ...ctx,
+      clientSecret: 'cs_test',
+      paymentMethod,
+    });
+
+    expect(ctx.complete).toHaveBeenCalledTimes(1);
+    expect(ctx.complete).toHaveBeenCalledWith('success');
+    expect(ctx.setError).toHaveBeenCalledWith(GENERIC_ERROR);
+    expect(ctx.setSuccess).not.toHaveBeenCalled();
+    expect(ctx.setLoading).toHaveBeenLastCalledWith(false);
   });
 
   it('fails the sheet without charging when there is no clientSecret', async () => {

--- a/lego-webapp/pages/events/@eventIdOrSlug/__tests__/confirmPaymentRequest.spec.ts
+++ b/lego-webapp/pages/events/@eventIdOrSlug/__tests__/confirmPaymentRequest.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { confirmPaymentRequest } from '../confirmPaymentRequest';
+import type { PaymentMethod, Stripe } from '@stripe/stripe-js';
+
+const paymentMethod = { id: 'pm_123' } as unknown as PaymentMethod;
+
+type ConfirmResult = { error?: { message?: string } };
+
+const setup = (confirmResults: ConfirmResult[]) => {
+  const confirmCardPayment = vi.fn();
+  confirmResults.forEach((result) =>
+    confirmCardPayment.mockResolvedValueOnce(result),
+  );
+  return {
+    stripe: { confirmCardPayment } as unknown as Stripe,
+    confirmCardPayment,
+    complete: vi.fn(),
+    setError: vi.fn(),
+    setLoading: vi.fn(),
+    setSuccess: vi.fn(),
+  };
+};
+
+describe('confirmPaymentRequest', () => {
+  it('dismisses the wallet sheet and finalises the payment on success', async () => {
+    const ctx = setup([{}, {}]); // both confirmation steps succeed
+
+    await confirmPaymentRequest({
+      ...ctx,
+      clientSecret: 'cs_test',
+      paymentMethod,
+    });
+
+    // The regression guard: the sheet must be dismissed, otherwise it spins forever.
+    expect(ctx.complete).toHaveBeenCalledWith('success');
+    // First call confirms with the wallet's PaymentMethod and defers next actions.
+    expect(ctx.confirmCardPayment).toHaveBeenNthCalledWith(
+      1,
+      'cs_test',
+      { payment_method: 'pm_123' },
+      { handleActions: false },
+    );
+    // Second call runs any required next actions (e.g. 3D Secure).
+    expect(ctx.confirmCardPayment).toHaveBeenNthCalledWith(2, 'cs_test');
+    expect(ctx.setSuccess).toHaveBeenCalled();
+    expect(ctx.setError).not.toHaveBeenCalled();
+    expect(ctx.setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('fails the sheet and surfaces the error when confirmation is rejected', async () => {
+    const ctx = setup([{ error: { message: 'Card declined' } }]);
+
+    await confirmPaymentRequest({
+      ...ctx,
+      clientSecret: 'cs_test',
+      paymentMethod,
+    });
+
+    expect(ctx.complete).toHaveBeenCalledWith('fail');
+    expect(ctx.setError).toHaveBeenCalledWith('Card declined');
+    expect(ctx.setSuccess).not.toHaveBeenCalled();
+    // Must not run the second confirmation after a failure.
+    expect(ctx.confirmCardPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports an error if a required next action fails after success', async () => {
+    const ctx = setup([{}, { error: { message: '3D Secure failed' } }]);
+
+    await confirmPaymentRequest({
+      ...ctx,
+      clientSecret: 'cs_test',
+      paymentMethod,
+    });
+
+    expect(ctx.complete).toHaveBeenCalledWith('success');
+    expect(ctx.setError).toHaveBeenCalledWith('3D Secure failed');
+    expect(ctx.setSuccess).not.toHaveBeenCalled();
+  });
+
+  it('fails the sheet without charging when there is no clientSecret', async () => {
+    const ctx = setup([]);
+
+    await confirmPaymentRequest({
+      ...ctx,
+      clientSecret: undefined,
+      paymentMethod,
+    });
+
+    expect(ctx.complete).toHaveBeenCalledWith('fail');
+    expect(ctx.setError).toHaveBeenCalled();
+    expect(ctx.confirmCardPayment).not.toHaveBeenCalled();
+    expect(ctx.setSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/lego-webapp/pages/events/@eventIdOrSlug/confirmPaymentRequest.ts
+++ b/lego-webapp/pages/events/@eventIdOrSlug/confirmPaymentRequest.ts
@@ -1,0 +1,68 @@
+import type {
+  PaymentMethod,
+  PaymentRequestCompleteStatus,
+  Stripe,
+} from '@stripe/stripe-js';
+
+const GENERIC_ERROR =
+  'Det oppsto en ukjent feil. Hvis problemet vedvarer, ta kontakt med Webkom.';
+
+type ConfirmPaymentRequestArgs = {
+  stripe: Stripe;
+  clientSecret: string | undefined;
+  paymentMethod: PaymentMethod;
+  complete: (status: PaymentRequestCompleteStatus) => void;
+  setError: (errorMessage: string) => void;
+  setLoading: (loading: boolean) => void;
+  setSuccess: () => void;
+};
+
+/**
+ * Confirms a wallet (Apple Pay / Google Pay) payment triggered by a Stripe
+ * `paymentmethod` event.
+ *
+ * `complete()` must be called on every path to dismiss the wallet sheet –
+ * if it isn't, the Apple Pay / Google Pay sheet spins forever (the bug this
+ * replaced). `complete('success')` is sent before running any required next
+ * actions (e.g. 3D Secure), as recommended by Stripe.
+ */
+export const confirmPaymentRequest = async ({
+  stripe,
+  clientSecret,
+  paymentMethod,
+  complete,
+  setError,
+  setLoading,
+  setSuccess,
+}: ConfirmPaymentRequestArgs) => {
+  if (!clientSecret) {
+    complete('fail');
+    setError('Betalingen er ikke klar enda. Vent et øyeblikk og prøv igjen.');
+    return;
+  }
+
+  const { error: confirmError } = await stripe.confirmCardPayment(
+    clientSecret,
+    { payment_method: paymentMethod.id },
+    { handleActions: false },
+  );
+
+  if (confirmError) {
+    complete('fail');
+    setError(confirmError.message ?? GENERIC_ERROR);
+    return;
+  }
+
+  complete('success');
+  setLoading(true);
+
+  const { error } = await stripe.confirmCardPayment(clientSecret);
+
+  if (error) {
+    setError(error.message ?? GENERIC_ERROR);
+  } else {
+    setSuccess();
+  }
+
+  setLoading(false);
+};

--- a/lego-webapp/pages/events/@eventIdOrSlug/confirmPaymentRequest.ts
+++ b/lego-webapp/pages/events/@eventIdOrSlug/confirmPaymentRequest.ts
@@ -7,6 +7,9 @@ import type {
 const GENERIC_ERROR =
   'Det oppsto en ukjent feil. Hvis problemet vedvarer, ta kontakt med Webkom.';
 
+export const PAYMENT_NOT_READY_ERROR =
+  'Betalingen er ikke klar enda. Vent et øyeblikk og prøv igjen.';
+
 type ConfirmPaymentRequestArgs = {
   stripe: Stripe;
   clientSecret: string | undefined;
@@ -24,7 +27,8 @@ type ConfirmPaymentRequestArgs = {
  * `complete()` must be called on every path to dismiss the wallet sheet –
  * if it isn't, the Apple Pay / Google Pay sheet spins forever (the bug this
  * replaced). `complete('success')` is sent before running any required next
- * actions (e.g. 3D Secure), as recommended by Stripe.
+ * actions (e.g. 3D Secure), as recommended by Stripe:
+ * https://docs.stripe.com/stripe-js/elements/payment-request-button#complete-payment-intents
  */
 export const confirmPaymentRequest = async ({
   stripe,
@@ -37,31 +41,41 @@ export const confirmPaymentRequest = async ({
 }: ConfirmPaymentRequestArgs) => {
   if (!clientSecret) {
     complete('fail');
-    setError('Betalingen er ikke klar enda. Vent et øyeblikk og prøv igjen.');
+    setError(PAYMENT_NOT_READY_ERROR);
     return;
   }
 
-  const { error: confirmError } = await stripe.confirmCardPayment(
-    clientSecret,
-    { payment_method: paymentMethod.id },
-    { handleActions: false },
-  );
+  try {
+    const { error: confirmError } = await stripe.confirmCardPayment(
+      clientSecret,
+      { payment_method: paymentMethod.id },
+      { handleActions: false },
+    );
 
-  if (confirmError) {
+    if (confirmError) {
+      complete('fail');
+      setError(confirmError.message ?? GENERIC_ERROR);
+      return;
+    }
+  } catch {
     complete('fail');
-    setError(confirmError.message ?? GENERIC_ERROR);
+    setError(GENERIC_ERROR);
     return;
   }
 
   complete('success');
   setLoading(true);
 
-  const { error } = await stripe.confirmCardPayment(clientSecret);
+  try {
+    const { error } = await stripe.confirmCardPayment(clientSecret);
 
-  if (error) {
-    setError(error.message ?? GENERIC_ERROR);
-  } else {
-    setSuccess();
+    if (error) {
+      setError(error.message ?? GENERIC_ERROR);
+    } else {
+      setSuccess();
+    }
+  } catch {
+    setError(GENERIC_ERROR);
   }
 
   setLoading(false);


### PR DESCRIPTION
# Description

Fix Apple Pay / Google Pay infinite loading

Apple Pay (and Google Pay) opened the wallet sheet and then span forever, while card payments worked fine. The `paymentmethod` handler never called Stripe's `complete()` - it used a stale closure and was blocked by a prematurely-set `paymentStarted` flag so the sheet never dismissed (Stripe requires complete() within 30s). This confirms the payment inside the listener using the event's own paymentMethod/complete and re-registers it when clientSecret changes, and pulls the logic into `confirmPaymentRequest` with unit tests asserting `complete()` is always called. 

Added spec tests

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [ ] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #5864 
