### PR TITLE
Fix: smooth animation for closing search menu

### DIFF
--- a/lego-webapp/components/Header/index.tsx
+++ b/lego-webapp/components/Header/index.tsx
@@ -167,6 +167,13 @@ const Header = () => {
   const loggedIn = useIsLoggedIn();
   const currentUser = useCurrentUser();
   const searchOpen = useAppSelector((state) => state.search.open);
+  const [renderSearch, setRenderSearch] = useState(searchOpen);
+
+  useEffect(() => {
+    if (searchOpen) {
+      setRenderSearch(true);
+    }
+  }, [searchOpen]);
 
   useEffect(() => {
     if (
@@ -249,7 +256,9 @@ const Header = () => {
           </div>
         </div>
       </div>
-      {searchOpen && <Search />}
+      {renderSearch && (
+        <Search closing={!searchOpen} onClosed={() => setRenderSearch(false)} />
+      )}
     </header>
   );
 };

--- a/lego-webapp/components/Search/Search.module.css
+++ b/lego-webapp/components/Search/Search.module.css
@@ -11,6 +11,10 @@
   animation: fade-in var(--easing-fast) forwards;
 }
 
+.wrapper.closing {
+  animation: fade-out var(--easing-fast) forwards;
+}
+
 @keyframes fade-in {
   from {
     opacity: 0;
@@ -18,6 +22,16 @@
 
   to {
     opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
   }
 }
 

--- a/lego-webapp/components/Search/index.tsx
+++ b/lego-webapp/components/Search/index.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import { debounce } from 'lodash-es';
 import { useMemo, useState } from 'react';
 import { navigate } from 'vike/client/router';
@@ -17,7 +18,12 @@ import {
   getAllLinksFiltered,
 } from './utils';
 
-const Search = () => {
+type SearchProps = {
+  closing: boolean;
+  onClosed: () => void;
+};
+
+const Search = ({ closing, onClosed }: SearchProps) => {
   const loggedIn = useIsLoggedIn();
   const results = useAppSelector(selectAutocomplete);
   const searching = useAppSelector((state) => state.search.searching);
@@ -97,7 +103,15 @@ const Search = () => {
   );
 
   return (
-    <div className={styles.wrapper} tabIndex={-1}>
+    <div
+      className={cx(styles.wrapper, closing && styles.closing)}
+      onAnimationEnd={(e) => {
+        if (closing && e.target === e.currentTarget) {
+          onClosed();
+        }
+      }}
+      tabIndex={-1}
+    >
       <div className={styles.content}>
         <SearchBar
           query={query}


### PR DESCRIPTION
# Description

Opening the search menu had a smooth animation, but closing it was instant. The component was being unmounted before the CSS transition could play, so the closing animation never ran.

Annoyed me for a long time...

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #5992 
