### PR TITLE
Fix: pin React to 18 to remove duplicate React 19

### DIFF
--- a/lego-webapp/package.json
+++ b/lego-webapp/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@gamestdio/websocket": "^0.3.2",
+    "@gsap/react": "^2.1.2",
     "@reduxjs/toolkit": "^2.6.0",
     "@sentry/node": "^9.2.0",
     "@sentry/react": "^9.1.0",
@@ -42,6 +43,7 @@
     "final-form": "^4.20.10",
     "final-form-arrays": "^3.1.0",
     "fuzzy": "^0.1.3",
+    "gsap": "^3.14.2",
     "immer": "^10.1.1",
     "isomorphic-fetch": "^3.0.0",
     "js-cookie": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,16 @@
     "url": "github.com/webkom/lego-webapp"
   },
   "dependencies": {
-    "@gsap/react": "^2.1.2",
-    "gsap": "^3.14.2",
     "prettier": "^3.5.3"
   },
   "prettier": {
     "singleQuote": true
+  },
+  "pnpm": {
+    "overrides": {
+      "react": "^18.3.1",
+      "react-dom": "^18.3.1"
+    }
   },
   "packageManager": "pnpm@10.6.5"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,15 +27,9 @@ catalogs:
     postcss-nested:
       specifier: ^7.0.2
       version: 7.0.2
-    react:
-      specifier: ^18.3.1
-      version: 18.3.1
     react-aria-components:
       specifier: ^1.7.1
       version: 1.7.1
-    react-dom:
-      specifier: ^18.3.1
-      version: 18.3.1
     typescript:
       specifier: ^5.6.3
       version: 5.6.3
@@ -46,16 +40,14 @@ catalogs:
       specifier: ^3.0.9
       version: 3.0.9
 
+overrides:
+  react: ^18.3.1
+  react-dom: ^18.3.1
+
 importers:
 
   .:
     dependencies:
-      '@gsap/react':
-        specifier: ^2.1.2
-        version: 2.1.2(gsap@3.14.2)(react@19.2.7)
-      gsap:
-        specifier: ^3.14.2
-        version: 3.14.2
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -65,6 +57,9 @@ importers:
       '@gamestdio/websocket':
         specifier: ^0.3.2
         version: 0.3.2
+      '@gsap/react':
+        specifier: ^2.1.2
+        version: 2.1.2(gsap@3.14.2)(react@18.3.1)
       '@reduxjs/toolkit':
         specifier: ^2.6.0
         version: 2.6.0(react-redux@9.2.0(@types/react@18.3.18)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
@@ -119,6 +114,9 @@ importers:
       fuzzy:
         specifier: ^0.1.3
         version: 0.1.3
+      gsap:
+        specifier: ^3.14.2
+        version: 3.14.2
       immer:
         specifier: ^10.1.1
         version: 10.1.1
@@ -171,7 +169,7 @@ importers:
         specifier: ^6.15.2
         version: 6.15.2
       react:
-        specifier: 'catalog:'
+        specifier: ^18.3.1
         version: 18.3.1
       react-aria-components:
         specifier: 'catalog:'
@@ -183,7 +181,7 @@ importers:
         specifier: ^2.3.3
         version: 2.3.3(react@18.3.1)
       react-dom:
-        specifier: 'catalog:'
+        specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-dropzone:
         specifier: ^14.3.8
@@ -365,7 +363,7 @@ importers:
         version: 1.6.2
       lucide-react:
         specifier: 'catalog:'
-        version: 0.483.0(react@19.2.7)
+        version: 0.483.0(react@18.3.1)
       postcss-custom-media:
         specifier: 'catalog:'
         version: 11.0.5(postcss@8.5.3)
@@ -373,27 +371,27 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2(postcss@8.5.3)
       react:
-        specifier: 'catalog:'
-        version: 19.2.7
+        specifier: ^18.3.1
+        version: 18.3.1
       react-aria-components:
         specifier: 'catalog:'
-        version: 1.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-cropper:
         specifier: ^2.3.3
-        version: 2.3.3(react@19.2.7)
+        version: 2.3.3(react@18.3.1)
       react-dom:
-        specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       react-dropzone:
         specifier: ^14.3.8
-        version: 14.3.8(react@19.2.7)
+        version: 14.3.8(react@18.3.1)
       react-tiny-popover:
         specifier: ^8.1.6
-        version: 8.1.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 8.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@react-types/shared':
         specifier: ^3.28.0
-        version: 3.28.0(react@19.2.7)
+        version: 3.28.0(react@18.3.1)
       '@storybook/addon-essentials':
         specifier: ^8.6.14
         version: 8.6.14(@types/react@18.3.18)(storybook@8.6.17(prettier@3.5.3))
@@ -402,16 +400,16 @@ importers:
         version: 8.6.4(storybook@8.6.17(prettier@3.5.3))
       '@storybook/addon-links':
         specifier: ^10.0.1
-        version: 10.0.1(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))
+        version: 10.0.1(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))
       '@storybook/blocks':
         specifier: ^8.6.4
-        version: 8.6.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))
+        version: 8.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))
       '@storybook/react':
         specifier: ^10.0.1
-        version: 10.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)
+        version: 10.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)
       '@storybook/react-vite':
         specifier: ^10.3.6
-        version: 10.3.6(esbuild@0.25.12)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.3)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)(vite@6.4.3(@types/node@22.7.7))
+        version: 10.3.6(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.3)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)(vite@6.4.3(@types/node@22.7.7))
       '@storybook/test':
         specifier: ^8.6.4
         version: 8.6.4(storybook@8.6.17(prettier@3.5.3))
@@ -494,10 +492,10 @@ importers:
         specifier: 'catalog:'
         version: 0.483.0(react@18.3.1)
       react:
-        specifier: 'catalog:'
+        specifier: ^18.3.1
         version: 18.3.1
       react-dom:
-        specifier: 'catalog:'
+        specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@eslint/js':
@@ -845,7 +843,7 @@ packages:
     resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
     peerDependencies:
       '@types/react': '*'
-      react: '>=16.8.0'
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -862,7 +860,7 @@ packages:
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
     resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^18.3.1
 
   '@emotion/utils@1.4.2':
     resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
@@ -1406,7 +1404,7 @@ packages:
     resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
     peerDependencies:
       gsap: ^3.12.5
-      react: '>=17'
+      react: ^18.3.1
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1500,7 +1498,7 @@ packages:
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
       '@types/react': '>=16'
-      react: '>=16'
+      react: ^18.3.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1792,7 +1790,7 @@ packages:
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1801,7 +1799,7 @@ packages:
     resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1811,8 +1809,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
+      react-dom: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1824,8 +1822,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
+      react-dom: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1836,7 +1834,7 @@ packages:
     resolution: {integrity: sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1846,8 +1844,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
+      react-dom: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1858,7 +1856,7 @@ packages:
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1868,8 +1866,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
+      react-dom: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1881,8 +1879,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
+      react-dom: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1894,8 +1892,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
+      react-dom: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1906,7 +1904,7 @@ packages:
     resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1915,7 +1913,7 @@ packages:
     resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1924,7 +1922,7 @@ packages:
     resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1933,7 +1931,7 @@ packages:
     resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1942,7 +1940,7 @@ packages:
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1950,134 +1948,134 @@ packages:
   '@react-aria/autocomplete@3.0.0-beta.1':
     resolution: {integrity: sha512-ZeVR1tKJOZK5/RTuN8eprlP1lyeihdDfDYPBkdg2iT5h775LSZyOingPux9aLtdqt/uj6JIS5amK9ErI7+axug==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/breadcrumbs@3.5.22':
     resolution: {integrity: sha512-Jhx3eJqvuSUFL5/TzJ7EteluySdgKVkYGJ72Jz6AdEkiuoQAFbRZg4ferRIXQlmFL2cj7Z3jo8m8xGitebMtgw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/button@3.12.1':
     resolution: {integrity: sha512-IgCENCVUzjfI4nVgJ8T1z2oD81v3IO2Ku96jVljqZ/PWnFACsRikfLeo8xAob3F0LkRW4CTK4Tjy6BRDsy2l6A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/calendar@3.7.2':
     resolution: {integrity: sha512-q16jWzBCoMoohOF75rJbqh+4xlKOhagPC96jsARZmaqWOEHpFYGK/1rH9steC5+Dqe7y1nipAoLRynm18rrt3w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/checkbox@3.15.3':
     resolution: {integrity: sha512-/m5JYoGsi5L0NZnacgqEcMqBo6CcTmsJ9nAY/07MDCUJBcL/Xokd8cL/1K21n6K69MiCPcxORbSBdxJDm9dR0A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/collections@3.0.0-beta.1':
     resolution: {integrity: sha512-udrHajGknkDioGbuqOdWjQ2P7J6fYGlkVGuIJwLxML+WgrroC+i76A4BBOD4ifJKxVAZ8TMyGSztt4RUdn+jDA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/color@3.0.5':
     resolution: {integrity: sha512-F+by1SOvH+qr47jhaZUYLCYMjRFxEBiG2UpNyd0iByIOweeXnU9sRHRAjLSWx/nULB6ZrUhNzE3XhI0SoZyHUw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/combobox@3.12.1':
     resolution: {integrity: sha512-Al43cVQ2XiuPTCZ8jhz5Vmoj5Vqm6GADBtrL+XHZd7lM1gkD3q27GhKYiEt0jrcoBjjdqIiYWEaFLYg5LSQPzA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/datepicker@3.14.1':
     resolution: {integrity: sha512-77HaB+dFaMu7OpDQqjDiyZdaJlkwMgQHjTRvplBVc3Pau1sfQ1LdFC4+ZAXSbQTVSYt6GaN9S2tL4qoc+bO05w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/dialog@3.5.23':
     resolution: {integrity: sha512-ud8b4G5vcFEZPEjzdXrjOadwRMBKBDLiok6lIl1rsPkd1qnLMFxsl3787kct1Ex0PVVKOPlcH7feFw+1T7NsLw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/disclosure@3.0.3':
     resolution: {integrity: sha512-YMZG6NYugRMTElq4bspstML15KFUwZ+ZVUTSQHLLLLnwxkj+R9NbsDonMkH6lpgC02ru0Kgo2+1NljIGz9a5/Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/dnd@3.9.1':
     resolution: {integrity: sha512-Rg43C+MQSr7IN1wv0iAemW59RANE39TsVs1QX9ryRh0Unc14jnm+GhZ928XNuu/rJ6BMUM8Cb9uQuYcVPgeDxA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/focus@3.20.1':
     resolution: {integrity: sha512-lgYs+sQ1TtBrAXnAdRBQrBo0/7o5H6IrfDxec1j+VRpcXL0xyk0xPq+m3lZp8typzIghqDgpnKkJ5Jf4OrzPIw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/form@3.0.14':
     resolution: {integrity: sha512-UYoqdGetKV+4lwGnJ22sWKywobOWYBcOetiBYTlrrnCI6e5j1Jk5iLkLvesCOoI7yfWIW9Ban5Qpze5MUrXUhQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/grid@3.12.1':
     resolution: {integrity: sha512-f0Sx/O6VVjNcg5xq0cLhA7QSCkZodV+/Y0UXJTg/NObqgPX/tqh/KNEy7zeVd22FS6SUpXV+fJU99yLPo37rjQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/gridlist@3.11.1':
     resolution: {integrity: sha512-x2lrQO0kC+kdoCH+iUY6VsgoJlZ/x/w10dKc66npXeVC2EHo2InJDINt9VEIaANnh9i7TiTthdQVeePCP22tMQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/i18n@3.12.7':
     resolution: {integrity: sha512-eLbYO2xrpeOKIEmLv2KD5LFcB0wltFqS+pUjsOzkKZg6H3b6AFDmJPxr/a0x2KGHtpGJvuHwCSbpPi9PzSSQLg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/interactions@3.24.1':
     resolution: {integrity: sha512-OWEcIC6UQfWq4Td5Ptuh4PZQ4LHLJr/JL2jGYvuNL6EgL3bWvzPrRYIF/R64YbfVxIC7FeZpPSkS07sZ93/NoA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/label@3.7.16':
     resolution: {integrity: sha512-tPog3rc5pQ9s2/5bIBtmHtbj+Ebqs2yyJgJdFjZ1/HxrjF8HMrgtBPHCn/70YD5XvmuC3OSkua84kLjNX5rBbA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/landmark@3.0.1':
     resolution: {integrity: sha512-rsbpmDfI8wmTcsOCaLdI2WuvM4z4yBZyOhMSdIxzKxxD0XPM03BBlegPqxZ/VisSwvXT8VB38r5STzmpH3ocLg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/link@3.7.10':
     resolution: {integrity: sha512-prf7s7O1PHAtA+H2przeGr8Ig4cBjk1f0kO0bQQAC3QvVOOUO7WLNU/N+xgOMNkCKEazDl21QM1o0bDRQCcXZg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/listbox@3.14.2':
     resolution: {integrity: sha512-pIwMNZs2WaH+XIax2yemI2CNs5LVV5ooVgEh7gTYoAVWj2eFa3Votmi54VlvkN937bhD5+blH32JRIu9U8XqVw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/live-announcer@3.4.1':
     resolution: {integrity: sha512-4X2mcxgqLvvkqxv2l1n00jTzUxxe0kkLiapBGH1LHX/CxA1oQcHDqv8etJ2ZOwmS/MSBBiWnv3DwYHDOF6ubig==}
@@ -2085,208 +2083,208 @@ packages:
   '@react-aria/menu@3.18.1':
     resolution: {integrity: sha512-czdJFNBW/B7QodyLDyQ+TvT8tZjCru7PrhUDkJS36ie/pTeQDFpIczgYjmKfJs5pP6olqLKXbwJy1iNTh01WTQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/meter@3.4.21':
     resolution: {integrity: sha512-IjV4RdotPG3QC9Zjc8VaT+rvypB6yh9pUiEAjJEFhga+ORN/EWBLI8LHKhfep+50z8hH6AP3HLaKBUdZu+4WyQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/numberfield@3.11.12':
     resolution: {integrity: sha512-VQ4dfaf+k7n2tbP8iB1OLFYTLCh9ReyV7dNLrDvH24V7ByaHakobZjwP8tF6CpvafNYaXPUflxnHpIgXvN3QYA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/overlays@3.26.1':
     resolution: {integrity: sha512-AtQ0mp+H0alFFkojKBADEUIc1AKFsSobH4QNoxQa3V4bZKQoXxga7cRhD5RRYanu3XCQOkIxZJ3vdVK/LVVBXA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/progress@3.4.21':
     resolution: {integrity: sha512-KNjoJTY2AU3L+3rozwC81lwDWn6Yk2XQbcQaxEs5frRBbuiCD7hEdrerLIgKa/J85e61MDuEel0Onc0kV9kpyw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/radio@3.11.1':
     resolution: {integrity: sha512-plAO5MW+QD9/kMe5NNKBzKf/+b6CywdoZ5a1T/VbvkBQYYcHaYQeBuKQ4l+hF+OY2tKAWP0rrjv7tEtacPc9TA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/searchfield@3.8.2':
     resolution: {integrity: sha512-xOhmzDd04CAl2d5L/g+PPqUSFCN7Ue11M9qTHnjoQ3HDJ4D82vY7Qik/crKGpJ2bV5ZoRxRuFaebqGRKCiJhSQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/select@3.15.3':
     resolution: {integrity: sha512-HNtDZTASz6Zt9cFUK+9rmS3XmTwVz/tx1+7W3NNGy5Xx4J8hua0BymcbKiC+Pp/ibPGJT4b7KYyE2N9J17/95w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/selection@3.23.1':
     resolution: {integrity: sha512-z4vVw7Fw0+nK46PPlCV8TyieCS+EOUp3eguX8833fFJ/QDlFp3Ewgw2T5qCIix5U3siXPYU0ZmAMOdrjibdGpQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/separator@3.4.7':
     resolution: {integrity: sha512-zALorCd1my7AAYjRCgR1RdI/w8usVH4GCD8d8MsNyKhZUSDn+TxeriDioNllfgL51rxFRFtnWFhD3/qYVK/vCg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/slider@3.7.17':
     resolution: {integrity: sha512-B+pdHiuM9G6zLYqvkMWAEiP2AppyC3IU032yUxBUrzh3DDoHPgU8HyFurFKS0diwigzcCBcq0yQ1YTalPzWV5A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/spinbutton@3.6.13':
     resolution: {integrity: sha512-phF7WU4mTryPY+IORqQC6eGvCdLItJ41KJ8ZWmpubnLkhqyyxBn8BirXlxWC5UIIvir9c3oohX2Vip/bE5WJiA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/ssr@3.9.7':
     resolution: {integrity: sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==}
     engines: {node: '>= 12'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-aria/switch@3.7.1':
     resolution: {integrity: sha512-CE7G9pPeltbE5wEVIPlrbjarYoMNS8gsb3+RD4Be/ghKSpwppmQyn12WIs6oQl3YQSBD/GZhfA6OTyOBo0Ro9A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/table@3.17.1':
     resolution: {integrity: sha512-yRZoeNwg+7ZNdq7kP9x+u9yMBL4spIdWvY9XTrYGq2XzNzl1aUUBNVszOV3hOwiU0DEF2zzUuuc8gc8Wys40zw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/tabs@3.10.1':
     resolution: {integrity: sha512-9tcmp4L0cCTSkJAVvsw5XkjTs4MP4ajJsWPc9IUXYoutZWSDs2igqx3/7KKjRM4OrjSolNXFf8uWyr9Oqg+vCg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/tag@3.5.1':
     resolution: {integrity: sha512-dFB7bFeCoCZmyiTKwCsXPcQgqPMtqCtdF9B2gn9S/P6esXrPPr5jCvZKyKFZidbKpqiaQnj+SAln5qPBEftoSg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/textfield@3.17.1':
     resolution: {integrity: sha512-W/4nBdyXTOFPQXJ8eRK+74QFIpGR+x24SRjdl+y3WO6gFJNiiopWj8+slSK/T8LoD3g3QlzrtX/ooVQHCG3uQw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/toast@3.0.1':
     resolution: {integrity: sha512-WDzKvQsroIowe4y/5dsZDakG4g0mDju4ZhcEPY3SFVnEBbAH1k0fwSgfygDWZdwg9FS3+oA1IYcbVt4ClK3Vfg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/toggle@3.11.1':
     resolution: {integrity: sha512-9SBvSFpGcLODN1u64tQ8aL6uLFnuuJRA2N0Kjmxp5PE1gk8IKG+BXsjZmq7auDAN5WPISBXw1RzEOmbghruBTQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/toolbar@3.0.0-beta.14':
     resolution: {integrity: sha512-F9wFYhcbVUveo6+JfAjKyz19BnBaXBYG7YyZdGurhn5E1bD+Zrwz/ZCTrrx40xJsbofciCiiwnKiXmzB20Kl5Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/tooltip@3.8.1':
     resolution: {integrity: sha512-g5Vr5HFGfLQRxdYs8nZeXeNrni5YcRGegRjnEDUZwW+Gwvu8KTrD7IeXrBDndS+XoTzKC4MzfvtyXWWpYmT0KQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/tree@3.0.1':
     resolution: {integrity: sha512-USYRpbpbUChDFSquCc6eYQ+czTuge5m9XH1F/xfSJD0gEe9BG7dRJ9GB/dy6yBoZoNy3VWpTNrHUfPnmiKpgUw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/utils@3.28.1':
     resolution: {integrity: sha512-mnHFF4YOVu9BRFQ1SZSKfPhg3z+lBRYoW5mLcYTQihbKhz48+I1sqRkP7ahMITr8ANH3nb34YaMME4XWmK2Mgg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/virtualizer@4.1.3':
     resolution: {integrity: sha512-WzxqQa0mVw96EKHWZIJYQlZfmpOJNpj7PX2Bliawm4rkSS1hpw38waQEHyR95Aexk4vTo5OQnO3w8pun0LXfqg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-aria/visually-hidden@3.8.21':
     resolution: {integrity: sha512-iii5qO+cVHrHiOeiBYCnTRUQG2eOgEPFmiMG4dAuby8+pJJ8U4BvffX2sDTYWL6ztLLBYyrsUHPSw1Ld03JhmA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-stately/autocomplete@3.0.0-beta.0':
     resolution: {integrity: sha512-nWRbDzqHzdZySIqwoEBMIdineoQxR1Wzmb86r+NICBX9cNv0tZBLNnHywHsul/MN61/TthdOpay1QwZUoQSrXw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/calendar@3.7.1':
     resolution: {integrity: sha512-DXsJv2Xm1BOqJAx5846TmTG1IZ0oKrBqYAzWZG7hiDq3rPjYGgKtC/iJg9MUev6pHhoZlP9fdRCNFiCfzm5bLQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/checkbox@3.6.12':
     resolution: {integrity: sha512-gMxrWBl+styUD+2ntNIcviVpGt2Y+cHUGecAiNI3LM8/K6weI7938DWdLdK7i0gDmgSJwhoNRSavMPI1W6aMZQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/collections@3.12.2':
     resolution: {integrity: sha512-RoehfGwrsYJ/WGtyGSLZNYysszajnq0Q3iTXg7plfW1vNEzom/A31vrLjOSOHJWAtwW339SDGGRpymDtLo4GWA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/color@3.8.3':
     resolution: {integrity: sha512-0KaVN2pIOxdAKanFxkx/8zl+73tCoUn2+k7nvK7SpAsFpWScteEHW6hMdmQVwQ2+X+OtQRYHyhhTXULMIIY6iw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/combobox@3.10.3':
     resolution: {integrity: sha512-l4yr8lSHfwFdA+ZpY15w98HkgF1iHytjerdQkMa4C0dCl4NWUyyWMOcgmHA8G56QEdbFo5dXyW6hzF2PJnUOIg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/data@3.12.2':
     resolution: {integrity: sha512-u0yQkISnPyR5RjpNJCSxyC28bx/UvUKtVYRH5yx/MtXbP+2Byn7ItQ+evRqpJB5XsWFlyohGebgbXvL3JSBVsg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/datepicker@3.13.0':
     resolution: {integrity: sha512-I0Y/aQraQyRLMWnh5tBZMiZ0xlmvPjFErXnQaeD7SdOYUHNtQS4BAQsMByQrMfg8uhOqUTKlIh7xEZusuqYWOA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/disclosure@3.0.2':
     resolution: {integrity: sha512-hiArGiJY2y9HcLaGaO1WaXgrTsowd64ZMh8ADVSmxr9drqiMSZ1GXmKuf3DDRHfqKMXX96HNkx5nbv2pczWCsg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/dnd@3.5.2':
     resolution: {integrity: sha512-W3Q3O3eIMPHGVKSvkswY8+WCXEli6Wr+LLXYizwAl0dt2+dKKE4r91YugSVnJxXq3cw1/Z4nccmsAPRZa31plQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/flags@3.1.0':
     resolution: {integrity: sha512-KSHOCxTFpBtxhIRcKwsD1YDTaNxFtCYuAUb0KEihc16QwqZViq4hasgPBs2gYm7fHRbw7WYzWKf6ZSo/+YsFlg==}
@@ -2294,249 +2292,249 @@ packages:
   '@react-stately/form@3.1.2':
     resolution: {integrity: sha512-sKgkV+rxeqM1lf0dCq2wWzdYa5Z0wz/MB3yxjodffy8D43PjFvUOMWpgw/752QHPGCd1XIxA3hE58Dw9FFValg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/grid@3.11.0':
     resolution: {integrity: sha512-Wp6kza+2MzNybls9pRWvIwAHwMnSV1eUZXZxLwJy+JVS5lghkr731VvT+YD79z70osJKmgxgmiQGm4/yfetXdA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/layout@4.2.1':
     resolution: {integrity: sha512-8ndL33URRyDm6Z+NUR2gS0eVOZQB2mP4pGyvSaM8W68RKF5+XXaPY4QLBuCo2+TsNlqsBNbI2qAznQW1SPQ3+g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-stately/list@3.12.0':
     resolution: {integrity: sha512-6niQWJ6TZwOKLAOn2wIsxtOvWenh3rKiKdOh4L4O4f7U+h1Hu000Mu4lyIQm2P9uZAkF2Y5QNh6dHN+hSd6h3A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/menu@3.9.2':
     resolution: {integrity: sha512-mVCFMUQnEMs6djOqgHC2d46k/5Mv5f6UYa4TMnNDSiY8QlHG4eIdmhBmuYpOwWuOOHJ0xKmLQ4PWLzma/mBorg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/numberfield@3.9.10':
     resolution: {integrity: sha512-47ta1GyfLsSaDJIdH6A0ARttPV32nu8a5zUSE2hTfRqwgAd3ksWW5ZEf6qIhDuhnE9GtaIuacsctD8C7M3EOPw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/overlays@3.6.14':
     resolution: {integrity: sha512-RRalTuHdwrKO1BmXKaqBtE1GGUXU4VUAWwgh4lsP2EFSixDHmOVLxHFDWYvOPChBhpi8KXfLEgm6DEgPBvLBZQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/radio@3.10.11':
     resolution: {integrity: sha512-dclixp3fwNBbgpbi66x36YGaNwN7hI1nbuhkcnLAE0hWkTO8/wtKBgGqRKSfNV7MSiWlhBhhcdPcQ+V7q7AQIQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/searchfield@3.5.10':
     resolution: {integrity: sha512-6K0+k/8BO/Iq+ODC5mUSIb+tymemliSiSG6B5auWWOZjnnQ0+9M0MYCUdsiJDPk5aUml5aNYI6rlMZO13uHmVw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/select@3.6.11':
     resolution: {integrity: sha512-8pD4PNbZQNWg33D4+Fa0mrajUCYV3aA5YIwW3GY8NSRwBspaW4PKSZJtDT5ieN0WAO44YkAmX4idRaMAvqRusA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/selection@3.20.0':
     resolution: {integrity: sha512-woUSHMTyQiNmCf63Dyot1WXFfWnm6PFYkI9kymcq1qrrly4g/j27U+5PaRWOHawMiJwn1e1GTogk8B+K5ahshQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/slider@3.6.2':
     resolution: {integrity: sha512-5S9omr29Viv2PRyZ056ZlazGBM8wYNNHakxsTHcSdG/G8WQLrWspWIMiCd4B37cCTkt9ik6AQ6Y3muHGXJI0IQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/table@3.14.0':
     resolution: {integrity: sha512-ALHIgAgSyHeyUiBDWIxmIEl9P4Gy5jlGybcT/rDBM8x7Ik/C/0Hd9f9Y5ubiZSpUGeAXlIaeEdSm0HBfYtQVRw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/tabs@3.8.0':
     resolution: {integrity: sha512-I8ctOsUKPviJ82xWAcZMvWqz5/VZurkE+W9n9wrFbCgHAGK/37bx+PM1uU/Lk4yKp8WrPYSFOEPil5liD+M+ew==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/toast@3.0.0':
     resolution: {integrity: sha512-g7e4hNO9E6kOqyBeLRAfZBihp1EIQikmaH3Uj/OZJXKvIDKJlNlpvwstUIcmEuEzqA1Uru78ozxIVWh3pg9ubg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/toggle@3.8.2':
     resolution: {integrity: sha512-5KPpT6zvt8H+WC9UbubhCTZltREeYb/3hKdl4YkS7BbSOQlHTFC0pOk8SsQU70Pwk26jeVHbl5le/N8cw00x8w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/tooltip@3.5.2':
     resolution: {integrity: sha512-z81kwZWnnf2SE5/rHMrejH5uQu3dXUjrhIa2AGT038DNOmRyS9TkFBywPCiiE7tHpUg/rxZrPxx01JFGvOkmgg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/tree@3.8.8':
     resolution: {integrity: sha512-21WB9kKT9+/tr6B8Q4G53tZXl/3dftg5sZqCR6x055FGd2wGVbkxsLhQLmC+XVkTiLU9pB3BjvZ9eaSj1D8Wmg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/utils@3.10.5':
     resolution: {integrity: sha512-iMQSGcpaecghDIh3mZEpZfoFH3ExBwTtuBEcvZ2XnGzCgQjeYXcMdIUwAfVQLXFTdHUHGF6Gu6/dFrYsCzySBQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-stately/virtualizer@4.3.1':
     resolution: {integrity: sha512-yWRR9NhaD9NQezRUm1n0cQAYAOAYLOJSxVrCAKyhz/AYvG5JMMvFk3kzgrX8YZXoZKjybcdvy3YZ+jbCSprR6g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@react-types/autocomplete@3.0.0-alpha.29':
     resolution: {integrity: sha512-brP6fb7RAdfu/liaE4gFZIZQJLXksgtOzdu/I5cmcHfpqScAFmgedZHkJoeutK9wTWtNnfuKAFQ2w9KKlIBj9w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/breadcrumbs@3.7.11':
     resolution: {integrity: sha512-pMvMLPFr7qs4SSnQ0GyX7i3DkWVs9wfm1lGPFbBO7pJLrHTSK/6Ii4cTEvP6d5o2VgjOVkvce9xCLWW5uosuEQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/button@3.11.0':
     resolution: {integrity: sha512-gJh5i0JiBiZGZGDo+tXMp6xbixPM7IKZ0sDuxTYBG49qNzzWJq0uNYltO3emwSVXFSsBgRV/Wu8kQGhfuN7wIw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/calendar@3.6.1':
     resolution: {integrity: sha512-EMbFJX/3gD5j+R0qZEGqK+wlhBxMSHhGP8GqP9XGbpuJPE3w9/M/PVWdh8FUdzf9srYxPOq5NgiGI1JUJvdZqw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/checkbox@3.9.2':
     resolution: {integrity: sha512-BruOLjr9s0BS2+G1Q2ZZ0ubnSTG54hZWr59lCHXaLxMdA/+KVsR6JVMQuYKsW0P8RDDlQXE/QGz3n9yB/Ara4A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/color@3.0.3':
     resolution: {integrity: sha512-oIVdluqe4jYW6tHEHX80tuhhjCA93HElTzbzIGhDezgEbC/EEhWnoC3sGlkUTqIGdzhZG0T+HAkf3AZbCrXqZA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/combobox@3.13.3':
     resolution: {integrity: sha512-ASPLWuHke4XbnoOWUkNTguUa2cnpIsHPV0bcnfushC0yMSC4IEOlthstEbcdzjVUpWXSyaoI1R4POXmdIP53Nw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/datepicker@3.11.0':
     resolution: {integrity: sha512-GAYgPzqKvd1lR2sLYYMlUkNg2+QoM2uVUmpeQLP1SbYpDr1y8lG5cR54em1G4X/qY4+nCWGiwhRC2veP0D0kfA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/dialog@3.5.16':
     resolution: {integrity: sha512-2D16XjuW9fG3LkVIXu3RzUp3zcK2IZOWlAl+r5i0aLw2Q0QHyYMfGbmgvhxVeAhxhEj/57/ziSl/8rJ9pzmFnw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/form@3.7.10':
     resolution: {integrity: sha512-PPn1OH/QlQLPaoFqp9EMVSlNk41aiNLwPaMyRhzYvFBGLmtbuX+7JCcH2DgV1peq3KAuUKRDdI2M1iVdHYwMPw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/grid@3.3.0':
     resolution: {integrity: sha512-9IXgD5qXXxz+S9RK+zT8umuTCEcE4Yfdl0zUGyTCB8LVcPEeZuarLGXZY/12Rkbd8+r6MUIKTxMVD3Nq9X5Ksg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/link@3.5.11':
     resolution: {integrity: sha512-aX9sJod9msdQaOT0NUTYNaBKSkXGPazSPvUJ/Oe4/54T3sYkWeRqmgJ84RH55jdBzpbObBTg8qxKiPA26a1q9Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/listbox@3.5.5':
     resolution: {integrity: sha512-6cUjbYZVa0X2UMsenQ50ZaAssTUfzX3D0Q0Wd5nNf4W7ntBroDg6aBfNQoPDZikPUy8u+Y3uc/xZQfv30si7NA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/menu@3.9.15':
     resolution: {integrity: sha512-vNEeGxKLYBJc3rwImnEhSVzeIrhUSSRYRk617oGZowX3NkWxnixFGBZNy0w8j0z8KeNz3wRM4xqInRord1mDbw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/meter@3.4.7':
     resolution: {integrity: sha512-2GwNJ65+jd8lvrHMel/kiU8o7oPAOt1Sd+kezaeGBTbzKxUhCOAAlp9+zMha8vHQwmMvqcmfAHAqIBGaaCfh5w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/numberfield@3.8.9':
     resolution: {integrity: sha512-YqhawYUULiZnUba0/9Vaps8WAT2lto4V6CD/X7s048jiOrHiiIX03RDEAQuKOt1UYdzBJDHfSew9uGMyf/nC0g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/overlays@3.8.13':
     resolution: {integrity: sha512-xgT843KIh1otvYPQ6kCGTVUICiMF5UQ7SZUQZd4Zk3VtiFIunFVUvTvL03cpt0026UmY7tbv7vFrPKcT6xjsjw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/progress@3.5.10':
     resolution: {integrity: sha512-YDQExymdgORnSvXTtOW7SMhVOinlrD3bAlyCxO+hSAVaI1Ax38pW5dUFf6H85Jn7hLpjPQmQJvNsfsJ09rDFjQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/radio@3.8.7':
     resolution: {integrity: sha512-K620hnDmSR7u9cZfwJIfoLvmZS1j9liD7nDXBm+N6aiq9E+8sw312sIEX5iR2TrQ4xovvJQZN7DWxPVr+1LfWw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/searchfield@3.6.0':
     resolution: {integrity: sha512-eHQSP85j0hWhWEauPDdr+4kmLB3hUEWxU4ANNubalkupXKhGeRge5/ysHrWjEsLmoodfQ+RS6QIRLQRDsQF/4g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/select@3.9.10':
     resolution: {integrity: sha512-vvC5+cBSOu6J6lm74jhhP3Zvo1JO8m0FNX+Q95wapxrhs2aYYeMIgVuvNKeOuhVqzpBZxWmblBjCVNzCArZOaQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/shared@3.28.0':
     resolution: {integrity: sha512-9oMEYIDc3sk0G5rysnYvdNrkSg7B04yTKl50HHSZVbokeHpnU0yRmsDaWb9B/5RprcKj8XszEk5guBO8Sa/Q+Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/slider@3.7.9':
     resolution: {integrity: sha512-MxCIVkrBSbN3AxIYW4hOpTcwPmIuY4841HF36sDLFWR3wx06z70IY3GFwV7Cbp814vhc84d4ABnPMwtE+AZRGQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/switch@3.5.9':
     resolution: {integrity: sha512-7XIS5qycIKhdfcWfzl8n458/7tkZKCNfMfZmIREgozKOtTBirjmtRRsefom2hlFT8VIlG7COmY4btK3oEuEhnQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/table@3.11.0':
     resolution: {integrity: sha512-83cGyszL+sQ0uFNZvrnvDMg2KIxpe3l5U48IH9lvq2NC41Y4lGG0d7sBU6wgcc3vnQ/qhOE5LcbceGKEi2YSyw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/tabs@3.3.13':
     resolution: {integrity: sha512-jqaK2U+WKChAmYBMO8QxQlFaIM8zDRY9+ignA1HwIyRw7vli4Mycc4RcMxTPm8krvgo+zuVrped9QB+hsDjCsQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/textfield@3.12.0':
     resolution: {integrity: sha512-B0vzCIBUbYWrlFk+odVXrSmPYwds9G+G+HiOO/sJr4eZ4RYiIqnFbZ7qiWhWXaou7vi71iXVqKQ8mxA6bJwPEQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@react-types/tooltip@3.4.15':
     resolution: {integrity: sha512-qiYwQLiEwYqrt/m8iQA8abl9k/9LrbtMNoEevL4jN4H0I5NrG55E78GYTkSzBBYmhBO4KnPVT0SfGM1tYaQx/A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   '@reduxjs/toolkit@2.6.0':
     resolution: {integrity: sha512-mWJCYpewLRyTuuzRSEC/IwIBBkYg2dKtQas8mty5MaV2iXzcmicS3gW554FDeOvLnY3x13NIk8MB1e8wHO7rqQ==}
     peerDependencies:
-      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react: ^18.3.1
       react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
     peerDependenciesMeta:
       react:
@@ -2550,7 +2548,7 @@ packages:
   '@restart/hooks@0.4.16':
     resolution: {integrity: sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^18.3.1
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -2790,7 +2788,7 @@ packages:
     resolution: {integrity: sha512-aP2sXHH+erbomuzU762ktg340IGDh8zD7ueuqwBwGu98fhCpTYsLXiS85I29tUvPLljwNU9puLPmxbgW4iZ2tQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^16.14.0 || 17.x || 18.x || 19.x
+      react: ^18.3.1
 
   '@sentry/vite-plugin@3.2.2':
     resolution: {integrity: sha512-WSkHOhZszMrIE9zmx2l4JhMnMlZmN/yAoHyf59pwFLIMctuZak6lNPbTbIFkFHDzIJ9Nut5RAVsw1qjmWc1PTA==}
@@ -2834,7 +2832,7 @@ packages:
   '@storybook/addon-links@10.0.1':
     resolution: {integrity: sha512-WZesF+L7v6CkMV3nRFjWqzcKG6xbBVgdnGz2PeP5EcZqE9pdB5YfDy5Ym7hHIgmBHjXMGeShOQT60rVhde/d8Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
       storybook: ^10.0.1
     peerDependenciesMeta:
       react:
@@ -2863,8 +2861,8 @@ packages:
   '@storybook/blocks@8.6.14':
     resolution: {integrity: sha512-rBMHAfA39AGHgkrDze4RmsnQTMw1ND5fGWobr9pDcJdnDKWQWNRD7Nrlxj0gFlN3n4D9lEZhWGdFrCbku7FVAQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
       storybook: ^8.6.14
     peerDependenciesMeta:
       react:
@@ -2875,8 +2873,8 @@ packages:
   '@storybook/blocks@8.6.4':
     resolution: {integrity: sha512-+oPXwT3KzJzsdkQuGEzBqOKTIFlb6qmlCWWbDwAnP0SEqYHoTVRTAIa44icFP0EZeIe+ypFVAm1E7kWTLmw1hQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
       storybook: ^8.6.4
     peerDependenciesMeta:
       react:
@@ -2931,15 +2929,15 @@ packages:
     resolution: {integrity: sha512-UxgyK5W3/UV4VrI3dl6ajGfHM4aOqMAkFLWe2KibeQudLf6NJpDrDMSHwZj+3iKC4jFU7dkKbbtH2h/al4sW3Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@storybook/icons@1.6.0':
     resolution: {integrity: sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@storybook/instrumenter@8.6.4':
     resolution: {integrity: sha512-8OtIWLhayTUdqJEeXiPm6l3LTdSkWgQzzV2l2HIe4Adedeot+Rkwu6XHmyRDpnb0+Ish6zmMDqtJBxC2PQsy6Q==}
@@ -2949,37 +2947,37 @@ packages:
   '@storybook/react-dom-shim@10.0.1':
     resolution: {integrity: sha512-fK6SLWKK0wsnBVRAjWwf+T7cMHXdgQ34Xk18QeAAXWJyT8UAb7x1QwdepOWBG2Gs2hVjJjD5ky/sRzK1L3kA9A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
       storybook: ^10.0.1
 
   '@storybook/react-dom-shim@10.3.6':
     resolution: {integrity: sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
       storybook: ^10.3.6
 
   '@storybook/react-dom-shim@8.6.14':
     resolution: {integrity: sha512-0hixr3dOy3f3M+HBofp3jtMQMS+sqzjKNgl7Arfuj3fvjmyXOks/yGjDImySR4imPtEllvPZfhiQNlejheaInw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react: ^18.3.1
+      react-dom: ^18.3.1
       storybook: ^8.6.14
 
   '@storybook/react-vite@10.3.6':
     resolution: {integrity: sha512-tySQRc+8q7V2NkylQMNJjDV8zXy6tkxb8oDqw/DIhHhI9Xn77MTKVZ8Cihbo5NMm7HYTB6xDKr6wqdSMgdufYQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
       storybook: ^10.3.6
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@storybook/react@10.0.1':
     resolution: {integrity: sha512-MtQ4G8q2wTe2E9zeuyAP/pZgwZEI+ijHZo8spndLdNF1gj+ihsdJguDS+ZAbfZSMNz0s2zroX4t+SKDSBbqBdg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
       storybook: ^10.0.1
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
@@ -2989,8 +2987,8 @@ packages:
   '@storybook/react@10.3.6':
     resolution: {integrity: sha512-oZQZ6xayWe5IdHmFUTL0TL8rX/gpNNh9gWhT2vzW5eeUvlkVG/RBKdsja6Ndrk2s1D9vcnwiI6r6CNXy3IEEmg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
       storybook: ^10.3.6
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
@@ -3011,8 +3009,8 @@ packages:
     resolution: {integrity: sha512-q9Wl6JKg9JUU9zRcQyx4rkKauiM4Il+/ohJemQkLa4SsFEvcXVzX9X89cRLiaAEiNOaJ/2EQML+aWNSHc0EXBw==}
     peerDependencies:
       '@stripe/stripe-js': '>=8.0.0 <9.0.0'
-      react: '>=16.8.0 <20.0.0'
-      react-dom: '>=16.8.0 <20.0.0'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@stripe/stripe-js@5.7.0':
     resolution: {integrity: sha512-9pCOK3AH75hDKPRyJm9PO5TA3aHZ/PVlIBOZwpi6mABxwr6mMIBjqgZEUThIE5zFEkOmaKXwxBgTsVKC29x+mQ==}
@@ -3263,8 +3261,8 @@ packages:
     peerDependencies:
       '@tiptap/core': ^2.7.0
       '@tiptap/pm': ^2.7.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   '@tiptap/starter-kit@2.11.5':
     resolution: {integrity: sha512-SLI7Aj2ruU1t//6Mk8f+fqW+18uTqpdfLUJYgwu0CkqBckrkRZYZh6GVLk/02k3H2ki7QkFxiFbZrdbZdng0JA==}
@@ -3756,7 +3754,7 @@ packages:
     resolution: {integrity: sha512-Yn4XzPCts7I4FwrXIifSzEayUC2nqAjuhOqED2eRvr80z58PvxOU8AZRPlTuEvkidbO55o9osZyrcxdIgKbWVg==}
     peerDependencies:
       prop-types: ^15.7.2
-      react: ^16.8.2 | ^17.0.0 | ^18.0.0
+      react: ^18.3.1
 
   '@zxing/browser@0.0.7':
     resolution: {integrity: sha512-AepzMgDnD6EjxewqmXpHJsi4S3Gw9ilZJLIbTf6fWuWySEcHBodnGu3p7FWlgq1Sd5QyfPhTum5z3CBkkhMVng==}
@@ -5127,8 +5125,8 @@ packages:
   input-format@0.3.14:
     resolution: {integrity: sha512-gHMrgrbCgmT4uK5Um5eVDUohuV9lcs95ZUUN9Px2Y0VIfjTzT2wF8Q3Z4fwLFm7c5Z2OXCm53FHoovj6SlOKdg==}
     peerDependencies:
-      react: '>=18.1.0'
-      react-dom: '>=18.1.0'
+      react: ^18.3.1
+      react-dom: ^18.3.1
     peerDependenciesMeta:
       react:
         optional: true
@@ -5441,7 +5439,7 @@ packages:
     resolution: {integrity: sha512-dIcDGo+n4FP2FPIHDcqB7cUE+omkcEgQJpc7sNNP4+XZ9FUhFAkKjGnHMzsZM+B4yF93sK166z9K5cKTe/JpzA==}
     peerDependencies:
       linkifyjs: ^4.0.0
-      react: '>= 15.0.0'
+      react: ^18.3.1
 
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
@@ -5513,7 +5511,7 @@ packages:
   lucide-react@0.483.0:
     resolution: {integrity: sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -6112,24 +6110,24 @@ packages:
   react-aria-components@1.7.1:
     resolution: {integrity: sha512-kTAlrxcW7n+rQDwlZSz5+o+HknjPGv/pn0OQ1FF92WsjoTaqQMJtWbEAHXrhrQaiW/3T4CANTpdR1soai4uK6g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-aria@3.38.1:
     resolution: {integrity: sha512-DDdWsAlHPKVQ5E8G0kfDHNs0Lk1Xrs3G7soz6Ew8Ls5vNfp1BusbR2b1wC7ppqq2jDQiyJS816UNmDuGyQVyxA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-canvas-confetti@2.0.7:
     resolution: {integrity: sha512-DIj44O35TPAwJkUSIZqWdVsgAMHtVf8h7YNmnr3jF3bn5mG+d7Rh9gEcRmdJfYgRzh6K+MAGujwUoIqQyLnMJw==}
     peerDependencies:
-      react: '*'
+      react: ^18.3.1
 
   react-cropper@2.3.3:
     resolution: {integrity: sha512-zghiEYkUb41kqtu+2jpX2Ntigf+Jj1dF9ew4lAobPzI2adaPE31z0p+5TcWngK6TvmWQUwK3lj4G+NDh1PDQ1w==}
     peerDependencies:
-      react: '>=17.0.2'
+      react: ^18.3.1
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -6145,16 +6143,11 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-dom@19.2.7:
-    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
-    peerDependencies:
-      react: ^19.2.7
-
   react-dropzone@14.3.8:
     resolution: {integrity: sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      react: '>= 16.8 || 18.0.0'
+      react: ^18.3.1
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -6164,29 +6157,29 @@ packages:
     peerDependencies:
       final-form: ^4.15.0
       final-form-arrays: '>=1.0.4'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^18.3.1
       react-final-form: ^6.2.1
 
   react-final-form@6.5.9:
     resolution: {integrity: sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==}
     peerDependencies:
       final-form: ^4.20.4
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^18.3.1
 
   react-helmet-async@2.0.5:
     resolution: {integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==}
     peerDependencies:
-      react: ^16.6.0 || ^17.0.0 || ^18.0.0
+      react: ^18.3.1
 
   react-image-crop@11.0.7:
     resolution: {integrity: sha512-ZciKWHDYzmm366JDL18CbrVyjnjH0ojufGDmScfS4ZUqLHg4nm6ATY+K62C75W4ZRNt4Ii+tX0bSjNk9LQ2xzQ==}
     peerDependencies:
-      react: '>=16.13.1'
+      react: ^18.3.1
 
   react-infinite-scroller@1.2.6:
     resolution: {integrity: sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==}
     peerDependencies:
-      react: ^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react: ^18.3.1
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -6203,32 +6196,32 @@ packages:
   react-overlays@5.2.1:
     resolution: {integrity: sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==}
     peerDependencies:
-      react: '>=16.3.0'
-      react-dom: '>=16.3.0'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-phone-number-input@3.4.16:
     resolution: {integrity: sha512-ix1+SIyGuLxnlAeW+XQNhwOmmDd4Zmr6Ng1eQl0E2XS8xIuue3gdZeBG4LGTMjTIFneOTO9pUPL+AEDhV6+r+A==}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-qr-reader@3.0.0-beta-1:
     resolution: {integrity: sha512-5HeFH9x/BlziRYQYGK2AeWS9WiKYZtGGMs9DXy3bcySTX3C9UJL9EwcPnWw8vlf7JP4FcrAlr1SnZ5nsWLQGyw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-qrcode-logo@3.0.0:
     resolution: {integrity: sha512-2+vZ3GNBdUpYxIKyt6SFZsDGXa0xniyUQ0wPI4O0hJTzRjttPIx1pPnH9IWQmp/4nDMoN47IBhi3Breu1KudYw==}
     peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
     peerDependencies:
       '@types/react': ^18.2.25 || ^19
-      react: ^18.0 || ^19
+      react: ^18.3.1
       redux: ^5.0.0
     peerDependenciesMeta:
       '@types/react':
@@ -6245,7 +6238,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6255,7 +6248,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6263,32 +6256,32 @@ packages:
   react-select@5.10.2:
     resolution: {integrity: sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-stately@3.36.1:
     resolution: {integrity: sha512-H9kiGAylNec/iE5qk7qQLV1cvtSAIVq3mgt87zx2EA+f+/sYy2oBtchFPaDiBf/m7xMEKf0Fr9zSLU6G99xQ8g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^18.3.1
 
   react-streaming@0.3.50:
     resolution: {integrity: sha512-BRjWzY83dtnjgFUCYM0H2J3iRuYruE++/AidXmjxRclTsz1O/zBdUVgjAO2uKb05y/zybskcKjmK/5xyMc1MSg==}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-streaming@0.4.2:
     resolution: {integrity: sha512-b192E9E0TnE9wWdc8uZg00MMY36btQmFV25cDOGcWQwl5qF8vzNcQPVJwWkljLOec5qIJWumH9cvEvAL1JlAGg==}
     peerDependencies:
-      react: '>=19'
-      react-dom: '>=19'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6296,54 +6289,50 @@ packages:
   react-swipeable@7.0.2:
     resolution: {integrity: sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==}
     peerDependencies:
-      react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.3.1
 
   react-tagcloud@2.3.3:
     resolution: {integrity: sha512-4E2lTU7wYU0bisi2x3xInueufHzYFkSuqoKsY0Ky8U4Ki60StVX0MicYtsiScvY2QcFbSULWt6evbEwYVKXl4g==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^18.3.1
 
   react-textarea-autosize@8.5.7:
     resolution: {integrity: sha512-2MqJ3p0Jh69yt9ktFIaZmORHXw4c4bxSIhCeWiFwmJ9EYKgLmuNII3e9c9b2UO+ijl4StnpZdqpxNIhTdHvqtQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
 
   react-tiny-popover@8.1.6:
     resolution: {integrity: sha512-jeZnGqHxb5TX7pCzpqLoVJned7DTVnLrLoCQQGFTyvlxXB/QUaet7O0krG22t5FReMBH035SLnzThKvk8tIfsg==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-treeview@0.4.7:
     resolution: {integrity: sha512-k1Q954z/Ts3O9QW4SI1dGZVOwGbGJwjMGQvN/JhAknF1vifRp6bCLJiPaQ3br5af7Mdk7HSAb3JiyQIQJnnaPQ==}
     peerDependencies:
-      react: '>=0.14.0'
+      react: ^18.3.1
 
   react-turnstile@1.1.4:
     resolution: {integrity: sha512-oluyRWADdsufCt5eMqacW4gfw8/csr6Tk+fmuaMx0PWMKP1SX1iCviLvD2D5w92eAzIYDHi/krUWGHhlfzxTpQ==}
     peerDependencies:
-      react: '>= 16.13.1'
-      react-dom: '>= 16.13.1'
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   react-youtube@10.1.0:
     resolution: {integrity: sha512-ZfGtcVpk0SSZtWCSTYOQKhfx5/1cfyEW1JN/mugGNfAxT3rmVJeMbGpA9+e78yG21ls5nc/5uZJETE3cm3knBg==}
     engines: {node: '>= 14.x'}
     peerDependencies:
-      react: '>=0.14.1'
+      react: ^18.3.1
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
-
-  react@19.2.7:
-    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@2.3.8:
@@ -6361,8 +6350,8 @@ packages:
     resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
+      react-dom: ^18.3.1
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
@@ -6491,9 +6480,6 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-
-  scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
@@ -6918,7 +6904,7 @@ packages:
   uncontrollable@7.2.1:
     resolution: {integrity: sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==}
     peerDependencies:
-      react: '>=15.0.0'
+      react: ^18.3.1
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -6969,7 +6955,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6978,7 +6964,7 @@ packages:
     resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6987,7 +6973,7 @@ packages:
     resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6996,7 +6982,7 @@ packages:
     resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7006,7 +6992,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.3.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7014,12 +7000,12 @@ packages:
   use-sync-external-store@1.4.0:
     resolution: {integrity: sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^18.3.1
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -7056,8 +7042,8 @@ packages:
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
     peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.3.1
+      react-dom: ^18.3.1
 
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
@@ -7069,8 +7055,8 @@ packages:
   vike-react@0.5.13:
     resolution: {integrity: sha512-gk5YzLqc349uCSatIZLuLA3/ZtpjWHOjPk1jVyQROqbJ3l6kJbsST7u7ItblKuQr+C5TTcFnJ73Hhl8lSMdXxg==}
     peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
+      react: ^18.3.1
+      react-dom: ^18.3.1
       vike: '>=0.4.182'
 
   vike-server@1.0.12:
@@ -8135,10 +8121,10 @@ snapshots:
 
   '@gamestdio/websocket@0.3.2': {}
 
-  '@gsap/react@2.1.2(gsap@3.14.2)(react@19.2.7)':
+  '@gsap/react@2.1.2(gsap@3.14.2)(react@18.3.1)':
     dependencies:
       gsap: 3.14.2
-      react: 19.2.7
+      react: 18.3.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -8230,11 +8216,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mdx-js/react@3.1.1(@types/react@18.3.18)(react@19.2.7)':
+  '@mdx-js/react@3.1.1(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@types/mdx': 2.0.14
       '@types/react': 18.3.18
-      react: 19.2.7
+      react: 18.3.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -8729,25 +8715,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/autocomplete@3.0.0-beta.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/combobox': 3.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/listbox': 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/searchfield': 3.8.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/textfield': 3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/autocomplete': 3.0.0-beta.0(react@19.2.7)
-      '@react-stately/combobox': 3.10.3(react@19.2.7)
-      '@react-types/autocomplete': 3.0.0-alpha.29(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/breadcrumbs@3.5.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8758,17 +8725,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/breadcrumbs@3.5.22(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/link': 3.7.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/breadcrumbs': 3.7.11(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/button@3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8781,18 +8737,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/button@3.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/toolbar': 3.0.0-beta.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/toggle': 3.8.2(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/calendar@3.7.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8808,21 +8752,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/calendar@3.7.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/live-announcer': 3.4.1
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/calendar': 3.7.1(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/calendar': 3.6.1(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/checkbox@3.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8840,22 +8769,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/checkbox@3.15.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/form': 3.0.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/toggle': 3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/checkbox': 3.6.12(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/toggle': 3.8.2(react@19.2.7)
-      '@react-types/checkbox': 3.9.2(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/collections@3.0.0-beta.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8866,17 +8779,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.4.0(react@18.3.1)
-
-  '@react-aria/collections@3.0.0-beta.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/ssr': 3.9.7(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      use-sync-external-store: 1.4.0(react@19.2.7)
 
   '@react-aria/color@3.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8895,24 +8797,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/color@3.0.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/numberfield': 3.11.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/slider': 3.7.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/spinbutton': 3.6.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/textfield': 3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/visually-hidden': 3.8.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/color': 3.8.3(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-types/color': 3.0.3(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/combobox@3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8934,27 +8818,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/combobox@3.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/listbox': 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/live-announcer': 3.4.1
-      '@react-aria/menu': 3.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/overlays': 3.26.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/textfield': 3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/combobox': 3.10.3(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/combobox': 3.13.3(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/datepicker@3.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8979,29 +8842,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/datepicker@3.14.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@internationalized/number': 3.6.0
-      '@internationalized/string': 3.2.5
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/form': 3.0.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/spinbutton': 3.6.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/datepicker': 3.13.0(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/calendar': 3.6.1(react@19.2.7)
-      '@react-types/datepicker': 3.11.0(react@19.2.7)
-      '@react-types/dialog': 3.5.16(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/dialog@3.5.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9013,17 +8853,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/dialog@3.5.23(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/overlays': 3.26.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/dialog': 3.5.16(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/disclosure@3.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/ssr': 3.9.7(react@18.3.1)
@@ -9033,16 +8862,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/disclosure@3.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/ssr': 3.9.7(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/disclosure': 3.0.2(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/dnd@3.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9059,21 +8878,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/dnd@3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@internationalized/string': 3.2.5
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/live-announcer': 3.4.1
-      '@react-aria/overlays': 3.26.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/dnd': 3.5.2(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/focus@3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9084,16 +8888,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/focus@3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      clsx: 2.1.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/form@3.0.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9103,16 +8897,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/form@3.0.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/grid@3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9132,24 +8916,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/grid@3.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/live-announcer': 3.4.1
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/grid': 3.11.0(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-types/checkbox': 3.9.2(react@19.2.7)
-      '@react-types/grid': 3.3.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/gridlist@3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9166,22 +8932,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/gridlist@3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/grid': 3.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/list': 3.12.0(react@19.2.7)
-      '@react-stately/tree': 3.8.8(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/i18n@3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@internationalized/date': 3.7.0
@@ -9195,19 +8945,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/i18n@3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@internationalized/message': 3.1.6
-      '@internationalized/number': 3.6.0
-      '@internationalized/string': 3.2.5
-      '@react-aria/ssr': 3.9.7(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/interactions@3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/ssr': 3.9.7(react@18.3.1)
@@ -9218,16 +8955,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/interactions@3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/ssr': 3.9.7(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/flags': 3.1.0
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/label@3.7.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9235,14 +8962,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/label@3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/landmark@3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9253,15 +8972,6 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
-  '@react-aria/landmark@3.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      use-sync-external-store: 1.6.0(react@19.2.7)
-
   '@react-aria/link@3.7.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9271,16 +8981,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/link@3.7.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/link': 3.5.11(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/listbox@3.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9295,20 +8995,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/listbox@3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/list': 3.12.0(react@19.2.7)
-      '@react-types/listbox': 3.5.5(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/live-announcer@3.4.1':
     dependencies:
@@ -9333,25 +9019,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/menu@3.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/overlays': 3.26.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/menu': 3.9.2(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-stately/tree': 3.8.8(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/menu': 3.9.15(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/meter@3.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/progress': 3.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9360,15 +9027,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/meter@3.4.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/progress': 3.4.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/meter': 3.4.7(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/numberfield@3.11.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9386,22 +9044,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/numberfield@3.11.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/spinbutton': 3.6.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/textfield': 3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/numberfield': 3.9.10(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/numberfield': 3.8.9(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/overlays@3.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9418,22 +9060,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/overlays@3.26.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/ssr': 3.9.7(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/visually-hidden': 3.8.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/overlays': 3.6.14(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/overlays': 3.8.13(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/progress@3.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9444,17 +9070,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/progress@3.4.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/progress': 3.5.10(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/radio@3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9471,21 +9086,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/radio@3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/form': 3.0.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/radio': 3.10.11(react@19.2.7)
-      '@react-types/radio': 3.8.7(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/searchfield@3.8.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9498,19 +9098,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/searchfield@3.8.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/textfield': 3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/searchfield': 3.5.10(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/searchfield': 3.6.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/select@3.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9531,25 +9118,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/select@3.15.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/form': 3.0.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/listbox': 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/menu': 3.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/visually-hidden': 3.8.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/select': 3.6.11(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/select': 3.9.10(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/selection@3.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9562,18 +9130,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/selection@3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/separator@3.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9581,14 +9137,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/separator@3.4.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/slider@3.7.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9603,19 +9151,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/slider@3.7.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/slider': 3.6.2(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/slider': 3.7.9(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/spinbutton@3.6.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9627,26 +9162,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/spinbutton@3.6.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/live-announcer': 3.4.1
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/ssr@3.9.7(react@18.3.1)':
     dependencies:
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-aria/ssr@3.9.7(react@19.2.7)':
-    dependencies:
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-aria/switch@3.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9657,16 +9176,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/switch@3.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/toggle': 3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/toggle': 3.8.2(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/switch': 3.5.9(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/table@3.17.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9688,26 +9197,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/table@3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/grid': 3.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/live-announcer': 3.4.1
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/visually-hidden': 3.8.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/flags': 3.1.0
-      '@react-stately/table': 3.14.0(react@19.2.7)
-      '@react-types/checkbox': 3.9.2(react@19.2.7)
-      '@react-types/grid': 3.3.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/table': 3.11.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/tabs@3.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9720,19 +9209,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/tabs@3.10.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/tabs': 3.8.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/tabs': 3.3.13(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/tag@3.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9749,21 +9225,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/tag@3.5.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/gridlist': 3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/list': 3.12.0(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/textfield@3.17.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/form': 3.0.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9778,20 +9239,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/textfield@3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/form': 3.0.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/textfield': 3.12.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/toast@3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/i18n': 3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9805,19 +9252,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/toast@3.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/landmark': 3.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/toast': 3.0.0(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/toggle@3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9829,17 +9263,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/toggle@3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/toggle': 3.8.2(react@19.2.7)
-      '@react-types/checkbox': 3.9.2(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/toolbar@3.0.0-beta.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/focus': 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9849,16 +9272,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/toolbar@3.0.0-beta.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/tooltip@3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9870,17 +9283,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/tooltip@3.8.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/tooltip': 3.5.2(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/tooltip': 3.4.15(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/tree@3.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9895,19 +9297,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/tree@3.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/gridlist': 3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/tree': 3.8.8(react@19.2.7)
-      '@react-types/button': 3.11.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/utils@3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/ssr': 3.9.7(react@18.3.1)
@@ -9918,17 +9307,6 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/utils@3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/ssr': 3.9.7(react@19.2.7)
-      '@react-stately/flags': 3.1.0
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      clsx: 2.1.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   '@react-aria/virtualizer@4.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9941,17 +9319,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/virtualizer@4.1.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/virtualizer': 4.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-aria/visually-hidden@3.8.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9961,26 +9328,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-aria/visually-hidden@3.8.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-stately/autocomplete@3.0.0-beta.0(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/autocomplete@3.0.0-beta.0(react@19.2.7)':
-    dependencies:
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/calendar@3.7.1(react@18.3.1)':
     dependencies:
@@ -9991,15 +9343,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/calendar@3.7.1(react@19.2.7)':
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/calendar': 3.6.1(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/checkbox@3.6.12(react@18.3.1)':
     dependencies:
       '@react-stately/form': 3.1.2(react@18.3.1)
@@ -10009,26 +9352,11 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/checkbox@3.6.12(react@19.2.7)':
-    dependencies:
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/checkbox': 3.9.2(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/collections@3.12.2(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/collections@3.12.2(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/color@3.8.3(react@18.3.1)':
     dependencies:
@@ -10043,19 +9371,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/color@3.8.3(react@19.2.7)':
-    dependencies:
-      '@internationalized/number': 3.6.0
-      '@internationalized/string': 3.2.5
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/numberfield': 3.9.10(react@19.2.7)
-      '@react-stately/slider': 3.6.2(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/color': 3.0.3(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/combobox@3.10.3(react@18.3.1)':
     dependencies:
       '@react-stately/collections': 3.12.2(react@18.3.1)
@@ -10069,30 +9384,11 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/combobox@3.10.3(react@19.2.7)':
-    dependencies:
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/list': 3.12.0(react@19.2.7)
-      '@react-stately/overlays': 3.6.14(react@19.2.7)
-      '@react-stately/select': 3.6.11(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/combobox': 3.13.3(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/data@3.12.2(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/data@3.12.2(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/datepicker@3.13.0(react@18.3.1)':
     dependencies:
@@ -10106,18 +9402,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/datepicker@3.13.0(react@19.2.7)':
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@internationalized/string': 3.2.5
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/overlays': 3.6.14(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/datepicker': 3.11.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/disclosure@3.0.2(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.5(react@18.3.1)
@@ -10125,26 +9409,12 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/disclosure@3.0.2(react@19.2.7)':
-    dependencies:
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/dnd@3.5.2(react@18.3.1)':
     dependencies:
       '@react-stately/selection': 3.20.0(react@18.3.1)
       '@react-types/shared': 3.28.0(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/dnd@3.5.2(react@19.2.7)':
-    dependencies:
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/flags@3.1.0':
     dependencies:
@@ -10156,12 +9426,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/form@3.1.2(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/grid@3.11.0(react@18.3.1)':
     dependencies:
       '@react-stately/collections': 3.12.2(react@18.3.1)
@@ -10170,15 +9434,6 @@ snapshots:
       '@react-types/shared': 3.28.0(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/grid@3.11.0(react@19.2.7)':
-    dependencies:
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-types/grid': 3.3.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/layout@4.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10192,18 +9447,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-stately/layout@4.2.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/table': 3.14.0(react@19.2.7)
-      '@react-stately/virtualizer': 4.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/grid': 3.3.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/table': 3.11.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-stately/list@3.12.0(react@18.3.1)':
     dependencies:
       '@react-stately/collections': 3.12.2(react@18.3.1)
@@ -10213,15 +9456,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/list@3.12.0(react@19.2.7)':
-    dependencies:
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/menu@3.9.2(react@18.3.1)':
     dependencies:
       '@react-stately/overlays': 3.6.14(react@18.3.1)
@@ -10229,14 +9463,6 @@ snapshots:
       '@react-types/shared': 3.28.0(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/menu@3.9.2(react@19.2.7)':
-    dependencies:
-      '@react-stately/overlays': 3.6.14(react@19.2.7)
-      '@react-types/menu': 3.9.15(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/numberfield@3.9.10(react@18.3.1)':
     dependencies:
@@ -10247,28 +9473,12 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/numberfield@3.9.10(react@19.2.7)':
-    dependencies:
-      '@internationalized/number': 3.6.0
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/numberfield': 3.8.9(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/overlays@3.6.14(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/overlays': 3.8.13(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/overlays@3.6.14(react@19.2.7)':
-    dependencies:
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/overlays': 3.8.13(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/radio@3.10.11(react@18.3.1)':
     dependencies:
@@ -10279,28 +9489,12 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/radio@3.10.11(react@19.2.7)':
-    dependencies:
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/radio': 3.8.7(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/searchfield@3.5.10(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/searchfield': 3.6.0(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/searchfield@3.5.10(react@19.2.7)':
-    dependencies:
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/searchfield': 3.6.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/select@3.6.11(react@18.3.1)':
     dependencies:
@@ -10312,16 +9506,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/select@3.6.11(react@19.2.7)':
-    dependencies:
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/list': 3.12.0(react@19.2.7)
-      '@react-stately/overlays': 3.6.14(react@19.2.7)
-      '@react-types/select': 3.9.10(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/selection@3.20.0(react@18.3.1)':
     dependencies:
       '@react-stately/collections': 3.12.2(react@18.3.1)
@@ -10330,14 +9514,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/selection@3.20.0(react@19.2.7)':
-    dependencies:
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/slider@3.6.2(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.5(react@18.3.1)
@@ -10345,14 +9521,6 @@ snapshots:
       '@react-types/slider': 3.7.9(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/slider@3.6.2(react@19.2.7)':
-    dependencies:
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/slider': 3.7.9(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/table@3.14.0(react@18.3.1)':
     dependencies:
@@ -10367,19 +9535,6 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/table@3.14.0(react@19.2.7)':
-    dependencies:
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/flags': 3.1.0
-      '@react-stately/grid': 3.11.0(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/grid': 3.3.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/table': 3.11.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/tabs@3.8.0(react@18.3.1)':
     dependencies:
       '@react-stately/list': 3.12.0(react@18.3.1)
@@ -10388,25 +9543,11 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/tabs@3.8.0(react@19.2.7)':
-    dependencies:
-      '@react-stately/list': 3.12.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/tabs': 3.3.13(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/toast@3.0.0(react@18.3.1)':
     dependencies:
       '@swc/helpers': 0.5.11
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
-
-  '@react-stately/toast@3.0.0(react@19.2.7)':
-    dependencies:
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
 
   '@react-stately/toggle@3.8.2(react@18.3.1)':
     dependencies:
@@ -10416,27 +9557,12 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/toggle@3.8.2(react@19.2.7)':
-    dependencies:
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/checkbox': 3.9.2(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/tooltip@3.5.2(react@18.3.1)':
     dependencies:
       '@react-stately/overlays': 3.6.14(react@18.3.1)
       '@react-types/tooltip': 3.4.15(react@18.3.1)
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/tooltip@3.5.2(react@19.2.7)':
-    dependencies:
-      '@react-stately/overlays': 3.6.14(react@19.2.7)
-      '@react-types/tooltip': 3.4.15(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/tree@3.8.8(react@18.3.1)':
     dependencies:
@@ -10447,24 +9573,10 @@ snapshots:
       '@swc/helpers': 0.5.11
       react: 18.3.1
 
-  '@react-stately/tree@3.8.8(react@19.2.7)':
-    dependencies:
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-
   '@react-stately/utils@3.10.5(react@18.3.1)':
     dependencies:
       '@swc/helpers': 0.5.11
       react: 18.3.1
-
-  '@react-stately/utils@3.10.5(react@19.2.7)':
-    dependencies:
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
 
   '@react-stately/virtualizer@4.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10474,14 +9586,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@react-stately/virtualizer@4.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@react-types/autocomplete@3.0.0-alpha.29(react@18.3.1)':
     dependencies:
       '@react-types/combobox': 3.13.3(react@18.3.1)
@@ -10489,34 +9593,16 @@ snapshots:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/autocomplete@3.0.0-alpha.29(react@19.2.7)':
-    dependencies:
-      '@react-types/combobox': 3.13.3(react@19.2.7)
-      '@react-types/searchfield': 3.6.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/breadcrumbs@3.7.11(react@18.3.1)':
     dependencies:
       '@react-types/link': 3.5.11(react@18.3.1)
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/breadcrumbs@3.7.11(react@19.2.7)':
-    dependencies:
-      '@react-types/link': 3.5.11(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/button@3.11.0(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/button@3.11.0(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/calendar@3.6.1(react@18.3.1)':
     dependencies:
@@ -10524,21 +9610,10 @@ snapshots:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/calendar@3.6.1(react@19.2.7)':
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/checkbox@3.9.2(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/checkbox@3.9.2(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/color@3.0.3(react@18.3.1)':
     dependencies:
@@ -10546,21 +9621,10 @@ snapshots:
       '@react-types/slider': 3.7.9(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/color@3.0.3(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/slider': 3.7.9(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/combobox@3.13.3(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/combobox@3.13.3(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/datepicker@3.11.0(react@18.3.1)':
     dependencies:
@@ -10570,65 +9634,31 @@ snapshots:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/datepicker@3.11.0(react@19.2.7)':
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@react-types/calendar': 3.6.1(react@19.2.7)
-      '@react-types/overlays': 3.8.13(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/dialog@3.5.16(react@18.3.1)':
     dependencies:
       '@react-types/overlays': 3.8.13(react@18.3.1)
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/dialog@3.5.16(react@19.2.7)':
-    dependencies:
-      '@react-types/overlays': 3.8.13(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/form@3.7.10(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/form@3.7.10(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/grid@3.3.0(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/grid@3.3.0(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/link@3.5.11(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/link@3.5.11(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/listbox@3.5.5(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/listbox@3.5.5(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/menu@3.9.15(react@18.3.1)':
     dependencies:
@@ -10636,61 +9666,30 @@ snapshots:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/menu@3.9.15(react@19.2.7)':
-    dependencies:
-      '@react-types/overlays': 3.8.13(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/meter@3.4.7(react@18.3.1)':
     dependencies:
       '@react-types/progress': 3.5.10(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/meter@3.4.7(react@19.2.7)':
-    dependencies:
-      '@react-types/progress': 3.5.10(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/numberfield@3.8.9(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/numberfield@3.8.9(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/overlays@3.8.13(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/overlays@3.8.13(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/progress@3.5.10(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/progress@3.5.10(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/radio@3.8.7(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/radio@3.8.7(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/searchfield@3.6.0(react@18.3.1)':
     dependencies:
@@ -10698,49 +9697,24 @@ snapshots:
       '@react-types/textfield': 3.12.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/searchfield@3.6.0(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/textfield': 3.12.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/select@3.9.10(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/select@3.9.10(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/shared@3.28.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
-
-  '@react-types/shared@3.28.0(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
 
   '@react-types/slider@3.7.9(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/slider@3.7.9(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/switch@3.5.9(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/switch@3.5.9(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/table@3.11.0(react@18.3.1)':
     dependencies:
@@ -10748,43 +9722,21 @@ snapshots:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/table@3.11.0(react@19.2.7)':
-    dependencies:
-      '@react-types/grid': 3.3.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/tabs@3.3.13(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/tabs@3.3.13(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@react-types/textfield@3.12.0(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/textfield@3.12.0(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   '@react-types/tooltip@3.4.15(react@18.3.1)':
     dependencies:
       '@react-types/overlays': 3.8.13(react@18.3.1)
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
-
-  '@react-types/tooltip@3.4.15(react@19.2.7)':
-    dependencies:
-      '@react-types/overlays': 3.8.13(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
 
   '@reduxjs/toolkit@2.6.0(react-redux@9.2.0(@types/react@18.3.18)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
     dependencies:
@@ -11063,12 +10015,12 @@ snapshots:
 
   '@storybook/addon-docs@8.6.14(@types/react@18.3.18)(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@18.3.18)(react@19.2.7)
-      '@storybook/blocks': 8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))
+      '@mdx-js/react': 3.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@storybook/blocks': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))
       '@storybook/csf-plugin': 8.6.14(storybook@8.6.17(prettier@3.5.3))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.17(prettier@3.5.3)
       ts-dedent: 2.3.0
     transitivePeerDependencies:
@@ -11104,12 +10056,12 @@ snapshots:
       storybook: 8.6.17(prettier@3.5.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@10.0.1(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))':
+  '@storybook/addon-links@10.0.1(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 8.6.17(prettier@3.5.3)
     optionalDependencies:
-      react: 19.2.7
+      react: 18.3.1
 
   '@storybook/addon-measure@8.6.14(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
@@ -11132,23 +10084,23 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.17(prettier@3.5.3)
 
-  '@storybook/blocks@8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))':
+  '@storybook/blocks@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
-      '@storybook/icons': 1.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@storybook/icons': 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook: 8.6.17(prettier@3.5.3)
       ts-dedent: 2.3.0
     optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/blocks@8.6.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))':
+  '@storybook/blocks@8.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
-      '@storybook/icons': 1.2.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@storybook/icons': 1.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook: 8.6.17(prettier@3.5.3)
       ts-dedent: 2.2.0
     optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/builder-vite@10.3.6(esbuild@0.25.12)(rollup@4.60.3)(storybook@8.6.17(prettier@3.5.3))(vite@6.4.3(@types/node@22.7.7))':
     dependencies:
@@ -11202,15 +10154,15 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@1.2.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@storybook/icons@1.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/icons@1.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@storybook/icons@1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/instrumenter@8.6.4(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
@@ -11218,35 +10170,35 @@ snapshots:
       '@vitest/utils': 2.1.9
       storybook: 8.6.17(prettier@3.5.3)
 
-  '@storybook/react-dom-shim@10.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))':
+  '@storybook/react-dom-shim@10.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.17(prettier@3.5.3)
 
-  '@storybook/react-dom-shim@10.3.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))':
+  '@storybook/react-dom-shim@10.3.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.17(prettier@3.5.3)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))':
+  '@storybook/react-dom-shim@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))':
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.17(prettier@3.5.3)
 
-  '@storybook/react-vite@10.3.6(esbuild@0.25.12)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.3)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)(vite@6.4.3(@types/node@22.7.7))':
+  '@storybook/react-vite@10.3.6(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.3)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)(vite@6.4.3(@types/node@22.7.7))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.6.3)(vite@6.4.3(@types/node@22.7.7))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
       '@storybook/builder-vite': 10.3.6(esbuild@0.25.12)(rollup@4.60.3)(storybook@8.6.17(prettier@3.5.3))(vite@6.4.3(@types/node@22.7.7))
-      '@storybook/react': 10.3.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)
+      '@storybook/react': 10.3.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)
       empathic: 2.0.0
       magic-string: 0.30.21
-      react: 19.2.7
+      react: 18.3.1
       react-docgen: 8.0.3
-      react-dom: 19.2.7(react@19.2.7)
+      react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.12
       storybook: 8.6.17(prettier@3.5.3)
       tsconfig-paths: 4.2.0
@@ -11258,24 +10210,24 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)':
+  '@storybook/react@10.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@storybook/react-dom-shim': 10.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.17(prettier@3.5.3)
     optionalDependencies:
       typescript: 5.6.3
 
-  '@storybook/react@10.3.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)':
+  '@storybook/react@10.3.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))(typescript@5.6.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.5.3))
-      react: 19.2.7
+      '@storybook/react-dom-shim': 10.3.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.17(prettier@3.5.3))
+      react: 18.3.1
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.6.3)
-      react-dom: 19.2.7(react@19.2.7)
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.17(prettier@3.5.3)
     optionalDependencies:
       typescript: 5.6.3
@@ -14254,10 +13206,6 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  lucide-react@0.483.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-
   lz-string@1.5.0: {}
 
   magic-string@0.30.17:
@@ -14870,37 +13818,6 @@ snapshots:
       react-stately: 3.36.1(react@18.3.1)
       use-sync-external-store: 1.4.0(react@18.3.1)
 
-  react-aria-components@1.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@internationalized/string': 3.2.5
-      '@react-aria/autocomplete': 3.0.0-beta.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/collections': 3.0.0-beta.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/dnd': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/live-announcer': 3.4.1
-      '@react-aria/toolbar': 3.0.0-beta.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/virtualizer': 4.1.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/autocomplete': 3.0.0-beta.0(react@19.2.7)
-      '@react-stately/layout': 4.2.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-stately/table': 3.14.0(react@19.2.7)
-      '@react-stately/utils': 3.10.5(react@19.2.7)
-      '@react-stately/virtualizer': 4.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/form': 3.7.10(react@19.2.7)
-      '@react-types/grid': 3.3.0(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      '@react-types/table': 3.11.0(react@19.2.7)
-      '@swc/helpers': 0.5.11
-      client-only: 0.0.1
-      react: 19.2.7
-      react-aria: 3.38.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-dom: 19.2.7(react@19.2.7)
-      react-stately: 3.36.1(react@19.2.7)
-      use-sync-external-store: 1.4.0(react@19.2.7)
-
   react-aria@3.38.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@internationalized/string': 3.2.5
@@ -14948,53 +13865,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-aria@3.38.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@internationalized/string': 3.2.5
-      '@react-aria/breadcrumbs': 3.5.22(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/button': 3.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/calendar': 3.7.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/checkbox': 3.15.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/color': 3.0.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/combobox': 3.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/datepicker': 3.14.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/dialog': 3.5.23(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/disclosure': 3.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/dnd': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/focus': 3.20.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/gridlist': 3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/i18n': 3.12.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.24.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/label': 3.7.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/landmark': 3.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/link': 3.7.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/listbox': 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/menu': 3.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/meter': 3.4.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/numberfield': 3.11.12(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/overlays': 3.26.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/progress': 3.4.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/radio': 3.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/searchfield': 3.8.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/select': 3.15.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/selection': 3.23.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/separator': 3.4.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/slider': 3.7.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/ssr': 3.9.7(react@19.2.7)
-      '@react-aria/switch': 3.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/table': 3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/tabs': 3.10.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/tag': 3.5.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/textfield': 3.17.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/toast': 3.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/tooltip': 3.8.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/tree': 3.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.28.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/visually-hidden': 3.8.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   react-canvas-confetti@2.0.7(react@18.3.1):
     dependencies:
       '@types/canvas-confetti': 1.9.0
@@ -15005,11 +13875,6 @@ snapshots:
     dependencies:
       cropperjs: 1.6.2
       react: 18.3.1
-
-  react-cropper@2.3.3(react@19.2.7):
-    dependencies:
-      cropperjs: 1.6.2
-      react: 19.2.7
 
   react-docgen-typescript@2.4.0(typescript@5.6.3):
     dependencies:
@@ -15036,24 +13901,12 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-dom@19.2.7(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      scheduler: 0.27.0
-
   react-dropzone@14.3.8(react@18.3.1):
     dependencies:
       attr-accept: 2.2.5
       file-selector: 2.1.2
       prop-types: 15.8.1
       react: 18.3.1
-
-  react-dropzone@14.3.8(react@19.2.7):
-    dependencies:
-      attr-accept: 2.2.5
-      file-selector: 2.1.2
-      prop-types: 15.8.1
-      react: 19.2.7
 
   react-fast-compare@3.2.2: {}
 
@@ -15210,36 +14063,6 @@ snapshots:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  react-stately@3.36.1(react@19.2.7):
-    dependencies:
-      '@react-stately/calendar': 3.7.1(react@19.2.7)
-      '@react-stately/checkbox': 3.6.12(react@19.2.7)
-      '@react-stately/collections': 3.12.2(react@19.2.7)
-      '@react-stately/color': 3.8.3(react@19.2.7)
-      '@react-stately/combobox': 3.10.3(react@19.2.7)
-      '@react-stately/data': 3.12.2(react@19.2.7)
-      '@react-stately/datepicker': 3.13.0(react@19.2.7)
-      '@react-stately/disclosure': 3.0.2(react@19.2.7)
-      '@react-stately/dnd': 3.5.2(react@19.2.7)
-      '@react-stately/form': 3.1.2(react@19.2.7)
-      '@react-stately/list': 3.12.0(react@19.2.7)
-      '@react-stately/menu': 3.9.2(react@19.2.7)
-      '@react-stately/numberfield': 3.9.10(react@19.2.7)
-      '@react-stately/overlays': 3.6.14(react@19.2.7)
-      '@react-stately/radio': 3.10.11(react@19.2.7)
-      '@react-stately/searchfield': 3.5.10(react@19.2.7)
-      '@react-stately/select': 3.6.11(react@19.2.7)
-      '@react-stately/selection': 3.20.0(react@19.2.7)
-      '@react-stately/slider': 3.6.2(react@19.2.7)
-      '@react-stately/table': 3.14.0(react@19.2.7)
-      '@react-stately/tabs': 3.8.0(react@19.2.7)
-      '@react-stately/toast': 3.0.0(react@19.2.7)
-      '@react-stately/toggle': 3.8.2(react@19.2.7)
-      '@react-stately/tooltip': 3.5.2(react@19.2.7)
-      '@react-stately/tree': 3.8.8(react@19.2.7)
-      '@react-types/shared': 3.28.0(react@19.2.7)
-      react: 19.2.7
-
   react-streaming@0.3.50(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@brillout/import': 0.2.6
@@ -15288,10 +14111,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  react-tiny-popover@8.1.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-tiny-popover@8.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -15324,8 +14147,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  react@19.2.7: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -15539,8 +14360,6 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-
-  scheduler@0.27.0: {}
 
   secure-json-parse@2.7.0: {}
 
@@ -16099,17 +14918,9 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  use-sync-external-store@1.4.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
-
-  use-sync-external-store@1.6.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
# Description

This PR stops dependencies to autoInstallPeers. React 18 overrides other react versions if it should occur

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.


# Testing

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #5994 
