### PR TITLE
Refactor theme handling into a single resolver

### DIFF
--- a/lego-webapp/components/Header/ToggleTheme.tsx
+++ b/lego-webapp/components/Header/ToggleTheme.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { MoonStar, Sun } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useAppDispatch } from '~/redux/hooks';
 import { applySelectedTheme, getTheme, useTheme } from '~/utils/themeUtils';
 import styles from './toggleTheme.module.css';
 import type { ReactNode, MouseEvent } from 'react';
@@ -20,6 +21,7 @@ const ToggleTheme = ({
   variant = 'navbar',
 }: Props) => {
   const theme = useTheme();
+  const dispatch = useAppDispatch();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -28,9 +30,7 @@ const ToggleTheme = ({
 
   const handleThemeChange = (e: MouseEvent) => {
     e.preventDefault();
-    const currentTheme = getTheme();
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    applySelectedTheme(newTheme);
+    dispatch(applySelectedTheme(getTheme() === 'dark' ? 'light' : 'dark'));
   };
 
   const Component = isButton ? 'button' : 'div';

--- a/lego-webapp/components/Header/ToggleTheme.tsx
+++ b/lego-webapp/components/Header/ToggleTheme.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import { MoonStar, Sun } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useAppDispatch } from '~/redux/hooks';
-import { applySelectedTheme, getTheme, useTheme } from '~/utils/themeUtils';
+import { applySelectedTheme, useTheme } from '~/utils/themeUtils';
 import styles from './toggleTheme.module.css';
 import type { ReactNode, MouseEvent } from 'react';
 
@@ -30,7 +30,7 @@ const ToggleTheme = ({
 
   const handleThemeChange = (e: MouseEvent) => {
     e.preventDefault();
-    dispatch(applySelectedTheme(getTheme() === 'dark' ? 'light' : 'dark'));
+    dispatch(applySelectedTheme(theme === 'dark' ? 'light' : 'dark'));
   };
 
   const Component = isButton ? 'button' : 'div';

--- a/lego-webapp/components/Header/index.tsx
+++ b/lego-webapp/components/Header/index.tsx
@@ -165,7 +165,6 @@ const AccountDropdown = () => {
 const Header = () => {
   const dispatch = useAppDispatch();
   const loggedIn = useIsLoggedIn();
-  const currentUser = useCurrentUser();
   const searchOpen = useAppSelector((state) => state.search.open);
   const [renderSearch, setRenderSearch] = useState(searchOpen);
 

--- a/lego-webapp/components/Header/index.tsx
+++ b/lego-webapp/components/Header/index.tsx
@@ -14,7 +14,6 @@ import { useCurrentUser, useIsLoggedIn } from '~/redux/slices/auth';
 import { selectUpcomingMeetingId } from '~/redux/slices/meetings';
 import utilStyles from '~/styles/utilities.module.css';
 import { Keyboard } from '~/utils/constants';
-import { applySelectedTheme, getOSTheme, getTheme } from '~/utils/themeUtils';
 import Dropdown from '../Dropdown';
 import NotificationsDropdown from '../HeaderNotifications';
 import { ProfilePicture } from '../Image';
@@ -175,21 +174,6 @@ const Header = () => {
       setRenderSearch(true);
     }
   }, [searchOpen]);
-
-  useEffect(() => {
-    if (
-      !import.meta.env.SSR &&
-      loggedIn &&
-      currentUser &&
-      (currentUser.selectedTheme === 'auto'
-        ? getTheme() !== getOSTheme()
-        : getTheme() !== currentUser.selectedTheme)
-    ) {
-      applySelectedTheme(currentUser.selectedTheme || 'light', {
-        updateUserTheme: false,
-      });
-    }
-  }, [loggedIn, currentUser]);
 
   useEffect(() => {
     if (searchOpen) {

--- a/lego-webapp/components/Reactions/ReactionPickerCategory.tsx
+++ b/lego-webapp/components/Reactions/ReactionPickerCategory.tsx
@@ -11,7 +11,7 @@ import {
   Plane,
   Smile,
 } from 'lucide-react';
-import { getTheme } from '~/utils/themeUtils';
+import { useTheme } from '~/utils/themeUtils';
 import styles from './ReactionPickerCategory.module.css';
 
 type Props = {
@@ -21,9 +21,9 @@ type Props = {
   isSearching: boolean;
 };
 
-const mapCategoryNameToIcon = (name, isActive) => {
+const mapCategoryNameToIcon = (name, isActive, theme) => {
   const fill = isActive
-    ? getTheme() === 'dark'
+    ? theme === 'dark'
       ? 'var(--color-blue-5)'
       : 'var(--color-blue-6)'
     : 'transparent';
@@ -64,6 +64,7 @@ const ReactionPickerCategory = ({
   onCategoryClick,
   isSearching,
 }: Props) => {
+  const theme = useTheme();
   const categoryClasses = [styles.category];
 
   if (isActive) {
@@ -78,7 +79,10 @@ const ReactionPickerCategory = ({
     <div title={name} onClick={() => onCategoryClick(name)}>
       <div className={styles.container}>
         <div className={cx(categoryClasses)}>
-          <Icon size={22} iconNode={mapCategoryNameToIcon(name, isActive)} />
+          <Icon
+            size={22}
+            iconNode={mapCategoryNameToIcon(name, isActive, theme)}
+          />
         </div>
       </div>
     </div>

--- a/lego-webapp/pages/+Head.tsx
+++ b/lego-webapp/pages/+Head.tsx
@@ -8,7 +8,7 @@ import { themeBootstrapScript } from '~/utils/themeUtils';
 export default function HeadDefault() {
   const pageContext = usePageContext();
   const state = pageContext.store.getState();
-  const selectedTheme = selectCurrentUser(state)?.selectedTheme || 'auto';
+  const selectedTheme = selectCurrentUser(state)?.selectedTheme;
 
   return (
     <>
@@ -73,7 +73,6 @@ export default function HeadDefault() {
           dangerouslySetInnerHTML={{ __html: pageContext.preparedStateCode }}
         />
       )}
-      {/* Resolve and apply the theme before first paint */}
       <script
         dangerouslySetInnerHTML={{
           __html: themeBootstrapScript(selectedTheme),

--- a/lego-webapp/pages/+Head.tsx
+++ b/lego-webapp/pages/+Head.tsx
@@ -3,15 +3,7 @@
 import { usePageContext } from 'vike-react/usePageContext';
 import { selectCurrentUser } from '~/redux/slices/auth';
 import { appConfig } from '~/utils/appConfig';
-
-const autoThemeScript = `
-(function () {
-  try {
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches === true) {
-      document.documentElement.setAttribute('data-theme', 'dark');
-    }
-  } catch (e) {}
-})();`;
+import { themeBootstrapScript } from '~/utils/themeUtils';
 
 export default function HeadDefault() {
   const pageContext = usePageContext();
@@ -81,13 +73,12 @@ export default function HeadDefault() {
           dangerouslySetInnerHTML={{ __html: pageContext.preparedStateCode }}
         />
       )}
-      {
-        // If user has selected auto and device is in dark mode; ensure we update
-        // the theme before first render to screen
-        selectedTheme === 'auto' ? (
-          <script dangerouslySetInnerHTML={{ __html: autoThemeScript }} />
-        ) : undefined
-      }
+      {/* Resolve and apply the theme before first paint */}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: themeBootstrapScript(selectedTheme),
+        }}
+      />
       <script
         dangerouslySetInnerHTML={{
           __html: `window.__CONFIG__ = ${JSON.stringify(appConfig)};`,

--- a/lego-webapp/pages/+Wrapper.tsx
+++ b/lego-webapp/pages/+Wrapper.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, useState } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { Provider } from 'react-redux';
 import { usePageContext } from 'vike-react/usePageContext';
-import { ThemeContextListener } from '~/utils/themeUtils';
+import { ThemeManager } from '~/utils/themeUtils';
 
 export default function StoreProvider({ children }: PropsWithChildren) {
   const pageContext = usePageContext();
@@ -13,7 +13,7 @@ export default function StoreProvider({ children }: PropsWithChildren) {
       <HelmetProvider
         context={import.meta.env.SSR ? pageContext.helmetContext : undefined}
       >
-        <ThemeContextListener />
+        <ThemeManager />
         {children}
       </HelmetProvider>
     </Provider>

--- a/lego-webapp/pages/+onBeforeRenderHtml.tsx
+++ b/lego-webapp/pages/+onBeforeRenderHtml.tsx
@@ -6,8 +6,10 @@ import { PageContextProvider } from 'vike-react/usePageContext';
 import { fetchMeta } from '~/redux/actions/MetaActions';
 import { loginAutomaticallyIfPossible } from '~/redux/actions/UserActions';
 import { selectCurrentUser } from '~/redux/slices/auth';
+import { setTheme } from '~/redux/slices/theme';
 import { sentryServerConfig } from '~/sentry.server.config';
 import { prepareWithTimeout } from '~/utils/prepareWithTimeout';
+import { resolveTheme } from '~/utils/themeUtils';
 import createStore from '../redux/createStore';
 import Wrapper from './+Wrapper';
 
@@ -31,17 +33,13 @@ export async function onBeforeRenderHtml(pageContext: PageContextServer) {
   }
 
   const state = pageContext.store.getState();
-  // No-JS fallback only - the +Head bootstrap script re-resolves the theme
-  // (device choice, OS preference) before first paint
-  const accountTheme = selectCurrentUser(state)?.selectedTheme;
-  config({
-    htmlAttributes: {
-      'data-theme':
-        accountTheme === 'dark' || accountTheme === 'light'
-          ? accountTheme
-          : 'light',
-    },
-  });
+  const theme = resolveTheme(
+    selectCurrentUser(state)?.selectedTheme,
+    null,
+    false,
+  );
+  pageContext.store.dispatch(setTheme(theme));
+  config({ htmlAttributes: { 'data-theme': theme } });
 
   // Helmet support
   pageContext.helmetContext = {};

--- a/lego-webapp/pages/+onBeforeRenderHtml.tsx
+++ b/lego-webapp/pages/+onBeforeRenderHtml.tsx
@@ -31,8 +31,17 @@ export async function onBeforeRenderHtml(pageContext: PageContextServer) {
   }
 
   const state = pageContext.store.getState();
-  const selectedTheme = selectCurrentUser(state)?.selectedTheme || 'light';
-  config({ htmlAttributes: { 'data-theme': selectedTheme } });
+  // No-JS fallback only - the +Head bootstrap script re-resolves the theme
+  // (device choice, OS preference) before first paint
+  const accountTheme = selectCurrentUser(state)?.selectedTheme;
+  config({
+    htmlAttributes: {
+      'data-theme':
+        accountTheme === 'dark' || accountTheme === 'light'
+          ? accountTheme
+          : 'light',
+    },
+  });
 
   // Helmet support
   pageContext.helmetContext = {};

--- a/lego-webapp/pages/index/_components/public/useReadmeRotation.ts
+++ b/lego-webapp/pages/index/_components/public/useReadmeRotation.ts
@@ -1,7 +1,7 @@
 import { gsap } from 'gsap';
 import { useEffect, useRef, useState } from 'react';
 
-const ROTATION_SECONDS = 10;
+const ROTATION_SECONDS = 6;
 const CROSSFADE_SECONDS = 0.6;
 
 /**

--- a/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
+++ b/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
@@ -38,6 +38,7 @@ import ThemeSelector from './ThemeSelector';
 import UserImage from './UserImage';
 import styles from './UserSettings.module.css';
 import type { CurrentUser } from '~/redux/models/User';
+import type { ThemePreference } from '~/utils/themeUtils';
 
 type GenderKey = keyof typeof Gender;
 
@@ -49,7 +50,7 @@ type FormValues = {
   allergies: string;
   email: string;
   phoneNumber?: string;
-  selectedTheme: string;
+  selectedTheme: ThemePreference;
   isAbakusMember: boolean;
   githubUsername?: string;
   linkedinId?: string;

--- a/lego-webapp/redux/actions/UserActions.ts
+++ b/lego-webapp/redux/actions/UserActions.ts
@@ -510,7 +510,10 @@ export function resetPassword({
   });
 }
 
-export function updateUserTheme(username: string, theme: 'light' | 'dark') {
+export function updateUserTheme(
+  username: string,
+  theme: 'light' | 'dark' | 'auto',
+) {
   return updateUser(
     {
       username,

--- a/lego-webapp/utils/__tests__/themeUtils.spec.ts
+++ b/lego-webapp/utils/__tests__/themeUtils.spec.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { selectCurrentUser } from '~/redux/slices/auth';
+import {
+  applySelectedTheme,
+  resolveTheme,
+  themeBootstrapScript,
+} from '../themeUtils';
+import type { ThemePreference } from '../themeUtils';
+
+vi.mock('~/redux/actions/UserActions', () => ({
+  updateUserTheme: (username: string, theme: string) => ({
+    type: 'user/updateTheme',
+    username,
+    theme,
+  }),
+}));
+vi.mock('~/redux/hooks', () => ({
+  useAppDispatch: vi.fn(),
+  useAppSelector: vi.fn(),
+}));
+vi.mock('~/redux/slices/auth', () => ({ selectCurrentUser: vi.fn() }));
+vi.mock('~/redux/slices/theme', () => ({
+  setTheme: (theme: string) => ({ type: 'theme/setTheme', theme }),
+}));
+
+const stubMatchMedia = (osDark: boolean) =>
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: osDark }));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('resolveTheme', () => {
+  it('prefers an explicit account theme over everything', () => {
+    expect(resolveTheme('dark', 'light', false)).toBe('dark');
+    expect(resolveTheme('light', 'dark', true)).toBe('light');
+  });
+
+  it('follows the OS for account auto, ignoring the device choice', () => {
+    expect(resolveTheme('auto', 'dark', false)).toBe('light');
+    expect(resolveTheme('auto', 'light', true)).toBe('dark');
+  });
+
+  it('uses the stored device choice when logged out', () => {
+    expect(resolveTheme(undefined, 'dark', false)).toBe('dark');
+    expect(resolveTheme(null, 'light', true)).toBe('light');
+  });
+
+  it('falls back to the OS preference last', () => {
+    expect(resolveTheme(undefined, null, true)).toBe('dark');
+    expect(resolveTheme(undefined, 'garbage', false)).toBe('light');
+  });
+});
+
+describe('themeBootstrapScript', () => {
+  const runBootstrap = (
+    account: ThemePreference | undefined,
+    stored: string | null,
+    osDark: boolean,
+  ) => {
+    document.documentElement.removeAttribute('data-theme');
+    localStorage.clear();
+    if (stored !== null) localStorage.setItem('theme-preference', stored);
+    stubMatchMedia(osDark);
+
+    new Function(themeBootstrapScript(account))();
+
+    return document.documentElement.getAttribute('data-theme');
+  };
+
+  it('always agrees with resolveTheme', () => {
+    const accounts = [undefined, 'auto', 'light', 'dark'] as const;
+    const storedValues = [null, 'auto', 'light', 'dark', 'garbage'];
+
+    for (const account of accounts) {
+      for (const stored of storedValues) {
+        for (const osDark of [false, true]) {
+          expect(runBootstrap(account, stored, osDark)).toBe(
+            resolveTheme(account, stored, osDark),
+          );
+        }
+      }
+    }
+  });
+
+  it('ignores the legacy theme key', () => {
+    localStorage.setItem('theme', 'light');
+    stubMatchMedia(true);
+
+    new Function(themeBootstrapScript(undefined))();
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('falls back to the OS preference when localStorage throws', () => {
+    stubMatchMedia(true);
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('denied');
+      },
+    });
+
+    new Function(themeBootstrapScript(undefined))();
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('cannot break out of the script tag', () => {
+    expect(themeBootstrapScript('</script>' as never)).not.toContain(
+      '</script>',
+    );
+  });
+});
+
+describe('applySelectedTheme', () => {
+  const dispatch = vi.fn();
+  const getState = vi.fn();
+
+  const apply = (preference: ThemePreference) =>
+    applySelectedTheme(preference)(dispatch, getState, undefined as never);
+
+  beforeEach(() => {
+    dispatch.mockClear();
+    stubMatchMedia(false);
+    vi.mocked(selectCurrentUser).mockReturnValue(undefined);
+  });
+
+  it('stores the choice on the device and applies it when logged out', () => {
+    apply('dark');
+
+    expect(localStorage.getItem('theme-preference')).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'theme/setTheme',
+      theme: 'dark',
+    });
+  });
+
+  it('clears the device choice and follows the OS on auto', () => {
+    localStorage.setItem('theme-preference', 'dark');
+    stubMatchMedia(true);
+
+    apply('auto');
+
+    expect(localStorage.getItem('theme-preference')).toBeNull();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('syncs to the account instead of the device when logged in', () => {
+    vi.mocked(selectCurrentUser).mockReturnValue({
+      username: 'test1',
+    } as never);
+
+    apply('light');
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'user/updateTheme',
+      username: 'test1',
+      theme: 'light',
+    });
+    expect(localStorage.getItem('theme-preference')).toBeNull();
+  });
+
+  it('ignores values that are not a theme preference', () => {
+    apply(undefined as never);
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(localStorage.getItem('theme-preference')).toBeNull();
+  });
+});

--- a/lego-webapp/utils/themeUtils.tsx
+++ b/lego-webapp/utils/themeUtils.tsx
@@ -1,101 +1,135 @@
 import { throttle } from 'lodash-es';
-import { createContext, useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { updateUserTheme } from '~/redux/actions/UserActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
-import { useCurrentUser, useIsLoggedIn } from '~/redux/slices/auth';
+import { selectCurrentUser, useCurrentUser } from '~/redux/slices/auth';
 import { setTheme } from '~/redux/slices/theme';
+import type { AppDispatch } from '~/redux/createStore';
+import type { RootState } from '~/redux/rootReducer';
 
-type ThemeChangeEventDetail = {
-  updateUserTheme?: boolean;
+export type ThemePreference = 'light' | 'dark' | 'auto';
+export type ResolvedTheme = 'light' | 'dark';
+
+// The one precedence rule for the whole app: an explicit account theme wins,
+// then an explicit choice stored on this device, then the OS. 'auto' (and
+// anything unknown) falls through to the next level
+export const resolveTheme = (
+  account: unknown,
+  stored: unknown,
+  osDark: boolean,
+): ResolvedTheme =>
+  account === 'dark' || account === 'light'
+    ? account
+    : stored === 'dark' || stored === 'light'
+      ? stored
+      : osDark
+        ? 'dark'
+        : 'light';
+
+// Pre-paint script for +Head, built from resolveTheme itself so the theme
+// painted first can never disagree with what ThemeManager applies after
+// hydration
+export const themeBootstrapScript = (account: ThemePreference) => `
+(function () {
+  try {
+    var stored = null;
+    try { stored = localStorage.getItem('theme'); } catch (e) {}
+    document.documentElement.setAttribute(
+      'data-theme',
+      (${resolveTheme.toString()})(
+        ${JSON.stringify(account)},
+        stored,
+        window.matchMedia('(prefers-color-scheme: dark)').matches
+      )
+    );
+  } catch (e) {}
+})();`;
+
+const osPrefersDark = () =>
+  window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+const storedPreference = () => {
+  try {
+    return localStorage.getItem('theme');
+  } catch {
+    return null;
+  }
 };
 
-type ApplySelectedThemeOptions = {
-  updateUserTheme?: boolean;
+// The only place data-theme is written after first paint
+const applyResolvedTheme = (dispatch: AppDispatch, resolved: ResolvedTheme) => {
+  document.documentElement.setAttribute('data-theme', resolved);
+  dispatch(setTheme(resolved));
 };
 
-export const applySelectedTheme = (
-  theme: 'light' | 'dark' | 'auto',
-  options: ApplySelectedThemeOptions = {
-    updateUserTheme: true,
-  },
-) => {
-  if (import.meta.env.SSR) return;
-
-  document.documentElement.setAttribute(
-    'data-theme',
-    theme === 'auto' ? getOSTheme() : theme,
-  );
-
-  window.dispatchEvent(
-    new CustomEvent<ThemeChangeEventDetail>('themeChange', {
-      detail: {
-        updateUserTheme: options.updateUserTheme,
-      },
-    }),
-  );
-
-  localStorage.setItem('theme', theme);
-};
-
-export const getTheme = (): 'dark' | 'light' =>
+export const getTheme = (): ResolvedTheme =>
   !import.meta.env.SSR &&
   document.documentElement.getAttribute('data-theme') === 'dark'
     ? 'dark'
     : 'light';
 
-export const ThemeContext = createContext<'dark' | 'light'>(getTheme());
+export const useTheme = () => useAppSelector((state) => state.theme.theme);
 
-export const ThemeContextListener = () => {
+// Throttle ensures instant feedback the first time the user changes theme,
+// but also ensures the user can't spam the server with requests
+const syncUserTheme = throttle(
+  (dispatch: AppDispatch, username: string, theme: ResolvedTheme) =>
+    dispatch(updateUserTheme(username, theme)),
+  2000,
+);
+
+// The user explicitly picked a theme: store the choice on this device, apply
+// it, and sync it to their account when logged in
+export const applySelectedTheme =
+  (preference: ResolvedTheme) =>
+  (dispatch: AppDispatch, getState: () => RootState) => {
+    if (import.meta.env.SSR) return;
+
+    try {
+      localStorage.setItem('theme', preference);
+    } catch {
+      /* storage unavailable - the theme still applies for this page view */
+    }
+
+    applyResolvedTheme(
+      dispatch,
+      resolveTheme(null, preference, osPrefersDark()),
+    );
+
+    const username = selectCurrentUser(getState())?.username;
+    if (username) syncUserTheme(dispatch, username, preference);
+  };
+
+// Owns the theme after hydration: applies the resolved theme on mount and
+// re-resolves when the account preference changes (login, settings save),
+// when another tab changes the stored choice, or when the OS switches
+// appearance while the preference is 'auto'
+export const ThemeManager = () => {
   const dispatch = useAppDispatch();
-  const username = useCurrentUser()?.username;
-  const loggedIn = useIsLoggedIn();
-
-  // Throttle ensures instant feedback first time user changes theme,
-  // but also ensures user cant spam the server with requests
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const throttledUpdateUserTheme = useCallback(
-    throttle(
-      (username, theme) => dispatch(updateUserTheme(username, theme)),
-      2000,
-    ),
-    [dispatch],
-  );
+  const accountTheme = useCurrentUser()?.selectedTheme;
 
   useEffect(() => {
-    const handleThemeChange = (event?: Event) => {
-      const currentTheme = getTheme();
-      dispatch(setTheme(currentTheme)); // Synchronize local state
+    const resolve = () =>
+      applyResolvedTheme(
+        dispatch,
+        resolveTheme(accountTheme, storedPreference(), osPrefersDark()),
+      );
 
-      if (
-        (event as CustomEvent<ThemeChangeEventDetail> | undefined)?.detail
-          ?.updateUserTheme &&
-        loggedIn &&
-        username
-      )
-        throttledUpdateUserTheme(username, currentTheme); // Synchronize server state
+    resolve();
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === 'theme') resolve();
     };
+    const osQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
-    handleThemeChange();
-    window.addEventListener('themeChange', handleThemeChange);
+    window.addEventListener('storage', onStorage);
+    osQuery.addEventListener('change', resolve);
 
-    // Optimistically update theme from localStorage
-    const cachedTheme =
-      localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
-    applySelectedTheme(cachedTheme, { updateUserTheme: false });
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      osQuery.removeEventListener('change', resolve);
+    };
+  }, [dispatch, accountTheme]);
 
-    return () => window.removeEventListener('themeChange', handleThemeChange);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, loggedIn, username]);
-
-  return <></>;
-};
-
-export const useTheme = () => {
-  return useAppSelector((state) => state.theme.theme);
-};
-
-export const getOSTheme = () => {
-  return window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? 'dark'
-    : 'light';
+  return null;
 };

--- a/lego-webapp/utils/themeUtils.tsx
+++ b/lego-webapp/utils/themeUtils.tsx
@@ -1,114 +1,106 @@
-import { throttle } from 'lodash-es';
 import { useEffect } from 'react';
+import { Thunk } from 'app/types';
 import { updateUserTheme } from '~/redux/actions/UserActions';
 import { useAppDispatch, useAppSelector } from '~/redux/hooks';
-import { selectCurrentUser, useCurrentUser } from '~/redux/slices/auth';
+import { selectCurrentUser } from '~/redux/slices/auth';
 import { setTheme } from '~/redux/slices/theme';
 import type { AppDispatch } from '~/redux/createStore';
-import type { RootState } from '~/redux/rootReducer';
 
 export type ThemePreference = 'light' | 'dark' | 'auto';
-export type ResolvedTheme = 'light' | 'dark';
+type ResolvedTheme = 'light' | 'dark';
 
-// The one precedence rule for the whole app: an explicit account theme wins,
-// then an explicit choice stored on this device, then the OS. 'auto' (and
-// anything unknown) falls through to the next level
+const THEME_STORAGE_KEY = 'theme-preference';
+const LEGACY_THEME_STORAGE_KEY = 'theme';
+const PREFERS_DARK_QUERY = '(prefers-color-scheme: dark)';
+
 export const resolveTheme = (
   account: unknown,
   stored: unknown,
   osDark: boolean,
-): ResolvedTheme =>
-  account === 'dark' || account === 'light'
-    ? account
-    : stored === 'dark' || stored === 'light'
-      ? stored
-      : osDark
-        ? 'dark'
-        : 'light';
+): ResolvedTheme => {
+  if (account === 'dark' || account === 'light') return account;
+  if (account !== 'auto' && (stored === 'dark' || stored === 'light'))
+    return stored;
+  return osDark ? 'dark' : 'light';
+};
 
-// Pre-paint script for +Head, built from resolveTheme itself so the theme
-// painted first can never disagree with what ThemeManager applies after
-// hydration
-export const themeBootstrapScript = (account: ThemePreference) => `
+export const themeBootstrapScript = (account: ThemePreference | undefined) => `
 (function () {
   try {
     var stored = null;
-    try { stored = localStorage.getItem('theme'); } catch (e) {}
+    try { stored = localStorage.getItem('${THEME_STORAGE_KEY}'); } catch (e) {}
+    var osDark = window.matchMedia('${PREFERS_DARK_QUERY}').matches;
     document.documentElement.setAttribute(
       'data-theme',
-      (${resolveTheme.toString()})(
-        ${JSON.stringify(account)},
-        stored,
-        window.matchMedia('(prefers-color-scheme: dark)').matches
-      )
+      (${resolveTheme.toString()})(${JSON.stringify(account ?? null).replace(/</g, '\\u003c')}, stored, osDark)
     );
   } catch (e) {}
 })();`;
 
-const osPrefersDark = () =>
-  window.matchMedia('(prefers-color-scheme: dark)').matches;
+const osPrefersDark = () => window.matchMedia(PREFERS_DARK_QUERY).matches;
 
 const storedPreference = () => {
   try {
-    return localStorage.getItem('theme');
+    return localStorage.getItem(THEME_STORAGE_KEY);
   } catch {
     return null;
   }
 };
 
-// The only place data-theme is written after first paint
+const writeStoredPreference = (preference: ThemePreference) => {
+  try {
+    if (preference === 'auto') localStorage.removeItem(THEME_STORAGE_KEY);
+    else localStorage.setItem(THEME_STORAGE_KEY, preference);
+  } catch {
+    return;
+  }
+};
+
+const removeLegacyStoredPreference = () => {
+  try {
+    localStorage.removeItem(LEGACY_THEME_STORAGE_KEY);
+  } catch {
+    return;
+  }
+};
+
 const applyResolvedTheme = (dispatch: AppDispatch, resolved: ResolvedTheme) => {
   document.documentElement.setAttribute('data-theme', resolved);
   dispatch(setTheme(resolved));
 };
 
-export const getTheme = (): ResolvedTheme =>
-  !import.meta.env.SSR &&
-  document.documentElement.getAttribute('data-theme') === 'dark'
-    ? 'dark'
-    : 'light';
-
 export const useTheme = () => useAppSelector((state) => state.theme.theme);
 
-// Throttle ensures instant feedback the first time the user changes theme,
-// but also ensures the user can't spam the server with requests
-const syncUserTheme = throttle(
-  (dispatch: AppDispatch, username: string, theme: ResolvedTheme) =>
-    dispatch(updateUserTheme(username, theme)),
-  2000,
-);
-
-// The user explicitly picked a theme: store the choice on this device, apply
-// it, and sync it to their account when logged in
 export const applySelectedTheme =
-  (preference: ResolvedTheme) =>
-  (dispatch: AppDispatch, getState: () => RootState) => {
+  (preference: ThemePreference): Thunk<void> =>
+  (dispatch, getState) => {
     if (import.meta.env.SSR) return;
+    if (
+      preference !== 'light' &&
+      preference !== 'dark' &&
+      preference !== 'auto'
+    )
+      return;
 
-    try {
-      localStorage.setItem('theme', preference);
-    } catch {
-      /* storage unavailable - the theme still applies for this page view */
-    }
+    const username = selectCurrentUser(getState())?.username;
+    if (username) dispatch(updateUserTheme(username, preference));
+    else writeStoredPreference(preference);
 
     applyResolvedTheme(
       dispatch,
-      resolveTheme(null, preference, osPrefersDark()),
+      resolveTheme(preference, null, osPrefersDark()),
     );
-
-    const username = selectCurrentUser(getState())?.username;
-    if (username) syncUserTheme(dispatch, username, preference);
   };
 
-// Owns the theme after hydration: applies the resolved theme on mount and
-// re-resolves when the account preference changes (login, settings save),
-// when another tab changes the stored choice, or when the OS switches
-// appearance while the preference is 'auto'
 export const ThemeManager = () => {
   const dispatch = useAppDispatch();
-  const accountTheme = useCurrentUser()?.selectedTheme;
+  const accountTheme = useAppSelector(
+    (state) => selectCurrentUser(state)?.selectedTheme,
+  );
 
   useEffect(() => {
+    removeLegacyStoredPreference();
+
     const resolve = () =>
       applyResolvedTheme(
         dispatch,
@@ -118,16 +110,15 @@ export const ThemeManager = () => {
     resolve();
 
     const onStorage = (event: StorageEvent) => {
-      if (event.key === 'theme') resolve();
+      if (event.key === THEME_STORAGE_KEY || event.key === null) resolve();
     };
-    const osQuery = window.matchMedia('(prefers-color-scheme: dark)');
-
+    const osQuery = window.matchMedia(PREFERS_DARK_QUERY);
     window.addEventListener('storage', onStorage);
-    osQuery.addEventListener('change', resolve);
+    osQuery.addEventListener?.('change', resolve);
 
     return () => {
       window.removeEventListener('storage', onStorage);
-      osQuery.removeEventListener('change', resolve);
+      osQuery.removeEventListener?.('change', resolve);
     };
   }, [dispatch, accountTheme]);
 


### PR DESCRIPTION
# Description

Fix theme flash and refactor theme handling into a single resolver

Landing on the public frontpage in dark mode flashed dark → light: four independent theme writers (SSR attribute, pre-paint script, two hydration effects) each resolved the theme differently.

- One precedence rule in resolveTheme: explicit account theme → "auto" follows OS → logged out: device choice → OS
- The pre-paint script is generated from resolveTheme itself; a spec runs the script against the function to prevent drift
- ThemeManager owns the theme after hydration (account changes, cross-tab, live OS switching); the old listener, Header effect, and CustomEvent bus are gone
- New localStorage key — the old one was stamped on every visit and would pin existing devices to a theme they never chose

# Result

If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

# Testing

- [x] I have thoroughly tested my changes.
- [x] I have created tests for my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6009 
