### PR TITLE
Fix undefined and import type errors

### DIFF
--- a/lego-webapp/cypress/support/commands.ts
+++ b/lego-webapp/cypress/support/commands.ts
@@ -1,4 +1,7 @@
 import { apiBaseUrl } from './utils';
+import type { MountOptions, MountReturn } from 'cypress/react';
+import type { ReactNode } from 'react';
+import type store from '~/cypress/fixtures/store';
 
 declare global {
   namespace Cypress {
@@ -20,7 +23,10 @@ declare global {
         options: Partial<Cypress.RequestOptions>,
         username?: string,
       ): Chainable<Response<unknown>>;
-      mount: typeof mount;
+      mount(
+        component: ReactNode,
+        options?: MountOptions & { reduxStore?: ReturnType<typeof store> },
+      ): Chainable<MountReturn>;
     }
   }
 }

--- a/lego-webapp/pages/surveys/@surveyId/(wrapper)/submissions/Results.tsx
+++ b/lego-webapp/pages/surveys/@surveyId/(wrapper)/submissions/Results.tsx
@@ -80,7 +80,7 @@ const Results = ({
 }: Props) => {
   const dispatch = useAppDispatch();
   const event = useAppSelector(
-    (state) => selectEventById<EventForSurvey>(state, survey.event)!,
+    (state) => selectEventById<EventForSurvey>(state, survey.event ?? undefined)!,
   );
   const { fetchingSubmissions } = useContext(SurveysRouteContext);
 

--- a/lego-webapp/pages/surveys/@surveyId/(wrapper)/submissions/Results.tsx
+++ b/lego-webapp/pages/surveys/@surveyId/(wrapper)/submissions/Results.tsx
@@ -80,7 +80,8 @@ const Results = ({
 }: Props) => {
   const dispatch = useAppDispatch();
   const event = useAppSelector(
-    (state) => selectEventById<EventForSurvey>(state, survey.event ?? undefined)!,
+    (state) =>
+      selectEventById<EventForSurvey>(state, survey.event ?? undefined)!,
   );
   const { fetchingSubmissions } = useContext(SurveysRouteContext);
 

--- a/lego-webapp/pages/surveys/index/SurveyItem.tsx
+++ b/lego-webapp/pages/surveys/index/SurveyItem.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 const SurveyItem = ({ survey }: Props) => {
   const event = useAppSelector((state) =>
-    selectEventById<EventForSurvey>(state, survey?.event),
+    selectEventById<EventForSurvey>(state, survey?.event ?? undefined),
   );
 
   return (

--- a/lego-webapp/redux/actions/UserActions.ts
+++ b/lego-webapp/redux/actions/UserActions.ts
@@ -12,7 +12,7 @@ import { fetchMeta } from './MetaActions';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { PhotoConsent } from 'app/models';
 import type { Thunk, Token, EncodedToken, GetCookie } from 'app/types';
-import type { FormValues as ChangePasswordFormValues } from '~/pages/users/_components/ChangePassword';
+import type { FormValues as ChangePasswordFormValues } from '~/pages/users/@username/settings/profile/ChangePassword';
 import type { FormValues as UserConfirmationFormValues } from '~/pages/users/registration/+Page';
 import type { AppDispatch } from '~/redux/createStore';
 import type { RejectedPromiseAction } from '~/redux/middlewares/promiseMiddleware';

--- a/lego-webapp/redux/legoAdapter/createLegoAdapter.ts
+++ b/lego-webapp/redux/legoAdapter/createLegoAdapter.ts
@@ -111,7 +111,6 @@ function createLegoAdapter<
   Type extends EntityType,
   Entity extends Entities[Type][EntityId] & {
     id: EntityId;
-    // @ts-expect-error - This won't work for entities without id, but they should provide a selectId function
   } = Entities[Type][EntityId],
 >(
   entityType: Type,

--- a/lego-webapp/redux/slices/surveys.ts
+++ b/lego-webapp/redux/slices/surveys.ts
@@ -125,7 +125,7 @@ export function useFetchedSurvey(
     selectSurveyById(state, surveyId),
   ) as UnknownSurvey | undefined;
   const event = useAppSelector((state: RootState) =>
-    selectEventById<EventForSurvey>(state, survey?.event),
+    selectEventById<EventForSurvey>(state, survey?.event ?? undefined),
   );
 
   return {

--- a/lego-webapp/utils/appConfig.ts
+++ b/lego-webapp/utils/appConfig.ts
@@ -14,7 +14,7 @@ export interface AppConfig {
 
 const env = import.meta.env.SSR ? process.env : ({} as Record<string, string>);
 
-const defaultAppConfig = {
+export const defaultAppConfig = {
   serverUrl: env.API_URL || 'http://127.0.0.1:8000/api/v1',
   wsServerUrl: env.WS_URL || 'ws://127.0.0.1:8001',
   baseUrl: env.BASE_URL || 'http://127.0.0.1:8000',

--- a/packages/lego-editor/src/index.tsx
+++ b/packages/lego-editor/src/index.tsx
@@ -13,12 +13,12 @@ import Toolbar from './components/Toolbar';
 import styles from './Editor.module.css';
 import { useEffect, useState } from 'react';
 import cx from 'classnames';
-import { Figure } from './extensions/figure.tsx';
-import { ImageWithFileKey } from './extensions/image.ts';
+import { Figure } from './extensions/figure';
+import { ImageWithFileKey } from './extensions/image';
 import { Link } from '@tiptap/extension-link';
-import { Diff } from './extensions/diff.ts';
-import { Strike } from './extensions/strike.ts';
-import { ImageMenu } from './components/ImageMenu.tsx';
+import { Diff } from './extensions/diff';
+import { Strike } from './extensions/strike';
+import { ImageMenu } from './components/ImageMenu';
 
 export type ImageUploadFn = (
   file: File,


### PR DESCRIPTION
## Description

Fixes 12 of the ~141 type errors from `pnpm types` - the mechanical ones that don't require structural changes:

- **`packages/lego-editor/src/index.tsx`**: remove explicit `.ts`/`.tsx` extensions from 5 import paths (TS5097)
- **`utils/appConfig.ts`**: export `defaultAppConfig`, which `vitest.setup.ts` imports (TS2614)
- **`redux/actions/UserActions.ts`**: update stale `ChangePassword` import path after the component moved to `pages/users/@username/settings/profile/` (TS2307)
- **`redux/legoAdapter/createLegoAdapter.ts`**: remove unused `@ts-expect-error` directive (TS2578)
- **`cypress/support/commands.ts`**: declare the custom `mount` command with its real signature (including the `reduxStore` option) instead of referencing an unimported `mount` (TS2304)
- **`redux/slices/surveys.ts`**, **`pages/surveys/.../Results.tsx`**, **`pages/surveys/index/SurveyItem.tsx`**: coalesce `survey.event ?? undefined` when passing to `selectEventById`, which takes `EntityId | undefined` (TS2345)

## Test steps

- `pnpm types` - error count drops from 141 to 129 on the branch base; each of the 12 targeted errors is gone
