### PR TITLE
Modernise the shared form components

### DIFF
--- a/lego-webapp/components/Form/CheckBox.module.css
+++ b/lego-webapp/components/Form/CheckBox.module.css
@@ -65,27 +65,8 @@
   transform: scale(var(--scale, 1)) translateZ(0);
 }
 
-.checkbox.path input:checked {
-  --s: 2px;
-
-  transition-delay: 0.2s;
-}
-
-.checkbox.path svg {
-  stroke-dasharray: var(--a, 86.12);
-  stroke-dashoffset: var(--o, 86.12);
-  transition:
-    stroke-dasharray var(--linear-slow),
-    stroke-dashoffset var(--linear-slow);
-}
-
 .checkbox.bounce svg {
   --scale: 0;
-}
-
-.checkbox.path input:checked + svg {
-  --a: 16.1 86.12;
-  --o: 102.22;
 }
 
 .checkbox.bounce {

--- a/lego-webapp/components/Form/CheckBox.tsx
+++ b/lego-webapp/components/Form/CheckBox.tsx
@@ -68,8 +68,11 @@ const CheckBox = ({
 
 const RawField = createField(CheckBox, { inlineLabel: true });
 
-const StyledField = (props: ComponentProps<typeof RawField>) => (
-  <RawField labelClassName={styles.fieldLabel} {...props} />
+const StyledField = ({
+  labelClassName,
+  ...props
+}: ComponentProps<typeof RawField> & { labelClassName?: string }) => (
+  <RawField labelClassName={cx(styles.fieldLabel, labelClassName)} {...props} />
 );
 
 CheckBox.Field = StyledField;

--- a/lego-webapp/components/Form/Chip.module.css
+++ b/lego-webapp/components/Form/Chip.module.css
@@ -49,8 +49,8 @@
    on its own and each state just reassigns the variables it cares about. */
 .chip:has(.input:checked) {
   --chip-border: var(--lego-red-color);
-  --chip-background: var(--color-red-1);
-  --chip-color: var(--color-red-9);
+  --chip-background: var(--selected-background);
+  --chip-color: var(--color-red-7);
 }
 
 .chip:has(.input:checked):hover {

--- a/lego-webapp/components/Form/Chip.module.css
+++ b/lego-webapp/components/Form/Chip.module.css
@@ -1,0 +1,69 @@
+.chipField.chipField {
+  width: auto;
+}
+
+.chip {
+  --chip-border: var(--border-gray);
+  --chip-background: var(--lego-card-color);
+  --chip-color: var(--color-gray-8);
+
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  height: 34px;
+  padding: 0 var(--spacing-md);
+  border: 1.5px solid var(--chip-border);
+  border-radius: 999px;
+  background-color: var(--chip-background);
+  color: var(--chip-color);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    border-color var(--easing-fast),
+    background-color var(--easing-fast),
+    color var(--easing-fast);
+}
+
+/* Visually hidden, but still focusable and exposed to assistive technology.
+   display: none would drop it from the tab order and strand keyboard users. */
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+}
+
+.chip:hover {
+  --chip-border: var(--color-gray-4);
+}
+
+/* :has(.input:checked) already outranks :hover, so the selected palette wins
+   on its own and each state just reassigns the variables it cares about. */
+.chip:has(.input:checked) {
+  --chip-border: var(--lego-red-color);
+  --chip-background: var(--color-red-1);
+  --chip-color: var(--color-red-9);
+}
+
+.chip:has(.input:checked):hover {
+  --chip-border: var(--lego-red-color-hover);
+}
+
+/* The input's own focus ring is hidden with it, so the pill carries it. */
+.chip:has(.input:focus-visible) {
+  outline: 2px solid var(--lego-font-color);
+  outline-offset: var(--spacing-xs);
+}
+
+.chip:has(.input:disabled) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/lego-webapp/components/Form/Chip.module.css
+++ b/lego-webapp/components/Form/Chip.module.css
@@ -26,8 +26,7 @@
     color var(--easing-fast);
 }
 
-/* Visually hidden, but still focusable and exposed to assistive technology.
-   display: none would drop it from the tab order and strand keyboard users. */
+/* Visually hidden, not display: none, which would drop it from the tab order. */
 .input {
   position: absolute;
   width: 1px;
@@ -45,8 +44,6 @@
   --chip-border: var(--color-gray-4);
 }
 
-/* :has(.input:checked) already outranks :hover, so the selected palette wins
-   on its own and each state just reassigns the variables it cares about. */
 .chip:has(.input:checked) {
   --chip-border: var(--lego-red-color);
   --chip-background: var(--selected-background);
@@ -57,7 +54,7 @@
   --chip-border: var(--lego-red-color-hover);
 }
 
-/* The input's own focus ring is hidden with it, so the pill carries it. */
+/* The pill carries the hidden input's focus ring. */
 .chip:has(.input:focus-visible) {
   outline: 2px solid var(--lego-font-color);
   outline-offset: var(--spacing-xs);

--- a/lego-webapp/components/Form/Chip.module.css
+++ b/lego-webapp/components/Form/Chip.module.css
@@ -26,7 +26,6 @@
     color var(--easing-fast);
 }
 
-/* Visually hidden, not display: none, which would drop it from the tab order. */
 .input {
   position: absolute;
   width: 1px;

--- a/lego-webapp/components/Form/Chip.tsx
+++ b/lego-webapp/components/Form/Chip.tsx
@@ -1,7 +1,13 @@
 import cx from 'classnames';
+import { Keyboard } from '~/utils/constants';
 import styles from './Chip.module.css';
 import { createField } from './Field';
-import type { ComponentProps, InputHTMLAttributes, ReactNode } from 'react';
+import type {
+  ComponentProps,
+  InputHTMLAttributes,
+  KeyboardEvent,
+  ReactNode,
+} from 'react';
 
 type Props = {
   label?: ReactNode;
@@ -11,13 +17,32 @@ type Props = {
 
 /* A pill shaped alternative to RadioButton (type="radio") and CheckBox
    (type="checkbox"). */
-const Chip = ({ id, label, required, checked, className, ...props }: Props) => (
-  <label className={cx(styles.chip, className)} htmlFor={id}>
-    <input {...props} id={id} checked={checked} className={styles.input} />
-    <span>{label}</span>
-    {required && <span className={styles.required}>*</span>}
-  </label>
-);
+const Chip = ({ id, label, required, checked, className, ...props }: Props) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === Keyboard.ENTER) {
+      event.preventDefault();
+
+      const inputElement = event.target as HTMLInputElement;
+      if (!inputElement.checked || inputElement.type === 'checkbox') {
+        inputElement.click();
+      }
+    }
+  };
+
+  return (
+    <label className={cx(styles.chip, className)} htmlFor={id}>
+      <input
+        {...props}
+        id={id}
+        checked={checked}
+        className={styles.input}
+        onKeyDown={handleKeyDown}
+      />
+      <span>{label}</span>
+      {required && <span className={styles.required}>*</span>}
+    </label>
+  );
+};
 
 const RawField = createField(Chip, { ownLabel: true });
 

--- a/lego-webapp/components/Form/Chip.tsx
+++ b/lego-webapp/components/Form/Chip.tsx
@@ -9,14 +9,8 @@ type Props = {
   className?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-/**
- * A pill shaped alternative to RadioButton and CheckBox. Pass type="radio" for
- * a single choice group and type="checkbox" for a multiple choice one, exactly
- * as with the controls it replaces.
- *
- * The native input stays in the accessibility tree and the tab order, it is
- * only hidden visually, so the pill keeps keyboard and screen reader support.
- */
+/* A pill shaped alternative to RadioButton (type="radio") and CheckBox
+   (type="checkbox"). */
 const Chip = ({ id, label, required, checked, className, ...props }: Props) => (
   <label className={cx(styles.chip, className)} htmlFor={id}>
     <input {...props} id={id} checked={checked} className={styles.input} />

--- a/lego-webapp/components/Form/Chip.tsx
+++ b/lego-webapp/components/Form/Chip.tsx
@@ -1,0 +1,38 @@
+import cx from 'classnames';
+import styles from './Chip.module.css';
+import { createField } from './Field';
+import type { ComponentProps, InputHTMLAttributes, ReactNode } from 'react';
+
+type Props = {
+  label?: ReactNode;
+  required?: boolean;
+  className?: string;
+} & InputHTMLAttributes<HTMLInputElement>;
+
+/**
+ * A pill shaped alternative to RadioButton and CheckBox. Pass type="radio" for
+ * a single choice group and type="checkbox" for a multiple choice one, exactly
+ * as with the controls it replaces.
+ *
+ * The native input stays in the accessibility tree and the tab order, it is
+ * only hidden visually, so the pill keeps keyboard and screen reader support.
+ */
+const Chip = ({ id, label, required, checked, className, ...props }: Props) => (
+  <label className={cx(styles.chip, className)} htmlFor={id}>
+    <input {...props} id={id} checked={checked} className={styles.input} />
+    <span>{label}</span>
+    {required && <span className={styles.required}>*</span>}
+  </label>
+);
+
+const RawField = createField(Chip, { ownLabel: true });
+
+const StyledField = ({
+  fieldClassName,
+  ...props
+}: ComponentProps<typeof RawField> & { fieldClassName?: string }) => (
+  <RawField fieldClassName={cx(fieldClassName, styles.chipField)} {...props} />
+);
+
+Chip.Field = StyledField;
+export default Chip;

--- a/lego-webapp/components/Form/DatePicker.tsx
+++ b/lego-webapp/components/Form/DatePicker.tsx
@@ -18,6 +18,7 @@ type BaseDatePickerProps = {
   showTimePicker?: boolean;
   dateFormat?: string;
   name?: string;
+  id?: string;
   dropdownClassName?: string;
   onFocus: () => void;
   disabled?: boolean;
@@ -48,6 +49,7 @@ const DatePicker = ({
   showTimePicker = true,
   dateFormat = 'lll',
   name,
+  id,
   range = false,
   disabled = false,
 }: Props) => {
@@ -285,6 +287,7 @@ const DatePicker = ({
           prefixIconNode={<Calendar />}
           value={displayValue}
           name={name}
+          id={id}
           readOnly
           disabled={disabled}
         />

--- a/lego-webapp/components/Form/Field.module.css
+++ b/lego-webapp/components/Form/Field.module.css
@@ -1,5 +1,6 @@
 .field {
   width: 100%;
+  position: relative;
 }
 
 .inputWithError {
@@ -15,4 +16,15 @@
   color: var(--color-absolute-white);
   font-size: var(--font-size-sm);
   border-radius: var(--border-radius-md);
+}
+
+.fieldErrorOverlay {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  pointer-events: none;
 }

--- a/lego-webapp/components/Form/Field.module.css
+++ b/lego-webapp/components/Form/Field.module.css
@@ -18,6 +18,22 @@
   border-radius: var(--border-radius-md);
 }
 
+/* Reads as a note under the control instead of a block laid over what follows.
+   For controls an overlay has nothing sensible to cover: a row of chips, a list
+   of cards, an editor tall enough that the message lands far from the mistake. */
+.fieldErrorQuiet {
+  min-height: 0;
+  padding: 0;
+  margin-top: 0;
+  background: none;
+  color: var(--danger-color);
+  font-weight: 500;
+}
+
+.fieldErrorIcon {
+  flex: none;
+}
+
 .fieldErrorFlow {
   display: flex;
   flex-direction: column;
@@ -31,4 +47,10 @@
   z-index: 3;
   width: 100%;
   pointer-events: none;
+}
+
+.fieldErrorText {
+  composes: fieldErrorFlow;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
 }

--- a/lego-webapp/components/Form/Field.module.css
+++ b/lego-webapp/components/Form/Field.module.css
@@ -18,13 +18,17 @@
   border-radius: var(--border-radius-md);
 }
 
+.fieldErrorFlow {
+  display: flex;
+  flex-direction: column;
+}
+
 .fieldErrorOverlay {
+  composes: fieldErrorFlow;
   position: absolute;
   top: 100%;
   left: 0;
   z-index: 3;
-  display: flex;
-  flex-direction: column;
   width: 100%;
   pointer-events: none;
 }

--- a/lego-webapp/components/Form/Field.tsx
+++ b/lego-webapp/components/Form/Field.tsx
@@ -103,6 +103,8 @@ export function createField<T, ExtraProps extends object>(
       label,
       fieldStyle,
       description,
+      descriptionPosition,
+      inlineContent,
       fieldClassName,
       labelClassName,
       onChange,
@@ -159,6 +161,8 @@ export function createField<T, ExtraProps extends object>(
             noLabel={noLabel}
             description={description}
             descriptionId={descriptionId}
+            descriptionPosition={descriptionPosition}
+            inlineContent={inlineContent}
             inline={inlineLabel}
             required={required}
           >

--- a/lego-webapp/components/Form/Field.tsx
+++ b/lego-webapp/components/Form/Field.tsx
@@ -1,32 +1,46 @@
-import { Flex } from '@webkom/lego-bricks';
+import { Flex, Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { CircleAlert } from 'lucide-react';
 import { useId } from 'react';
 import { Label } from '~/components/Form/Label';
 import styles from './Field.module.css';
 import type { ComponentType } from 'react';
 import type { FieldInputProps, FieldRenderProps } from 'react-final-form';
 
+/* overlay floats below the field, inline owns its place in the flow, and
+   text is a quiet note for controls an overlay cannot cover sensibly. */
+export type ErrorVariant = 'overlay' | 'inline' | 'text';
+
 const FieldError = ({
   error,
   fieldName,
+  variant,
 }: {
   error: string;
   fieldName?: string;
+  variant: ErrorVariant;
 }) => (
   <Flex
     alignItems="center"
-    className={styles.fieldError}
+    gap="var(--spacing-xs)"
+    className={cx(
+      styles.fieldError,
+      variant === 'text' && styles.fieldErrorQuiet,
+    )}
     data-error-field-name={fieldName}
   >
+    {variant === 'text' && (
+      <Icon
+        iconNode={<CircleAlert />}
+        size={16}
+        className={styles.fieldErrorIcon}
+      />
+    )}
     {error}
   </Flex>
 );
 
-/**
- * Flattens an error into the messages to display. Validation errors reach us as
- * a string, an array (one entry per item of an array field) or an object keyed
- * by subfield, so anything but a string was previously dropped without a trace.
- */
+/* Validation errors arrive as a string, an array or an object per subfield. */
 export const toErrorMessages = (error: unknown): string[] => {
   if (error === null || error === undefined || error === false) {
     return [];
@@ -43,20 +57,21 @@ export const toErrorMessages = (error: unknown): string[] => {
   return [String(error)];
 };
 
-/**
- * Renders validation errors over the content below by default, so showing one
- * does not shift the surrounding layout. Pass `inline` where the message owns
- * its space in the flow, such as form level submission errors.
- */
+const ERROR_CONTAINER: Record<ErrorVariant, string> = {
+  overlay: styles.fieldErrorOverlay,
+  inline: styles.fieldErrorFlow,
+  text: styles.fieldErrorText,
+};
+
 export const RenderErrorMessage = ({
   error,
   fieldName,
-  inline = false,
+  variant = 'overlay',
   id,
 }: {
   error: unknown;
   fieldName?: string;
-  inline?: boolean;
+  variant?: ErrorVariant;
   id?: string;
 }) => {
   const errors = [...new Set(toErrorMessages(error))];
@@ -66,13 +81,14 @@ export const RenderErrorMessage = ({
   }
 
   return (
-    <div
-      id={id}
-      className={inline ? styles.fieldErrorFlow : styles.fieldErrorOverlay}
-      role="alert"
-    >
+    <div id={id} className={ERROR_CONTAINER[variant]} role="alert">
       {errors.map((error, index) => (
-        <FieldError key={index} error={error} fieldName={fieldName} />
+        <FieldError
+          key={index}
+          error={error}
+          fieldName={fieldName}
+          variant={variant}
+        />
       ))}
     </div>
   );
@@ -87,6 +103,8 @@ type Options = {
   ownLabel?: boolean;
   // Places the component after its label, the way a switch sits
   trailingControl?: boolean;
+  // How validation errors are shown, see ErrorVariant
+  errorVariant?: ErrorVariant;
 };
 
 /**
@@ -120,7 +138,8 @@ export function createField<T, ExtraProps extends object>(
     const hasError =
       !!showErrors && !!touched && toErrorMessages(anyError).length > 0;
     const fieldName = input?.name;
-    const { noLabel, inlineLabel, ownLabel, trailingControl } = options || {};
+    const { noLabel, inlineLabel, ownLabel, trailingControl, errorVariant } =
+      options || {};
 
     const generatedId = useId();
     const fieldId = id ?? generatedId;
@@ -177,6 +196,7 @@ export function createField<T, ExtraProps extends object>(
             id={errorId}
             error={anyError}
             fieldName={fieldName}
+            variant={errorVariant}
           />
         )}
       </Flex>

--- a/lego-webapp/components/Form/Field.tsx
+++ b/lego-webapp/components/Form/Field.tsx
@@ -121,6 +121,9 @@ export function createField<T, ExtraProps extends object>(
     const generatedId = useId();
     const fieldId = id ?? generatedId;
     const errorId = `${fieldId}-error`;
+    const descriptionId = `${fieldId}-description`;
+    const describedBy =
+      cx(description && descriptionId, hasError && errorId) || undefined;
 
     const component = (
       <Component
@@ -134,7 +137,7 @@ export function createField<T, ExtraProps extends object>(
           onChange?.(value);
         }}
         aria-invalid={hasError || undefined}
-        aria-describedby={hasError ? errorId : undefined}
+        aria-describedby={describedBy}
         aria-required={required || undefined}
         className={cx(className, hasError && styles.inputWithError)}
       />
@@ -155,6 +158,7 @@ export function createField<T, ExtraProps extends object>(
             label={label}
             noLabel={noLabel}
             description={description}
+            descriptionId={descriptionId}
             inline={inlineLabel}
             required={required}
           >

--- a/lego-webapp/components/Form/Field.tsx
+++ b/lego-webapp/components/Form/Field.tsx
@@ -22,24 +22,38 @@ const FieldError = ({
     </Flex>
   ) : null;
 
+/**
+ * Renders validation errors over the content below by default, so showing one
+ * does not shift the surrounding layout. Pass `inline` where the message owns
+ * its space in the flow, such as form level submission errors.
+ */
 export const RenderErrorMessage = ({
   error,
   fieldName,
+  inline = false,
 }: {
   error: Array<string> | string;
   fieldName?: string;
+  inline?: boolean;
 }) => {
-  if (Array.isArray(error)) {
-    return (
-      <>
-        {error.map((error) => (
-          <RenderErrorMessage key={error} error={error} fieldName={fieldName} />
-        ))}
-      </>
-    );
+  const errors = (Array.isArray(error) ? error.flat(Infinity) : [error]).filter(
+    Boolean,
+  );
+
+  if (errors.length === 0) {
+    return null;
   }
 
-  return <FieldError error={error} fieldName={fieldName} />;
+  return (
+    <div
+      className={inline ? styles.fieldErrorFlow : styles.fieldErrorOverlay}
+      role="alert"
+    >
+      {errors.map((error, index) => (
+        <FieldError key={index} error={error} fieldName={fieldName} />
+      ))}
+    </div>
+  );
 };
 
 type Options = {
@@ -108,9 +122,7 @@ export function createField<T, ExtraProps extends object>(
           {component}
         </Label>
         {hasError && (
-          <div className={styles.fieldErrorOverlay} role="alert">
-            <RenderErrorMessage error={anyError} fieldName={fieldName} />
-          </div>
+          <RenderErrorMessage error={anyError} fieldName={fieldName} />
         )}
       </Flex>
     );

--- a/lego-webapp/components/Form/Field.tsx
+++ b/lego-webapp/components/Form/Field.tsx
@@ -108,7 +108,9 @@ export function createField<T, ExtraProps extends object>(
           {component}
         </Label>
         {hasError && (
-          <RenderErrorMessage error={anyError} fieldName={fieldName} />
+          <div className={styles.fieldErrorOverlay} role="alert">
+            <RenderErrorMessage error={anyError} fieldName={fieldName} />
+          </div>
         )}
       </Flex>
     );

--- a/lego-webapp/components/Form/Field.tsx
+++ b/lego-webapp/components/Form/Field.tsx
@@ -85,6 +85,8 @@ type Options = {
   inlineLabel?: boolean;
   // The component renders the label itself, so no wrapper is added around it
   ownLabel?: boolean;
+  // Places the component after its label, the way a switch sits
+  trailingControl?: boolean;
 };
 
 /**
@@ -118,7 +120,7 @@ export function createField<T, ExtraProps extends object>(
     const hasError =
       !!showErrors && !!touched && toErrorMessages(anyError).length > 0;
     const fieldName = input?.name;
-    const { noLabel, inlineLabel, ownLabel } = options || {};
+    const { noLabel, inlineLabel, ownLabel, trailingControl } = options || {};
 
     const generatedId = useId();
     const fieldId = id ?? generatedId;
@@ -164,6 +166,7 @@ export function createField<T, ExtraProps extends object>(
             descriptionPosition={descriptionPosition}
             inlineContent={inlineContent}
             inline={inlineLabel}
+            trailing={trailingControl}
             required={required}
           >
             {component}

--- a/lego-webapp/components/Form/Field.tsx
+++ b/lego-webapp/components/Form/Field.tsx
@@ -7,8 +7,9 @@ import styles from './Field.module.css';
 import type { ComponentType } from 'react';
 import type { FieldInputProps, FieldRenderProps } from 'react-final-form';
 
-/* overlay floats below the field, inline owns its place in the flow, and
-   text is a quiet note for controls an overlay cannot cover sensibly. */
+/* inline owns its place in the flow, text is a quiet note without the red
+   block, and overlay floats below the field for the rare layout with room
+   under it to spare, since it paints over whatever follows. */
 export type ErrorVariant = 'overlay' | 'inline' | 'text';
 
 const FieldError = ({
@@ -66,7 +67,7 @@ const ERROR_CONTAINER: Record<ErrorVariant, string> = {
 export const RenderErrorMessage = ({
   error,
   fieldName,
-  variant = 'overlay',
+  variant = 'inline',
   id,
 }: {
   error: unknown;
@@ -101,8 +102,6 @@ type Options = {
   inlineLabel?: boolean;
   // The component renders the label itself, so no wrapper is added around it
   ownLabel?: boolean;
-  // Places the component after its label, the way a switch sits
-  trailingControl?: boolean;
   // How validation errors are shown, see ErrorVariant
   errorVariant?: ErrorVariant;
 };
@@ -128,6 +127,8 @@ export function createField<T, ExtraProps extends object>(
       fieldClassName,
       labelClassName,
       onChange,
+      onBlur,
+      onFocus,
       showErrors = true,
       className = null,
       id,
@@ -138,8 +139,7 @@ export function createField<T, ExtraProps extends object>(
     const hasError =
       !!showErrors && !!touched && toErrorMessages(anyError).length > 0;
     const fieldName = input?.name;
-    const { noLabel, inlineLabel, ownLabel, trailingControl, errorVariant } =
-      options || {};
+    const { noLabel, inlineLabel, ownLabel, errorVariant } = options || {};
 
     const generatedId = useId();
     const fieldId = id ?? generatedId;
@@ -158,6 +158,14 @@ export function createField<T, ExtraProps extends object>(
         onChange={(value) => {
           input.onChange?.(value);
           onChange?.(value);
+        }}
+        onBlur={(value) => {
+          input.onBlur?.(value);
+          onBlur?.(value);
+        }}
+        onFocus={(value) => {
+          input.onFocus?.(value);
+          onFocus?.(value);
         }}
         aria-invalid={hasError || undefined}
         aria-describedby={describedBy}
@@ -185,7 +193,6 @@ export function createField<T, ExtraProps extends object>(
             descriptionPosition={descriptionPosition}
             inlineContent={inlineContent}
             inline={inlineLabel}
-            trailing={trailingControl}
             required={required}
           >
             {component}

--- a/lego-webapp/components/Form/Field.tsx
+++ b/lego-webapp/components/Form/Field.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
+import { useId } from 'react';
 import { Label } from '~/components/Form/Label';
 import styles from './Field.module.css';
 import type { ComponentType } from 'react';
@@ -9,18 +10,38 @@ const FieldError = ({
   error,
   fieldName,
 }: {
-  error?: string;
+  error: string;
   fieldName?: string;
-}) =>
-  error ? (
-    <Flex
-      alignItems="center"
-      className={styles.fieldError}
-      data-error-field-name={fieldName}
-    >
-      {typeof error === 'object' ? JSON.stringify(error) : error}
-    </Flex>
-  ) : null;
+}) => (
+  <Flex
+    alignItems="center"
+    className={styles.fieldError}
+    data-error-field-name={fieldName}
+  >
+    {error}
+  </Flex>
+);
+
+/**
+ * Flattens an error into the messages to display. Validation errors reach us as
+ * a string, an array (one entry per item of an array field) or an object keyed
+ * by subfield, so anything but a string was previously dropped without a trace.
+ */
+export const toErrorMessages = (error: unknown): string[] => {
+  if (error === null || error === undefined || error === false) {
+    return [];
+  }
+  if (typeof error === 'string') {
+    return error.trim() ? [error] : [];
+  }
+  if (Array.isArray(error)) {
+    return error.flatMap(toErrorMessages);
+  }
+  if (typeof error === 'object') {
+    return Object.values(error).flatMap(toErrorMessages);
+  }
+  return [String(error)];
+};
 
 /**
  * Renders validation errors over the content below by default, so showing one
@@ -31,14 +52,14 @@ export const RenderErrorMessage = ({
   error,
   fieldName,
   inline = false,
+  id,
 }: {
-  error: Array<string> | string;
+  error: unknown;
   fieldName?: string;
   inline?: boolean;
+  id?: string;
 }) => {
-  const errors = (Array.isArray(error) ? error.flat(Infinity) : [error]).filter(
-    Boolean,
-  );
+  const errors = [...new Set(toErrorMessages(error))];
 
   if (errors.length === 0) {
     return null;
@@ -46,6 +67,7 @@ export const RenderErrorMessage = ({
 
   return (
     <div
+      id={id}
       className={inline ? styles.fieldErrorFlow : styles.fieldErrorOverlay}
       role="alert"
     >
@@ -61,6 +83,8 @@ type Options = {
   noLabel?: boolean;
   // Sets the label to be inline with the component
   inlineLabel?: boolean;
+  // The component renders the label itself, so no wrapper is added around it
+  ownLabel?: boolean;
 };
 
 /**
@@ -84,23 +108,34 @@ export function createField<T, ExtraProps extends object>(
       onChange,
       showErrors = true,
       className = null,
+      id,
       ...props
     } = fieldProps;
     const { error, submitError, touched } = meta;
     const anyError = error || submitError;
-    const hasError = showErrors && touched && anyError && anyError.length > 0;
+    const hasError =
+      !!showErrors && !!touched && toErrorMessages(anyError).length > 0;
     const fieldName = input?.name;
-    const { noLabel, inlineLabel } = options || {};
+    const { noLabel, inlineLabel, ownLabel } = options || {};
+
+    const generatedId = useId();
+    const fieldId = id ?? generatedId;
+    const errorId = `${fieldId}-error`;
 
     const component = (
       <Component
-        {...(input as FieldInputProps<T>)}
+        id={fieldId}
         {...(props as ExtraProps)}
-        label={!noLabel && !inlineLabel && label}
+        {...(input as FieldInputProps<T>)}
+        label={ownLabel ? label : !noLabel && !inlineLabel && label}
+        required={ownLabel ? required : undefined}
         onChange={(value) => {
           input.onChange?.(value);
           onChange?.(value);
         }}
+        aria-invalid={hasError || undefined}
+        aria-describedby={hasError ? errorId : undefined}
+        aria-required={required || undefined}
         className={cx(className, hasError && styles.inputWithError)}
       />
     );
@@ -111,18 +146,27 @@ export function createField<T, ExtraProps extends object>(
         className={cx(styles.field, fieldClassName)}
         style={fieldStyle}
       >
-        <Label
-          className={labelClassName}
-          label={label}
-          noLabel={noLabel}
-          description={description}
-          inline={inlineLabel}
-          required={required}
-        >
-          {component}
-        </Label>
+        {ownLabel ? (
+          component
+        ) : (
+          <Label
+            className={labelClassName}
+            htmlFor={noLabel ? undefined : fieldId}
+            label={label}
+            noLabel={noLabel}
+            description={description}
+            inline={inlineLabel}
+            required={required}
+          >
+            {component}
+          </Label>
+        )}
         {hasError && (
-          <RenderErrorMessage error={anyError} fieldName={fieldName} />
+          <RenderErrorMessage
+            id={errorId}
+            error={anyError}
+            fieldName={fieldName}
+          />
         )}
       </Flex>
     );

--- a/lego-webapp/components/Form/FieldSet.module.css
+++ b/lego-webapp/components/Form/FieldSet.module.css
@@ -1,3 +1,9 @@
 .fieldSet {
   border: 0;
 }
+
+.description {
+  margin-bottom: var(--spacing-sm);
+  color: var(--secondary-font-color);
+  font-size: var(--font-size-sm);
+}

--- a/lego-webapp/components/Form/FieldSet.module.css
+++ b/lego-webapp/components/Form/FieldSet.module.css
@@ -1,5 +1,9 @@
 .fieldSet {
   border: 0;
+
+  & legend {
+    margin-bottom: var(--spacing-sm);
+  }
 }
 
 .description {

--- a/lego-webapp/components/Form/FieldSet.tsx
+++ b/lego-webapp/components/Form/FieldSet.tsx
@@ -3,11 +3,13 @@ import cx from 'classnames';
 import styles from '~/components/Form/FieldSet.module.css';
 import { FieldDescription, LabelText } from '~/components/Form/Label';
 import type { HTMLProps, ReactNode } from 'react';
+import type { DescriptionPosition } from '~/components/Form/Label';
 
 type FieldSetProps = HTMLProps<HTMLFieldSetElement> & {
   legend: string;
   description?: string;
   descriptionId?: string;
+  descriptionPosition?: DescriptionPosition;
   required?: boolean;
   children: ReactNode;
 };
@@ -15,6 +17,7 @@ export const FieldSet = ({
   legend,
   description,
   descriptionId,
+  descriptionPosition = 'tooltip',
   required,
   children,
   ...fieldSetProps
@@ -26,11 +29,16 @@ export const FieldSet = ({
     <legend>
       <Flex alignItems="center" gap="var(--spacing-xs)">
         <LabelText label={legend} required={required} />
-        {description && (
+        {description && descriptionPosition === 'tooltip' && (
           <FieldDescription description={description} id={descriptionId} />
         )}
       </Flex>
     </legend>
+    {description && descriptionPosition === 'inline' && (
+      <p id={descriptionId} className={styles.description}>
+        {description}
+      </p>
+    )}
     {children}
   </fieldset>
 );

--- a/lego-webapp/components/Form/FieldSet.tsx
+++ b/lego-webapp/components/Form/FieldSet.tsx
@@ -1,17 +1,20 @@
+import { Flex } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import styles from '~/components/Form/FieldSet.module.css';
-import { LabelText } from '~/components/Form/Label';
+import { FieldDescription, LabelText } from '~/components/Form/Label';
 import type { HTMLProps, ReactNode } from 'react';
 
 type FieldSetProps = HTMLProps<HTMLFieldSetElement> & {
   legend: string;
   description?: string;
+  descriptionId?: string;
   required?: boolean;
   children: ReactNode;
 };
 export const FieldSet = ({
   legend,
   description,
+  descriptionId,
   required,
   children,
   ...fieldSetProps
@@ -21,7 +24,12 @@ export const FieldSet = ({
     {...fieldSetProps}
   >
     <legend>
-      <LabelText label={legend} description={description} required={required} />
+      <Flex alignItems="center" gap="var(--spacing-xs)">
+        <LabelText label={legend} required={required} />
+        {description && (
+          <FieldDescription description={description} id={descriptionId} />
+        )}
+      </Flex>
     </legend>
     {children}
   </fieldset>

--- a/lego-webapp/components/Form/Form.module.css
+++ b/lego-webapp/components/Form/Form.module.css
@@ -6,12 +6,13 @@
   gap: var(--spacing-lg);
 }
 
+/* Columns start together rather than centring against each other, so their
+   labels line up even when one column is taller than its neighbour. */
 .rowSection {
-  align-items: center;
+  align-items: flex-start;
 
   @media (--medium-viewport) {
     flex-direction: column;
-    align-items: flex-start;
   }
 }
 

--- a/lego-webapp/components/Form/Form.module.css
+++ b/lego-webapp/components/Form/Form.module.css
@@ -6,8 +6,7 @@
   gap: var(--spacing-lg);
 }
 
-/* Columns start together rather than centring against each other, so their
-   labels line up even when one column is taller than its neighbour. */
+/* flex-start keeps the labels aligned when one column is taller. */
 .rowSection {
   align-items: flex-start;
 
@@ -19,8 +18,13 @@
 .rowSection > div {
   flex: 1;
   min-width: 0;
+}
 
-  @media (--medium-viewport) {
+/* Doubled class to outweigh the mobile flex-basis lego-bricks gives children
+   of wrapping flexes, which in this stacked column becomes a fixed height. */
+@media (--medium-viewport) {
+  .rowSection.rowSection > div {
     width: 100%;
+    flex-basis: auto;
   }
 }

--- a/lego-webapp/components/Form/Label.module.css
+++ b/lego-webapp/components/Form/Label.module.css
@@ -1,6 +1,6 @@
 .label {
-  font-size: var(--font-size-lg);
-  margin-bottom: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-sm);
 }
 
 .inline {

--- a/lego-webapp/components/Form/Label.module.css
+++ b/lego-webapp/components/Form/Label.module.css
@@ -36,10 +36,6 @@
   min-width: 0;
 }
 
-.inlineTrailing {
-  flex: 1;
-}
-
 .inlineLabel {
   display: flex;
   flex-direction: column;

--- a/lego-webapp/components/Form/Label.module.css
+++ b/lego-webapp/components/Form/Label.module.css
@@ -10,12 +10,40 @@
   margin-bottom: 0;
 }
 
-.inline {
-  cursor: pointer;
+.descriptionText {
+  margin-bottom: var(--spacing-sm);
+  color: var(--secondary-font-color);
+  font-size: var(--font-size-sm);
+}
 
+/* The label sits closer to its description than to the control below it. */
+.labelRow:has(+ .descriptionText) {
+  margin-bottom: var(--spacing-xs);
+}
+
+.inline {
   .label {
     font-size: inherit;
   }
+
+  .descriptionText {
+    margin-top: var(--spacing-xs);
+    margin-bottom: 0;
+  }
+}
+
+/* Everything the field reveals shares this column, so it aligns with the label
+   text without repeating the control's width anywhere. */
+.inlineColumn {
+  min-width: 0;
+}
+
+/* Only the label and its description toggle the control, so only they are
+   styled as something to click. */
+.inlineLabel {
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
 }
 
 .required {

--- a/lego-webapp/components/Form/Label.module.css
+++ b/lego-webapp/components/Form/Label.module.css
@@ -17,7 +17,6 @@
   font-size: var(--font-size-sm);
 }
 
-/* The label sits closer to its description than to the control below it. */
 .labelRow:has(+ .descriptionText) {
   margin-bottom: var(--spacing-xs);
 }
@@ -33,20 +32,14 @@
   }
 }
 
-/* Everything the field reveals shares this column, so it aligns with the label
-   text without repeating the control's width anywhere. */
 .inlineColumn {
   min-width: 0;
 }
 
-/* A control on the trailing edge, as switches sit. The row has to fill the
-   field for the space between the text and the control to be real. */
 .inlineTrailing {
   flex: 1;
 }
 
-/* Only the label and its description toggle the control, so only they are
-   styled as something to click. */
 .inlineLabel {
   display: flex;
   flex-direction: column;

--- a/lego-webapp/components/Form/Label.module.css
+++ b/lego-webapp/components/Form/Label.module.css
@@ -1,5 +1,6 @@
 .label {
   font-size: var(--font-size-sm);
+  font-weight: 500;
 }
 
 .labelRow {
@@ -38,12 +39,22 @@
   min-width: 0;
 }
 
+/* A control on the trailing edge, as switches sit. The row has to fill the
+   field for the space between the text and the control to be real. */
+.inlineTrailing {
+  flex: 1;
+}
+
 /* Only the label and its description toggle the control, so only they are
    styled as something to click. */
 .inlineLabel {
   display: flex;
   flex-direction: column;
   cursor: pointer;
+
+  .label {
+    font-weight: 600;
+  }
 }
 
 .required {

--- a/lego-webapp/components/Form/Label.module.css
+++ b/lego-webapp/components/Form/Label.module.css
@@ -1,6 +1,13 @@
 .label {
   font-size: var(--font-size-sm);
+}
+
+.labelRow {
   margin-bottom: var(--spacing-sm);
+}
+
+.inlineRow {
+  margin-bottom: 0;
 }
 
 .inline {
@@ -8,7 +15,6 @@
 
   .label {
     font-size: inherit;
-    margin-bottom: 0;
   }
 }
 
@@ -21,5 +27,17 @@
 .description {
   display: inline-block;
   vertical-align: top;
-  margin-left: var(--spacing-sm);
+}
+
+.screenReaderOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
 }

--- a/lego-webapp/components/Form/Label.tsx
+++ b/lego-webapp/components/Form/Label.tsx
@@ -6,32 +6,49 @@ import type { HTMLProps, ReactNode } from 'react';
 
 type LabelTextProps = {
   label: ReactNode;
-  description?: string;
   required?: boolean;
   className?: string;
 };
 
-export const LabelText = ({
-  label,
-  description,
-  required,
-  className,
-}: LabelTextProps) => (
+export const LabelText = ({ label, required, className }: LabelTextProps) => (
   <Flex alignItems="center" className={cx(styles.label, className)}>
     {label}
     {required && <span className={styles.required}>*</span>}
-    {description && (
-      <Tooltip content={description} className={styles.description}>
-        <Icon size={18} iconNode={<HelpCircle />} />
-      </Tooltip>
-    )}
   </Flex>
+);
+
+type FieldDescriptionProps = {
+  description: string;
+  id?: string;
+};
+
+/**
+ * Sits next to the label rather than inside it. A tooltip nested in a <label>
+ * activates the control it is meant to explain, so clicking the help icon used
+ * to toggle the very checkbox or radio the user wanted to read about.
+ *
+ * The tooltip only renders its content while open, so the description is also
+ * kept in the page for assistive technology to reference.
+ */
+export const FieldDescription = ({
+  description,
+  id,
+}: FieldDescriptionProps) => (
+  <>
+    <Tooltip content={description} className={styles.description}>
+      <Icon size={18} iconNode={<HelpCircle />} />
+    </Tooltip>
+    <span id={id} className={styles.screenReaderOnly}>
+      {description}
+    </span>
+  </>
 );
 
 type LabelProps = HTMLProps<HTMLLabelElement> & {
   label: ReactNode;
   noLabel?: boolean;
   description?: string;
+  descriptionId?: string;
   required?: boolean;
   inline?: boolean;
 };
@@ -40,13 +57,15 @@ export const Label = ({
   label,
   noLabel,
   description,
+  descriptionId,
   required,
   inline,
   children,
   ...labelProps
 }: LabelProps) => {
   const LabelComponent = noLabel ? 'span' : 'label';
-  return (
+
+  const labelElement = (
     <LabelComponent {...labelProps}>
       {inline ? (
         <Flex
@@ -55,22 +74,33 @@ export const Label = ({
           className={styles.inline}
         >
           {children}
-          <LabelText
-            label={label}
-            description={description}
-            required={required}
-          />
+          <LabelText label={label} required={required} />
         </Flex>
       ) : (
-        <>
-          <LabelText
-            label={label}
-            description={description}
-            required={required}
-          />
-          {children}
-        </>
+        <LabelText label={label} required={required} />
       )}
     </LabelComponent>
+  );
+
+  const row = (
+    <Flex
+      alignItems="center"
+      gap="var(--spacing-xs)"
+      className={cx(styles.labelRow, inline && styles.inlineRow)}
+    >
+      {labelElement}
+      {description && (
+        <FieldDescription description={description} id={descriptionId} />
+      )}
+    </Flex>
+  );
+
+  return inline ? (
+    row
+  ) : (
+    <>
+      {row}
+      {children}
+    </>
   );
 };

--- a/lego-webapp/components/Form/Label.tsx
+++ b/lego-webapp/components/Form/Label.tsx
@@ -22,14 +22,8 @@ type FieldDescriptionProps = {
   id?: string;
 };
 
-/**
- * Sits next to the label rather than inside it. A tooltip nested in a <label>
- * activates the control it is meant to explain, so clicking the help icon used
- * to toggle the very checkbox or radio the user wanted to read about.
- *
- * The tooltip only renders its content while open, so the description is also
- * kept in the page for assistive technology to reference.
- */
+/* Sits next to the label, not inside it: a tooltip nested in a <label>
+   toggles the very control it explains. */
 export const FieldDescription = ({
   description,
   id,
@@ -74,8 +68,6 @@ export const Label = ({
 }: LabelProps) => {
   const LabelComponent = noLabel ? 'span' : 'label';
 
-  /* Visible text carries the id itself, so aria-describedby resolves to what
-     is on screen rather than to a copy kept for assistive technology. */
   const descriptionText = description && descriptionPosition === 'inline' && (
     <p id={descriptionId} className={styles.descriptionText}>
       {description}
@@ -92,12 +84,9 @@ export const Label = ({
     </LabelComponent>
   );
 
-  /* The control sits beside a column holding the label, its description and
-     whatever the field reveals, so all three line up under the label text
-     whatever the control's width. The revealed content is a sibling of the
-     <label> rather than a child: interactive content inside a label toggles
-     the control it belongs to. The control keeps its association through
-     htmlFor, so nothing has to be nested for the two to stay bound. */
+  /* The control sits beside a column of label, description and revealed
+     content. The revealed content stays outside the <label>: interactive
+     content inside one toggles the control it belongs to. */
   const inlineLayout = (
     <Flex
       alignItems={

--- a/lego-webapp/components/Form/Label.tsx
+++ b/lego-webapp/components/Form/Label.tsx
@@ -22,8 +22,11 @@ type FieldDescriptionProps = {
   id?: string;
 };
 
-/* Sits next to the label, not inside it: a tooltip nested in a <label>
-   toggles the very control it explains. */
+/**
+ * Sits next to the label rather than inside it. A tooltip nested in a <label>
+ * activates the control it is meant to explain, so clicking the help icon used
+ * to toggle the very checkbox or radio the user wanted to read about.
+ */
 export const FieldDescription = ({
   description,
   id,
@@ -50,7 +53,6 @@ type LabelProps = HTMLProps<HTMLLabelElement> & {
   inlineContent?: ReactNode;
   required?: boolean;
   inline?: boolean;
-  trailing?: boolean;
 };
 
 export const Label = ({
@@ -62,7 +64,6 @@ export const Label = ({
   inlineContent,
   required,
   inline,
-  trailing,
   children,
   ...labelProps
 }: LabelProps) => {
@@ -84,26 +85,17 @@ export const Label = ({
     </LabelComponent>
   );
 
-  /* The control sits beside a column of label, description and revealed
-     content. The revealed content stays outside the <label>: interactive
-     content inside one toggles the control it belongs to. */
   const inlineLayout = (
     <Flex
-      alignItems={
-        !trailing && (descriptionText || inlineContent)
-          ? 'flex-start'
-          : 'center'
-      }
-      justifyContent={trailing ? 'space-between' : undefined}
+      alignItems={descriptionText || inlineContent ? 'flex-start' : 'center'}
       gap="var(--spacing-sm)"
-      className={cx(styles.inline, trailing && styles.inlineTrailing)}
+      className={styles.inline}
     >
-      {!trailing && children}
+      {children}
       <Flex column className={styles.inlineColumn}>
         {labelElement}
         {inlineContent}
       </Flex>
-      {trailing && children}
     </Flex>
   );
 

--- a/lego-webapp/components/Form/Label.tsx
+++ b/lego-webapp/components/Form/Label.tsx
@@ -56,6 +56,7 @@ type LabelProps = HTMLProps<HTMLLabelElement> & {
   inlineContent?: ReactNode;
   required?: boolean;
   inline?: boolean;
+  trailing?: boolean;
 };
 
 export const Label = ({
@@ -67,6 +68,7 @@ export const Label = ({
   inlineContent,
   required,
   inline,
+  trailing,
   children,
   ...labelProps
 }: LabelProps) => {
@@ -98,15 +100,21 @@ export const Label = ({
      htmlFor, so nothing has to be nested for the two to stay bound. */
   const inlineLayout = (
     <Flex
-      alignItems={descriptionText || inlineContent ? 'flex-start' : 'center'}
+      alignItems={
+        !trailing && (descriptionText || inlineContent)
+          ? 'flex-start'
+          : 'center'
+      }
+      justifyContent={trailing ? 'space-between' : undefined}
       gap="var(--spacing-sm)"
-      className={styles.inline}
+      className={cx(styles.inline, trailing && styles.inlineTrailing)}
     >
-      {children}
+      {!trailing && children}
       <Flex column className={styles.inlineColumn}>
         {labelElement}
         {inlineContent}
       </Flex>
+      {trailing && children}
     </Flex>
   );
 

--- a/lego-webapp/components/Form/Label.tsx
+++ b/lego-webapp/components/Form/Label.tsx
@@ -44,11 +44,16 @@ export const FieldDescription = ({
   </>
 );
 
+/** Where a field's description is shown: behind a help icon, or as text. */
+export type DescriptionPosition = 'tooltip' | 'inline';
+
 type LabelProps = HTMLProps<HTMLLabelElement> & {
   label: ReactNode;
   noLabel?: boolean;
   description?: string;
   descriptionId?: string;
+  descriptionPosition?: DescriptionPosition;
+  inlineContent?: ReactNode;
   required?: boolean;
   inline?: boolean;
 };
@@ -58,6 +63,8 @@ export const Label = ({
   noLabel,
   description,
   descriptionId,
+  descriptionPosition = 'tooltip',
+  inlineContent,
   required,
   inline,
   children,
@@ -65,21 +72,42 @@ export const Label = ({
 }: LabelProps) => {
   const LabelComponent = noLabel ? 'span' : 'label';
 
+  /* Visible text carries the id itself, so aria-describedby resolves to what
+     is on screen rather than to a copy kept for assistive technology. */
+  const descriptionText = description && descriptionPosition === 'inline' && (
+    <p id={descriptionId} className={styles.descriptionText}>
+      {description}
+    </p>
+  );
+
   const labelElement = (
-    <LabelComponent {...labelProps}>
-      {inline ? (
-        <Flex
-          alignItems="center"
-          gap="var(--spacing-sm)"
-          className={styles.inline}
-        >
-          {children}
-          <LabelText label={label} required={required} />
-        </Flex>
-      ) : (
-        <LabelText label={label} required={required} />
-      )}
+    <LabelComponent
+      {...labelProps}
+      className={cx(labelProps.className, inline && styles.inlineLabel)}
+    >
+      <LabelText label={label} required={required} />
+      {inline && descriptionText}
     </LabelComponent>
+  );
+
+  /* The control sits beside a column holding the label, its description and
+     whatever the field reveals, so all three line up under the label text
+     whatever the control's width. The revealed content is a sibling of the
+     <label> rather than a child: interactive content inside a label toggles
+     the control it belongs to. The control keeps its association through
+     htmlFor, so nothing has to be nested for the two to stay bound. */
+  const inlineLayout = (
+    <Flex
+      alignItems={descriptionText || inlineContent ? 'flex-start' : 'center'}
+      gap="var(--spacing-sm)"
+      className={styles.inline}
+    >
+      {children}
+      <Flex column className={styles.inlineColumn}>
+        {labelElement}
+        {inlineContent}
+      </Flex>
+    </Flex>
   );
 
   const row = (
@@ -88,8 +116,8 @@ export const Label = ({
       gap="var(--spacing-xs)"
       className={cx(styles.labelRow, inline && styles.inlineRow)}
     >
-      {labelElement}
-      {description && (
+      {inline ? inlineLayout : labelElement}
+      {description && descriptionPosition === 'tooltip' && (
         <FieldDescription description={description} id={descriptionId} />
       )}
     </Flex>
@@ -100,6 +128,7 @@ export const Label = ({
   ) : (
     <>
       {row}
+      {descriptionText}
       {children}
     </>
   );

--- a/lego-webapp/components/Form/MultiSelectGroup.module.css
+++ b/lego-webapp/components/Form/MultiSelectGroup.module.css
@@ -3,3 +3,7 @@
   flex-flow: row wrap;
   gap: var(--spacing-sm);
 }
+
+.multiSelectGroup {
+  position: relative;
+}

--- a/lego-webapp/components/Form/MultiSelectGroup.tsx
+++ b/lego-webapp/components/Form/MultiSelectGroup.tsx
@@ -21,7 +21,7 @@ const MultiSelectGroup = ({
   children,
 }: Props) => {
   return (
-    <>
+    <div className={styles.multiSelectGroup}>
       <FieldSet legend={legend} description={description} required={required}>
         <div className={styles.group}>
           {Children.map(children, (child) =>
@@ -69,7 +69,7 @@ const MultiSelectGroup = ({
           return <></>;
         }}
       </FormSpy>
-    </>
+    </div>
   );
 };
 

--- a/lego-webapp/components/Form/MultiSelectGroup.tsx
+++ b/lego-webapp/components/Form/MultiSelectGroup.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import { Children, cloneElement, useId } from 'react';
 import { FormSpy } from 'react-final-form';
 import { FieldSet } from '~/components/Form/FieldSet';
@@ -20,7 +21,9 @@ const MultiSelectGroup = ({
   required,
   children,
 }: Props) => {
-  const errorId = `${useId()}-error`;
+  const groupId = useId();
+  const errorId = `${groupId}-error`;
+  const descriptionId = `${groupId}-description`;
 
   return (
     <FormSpy subscription={{ errors: true, submitErrors: true, touched: true }}>
@@ -36,9 +39,13 @@ const MultiSelectGroup = ({
             <FieldSet
               legend={legend}
               description={description}
+              descriptionId={descriptionId}
               required={required}
               aria-invalid={hasError || undefined}
-              aria-describedby={hasError ? errorId : undefined}
+              aria-describedby={
+                cx(description && descriptionId, hasError && errorId) ||
+                undefined
+              }
               aria-required={required || undefined}
             >
               <div className={styles.group}>

--- a/lego-webapp/components/Form/MultiSelectGroup.tsx
+++ b/lego-webapp/components/Form/MultiSelectGroup.tsx
@@ -4,12 +4,14 @@ import { FormSpy } from 'react-final-form';
 import { FieldSet } from '~/components/Form/FieldSet';
 import { RenderErrorMessage, toErrorMessages } from './Field';
 import styles from './MultiSelectGroup.module.css';
+import type { DescriptionPosition } from './Label';
 import type { ReactElement } from 'react';
 
 type Props = {
   name: string;
   legend: string;
   description?: string;
+  descriptionPosition?: DescriptionPosition;
   required?: boolean;
   children: ReactElement | ReactElement[];
 };
@@ -18,6 +20,7 @@ const MultiSelectGroup = ({
   name,
   legend,
   description,
+  descriptionPosition,
   required,
   children,
 }: Props) => {
@@ -40,6 +43,7 @@ const MultiSelectGroup = ({
               legend={legend}
               description={description}
               descriptionId={descriptionId}
+              descriptionPosition={descriptionPosition}
               required={required}
               aria-invalid={hasError || undefined}
               aria-describedby={

--- a/lego-webapp/components/Form/MultiSelectGroup.tsx
+++ b/lego-webapp/components/Form/MultiSelectGroup.tsx
@@ -65,6 +65,7 @@ const MultiSelectGroup = ({
                 id={errorId}
                 error={messages}
                 fieldName={name}
+                variant="text"
               />
             )}
           </div>

--- a/lego-webapp/components/Form/MultiSelectGroup.tsx
+++ b/lego-webapp/components/Form/MultiSelectGroup.tsx
@@ -1,7 +1,7 @@
-import { Children, cloneElement } from 'react';
+import { Children, cloneElement, useId } from 'react';
 import { FormSpy } from 'react-final-form';
 import { FieldSet } from '~/components/Form/FieldSet';
-import { RenderErrorMessage } from './Field';
+import { RenderErrorMessage, toErrorMessages } from './Field';
 import styles from './MultiSelectGroup.module.css';
 import type { ReactElement } from 'react';
 
@@ -20,56 +20,46 @@ const MultiSelectGroup = ({
   required,
   children,
 }: Props) => {
+  const errorId = `${useId()}-error`;
+
   return (
-    <div className={styles.multiSelectGroup}>
-      <FieldSet legend={legend} description={description} required={required}>
-        <div className={styles.group}>
-          {Children.map(children, (child) =>
-            cloneElement(child, {
-              name,
-            }),
-          )}
-        </div>
-      </FieldSet>
-      <FormSpy
-        subscription={{ errors: true, submitErrors: true, touched: true }}
-      >
-        {(props) => {
-          let error = '';
-          if (Array.isArray(props.errors?.[name])) {
-            error = Object.values(props.errors[name][0]).join('');
-          } else if (
-            props.errors?.[name] &&
-            typeof props.errors[name] === 'string'
-          ) {
-            error = props.errors[name];
-          }
+    <FormSpy subscription={{ errors: true, submitErrors: true, touched: true }}>
+      {(props) => {
+        const messages = [
+          ...toErrorMessages(props.errors?.[name]),
+          ...toErrorMessages(props.submitErrors?.[name]),
+        ];
+        const hasError = !!props.touched?.[name] && messages.length > 0;
 
-          const submitError = props.submitErrors
-            ? props.submitErrors[name]
-            : '';
-
-          if (props.touched?.[name]) {
-            return (
-              <>
-                <RenderErrorMessage
-                  key={error}
-                  error={error}
-                  fieldName={name}
-                />
-                <RenderErrorMessage
-                  key={submitError}
-                  error={submitError}
-                  fieldName={name}
-                />
-              </>
-            );
-          }
-
-          return <></>;
-        }}
-      </FormSpy>
-    </div>
+        return (
+          <div className={styles.multiSelectGroup}>
+            <FieldSet
+              legend={legend}
+              description={description}
+              required={required}
+              aria-invalid={hasError || undefined}
+              aria-describedby={hasError ? errorId : undefined}
+              aria-required={required || undefined}
+            >
+              <div className={styles.group}>
+                {Children.map(children, (child) =>
+                  cloneElement(child, {
+                    name,
+                  }),
+                )}
+              </div>
+            </FieldSet>
+            {hasError && (
+              <RenderErrorMessage
+                id={errorId}
+                error={messages}
+                fieldName={name}
+              />
+            )}
+          </div>
+        );
+      }}
+    </FormSpy>
   );
 };
 

--- a/lego-webapp/components/Form/RadioButton.tsx
+++ b/lego-webapp/components/Form/RadioButton.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import { Keyboard } from '~/utils/constants';
 import { createField } from './Field';
 import styles from './RadioButton.module.css';
-import type { ComponentProps, InputHTMLAttributes, KeyboardEvent } from 'react';
+import type { InputHTMLAttributes, KeyboardEvent } from 'react';
 
 type Props = {
   label?: string;
@@ -56,14 +56,5 @@ function RadioButton({
   );
 }
 
-const RawField = createField(RadioButton, { inlineLabel: true });
-
-const StyledField = ({
-  fieldClassName,
-  ...props
-}: ComponentProps<typeof RawField> & { fieldClassName?: string }) => (
-  <RawField fieldClassName={cx(fieldClassName, styles.radioField)} {...props} />
-);
-
-RadioButton.Field = StyledField;
+RadioButton.Field = createField(RadioButton, { inlineLabel: true });
 export default RadioButton;

--- a/lego-webapp/components/Form/SelectInput.tsx
+++ b/lego-webapp/components/Form/SelectInput.tsx
@@ -9,6 +9,7 @@ import type { StylesConfig, ThemeConfig } from 'react-select';
 
 type Props<Option, IsMulti extends boolean = false> = {
   name: string;
+  id?: string;
   label?: string;
   placeholder?: string;
   tags?: boolean;
@@ -85,6 +86,7 @@ const SelectInput = <
   IsMulti extends boolean = false,
 >({
   name,
+  id,
   label,
   fetching,
   selectStyle,
@@ -113,6 +115,7 @@ const SelectInput = <
           isDisabled={disabled}
           placeholder={!disabled && (placeholder || defaultPlaceholder)}
           instanceId={name}
+          inputId={id}
           isMulti={props.isMulti}
           value={value}
           isValidNewOption={isValidNewOption}
@@ -141,6 +144,7 @@ const SelectInput = <
         isDisabled={disabled}
         placeholder={disabled ? 'Tomt' : placeholder || defaultPlaceholder}
         instanceId={name}
+        inputId={id}
         value={value}
         options={options}
         isLoading={fetching}
@@ -159,7 +163,16 @@ const SelectInput = <
   );
 };
 
-SelectInput.Field = createField(SelectInput);
+const RawField = createField(SelectInput);
+
+/* react-select puts the id it is given on its container, so the label has to
+   point at the input instead. Naming it after the field keeps that id the one
+   react-select derives from instanceId. */
+const SelectField = (props: ComponentProps<typeof RawField>) => (
+  <RawField id={`react-select-${props.input.name}-input`} {...props} />
+);
+
+SelectInput.Field = SelectField;
 SelectInput.AutocompleteField = withAutocomplete({
   WrappedComponent: SelectInput.Field,
 });

--- a/lego-webapp/components/Form/Slider.module.css
+++ b/lego-webapp/components/Form/Slider.module.css
@@ -83,8 +83,6 @@
   font-weight: 600;
 }
 
-/* The input carries the interaction and the thumb; everything else is
-   decoration, so the track itself is transparent. */
 .input {
   position: absolute;
   top: 0;
@@ -101,9 +99,8 @@
   cursor: not-allowed;
 }
 
-/* The native thumb stays for dragging and keyboard, but is invisible: a thumb
-   the browser positions cannot be transitioned, so the visible one below is
-   drawn separately and eased between stops. */
+/* The native thumb cannot be transitioned, so it is invisible and a separate
+   decorative thumb is eased between stops. */
 .input::-webkit-slider-thumb {
   appearance: none;
   width: var(--slider-thumb);

--- a/lego-webapp/components/Form/Slider.module.css
+++ b/lego-webapp/components/Form/Slider.module.css
@@ -2,6 +2,9 @@
   --slider-thumb: 18px;
   --slider-progress: 0;
 
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
   width: 100%;
 }
 

--- a/lego-webapp/components/Form/Slider.module.css
+++ b/lego-webapp/components/Form/Slider.module.css
@@ -8,8 +8,6 @@
   width: 100%;
 }
 
-/* Every stop, the fill and the native thumb share this inset, so the
-   decoration lines up with the thumb the browser positions for us. */
 .track {
   position: relative;
   height: 46px;
@@ -147,6 +145,13 @@
 .slider:has(.input:focus-visible) .thumb {
   outline: 2px solid var(--lego-font-color);
   outline-offset: var(--spacing-xs);
+}
+
+/* There is no thumb before a value is picked, so the track carries the ring. */
+.unset:has(.input:focus-visible) .track {
+  outline: 2px solid var(--lego-font-color);
+  outline-offset: var(--spacing-xs);
+  border-radius: var(--border-radius-md);
 }
 
 @keyframes sliderThumbPop {

--- a/lego-webapp/components/Form/Slider.module.css
+++ b/lego-webapp/components/Form/Slider.module.css
@@ -1,0 +1,164 @@
+.slider {
+  --slider-thumb: 18px;
+  --slider-progress: 0;
+
+  width: 100%;
+}
+
+/* Every stop, the fill and the native thumb share this inset, so the
+   decoration lines up with the thumb the browser positions for us. */
+.track {
+  position: relative;
+  height: 46px;
+}
+
+.line,
+.fill {
+  position: absolute;
+  top: 16px;
+  left: calc(var(--slider-thumb) / 2);
+  height: 2px;
+  border-radius: 2px;
+}
+
+.line {
+  right: calc(var(--slider-thumb) / 2);
+  background-color: var(--border-gray);
+}
+
+.fill {
+  width: calc((100% - var(--slider-thumb)) * var(--slider-progress));
+  background-color: var(--lego-red-color);
+  transition: width var(--easing-medium);
+}
+
+.dot {
+  position: absolute;
+  top: 14px;
+  left: calc(
+    var(--slider-thumb) / 2 + (100% - var(--slider-thumb)) * var(--slider-stop)
+  );
+  width: 6px;
+  height: 6px;
+  margin-left: -3px;
+  border-radius: 50%;
+  background-color: var(--color-gray-3);
+  transition: background-color var(--easing-fast);
+}
+
+.dotOn {
+  background-color: var(--lego-red-color);
+}
+
+.tick {
+  position: absolute;
+  top: 28px;
+  left: calc(
+    var(--slider-thumb) / 2 + (100% - var(--slider-thumb)) * var(--slider-stop)
+  );
+  transform: translateX(-50%);
+  color: var(--color-gray-5);
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  transition: color var(--easing-fast);
+}
+
+.tickOn {
+  color: var(--lego-red-color);
+  font-weight: 600;
+}
+
+.value {
+  color: var(--color-gray-5);
+  font-size: var(--font-size-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.slider:not(.unset) .value {
+  color: var(--lego-red-color);
+  font-weight: 600;
+}
+
+/* The input carries the interaction and the thumb; everything else is
+   decoration, so the track itself is transparent. */
+.input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 32px;
+  margin: 0;
+  appearance: none;
+  background: none;
+  cursor: pointer;
+}
+
+.input:disabled {
+  cursor: not-allowed;
+}
+
+/* The native thumb stays for dragging and keyboard, but is invisible: a thumb
+   the browser positions cannot be transitioned, so the visible one below is
+   drawn separately and eased between stops. */
+.input::-webkit-slider-thumb {
+  appearance: none;
+  width: var(--slider-thumb);
+  height: var(--slider-thumb);
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  cursor: grab;
+}
+
+.input::-moz-range-thumb {
+  width: var(--slider-thumb);
+  height: var(--slider-thumb);
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  cursor: grab;
+}
+
+.input:focus-visible {
+  outline: none;
+}
+
+.thumb {
+  position: absolute;
+  top: 7px;
+  left: calc(
+    var(--slider-thumb) / 2 + (100% - var(--slider-thumb)) *
+      var(--slider-progress)
+  );
+  width: var(--slider-thumb);
+  height: var(--slider-thumb);
+  margin-left: calc(var(--slider-thumb) / -2);
+  border-radius: 50%;
+  background-color: var(--lego-red-color);
+  box-shadow:
+    0 0 0 3px var(--lego-background-color),
+    var(--shadow-sm);
+  pointer-events: none;
+  transition: left var(--easing-medium);
+  animation: sliderThumbPop var(--bounce) both;
+}
+
+.slider:has(.input:focus-visible) .thumb {
+  outline: 2px solid var(--lego-font-color);
+  outline-offset: var(--spacing-xs);
+}
+
+@keyframes sliderThumbPop {
+  from {
+    transform: scale(0);
+  }
+
+  to {
+    transform: scale(1);
+  }
+}
+
+.slider:has(.input:disabled) {
+  opacity: 0.5;
+}

--- a/lego-webapp/components/Form/Slider.tsx
+++ b/lego-webapp/components/Form/Slider.tsx
@@ -22,13 +22,8 @@ type Props = {
   className?: string;
 };
 
-/**
- * Picks one of a small, ordered set of options along a track.
- *
- * Built on a native range input so dragging, arrow keys, Home/End and touch
- * all come from the platform. The dots, fill and tick labels are decorative
- * and sit under the input, which is transparent apart from its thumb.
- */
+/* Picks one of a small, ordered set of options along a native range input;
+   the dots, fill and tick labels are decoration underneath it. */
 const Slider = ({
   options,
   value,

--- a/lego-webapp/components/Form/Slider.tsx
+++ b/lego-webapp/components/Form/Slider.tsx
@@ -1,0 +1,115 @@
+import { Flex } from '@webkom/lego-bricks';
+import cx from 'classnames';
+import { createField } from './Field';
+import { LabelText } from './Label';
+import styles from './Slider.module.css';
+import type { CSSProperties, ReactNode } from 'react';
+
+export type SliderOption = {
+  value: string;
+  label: string;
+};
+
+type Props = {
+  options: SliderOption[];
+  value?: string;
+  onChange?: (value: string) => void;
+  label?: ReactNode;
+  required?: boolean;
+  placeholder?: string;
+  id?: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+/**
+ * Picks one of a small, ordered set of options along a track.
+ *
+ * Built on a native range input so dragging, arrow keys, Home/End and touch
+ * all come from the platform. The dots, fill and tick labels are decorative
+ * and sit under the input, which is transparent apart from its thumb.
+ */
+const Slider = ({
+  options,
+  value,
+  onChange,
+  label,
+  required,
+  placeholder,
+  id,
+  disabled,
+  className,
+  ...props
+}: Props) => {
+  const index = options.findIndex((option) => option.value === value);
+  const lastIndex = Math.max(options.length - 1, 1);
+  const selected = index >= 0;
+  const progress = selected ? index / lastIndex : 0;
+
+  return (
+    <div
+      className={cx(styles.slider, !selected && styles.unset, className)}
+      style={{ '--slider-progress': progress } as CSSProperties}
+    >
+      <Flex
+        alignItems="baseline"
+        justifyContent="space-between"
+        gap="var(--spacing-sm)"
+      >
+        <label htmlFor={id}>
+          <LabelText label={label} required={required} />
+        </label>
+        <span className={styles.value}>
+          {selected ? options[index].label : placeholder}
+        </span>
+      </Flex>
+
+      <div className={styles.track}>
+        <span className={styles.line} />
+        <span className={styles.fill} />
+
+        {options.map((option, stop) => (
+          <span
+            key={option.value}
+            className={cx(
+              styles.dot,
+              selected && stop <= index && styles.dotOn,
+            )}
+            style={{ '--slider-stop': stop / lastIndex } as CSSProperties}
+          />
+        ))}
+
+        {options.map((option, stop) => (
+          <span
+            key={option.value}
+            className={cx(styles.tick, stop === index && styles.tickOn)}
+            style={{ '--slider-stop': stop / lastIndex } as CSSProperties}
+          >
+            {option.label}
+          </span>
+        ))}
+
+        {selected && <span className={styles.thumb} />}
+
+        <input
+          {...props}
+          id={id}
+          type="range"
+          className={styles.input}
+          min={0}
+          max={lastIndex}
+          step={1}
+          disabled={disabled}
+          value={selected ? index : 0}
+          aria-valuetext={selected ? options[index].label : placeholder}
+          onChange={(event) =>
+            onChange?.(options[Number(event.target.value)].value)
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
+Slider.Field = createField(Slider, { ownLabel: true });
+export default Slider;

--- a/lego-webapp/components/Form/Slider.tsx
+++ b/lego-webapp/components/Form/Slider.tsx
@@ -3,7 +3,12 @@ import cx from 'classnames';
 import { createField } from './Field';
 import { LabelText } from './Label';
 import styles from './Slider.module.css';
-import type { CSSProperties, ReactNode } from 'react';
+import type {
+  CSSProperties,
+  KeyboardEvent,
+  PointerEvent,
+  ReactNode,
+} from 'react';
 
 export type SliderOption = {
   value: string;
@@ -40,6 +45,18 @@ const Slider = ({
   const lastIndex = Math.max(options.length - 1, 1);
   const selected = index >= 0;
   const progress = selected ? index / lastIndex : 0;
+
+  /* With nothing selected the input is parked on the first stop, so picking
+     that stop is not a change the browser reports. Commit what the input holds
+     once the interaction ends. */
+  const commitUnset = (
+    event: PointerEvent<HTMLInputElement> | KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (selected) {
+      return;
+    }
+    onChange?.(options[Number(event.currentTarget.value)].value);
+  };
 
   return (
     <div
@@ -100,6 +117,8 @@ const Slider = ({
           onChange={(event) =>
             onChange?.(options[Number(event.target.value)].value)
           }
+          onPointerUp={commitUnset}
+          onKeyUp={commitUnset}
         />
       </div>
     </div>

--- a/lego-webapp/components/Form/SubmissionError.tsx
+++ b/lego-webapp/components/Form/SubmissionError.tsx
@@ -7,7 +7,7 @@ const SubmissionError = () =>
     <>
       {error && (
         <div className={styles.submissionErrorContainer}>
-          <RenderErrorMessage error={error} />
+          <RenderErrorMessage error={error} inline />
         </div>
       )}
     </>

--- a/lego-webapp/components/Form/SubmissionError.tsx
+++ b/lego-webapp/components/Form/SubmissionError.tsx
@@ -7,7 +7,7 @@ const SubmissionError = () =>
     <>
       {error && (
         <div className={styles.submissionErrorContainer}>
-          <RenderErrorMessage error={error} inline />
+          <RenderErrorMessage error={error} variant="inline" />
         </div>
       )}
     </>

--- a/lego-webapp/components/Form/SubmitButton.tsx
+++ b/lego-webapp/components/Form/SubmitButton.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@webkom/lego-bricks';
 import { spySubmittable } from '~/utils/formSpyUtils';
 import type { PressEvent } from '@webkom/lego-bricks';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 type Props = {
   children: ReactNode;
@@ -11,6 +11,7 @@ type Props = {
   danger?: boolean;
   disabled?: boolean;
   dark?: boolean;
+  size?: ComponentProps<typeof Button>['size'];
 };
 
 export const SubmitButton = ({
@@ -21,6 +22,7 @@ export const SubmitButton = ({
   danger = false,
   disabled = false,
   dark = false,
+  size,
 }: Props) =>
   spySubmittable(
     (submittable) => (
@@ -31,6 +33,7 @@ export const SubmitButton = ({
         className={className}
         danger={danger}
         dark={dark}
+        size={size}
       >
         {children}
       </Button>

--- a/lego-webapp/components/Form/TextEditor.module.css
+++ b/lego-webapp/components/Form/TextEditor.module.css
@@ -6,6 +6,8 @@
   padding: var(--spacing-xs) var(--spacing-sm);
   outline: none;
 
+  resize: vertical;
+
   &::placeholder {
     color: var(--placeholder-color);
   }

--- a/lego-webapp/components/Form/TextEditor.tsx
+++ b/lego-webapp/components/Form/TextEditor.tsx
@@ -23,5 +23,5 @@ function TextEditor({ className, ...props }: Props) {
   );
 }
 
-TextEditor.Field = createField(TextEditor);
+TextEditor.Field = createField(TextEditor, { errorVariant: 'text' });
 export default TextEditor;

--- a/lego-webapp/components/Form/ToggleSwitch.tsx
+++ b/lego-webapp/components/Form/ToggleSwitch.tsx
@@ -48,7 +48,10 @@ const ToggleSwitch = ({
   );
 };
 
-const RawField = createField(ToggleSwitch);
+const RawField = createField(ToggleSwitch, {
+  inlineLabel: true,
+  trailingControl: true,
+});
 
 const StyledField = (props: ComponentProps<typeof RawField>) => (
   <RawField {...props} />

--- a/lego-webapp/components/Form/ToggleSwitch.tsx
+++ b/lego-webapp/components/Form/ToggleSwitch.tsx
@@ -48,10 +48,7 @@ const ToggleSwitch = ({
   );
 };
 
-const RawField = createField(ToggleSwitch, {
-  inlineLabel: true,
-  trailingControl: true,
-});
+const RawField = createField(ToggleSwitch, { inlineLabel: true });
 
 const StyledField = (props: ComponentProps<typeof RawField>) => (
   <RawField {...props} />

--- a/lego-webapp/components/Form/index.ts
+++ b/lego-webapp/components/Form/index.ts
@@ -10,6 +10,7 @@ export { default as RadioButton } from './RadioButton';
 export { default as MultiSelectGroup } from './MultiSelectGroup';
 export { default as CheckBox } from './CheckBox';
 export { default as Chip } from './Chip';
+export { default as Slider } from './Slider';
 export { default as SelectInput } from './SelectInput';
 export { default as PhoneNumberInput } from './PhoneNumberInput';
 export { default as Captcha } from './Captcha';

--- a/lego-webapp/components/Form/index.ts
+++ b/lego-webapp/components/Form/index.ts
@@ -9,6 +9,7 @@ export { default as TimePicker } from './TimePicker';
 export { default as RadioButton } from './RadioButton';
 export { default as MultiSelectGroup } from './MultiSelectGroup';
 export { default as CheckBox } from './CheckBox';
+export { default as Chip } from './Chip';
 export { default as SelectInput } from './SelectInput';
 export { default as PhoneNumberInput } from './PhoneNumberInput';
 export { default as Captcha } from './Captcha';

--- a/lego-webapp/components/Header/Header.module.css
+++ b/lego-webapp/components/Header/Header.module.css
@@ -105,11 +105,12 @@ html[data-theme='dark'] img.logoDarkMode {
   display: block;
 }
 
-.searchButton {
+.searchButton.searchButton {
   display: flex;
   width: 24px;
   align-items: center;
   box-sizing: content-box;
+  padding-right: 0;
   z-index: 301;
 }
 

--- a/lego-webapp/cypress/e2e/profile_spec.ts
+++ b/lego-webapp/cypress/e2e/profile_spec.ts
@@ -106,6 +106,7 @@ describe('Profile settings', () => {
     cy.get('input[name=email]').clear().type(updatedUser.email);
 
     cy.contains('Lagre endringer').should('not.be.disabled').click();
+    cy.contains('Oppdatering av bruker fullført');
 
     cy.url().should('include', '/users/me');
     cy.contains('Innstillinger').click();

--- a/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
+++ b/lego-webapp/pages/users/@username/settings/profile/+Page.tsx
@@ -98,7 +98,7 @@ const UserSettings = () => {
       gender: values.gender.value,
     };
 
-    dispatch(updateUser(body));
+    return dispatch(updateUser(body));
   };
 
   // Only seed fields this form actually owns, otherwise unrelated user updates

--- a/lego-webapp/styles/globals.css
+++ b/lego-webapp/styles/globals.css
@@ -47,7 +47,7 @@ a {
 }
 
 p {
-  margin-bottom: var(--spacing-sm);
+  margin: 0;
   line-height: 1.3;
 }
 

--- a/lego-webapp/styles/globals.css
+++ b/lego-webapp/styles/globals.css
@@ -47,7 +47,7 @@ a {
 }
 
 p {
-  margin: 0;
+  margin-bottom: var(--spacing-sm);
   line-height: 1.3;
 }
 

--- a/lego-webapp/styles/variables.css
+++ b/lego-webapp/styles/variables.css
@@ -57,6 +57,14 @@
     var(--low-alpha)
   );
 
+  /* Wash marking a chosen control. Derived from the brand colour, so it follows
+     the theme without needing its own dark mode value. */
+  --selected-background: color-mix(
+    in srgb,
+    var(--lego-red-color) 4%,
+    transparent
+  );
+
   --color-gray-1: var(--dark-font-color);
   --color-gray-2: #e7e7e7;
   --color-gray-3: #d9d9d9;

--- a/lego-webapp/styles/variables.css
+++ b/lego-webapp/styles/variables.css
@@ -57,8 +57,7 @@
     var(--low-alpha)
   );
 
-  /* Wash marking a chosen control. Derived from the brand colour, so it follows
-     the theme without needing its own dark mode value. */
+  /* Wash marking a chosen control; follows the brand colour across themes. */
   --selected-background: color-mix(
     in srgb,
     var(--lego-red-color) 4%,

--- a/lego-webapp/styles/variables.css
+++ b/lego-webapp/styles/variables.css
@@ -57,7 +57,7 @@
     var(--low-alpha)
   );
 
-  /* Wash marking a chosen control; follows the brand colour across themes. */
+  /* Marking a chosen control */
   --selected-background: color-mix(
     in srgb,
     var(--lego-red-color) 4%,

--- a/packages/lego-bricks/src/components/Button/Button.module.css
+++ b/packages/lego-bricks/src/components/Button/Button.module.css
@@ -80,9 +80,7 @@
   }
 }
 
-/* The brand tokens rather than a fixed rung of the ramp, so the red button
-   matches every other red in the app and stays put across themes: both resolve
-   to the same pair of reds in light and dark. */
+/* Brand tokens, so the red button matches every other red across themes. */
 .dark {
   background-color: var(--lego-red-color);
   color: var(--button-color-white);

--- a/packages/lego-bricks/src/components/Button/Button.module.css
+++ b/packages/lego-bricks/src/components/Button/Button.module.css
@@ -80,8 +80,11 @@
   }
 }
 
+/* The brand tokens rather than a fixed rung of the ramp, so the red button
+   matches every other red in the app and stays put across themes: both resolve
+   to the same pair of reds in light and dark. */
 .dark {
-  background-color: var(--color-red-6);
+  background-color: var(--lego-red-color);
   color: var(--button-color-white);
   box-shadow: none;
 
@@ -94,7 +97,7 @@
   }
 
   &[data-hovered] {
-    background-color: var(--color-red-7);
+    background-color: var(--lego-red-color-hover);
   }
 
   &[data-pressed] {
@@ -220,7 +223,7 @@
 }
 
 .large {
-  font-size: var(--font-size-lg);
+  padding: var(--spacing-lg) var(--spacing-xl);
 }
 
 .round {

--- a/packages/lego-bricks/src/components/Card/BaseCard.tsx
+++ b/packages/lego-bricks/src/components/Card/BaseCard.tsx
@@ -8,14 +8,20 @@ type Props = {
   hoverable?: boolean;
   shadow?: boolean;
   className?: string;
-};
+} & Omit<ComponentProps<typeof Flex>, 'className'>;
 
 /**
  * Simple base card component, without any styling except the base card.
  *
  * Should be used with CardContent and CardFooter components, in order to have a consistent look.
  */
-export const BaseCard = ({ children, hoverable, shadow, className }: Props) => (
+export const BaseCard = ({
+  children,
+  hoverable,
+  shadow,
+  className,
+  ...props
+}: Props) => (
   <Flex
     column
     className={cx(
@@ -24,6 +30,7 @@ export const BaseCard = ({ children, hoverable, shadow, className }: Props) => (
       shadow && styles.shadow,
       className,
     )}
+    {...props}
   >
     {children}
   </Flex>

--- a/packages/lego-bricks/src/components/Card/Card.module.css
+++ b/packages/lego-bricks/src/components/Card/Card.module.css
@@ -13,11 +13,18 @@
 
 .withIcon {
   gap: var(--spacing-md);
+  align-items: center;
 
   @media (--small-viewport) {
     flex-direction: column;
+    align-items: flex-start;
     gap: var(--spacing-sm);
   }
+}
+
+.withIconContent {
+  flex: 1;
+  min-width: 0;
 }
 
 .header {

--- a/packages/lego-bricks/src/components/Card/index.tsx
+++ b/packages/lego-bricks/src/components/Card/index.tsx
@@ -90,7 +90,7 @@ export const Card = ({
   children,
   className,
   shadow = true,
-  hideOverflow = false,
+  hideOverflow: _hideOverflow,
   isHoverable = false,
   skeleton = false,
   severity,
@@ -106,9 +106,6 @@ export const Card = ({
         !skeleton && styles.padded,
         severity && styles[severity],
       )}
-      style={{
-        overflow: hideOverflow || skeleton ? 'hidden' : 'initial',
-      }}
       {...htmlAttributes}
     >
       {skeleton ? (

--- a/packages/lego-bricks/src/components/Card/index.tsx
+++ b/packages/lego-bricks/src/components/Card/index.tsx
@@ -20,25 +20,48 @@ const CardHeader = ({ children, className }: CardHeaderProps) => (
 
 type ContentWithIconProps = {
   severity?: Severity;
+  iconSize?: number;
   children: ReactNode;
 };
 
-const ContentWithIcon = ({ children, severity }: ContentWithIconProps) => {
+const ContentWithIcon = ({
+  children,
+  severity,
+  iconSize,
+}: ContentWithIconProps) => {
   let icon;
 
   switch (severity) {
     case 'danger':
-      icon = <Icon iconNode={<CircleAlert />} className={styles.dangerIcon} />;
+      icon = (
+        <Icon
+          iconNode={<CircleAlert />}
+          size={iconSize}
+          className={styles.dangerIcon}
+        />
+      );
       break;
     case 'info':
-      icon = <Icon iconNode={<Info />} className={styles.infoIcon} />;
+      icon = (
+        <Icon iconNode={<Info />} size={iconSize} className={styles.infoIcon} />
+      );
       break;
     case 'success':
-      icon = <Icon iconNode={<CircleCheck />} className={styles.successIcon} />;
+      icon = (
+        <Icon
+          iconNode={<CircleCheck />}
+          size={iconSize}
+          className={styles.successIcon}
+        />
+      );
       break;
     case 'warning':
       icon = (
-        <Icon iconNode={<TriangleAlert />} className={styles.warningIcon} />
+        <Icon
+          iconNode={<TriangleAlert />}
+          size={iconSize}
+          className={styles.warningIcon}
+        />
       );
       break;
   }
@@ -46,7 +69,7 @@ const ContentWithIcon = ({ children, severity }: ContentWithIconProps) => {
   return icon !== undefined ? (
     <Flex className={styles.withIcon}>
       {icon}
-      <Flex column>{children}</Flex>
+      <div className={styles.withIconContent}>{children}</div>
     </Flex>
   ) : (
     <>{children}</>
@@ -60,6 +83,7 @@ type Props = {
   isHoverable?: boolean;
   skeleton?: boolean;
   severity?: Severity;
+  iconSize?: number;
 } & HTMLAttributes<HTMLDivElement>;
 
 export const Card = ({
@@ -70,6 +94,7 @@ export const Card = ({
   isHoverable = false,
   skeleton = false,
   severity,
+  iconSize,
   ...htmlAttributes
 }: Props) => {
   return (
@@ -89,7 +114,9 @@ export const Card = ({
       {skeleton ? (
         <Skeleton />
       ) : (
-        <ContentWithIcon severity={severity}>{children}</ContentWithIcon>
+        <ContentWithIcon severity={severity} iconSize={iconSize}>
+          {children}
+        </ContentWithIcon>
       )}
     </BaseCard>
   );

--- a/packages/lego-bricks/src/components/ImageUpload/index.tsx
+++ b/packages/lego-bricks/src/components/ImageUpload/index.tsx
@@ -23,6 +23,7 @@ type BaseProps = {
   aspectRatio?: number;
   onDrop?: () => void;
   onClose?: () => void;
+  id?: string;
 };
 
 type Props = BaseProps &
@@ -40,6 +41,7 @@ type UploadAreaProps = {
   multiple?: boolean;
   image: string | null | undefined;
   accept: Accept;
+  id?: string;
 };
 
 const FilePreview = ({ file, onRemove }: FilePreviewProps) => {
@@ -68,7 +70,13 @@ const FilePreview = ({ file, onRemove }: FilePreviewProps) => {
   );
 };
 
-const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
+const UploadArea = ({
+  multiple,
+  onDrop,
+  image,
+  accept,
+  id,
+}: UploadAreaProps) => {
   const onDropCallback = useCallback(
     (files: Array<DropFile>) => {
       files[0] && !multiple ? onDrop(files.slice(-1)) : onDrop(files);
@@ -130,7 +138,7 @@ const UploadArea = ({ multiple, onDrop, image, accept }: UploadAreaProps) => {
         {image && (
           <Image alt="Opplastet bilde" className={styles.image} src={image} />
         )}
-        <input {...getInputProps()} />
+        <input {...getInputProps({ id })} />
       </div>
     </div>
   );
@@ -140,6 +148,7 @@ export const ImageUpload = ({
   crop = true,
   inModal = false,
   aspectRatio,
+  id,
   ...props
 }: Props) => {
   const cropper = useRef<Cropper>();
@@ -220,6 +229,7 @@ export const ImageUpload = ({
           multiple={props.multiple}
           image={img}
           accept={accept}
+          id={id}
         />
       )}
       <Modal

--- a/packages/lego-bricks/src/components/Layout/Flex.module.css
+++ b/packages/lego-bricks/src/components/Layout/Flex.module.css
@@ -80,6 +80,9 @@
   align-items: stretch;
 }
 
-.basis__small .flex {
+/* The basis belongs to this flex's own items. Left as a descendant selector it
+   also reached nested flexes, zeroing the height of anything laid out in a
+   column further down. */
+.basis__small > .flex {
   flex-basis: 0;
 }


### PR DESCRIPTION
## Description

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->

- New `Chip` (pill-shaped checkbox/radio) and `Slider` (pick one of an
  ordered set) controls.
- Accessibility: a generated id with an explicit label association,
  `aria-invalid`, `aria-describedby` and `aria-required`; `FieldSet` and
  `MultiSelectGroup` get the same, and group errors flatten to messages
  whatever shape they arrive in.
- Descriptions can render as inline text, not only a tooltip, and the tooltip
  moves out of the `<label>` so the help icon stops toggling the control it
  explains.
- `lego-bricks`: severity icons size with their content, `dark`/`large`
  Button use brand tokens, `Flex` basis applies to a flex's own items.

Touches `@webkom/lego-bricks`, which `admissions` also consumes. Nothing
breaks - `hideOverflow` stays an accepted prop — but it may want a version bump.

Tested and visuals changes in 4th PR

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.


## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Dependent on <!-- ... backend PR link, delete if none --> 

Resolves #6023

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>