### PR TITLE
Adopt the shared form components in the company interest form

### DIFF
--- a/lego-webapp/cypress/e2e/company_interest_spec.ts
+++ b/lego-webapp/cypress/e2e/company_interest_spec.ts
@@ -24,10 +24,12 @@ const createCompanyInterest = () => {
   field('phone').click().type('90909090');
   field('officeInTrondheim').click({ force: true });
 
-  field('semesters[0].checked').check();
+  // Chips hide their input visually, so it has to be checked with force, the
+  // same way the toggle switch above is clicked.
+  field('semesters[0].checked').check({ force: true });
   field('events[0].checked').check();
   field('otherOffers[0].checked').check();
-  field('companyType').check();
+  field('companyType').check({ force: true });
   field('comment').type('random comment');
   field('companyPresentationComment').type('some pitch for presentation');
 

--- a/lego-webapp/cypress/e2e/company_interest_spec.ts
+++ b/lego-webapp/cypress/e2e/company_interest_spec.ts
@@ -22,13 +22,15 @@ const createCompanyInterest = () => {
   field('mail').click().type('webkom@webkom.no');
 
   field('phone').click().type('90909090');
-  field('officeInTrondheim').click({ force: true });
+  // The switch is a button next to the hidden input the field is found by
+  field('officeInTrondheim').parent().find('button').click();
 
-  // Chips hide their input visually, so it has to be checked with force, the
-  // same way the toggle switch above is clicked.
+  // Chips hide their input visually and the option cards cover theirs with the
+  // label overlay that makes the whole card clickable, so every box below has
+  // to be checked with force, the same way the toggle switch above is clicked.
   field('semesters[0].checked').check({ force: true });
-  field('events[0].checked').check();
-  field('otherOffers[0].checked').check();
+  field('events[0].checked').check({ force: true });
+  field('otherOffers[0].checked').check({ force: true });
   field('companyType').check({ force: true });
   field('comment').type('random comment');
   field('companyPresentationComment').type('some pitch for presentation');

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
@@ -63,8 +63,7 @@
   padding: var(--spacing-md);
 }
 
-/* The card normally stacks its icon above the text on small screens, which
-   strands the icon on a row of its own; beside the text it stays a note. */
+/* Keep the icon beside the text instead of the stacked small-screen layout. */
 @media (--small-viewport) {
   .infoCard :global([class*='withIcon']) {
     flex-direction: row;
@@ -228,7 +227,31 @@
 }
 
 .toggleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
   cursor: pointer;
+}
+
+.toggleText {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.toggleLabel {
+  font-weight: 600;
+}
+
+.toggleDescription {
+  color: var(--secondary-font-color);
+  font-size: var(--font-size-sm);
+}
+
+.toggleControl {
+  width: auto;
+  flex: none;
 }
 
 .participantSlider {
@@ -239,8 +262,6 @@
   }
 }
 
-/* The surrounding group is a wrapping row built for chips, so a column of cards
-   has to claim the width itself rather than shrink to its longest label. */
 .cardList {
   width: 100%;
 }
@@ -254,40 +275,29 @@
     background-color var(--easing-fast);
 }
 
-/* The whole card is the control, as in the design. The label's overlay covers
-   the card so a click anywhere reaches it, which is safe only because these
-   cards hold nothing else interactive the way the event cards hold a pitch. */
+/* The whole card selects, via the label's overlay below. */
 .optionCard {
   position: relative;
   cursor: pointer;
 }
 
-/* Carried by the option's own label rather than any label in the card: an event
-   card also holds the pitch's label, which would otherwise lay a second overlay
-   over the whole card and swallow the editor. */
 .optionLabel::after {
   content: '';
   position: absolute;
   inset: 0;
 }
 
-/* The field wrapper is positioned so its error overlay can anchor to it, which
-   would make it the containing block for the label overlay above and shrink it
-   to the label. These options report errors through the group, not each on
-   their own, so nothing here needs that anchor. */
+/* Unpositioned, so the label's overlay stretches to the card around it rather
+   than to the field. */
 .optionField {
   position: static;
 }
 
-/* Same selected fill as Chip, so every choice on the page reads as picked the
-   same way. */
 .eventCard:has(input:checked) {
   border-color: var(--lego-red-color);
   background-color: var(--selected-background);
 }
 
-/* Sits above the label overlay that makes the rest of the card selectable, so
-   the editor inside stays reachable instead of being covered by it. */
 .eventPitch {
   position: relative;
   z-index: 1;
@@ -323,8 +333,7 @@
   align-self: flex-start;
 }
 
-/* Form inputs inherit their background, so on a selected card the pitch would
-   take the card's tint and stop reading as something you type into. */
+/* Inputs inherit their background, which on a tinted card hides the field. */
 .textEditor {
   background-color: var(--lego-card-color);
   width: 100%;
@@ -341,8 +350,6 @@
   transition: background-color var(--easing-fast);
 }
 
-/* Picks up the tint once the readme offer is selected, so the promo reads as
-   part of the choice rather than decoration beside it. */
 .readmePromoOn {
   background-color: var(--selected-background);
 }
@@ -361,7 +368,6 @@
     rotate: -4deg;
   }
 
-  /* Tucked under its neighbour so the pair reads as a stack of issues. */
   &:last-child {
     margin-top: var(--spacing-sm);
     margin-left: calc(-1 * var(--spacing-lg));

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
@@ -201,13 +201,7 @@
 .optionRow {
   display: flex;
   flex-wrap: wrap;
-  row-gap: var(--spacing-sm);
-  column-gap: var(--spacing-lg);
-}
-
-.optionRow > div,
-.inlineOption.inlineOption {
-  width: auto;
+  gap: var(--spacing-sm);
 }
 
 .toggleGroup {

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.module.css
@@ -63,6 +63,15 @@
   padding: var(--spacing-md);
 }
 
+/* The card normally stacks its icon above the text on small screens, which
+   strands the icon on a row of its own; beside the text it stays a note. */
+@media (--small-viewport) {
+  .infoCard :global([class*='withIcon']) {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
 .content {
   grid-area: content;
   font-size: var(--font-size-sm);
@@ -180,7 +189,7 @@
 }
 
 .section {
-  gap: var(--spacing-md);
+  gap: var(--spacing-lg);
 }
 
 .sectionHeader {
@@ -195,7 +204,6 @@
   color: var(--lego-red-color);
   font-size: var(--font-size-lg);
   font-weight: 700;
-  letter-spacing: 0.08em;
 }
 
 .optionRow {
@@ -208,44 +216,102 @@
   display: flex;
   flex-direction: column;
   border: 1.5px solid var(--border-gray);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--border-radius-lg);
 
   & > * {
-    padding: var(--spacing-sm) var(--spacing-md);
+    padding: var(--spacing-md);
   }
 
   & > * + * {
     border-top: 1.5px solid var(--border-gray);
   }
+}
 
-  & label {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-md);
+.toggleRow {
+  cursor: pointer;
+}
+
+.participantSlider {
+  width: 60%;
+
+  @media (--medium-viewport) {
+    width: 100%;
   }
 }
 
-.eventOption {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
+/* The surrounding group is a wrapping row built for chips, so a column of cards
+   has to claim the width itself rather than shrink to its longest label. */
+.cardList {
+  width: 100%;
 }
 
+.eventCard {
+  padding: var(--spacing-md);
+  border: 1.5px solid var(--border-gray);
+  border-radius: var(--border-radius-lg);
+  transition:
+    border-color var(--easing-fast),
+    background-color var(--easing-fast);
+}
+
+/* The whole card is the control, as in the design. The label's overlay covers
+   the card so a click anywhere reaches it, which is safe only because these
+   cards hold nothing else interactive the way the event cards hold a pitch. */
+.optionCard {
+  position: relative;
+  cursor: pointer;
+}
+
+/* Carried by the option's own label rather than any label in the card: an event
+   card also holds the pitch's label, which would otherwise lay a second overlay
+   over the whole card and swallow the editor. */
+.optionLabel::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
+
+/* The field wrapper is positioned so its error overlay can anchor to it, which
+   would make it the containing block for the label overlay above and shrink it
+   to the label. These options report errors through the group, not each on
+   their own, so nothing here needs that anchor. */
+.optionField {
+  position: static;
+}
+
+/* Same selected fill as Chip, so every choice on the page reads as picked the
+   same way. */
+.eventCard:has(input:checked) {
+  border-color: var(--lego-red-color);
+  background-color: var(--selected-background);
+}
+
+/* Sits above the label overlay that makes the rest of the card selectable, so
+   the editor inside stays reachable instead of being covered by it. */
 .eventPitch {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
-  margin-left: var(--spacing-xs);
-  padding-left: var(--spacing-md);
-  border-left: 2px solid var(--border-gray);
+  margin-top: var(--spacing-md);
+}
+
+.eventsFootnote {
+  font-size: var(--font-size-sm);
+  color: var(--secondary-font-color);
+  padding-top: var(--spacing-xs);
 }
 
 .otherOffers {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+}
+
+.priorityReasoning {
+  font-weight: 600;
+  margin-bottom: var(--spacing-sm);
 }
 
 .mutedText {
@@ -257,25 +323,94 @@
   align-self: flex-start;
 }
 
+/* Form inputs inherit their background, so on a selected card the pitch would
+   take the card's tint and stop reading as something you type into. */
 .textEditor {
+  background-color: var(--lego-card-color);
   width: 100%;
 }
 
-.readMe {
-  max-width: 280px;
+.readmePromo {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-lg);
+  background-color: var(--additive-background);
+  transition: background-color var(--easing-fast);
 }
 
-.readMe :global([class*='heading']) {
-  font-size: var(--font-size-lg);
+/* Picks up the tint once the readme offer is selected, so the promo reads as
+   part of the choice rather than decoration beside it. */
+.readmePromoOn {
+  background-color: var(--selected-background);
 }
 
-.readMe :global([class*='thumbnailContainer']) {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: var(--spacing-sm);
-  padding-top: 0;
-  margin: 0;
+.readmeCovers {
+  display: flex;
+  flex: none;
+  padding-right: var(--spacing-sm);
+}
+
+.readmeCover {
+  width: 110px;
   overflow: hidden;
+
+  &:first-child {
+    rotate: -4deg;
+  }
+
+  /* Tucked under its neighbour so the pair reads as a stack of issues. */
+  &:last-child {
+    margin-top: var(--spacing-sm);
+    margin-left: calc(-1 * var(--spacing-lg));
+    rotate: 3deg;
+  }
+}
+
+.readmeWordmark {
+  font-size: var(--font-size-xl);
+
+  a {
+    color: var(--lego-font-color);
+  }
+}
+
+.readmeDot {
+  color: var(--lego-red-color);
+}
+
+.readmeTagline {
+  margin: var(--spacing-xs) 0 var(--spacing-sm);
+  color: var(--secondary-font-color);
+  font-size: var(--font-size-sm);
+}
+
+.readmeStats {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  color: var(--color-gray-8);
+  font-size: var(--font-size-sm);
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+  }
+
+  li::before {
+    content: '';
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background-color: var(--lego-red-color);
+    flex: none;
+  }
 }
 
 .yearForm {

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -17,6 +17,7 @@ import {
   MultiSelectGroup,
   RowSection,
   SelectInput,
+  Slider,
   TextEditor,
   TextInput,
 } from '~/components/Form';
@@ -938,21 +939,17 @@ const CompanyInterestForm = ({ language }: Props) => {
                     </div>
                   </RowSection>
 
-                  <MultiSelectGroup
+                  <Field
                     name="participantRange"
-                    legend={FORM_LABELS.participantRange[language]}
-                  >
-                    {Object.keys(PARTICIPANT_RANGE_TYPES).map((key) => (
-                      <Field
-                        key={key}
-                        name={key}
-                        value={key}
-                        label={PARTICIPANT_RANGE_TYPES[key]}
-                        type="radio"
-                        component={Chip.Field}
-                      />
-                    ))}
-                  </MultiSelectGroup>
+                    label={FORM_LABELS.participantRange[language]}
+                    placeholder={
+                      isEnglish ? 'Pick a range' : 'Velg antall deltagere'
+                    }
+                    options={Object.entries(PARTICIPANT_RANGE_TYPES).map(
+                      ([value, rangeLabel]) => ({ value, label: rangeLabel }),
+                    )}
+                    component={Slider.Field}
+                  />
 
                   <MultiSelectGroup
                     name="events"

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -12,7 +12,7 @@ import arrayMutators from 'final-form-arrays';
 import { gsap } from 'gsap';
 import { ArrowLeft, Check } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { Field, FormSpy, useForm } from 'react-final-form';
+import { Field, FormSpy, useField, useForm } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
 import { navigate } from 'vike/client/router';
@@ -270,6 +270,37 @@ const SurveyOffersBox = ({
   </div>
 );
 
+const COMPANY_TO_COMPANY = 'company_to_company';
+
+/* Bedrift-til-bedrift is only on offer to companies with an office in
+   Trondheim. Taking the office away has to clear the choice too: an event that
+   is checked but not on screen still submits, and still holds the form back on
+   its pitch, which is required and nowhere to be seen. */
+const ClearHiddenCompanyToCompany = (): null => {
+  const form = useForm();
+  const {
+    input: { value: officeInTrondheim },
+  } = useField('officeInTrondheim', { subscription: { value: true } });
+
+  useEffect(() => {
+    if (officeInTrondheim) {
+      return;
+    }
+
+    const events = form.getState().values.events ?? [];
+    const index = events.findIndex(
+      (event) => event.name === COMPANY_TO_COMPANY,
+    );
+
+    if (events[index]?.checked) {
+      form.change(`events[${index}].checked`, false);
+      form.change('companyToCompanyComment', undefined);
+    }
+  }, [officeInTrondheim, form]);
+
+  return null;
+};
+
 const EventBox = ({
   fields,
   language,
@@ -289,7 +320,7 @@ const EventBox = ({
           .map((item, index) => ({ name: fields.value[index].name, index }))
           .filter(
             ({ name }) =>
-              values.officeInTrondheim || name !== 'company_to_company',
+              values.officeInTrondheim || name !== COMPANY_TO_COMPANY,
           )
           .map(({ name, index }) => {
             const entity = eventTypeEntities.find(
@@ -385,15 +416,9 @@ const OtherBox = ({
   </Flex>
 );
 
-/**
- * A switch row where the whole row is the control.
- *
- * The switch is a react-aria button, and react-aria only honours a click it did
- * not receive a press for when the click looks programmatic, so an overlay that
- * forwards through the label works in a test and does nothing under a real
- * cursor. The row changes the value itself instead, and stays out of the way
- * when the press landed on the switch, which already handles itself.
- */
+/* The whole row toggles. A react-aria switch ignores the click a <label>
+   forwards to it, so the row carries its own text and writes the value, and
+   steps aside for a press that landed on the switch. */
 const ToggleRow = ({
   name,
   label,
@@ -404,22 +429,37 @@ const ToggleRow = ({
   description?: string;
 }): ReactNode => {
   const form = useForm();
+  const {
+    input: { value },
+  } = useField(name, { subscription: { value: true } });
+
+  const labelId = `${name}-label`;
+  const descriptionId = `${name}-description`;
 
   const handleClick = (event: MouseEvent<HTMLDivElement>) => {
     if ((event.target as HTMLElement).closest('button')) {
       return;
     }
-    form.change(name, !form.getState().values[name]);
+    form.change(name, !value);
   };
 
   return (
     <div className={styles.toggleRow} onClick={handleClick}>
+      <div className={styles.toggleText}>
+        <span id={labelId} className={styles.toggleLabel}>
+          {label}
+        </span>
+        {description && (
+          <p id={descriptionId} className={styles.toggleDescription}>
+            {description}
+          </p>
+        )}
+      </div>
       <Field
         name={name}
         component={ToggleSwitch.Field}
-        label={label}
-        description={description}
-        descriptionPosition={description ? 'inline' : undefined}
+        fieldClassName={styles.toggleControl}
+        aria-labelledby={description ? `${labelId} ${descriptionId}` : labelId}
       />
     </div>
   );
@@ -867,6 +907,7 @@ const CompanyInterestForm = ({ language }: Props) => {
         onSubmit={onSubmit}
         validate={validate}
         initialValues={initialValues}
+        keepDirtyOnReinitialize
         subscription={{}}
         mutators={{
           ...arrayMutators,
@@ -905,6 +946,8 @@ const CompanyInterestForm = ({ language }: Props) => {
               )}
 
               <Form onSubmit={handleSubmit}>
+                <ClearHiddenCompanyToCompany />
+
                 <FormSection
                   id={SECTIONS[0].id}
                   number={1}

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -11,10 +11,10 @@ import { Helmet } from 'react-helmet-async';
 import { navigate } from 'vike/client/router';
 import {
   CheckBox,
+  Chip,
   Form,
   LegoFinalForm,
   MultiSelectGroup,
-  RadioButton,
   RowSection,
   SelectInput,
   TextEditor,
@@ -241,7 +241,7 @@ const SemesterBox = ({
         name={`semesters[${index}].checked`}
         label={semesterToText({ ...fields.value[index], language })}
         type="checkbox"
-        component={CheckBox.Field}
+        component={Chip.Field}
       />
     ))}
   </div>
@@ -261,7 +261,7 @@ const SurveyOffersBox = ({
         name={`companyCourseThemes[${index}].checked`}
         label={SURVEY_OFFERS[surveyOffersToString(item)][language]}
         type="checkbox"
-        component={CheckBox.Field}
+        component={Chip.Field}
       />
     ))}
   </div>
@@ -337,7 +337,7 @@ const TargetGradeBox = ({
         name={`targetGrades[${index}].checked`}
         label={TARGET_GRADES[targetGradeToString(key)][language]}
         type="checkbox"
-        component={CheckBox.Field}
+        component={Chip.Field}
       />
     ))}
   </div>
@@ -862,8 +862,7 @@ const CompanyInterestForm = ({ language }: Props) => {
                         value={key}
                         label={COMPANY_TYPES[key][language]}
                         type="radio"
-                        component={RadioButton.Field}
-                        fieldClassName={styles.inlineOption}
+                        component={Chip.Field}
                         showErrors={false}
                       />
                     ))}
@@ -950,8 +949,7 @@ const CompanyInterestForm = ({ language }: Props) => {
                         value={key}
                         label={PARTICIPANT_RANGE_TYPES[key]}
                         type="radio"
-                        component={RadioButton.Field}
-                        fieldClassName={styles.inlineOption}
+                        component={Chip.Field}
                       />
                     ))}
                   </MultiSelectGroup>

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -1,11 +1,18 @@
-import { Card, Flex, Icon, LoadingIndicator, Page } from '@webkom/lego-bricks';
+import {
+  Card,
+  Flex,
+  Icon,
+  Image,
+  LoadingIndicator,
+  Page,
+} from '@webkom/lego-bricks';
 import { usePreparedEffect } from '@webkom/react-prepare';
 import cx from 'classnames';
 import arrayMutators from 'final-form-arrays';
 import { gsap } from 'gsap';
 import { ArrowLeft, Check } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { Field, FormSpy } from 'react-final-form';
+import { Field, FormSpy, useForm } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { Helmet } from 'react-helmet-async';
 import { navigate } from 'vike/client/router';
@@ -26,7 +33,6 @@ import { SubmitButton } from '~/components/Form/SubmitButton';
 import ToggleSwitch from '~/components/Form/ToggleSwitch';
 import PillSwitch from '~/components/PillSwitch';
 import { readmeIfy } from '~/components/ReadmeLogo';
-import LatestReadme from '~/pages/index/_components/authenticated/LatestReadme';
 import {
   fetchSemesters,
   fetchSemestersForInterestform,
@@ -59,26 +65,22 @@ import {
   COMPANY_TYPES,
   EVENTS,
   FORM_LABELS,
-  OTHER_DESCRIPTIONS,
+  README_PROMO,
   OTHER_OFFERS,
   SURVEY_OFFERS,
   TARGET_GRADES,
-  TOOLTIP,
+  EVENT_DESCRIPTIONS,
 } from './Translations';
 import {
-  collaborationDescriptionToString,
-  collaborationToString,
   interestText,
-  otherOffersToString,
   PARTICIPANT_RANGE_MAP,
   PARTICIPANT_RANGE_TYPES,
   semesterToText,
   sortSemesterChronologically,
   surveyOffersToString,
   targetGradeToString,
-  othersDescriptionToString,
 } from './utils';
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import type { PillSwitchOption } from '~/components/PillSwitch';
 
 import type { DetailedCompanyInterest } from '~/redux/models/CompanyInterest';
@@ -279,7 +281,7 @@ const EventBox = ({
 }): ReactNode => (
   <FormSpy subscription={{ values: true }}>
     {({ values }) => (
-      <Flex column gap="var(--spacing-md)">
+      <Flex column gap="var(--spacing-sm)">
         <p className={styles.mutedText}>
           {FORM_LABELS.eventDescriptionIntro[language]}
         </p>
@@ -294,28 +296,41 @@ const EventBox = ({
               (eventTypeEntity) => eventTypeEntity.name === name,
             );
             return (
-              <div key={name} className={styles.eventOption}>
+              <div
+                key={name}
+                className={cx(styles.eventCard, styles.optionCard)}
+              >
                 <Field
                   name={`events[${index}].checked`}
                   label={EVENTS[name][language]}
                   type="checkbox"
                   component={CheckBox.Field}
-                  description={TOOLTIP[name][language]}
+                  description={EVENT_DESCRIPTIONS[name][language]}
+                  descriptionPosition="inline"
+                  fieldClassName={styles.optionField}
+                  labelClassName={styles.optionLabel}
+                  inlineContent={
+                    values.events?.[index]?.checked &&
+                    entity?.commentName && (
+                      <div className={styles.eventPitch}>
+                        {entity.description && (
+                          <p className={styles.mutedText}>
+                            {entity.description}
+                          </p>
+                        )}
+                        <Field
+                          placeholder={entity.commentPlaceholder}
+                          name={entity.commentName}
+                          label={FORM_LABELS.eventDescriptionHeader[language]}
+                          component={TextEditor.Field}
+                          rows={6}
+                          className={styles.textEditor}
+                          required
+                        />
+                      </div>
+                    )
+                  }
                 />
-                {values.events?.[index]?.checked && entity?.commentName && (
-                  <div className={styles.eventPitch}>
-                    <p className={styles.mutedText}>{entity.description}</p>
-                    <Field
-                      placeholder={entity.commentPlaceholder}
-                      name={entity.commentName}
-                      label={FORM_LABELS.eventDescriptionHeader[language]}
-                      component={TextEditor.Field}
-                      rows={6}
-                      className={styles.textEditor}
-                      required
-                    />
-                  </div>
-                )}
               </div>
             );
           })}
@@ -351,21 +366,105 @@ const OtherBox = ({
   fields: any;
   language: string;
 }): ReactNode => (
-  <Flex column gap="var(--spacing-md)">
-    {fields.map((key, index) => (
-      <Field
-        key={`otherOffers[${index}]`}
-        name={`otherOffers[${index}].checked`}
-        label={readmeIfy(OTHER_OFFERS[otherOffersToString(key)][language])}
-        type="checkbox"
-        component={CheckBox.Field}
-        description={
-          OTHER_DESCRIPTIONS[othersDescriptionToString(key)][language]
-        }
-      />
-    ))}
+  <Flex column gap="var(--spacing-sm)" className={styles.cardList}>
+    {fields.map((item, index) => {
+      const name = fields.value[index].name;
+      return (
+        <div key={name} className={cx(styles.eventCard, styles.optionCard)}>
+          <Field
+            name={`otherOffers[${index}].checked`}
+            label={readmeIfy(OTHER_OFFERS[name][language])}
+            type="checkbox"
+            component={CheckBox.Field}
+            fieldClassName={styles.optionField}
+            labelClassName={styles.optionLabel}
+          />
+        </div>
+      );
+    })}
   </Flex>
 );
+
+/**
+ * A switch row where the whole row is the control.
+ *
+ * The switch is a react-aria button, and react-aria only honours a click it did
+ * not receive a press for when the click looks programmatic, so an overlay that
+ * forwards through the label works in a test and does nothing under a real
+ * cursor. The row changes the value itself instead, and stays out of the way
+ * when the press landed on the switch, which already handles itself.
+ */
+const ToggleRow = ({
+  name,
+  label,
+  description,
+}: {
+  name: string;
+  label: string;
+  description?: string;
+}): ReactNode => {
+  const form = useForm();
+
+  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement).closest('button')) {
+      return;
+    }
+    form.change(name, !form.getState().values[name]);
+  };
+
+  return (
+    <div className={styles.toggleRow} onClick={handleClick}>
+      <Field
+        name={name}
+        component={ToggleSwitch.Field}
+        label={label}
+        description={description}
+        descriptionPosition={description ? 'inline' : undefined}
+      />
+    </div>
+  );
+};
+
+const ReadmePromo = ({ language }: { language: Language }): ReactNode => {
+  const readmes = useAppSelector((state) => state.readme);
+
+  return spyValues((values: CompanyInterestFormEntity) => {
+    const selected = values.otherOffers?.some(
+      (offer) => offer.name === 'readme' && offer.checked,
+    );
+    return (
+      <div className={cx(styles.readmePromo, selected && styles.readmePromoOn)}>
+        <div className={styles.readmeCovers}>
+          {readmes.slice(0, 2).map(({ image, pdf, title }) => (
+            <a key={title} href={pdf} className={styles.readmeCover}>
+              <Image src={image} alt={`Forsidebildet til ${title}`} />
+            </a>
+          ))}
+        </div>
+        <div>
+          <div className={styles.readmeWordmark}>
+            <a
+              href={'https://readme.abakus.no/'}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {readmeIfy('readme')}
+              <span className={styles.readmeDot}>.</span>
+            </a>
+          </div>
+          <p className={styles.readmeTagline}>
+            {README_PROMO.tagline[language]}
+          </p>
+          <ul className={styles.readmeStats}>
+            {README_PROMO.stats.map((stat) => (
+              <li key={stat.english}>{stat[language]}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  });
+};
 
 const CollaborationBox = ({
   fields,
@@ -374,21 +473,24 @@ const CollaborationBox = ({
   fields: any;
   language: string;
 }): ReactNode => (
-  <Flex column gap="var(--spacing-md)">
-    {fields.map((key, index) => (
-      <Field
-        key={`collaborations[${index}]`}
-        name={`collaborations[${index}].checked`}
-        label={COLLABORATION_TYPES[collaborationToString(key)][language]}
-        type="checkbox"
-        component={CheckBox.Field}
-        description={
-          COLLABORATION_DESCRIPTIONS[collaborationDescriptionToString(key)][
-            language
-          ]
-        }
-      />
-    ))}
+  <Flex column gap="var(--spacing-sm)" className={styles.cardList}>
+    {fields.map((item, index) => {
+      const name = fields.value[index].name;
+      return (
+        <div key={name} className={cx(styles.eventCard, styles.optionCard)}>
+          <Field
+            name={`collaborations[${index}].checked`}
+            label={COLLABORATION_TYPES[name][language]}
+            type="checkbox"
+            component={CheckBox.Field}
+            description={COLLABORATION_DESCRIPTIONS[name]?.[language]}
+            descriptionPosition="inline"
+            fieldClassName={styles.optionField}
+            labelClassName={styles.optionLabel}
+          />
+        </div>
+      );
+    })}
   </Flex>
 );
 
@@ -482,7 +584,7 @@ type CompanyInterestFormEntity = {
 type EventTypeEntity = {
   name: string;
   translated: string;
-  description: string;
+  description?: string;
   commentName?: string;
   commentPlaceholder?: string;
 };
@@ -870,14 +972,12 @@ const CompanyInterestForm = ({ language }: Props) => {
                   </MultiSelectGroup>
 
                   <div className={styles.toggleGroup}>
-                    <Field
+                    <ToggleRow
                       name="officeInTrondheim"
-                      component={ToggleSwitch.Field}
                       label={FORM_LABELS.officeInTrondheim[language]}
                     />
-                    <Field
+                    <ToggleRow
                       name="wantsThursdayEvent"
-                      component={ToggleSwitch.Field}
                       label={FORM_LABELS.wantsThursdayEvent[language]}
                       description={FORM_LABELS.wantsThursdayEventInfo[language]}
                     />
@@ -887,6 +987,7 @@ const CompanyInterestForm = ({ language }: Props) => {
                     name="companyCourseThemes"
                     legend={FORM_LABELS.companyCourseThemes[language]}
                     description={FORM_LABELS.companyCourseThemesInfo[language]}
+                    descriptionPosition="inline"
                   >
                     <FieldArray name="companyCourseThemes">
                       {(props) => (
@@ -949,6 +1050,7 @@ const CompanyInterestForm = ({ language }: Props) => {
                       ([value, rangeLabel]) => ({ value, label: rangeLabel }),
                     )}
                     component={Slider.Field}
+                    className={styles.participantSlider}
                   />
 
                   <MultiSelectGroup
@@ -966,6 +1068,10 @@ const CompanyInterestForm = ({ language }: Props) => {
                       )}
                     </FieldArray>
                   </MultiSelectGroup>
+                  <p className={styles.eventsFootnote}>
+                    * Bedrift-til-bedrift blir tilgjengelig om dere har kontorer
+                    i Trondheim.
+                  </p>
 
                   <MultiSelectGroup
                     name="collaborations"
@@ -987,9 +1093,7 @@ const CompanyInterestForm = ({ language }: Props) => {
                         {(props) => <OtherBox {...props} language={language} />}
                       </FieldArray>
                     </MultiSelectGroup>
-                    <div className={styles.readMe}>
-                      <LatestReadme collapsible={false} displayCount={2} />
-                    </div>
+                    <ReadmePromo language={language} />
                   </div>
                 </FormSection>
 
@@ -1000,7 +1104,9 @@ const CompanyInterestForm = ({ language }: Props) => {
                 >
                   {!edit && (
                     <div>
-                      <b>{interestText.priorityReasoningTitle[language]}</b>
+                      <p className={styles.priorityReasoning}>
+                        {interestText.priorityReasoningTitle[language]}
+                      </p>
                       <p className={styles.mutedText}>
                         {interestText.priorityReasoning[language]}
                       </p>
@@ -1009,7 +1115,11 @@ const CompanyInterestForm = ({ language }: Props) => {
 
                   <SubmissionError />
 
-                  <SubmitButton className={styles.submitButton}>
+                  <SubmitButton
+                    dark
+                    size="large"
+                    className={styles.submitButton}
+                  >
                     {edit
                       ? 'Oppdater bedriftsinteresse'
                       : FORM_LABELS.create[language]}

--- a/lego-webapp/pages/bdb/company-interest/Translations.ts
+++ b/lego-webapp/pages/bdb/company-interest/Translations.ts
@@ -39,7 +39,7 @@ export const EVENTS = {
   },
 };
 
-export const TOOLTIP = {
+export const EVENT_DESCRIPTIONS = {
   company_presentation: {
     norwegian:
       'Kom og fortell om hvem dere er og hva dere gjør i bedriften deres.',
@@ -59,15 +59,15 @@ export const TOOLTIP = {
   },
   breakfast_talk: {
     norwegian:
-      'Frokostforedragene foregår fra klokken 8 til 10/11, og holdes vanligvis på campus. Tildeling av frokostforedrag skjer uavhengig av andre tildelinger, så dere kan få frokostforedrag i tillegg til et annet arrangement. Vi ønsker gjerne at dere foreslår temaer til frokostforedraget dere ønsker å holde. Det er åpent for alt. Tidligere temaer har blant annet vært softskills, spennende caser fra jobb, teknologiutvikling, motivasjonsforedrag eller bærekraft.',
+      'Morgenforedrag på campus kl. 08–10/11 med fritt temavalg, tildelt uavhengig av andre arrangementer.',
     english:
-      'The breakfast talks take place from 8 am to 10/11 am, and are usually held on campus. Allocation of breakfast talks takes place independently of other allocations, so you can receive breakfast lectures in addition to another event. We would like you to suggest topics for the breakfast talks you wish to give. We are open to everything. Previous topics have included soft skills, exciting cases from work, technology development, motivational talks or sustainability.',
+      'Morning talks on campus from 8–10/11, on a topic of your choosing, allocated independently of other events.',
   },
   bedex: {
     norwegian:
-      'BedEx er Abakus sin bedriftsekskursjon til Oslo, spesialtilrettelagt for studenter i 4. og 5. klasse. Gjennom et firedagers opphold i Oslo, får studentene muligheten til å besøke 6 fremstående bedrifter. Disse bedriftene ønsker studentene velkommen i sine lokaler, hvor de gjennom nøye planlagte aktiviteter og direkte dialog med ansatte, tilbyr dybdeinnsikt i både sine operasjoner og arbeidskultur. BedEx-teamet organiserer en gruppeflyvning fra Trondheim til Oslo på formiddagen tirsdag 10. september, samt hotellopphold frem til og med fredag 13. september. Returreisen står hver student fritt til å arrangere selv, noe som gir rom for de som ønsker å tilbringe ekstra tid med familie i området eller nyte en forlenget helg i Oslo.',
+      'Fire dagers bedriftsekskursjon til Oslo for 4.- og 5.-klassinger, med besøk hos seks bedrifter. Vi organiserer felles flyreise fra Trondheim og hotell 10.–13. september.',
     english:
-      "BedEx is Abakus' company excursion to Oslo for students in their 4th and 5th year of study. During a four-day stay in Oslo, students have the opportunity to visit 6 prominent companies. These companies welcome the students to their premises, where, through carefully planned activities and direct dialogue with employees, they provide in-depth insight into both their operations and work culture. The BedEx team organizes a group flight from Trondheim to Oslo on the morning of tuesday September 10, as well as hotel accommodation until friday September 13. Each student is free to arrange their journey back to Trondheim, allowing those who wish to spend extra time with family in the area or enjoy an extended weekend in Oslo.",
+      'A four day company excursion to Oslo for 4th and 5th years, visiting six companies. We organise a group flight from Trondheim and hotel from 10–13 September.',
   },
   other: {
     norwegian:
@@ -125,13 +125,13 @@ export const SURVEY_OFFERS = {
 };
 
 export const OTHER_OFFERS = {
-  readme: {
-    norwegian: 'Annonse i readme',
-    english: 'Advertisement in readme',
-  },
   social_media: {
     norwegian: 'Profilering på sosiale medier',
     english: 'Profiling on social media',
+  },
+  readme: {
+    norwegian: 'Annonse i readme',
+    english: 'Advertisement in readme',
   },
 };
 
@@ -185,37 +185,33 @@ export const COLLABORATION_TYPES = {
 };
 
 export const COLLABORATION_DESCRIPTIONS = {
-  collaboration_omega: {
-    norwegian: 'Samarbeid med Omega linjeforening',
-    english: 'Event in collaboration with Omega',
-  },
-  collaboration_online: {
-    norwegian: 'Samarbeid med Online linjeforening',
-    english: 'Event in collaboration with Online',
-  },
-  collaboration_tihlde: {
-    norwegian: 'Samarbeid med TIHLDE linjeforening',
-    english: 'Event in collaboration with TIHLDE',
-  },
   collaboration_revue: {
     norwegian:
-      'Hver vår er det premiere på Abakus sin egne revy. Ta med studentene på en hyggelig kveld hvor dere presenterer selskapet deres, før dere sammen drar og ser på årets revy!',
+      'Hold bedriftspresentasjon på revydatoen, med promotering på revygensere, plakater o.l.',
     english:
-      'Every spring, Abakus puts on its own revue. Invite the students to a pleasant evening where you present your company, before heading together to watch this year’s revue!',
+      'Give a company presentation on the revue date, with promotion on revue merch, posters etc.',
   },
 };
 
-export const OTHER_DESCRIPTIONS = {
-  ad_readme: {
-    norwegian:
-      'readme er Gløshaugens største linjeforeningsmagasin, som kommer ut tre ganger i semesteret, og vi har et opplag på 500 eksemplarer hver utgave. Magasinet er gratis, distribueres på hele NTNUs campus Gløshaugen, og når ut til over 900 studenter innenfor datateknologi, cybersikkerhet, datakommunikasjon og informasjonsteknologi.',
-    english:
-      'readme is the largest student association magazine at Gløshaugen. It is published three times per semester, with a print run of 500 copies per issue. The magazine is free, distributed across NTNU’s Gløshaugen campus, and reaches more than 900 students in computer science, cyber security, data communications, and information technology',
+export const README_PROMO = {
+  tagline: {
+    norwegian: 'Gløshaugens største linjeforeningsmagasin',
+    english: 'The largest student magazine at Gløshaugen',
   },
-  prof_social_media: {
-    norwegian: '',
-    english: '',
-  },
+  stats: [
+    {
+      norwegian: '500 eksemplarer per utgave',
+      english: '500 copies per issue',
+    },
+    {
+      norwegian: 'Tre utgaver i semesteret',
+      english: 'Three issues per semester',
+    },
+    {
+      norwegian: 'Når 900+ teknologistudenter på campus',
+      english: 'Reaches 900+ tech students on campus',
+    },
+  ],
 };
 
 export const TARGET_GRADES = {
@@ -272,9 +268,9 @@ export const FORM_LABELS = {
   },
   wantsThursdayEventInfo: {
     norwegian:
-      'Torsdags-arrangementer er av de mest populære blant studentene, og vi ser ofte høyere påmelding og større engasjement på torsdager.',
+      'Torsdags-arrangementer er av de mest populære blant studentene, med høyere påmelding og større engasjement.',
     english:
-      'Thursday events are among the most popular with students, and we often see higher attendance and greater engagement on thursdays.',
+      'Thursday events are among the most popular with students, with higher sign-up numbers and greater engagement.',
   },
   contactPerson: {
     header: {
@@ -332,9 +328,9 @@ export const FORM_LABELS = {
   },
   companyCourseThemesInfo: {
     norwegian:
-      'Dette er temaer som studenter har uttrykt interesse for å lære mer om i vår bedriftsundersøkelse. Kryss av for de temaene dere kan ønske å holde kurs om eller snakke om på deres presentasjoner. (Uforpliktende)',
+      'Studentene har etterspurt disse temaene i bedriftsundersøkelsen vår. Kryss av for det dere kunne tenke dere å holde kurs om eller ta opp i presentasjonen. (Uforpliktende)',
     english:
-      'These are topics that students expressed interest in learning more about in our company survey. Check off the topics that you might be interested in arranging a course or workshop about or talk about in your presentations. (Non-binding)',
+      "Students asked for these topics in our company survey. Tick the ones you'd consider running a course on or covering in your presentation. (No commitment)",
   },
   participantRange: {
     norwegian: 'Antall deltagere',
@@ -349,13 +345,13 @@ export const FORM_LABELS = {
     english: 'Submit interest',
   },
   eventDescriptionHeader: {
-    norwegian: 'Pitch/forklar dine ønsker for arrangementet',
-    english: 'Pitch/explain your wishes for the event',
+    norwegian: 'Pitch/beskriv ønsket deres',
+    english: 'Pitch/describe your wishes',
   },
   eventDescriptionIntro: {
     norwegian:
-      'Skriv gjerne litt om hvilke type arrangementer dere ønsker å arrangere. Vi prøver å planlegge med flere ulike typer arrangementer og bedrifter der vi prøver å lage et variert, spennende og nyskapende program. Våre bedriftskontakter har også muligheten til å hjelpe med å utvikle gode arrangementer.',
+      'Fortell gjerne litt om hvilke typer arrangementer dere ønsker å holde. Vi ønsker et variert og nyskapende program, og bedriftskontaktene våre hjelper gjerne til med å utvikle arrangementet.',
     english:
-      'Please write a bit about what types of events you would like to arrange. We try to plan with several different types of events and companies, where we try to create a varied, exciting and innovative program. Our company contacts also have the opportunity to help develop good events.',
+      "Tell us a bit about the kind of events you'd like to host. We aim for a varied and innovative programme, and our company contacts are happy to help develop the event with you.",
   },
 };

--- a/lego-webapp/pages/bdb/company-interest/utils.tsx
+++ b/lego-webapp/pages/bdb/company-interest/utils.tsx
@@ -1,15 +1,7 @@
 import qs from 'qs';
 import { CompanyInterestEventType } from '~/redux/models/CompanyInterest';
 import { appConfig } from '~/utils/appConfig';
-import {
-  COLLABORATION_TYPES,
-  EVENTS,
-  SURVEY_OFFERS,
-  OTHER_OFFERS,
-  TARGET_GRADES,
-  COLLABORATION_DESCRIPTIONS,
-  OTHER_DESCRIPTIONS,
-} from './Translations';
+import { EVENTS, SURVEY_OFFERS, TARGET_GRADES } from './Translations';
 import type CompanySemester from '~/redux/models/CompanySemester';
 
 export const sortSemesterChronologically = (
@@ -81,23 +73,9 @@ export const eventToString = (event) =>
 export const surveyOffersToString = (offer) =>
   Object.keys(SURVEY_OFFERS)[Number(offer.charAt(offer.length - 2))];
 
-export const otherOffersToString = (offer) =>
-  Object.keys(OTHER_OFFERS)[Number(offer.charAt(offer.length - 2))];
-
-export const collaborationToString = (collab) =>
-  Object.keys(COLLABORATION_TYPES)[Number(collab.charAt(collab.length - 2))];
-
-export const othersDescriptionToString = (others) =>
-  Object.keys(OTHER_DESCRIPTIONS)[Number(others.charAt(others.length - 2))];
-
 export const targetGradeToString = (targetGrade) =>
   Object.keys(TARGET_GRADES)[
     Number(targetGrade.charAt(targetGrade.length - 2))
-  ];
-
-export const collaborationDescriptionToString = (collab) =>
-  Object.keys(COLLABORATION_DESCRIPTIONS)[
-    Number(collab.charAt(collab.length - 2))
   ];
 
 export const getCsvUrl = (
@@ -213,12 +191,6 @@ export const interestText = {
     english:
       'Please write a little bit about the type of presentation you would like in terms of content and networking. In contrast to the company presentation, this is scheduled to start at lunchtime and will hold networking at Gløshaugen.',
   },
-  courseDescription: {
-    norwegian:
-      'På et faglig arrangement skal dere lære bort noe til studentene. Dette kan være gjennom foredrag, workshops eller lignende. Fortell hva dere kan holde kurs i, og pitch gjerne en fullstendig idé til gjennomføring av kurset. Er det noe dere kan lære bort som sammenfaller med temaene studentene har svart at de ønsker seg, eller driver dere med noe annet studentene vil være interesserte i?',
-    english:
-      'At a course or workshop, you must teach something to the students. This can be through talks or interactive workshops. Tell us what you can hold a course about, and feel free to pitch a complete idea for carrying out the course. Is there something you can teach that coincides with the topics the students have answered that they want, or do you do something else the students will be interested in?',
-  },
   breakfastTalkDescription: {
     norwegian:
       'Frokostforedragene foregår fra klokken 8 til 10/11, og holdes vanligvis på campus. Tildeling av frokostforedrag skjer uavhengig av andre tildelinger, så dere kan få frokostforedrag i tillegg til et annet arrangement. Vi ønsker gjerne at dere foreslår temaer til frokostforedraget dere ønsker å holde. Det er åpent for alt. Tidligere temaer har blant annet vært softskills, spennende caser fra jobb, teknologiutvikling, motivasjonsforedrag eller bærekraft.',
@@ -231,11 +203,17 @@ export const interestText = {
     english:
       "BedEx is Abakus' company excursion to Oslo for students in their 4th and 5th year of study. During a four-day stay in Oslo, students have the opportunity to visit 6 prominent companies. These companies welcome the students to their premises, where, through carefully planned activities and direct dialogue with employees, they provide in-depth insight into both their operations and work culture. The BedEx team organizes a group flight from Trondheim to Oslo on the morning of tuesday September 10, as well as hotel accommodation until friday September 13. Each student is free to arrange their journey back to Trondheim, allowing those who wish to spend extra time with family in the area or enjoy an extended weekend in Oslo.",
   },
+  courseDescription: {
+    norwegian:
+      'Fortell hva dere kan holde kurs i, og pitch gjerne en fullstendig idé til gjennomføring av kurset. Er det noe dere kan lære bort som sammenfaller med temaene studentene har svart at de ønsker seg, eller driver dere med noe annet studentene vil være interesserte i?',
+    english:
+      'Tell us what you can hold a course about, and feel free to pitch a complete idea for carrying out the course. Is there something you can teach that coincides with the topics the students have answered that they want, or do you do something else the students will be interested in?',
+  },
   otherEventDescription: {
     norwegian:
-      'Har dere ønsker om å arrangere noe mer enn en vanlig bedriftspresentasjon eller noe som ikke helt passer som et faglig arrangement? Skriv en beskrivelse av hva dere har tenkt eller ønsker. Også mulig å sparre med oss så kan vi finne på spennende arrangementer.',
+      'Skriv en beskrivelse av hva dere har tenkt eller ønsker. Også mulig å sparre med oss så kan vi finne på spennende arrangementer.',
     english:
-      "Do you have any wishes to arrange something more than a regular company presentation or something that doesn't quite fit as a professional event? Write a description of what you have in mind or want. It is also possible to brainstorm with us so that we can come up with exciting events.",
+      'Write a description of what you have in mind or want. It is also possible to brainstorm with us so that we can come up with exciting events.',
   },
   startUpDescription: {
     norwegian:


### PR DESCRIPTION
## Description

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->

Rebuilds the form's inputs on the refreshed components: chips for semesters,
target grades, course themes and company type; the slider for participant
range; cards for events, collaborations and other offers; toggle rows for the
two yes/no questions; a readme promo beside the offers. Translations and
`utils` shed the string-mapping helpers the old markup needed.

The last commit fixes the form's own logic: clearing "kontor i Trondheim"
hid Bedrift-til-bedrift but left the event checked, so its required pitch
blocked submission from a field no longer on screen.

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

Tested and visual changes in 4th PR
## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Dependent on <!-- ... backend PR link, delete if none --> 

Resolves #6024

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>