### PR TITLE
Keep company interest form values when switching language

### DIFF
--- a/lego-webapp/cypress/e2e/company_interest_spec.ts
+++ b/lego-webapp/cypress/e2e/company_interest_spec.ts
@@ -42,11 +42,30 @@ describe('Company interest', () => {
   beforeEach(() => {
     cy.resetDb();
   });
-  it.only('Should be able to create company interest', () => {
+  it('Should be able to create company interest', () => {
     createCompanyInterest();
     // Success toast
     cy.contains('Bedriftsinteresse opprettet');
     cy.url().should('include', '/pages/bedrifter/for-bedrifter');
+  });
+
+  it('should keep filled fields when switching language', () => {
+    cy.visit('/interesse');
+    cy.waitForHydration();
+
+    field('contactPerson').click().type('webkom');
+    field('semesters[0].checked').check({ force: true });
+
+    cy.contains('button', 'English').click();
+    cy.url().should('include', 'lang=en');
+    cy.contains('Submit interest');
+    field('contactPerson').should('have.value', 'webkom');
+    field('semesters[0].checked').should('be.checked');
+
+    cy.contains('button', 'Norsk').click();
+    cy.url().should('not.include', 'lang=en');
+    cy.contains('Send bedriftsinteresse');
+    field('contactPerson').should('have.value', 'webkom');
   });
 });
 

--- a/lego-webapp/cypress/e2e/company_interest_spec.ts
+++ b/lego-webapp/cypress/e2e/company_interest_spec.ts
@@ -1,6 +1,7 @@
 import {
   field,
   selectField,
+  t,
   NO_OPTIONS_MESSAGE,
 } from '~/cypress/support/utils';
 
@@ -77,14 +78,17 @@ describe('Admin company interest', () => {
 
   it('should be able to create and delete interest', () => {
     createCompanyInterest();
-    cy.url().should('include', `/companyInterest`);
+    cy.url().should('include', '/bdb/company-interest');
 
-    cy.contains('BEKK');
-    cy.contains('webkom@webkom.no');
-    cy.contains('90909090');
-    cy.contains('Slett').click().click();
+    cy.contains('tr', 'BEKK').within(() => {
+      cy.contains('webkom');
+      cy.contains('webkom@webkom.no');
+    });
 
-    cy.should('not.contain', 'BEKK');
+    cy.contains('tr', 'BEKK').find('button').click();
+    cy.get(t('Modal__content')).should('be.visible').contains('Ja').click();
+
+    cy.contains('tr', 'BEKK').should('not.exist');
   });
 
   it('should not be able to create if invalid input', () => {
@@ -95,7 +99,7 @@ describe('Admin company interest', () => {
     selectField('company').click();
     cy.focused().type('BEKK', { force: true });
     selectField('company')
-      .find('.Select-menu-outer')
+      .find('[id=react-select-company-listbox]')
       .should('not.contain', NO_OPTIONS_MESSAGE)
       .and('contain', 'BEKK');
     cy.focused().type('{enter}', { force: true });
@@ -104,18 +108,19 @@ describe('Admin company interest', () => {
 
     field('mail').click().type('webkom@webko');
 
-    field('phone').click().type('');
+    // Phone is left empty on purpose, it is required
+    field('phone').click();
 
     field('comment').type('random comment');
 
     cy.contains('Send bedriftsinteresse').click();
 
-    cy.url().should('not.include', `/companyInterest`);
+    cy.url().should('include', '/interesse');
   });
 
   it('should be able to edit company interest', () => {
     createCompanyInterest();
-    cy.url().should('include', `/companyInterest`);
+    cy.url().should('include', '/bdb/company-interest');
     cy.contains('BEKK').click();
     cy.url().should('include', `edit`);
 
@@ -126,9 +131,9 @@ describe('Admin company interest', () => {
 
     field('contactPerson').type('plebkom');
 
-    field('semesters[0].checked').should('have.attr', 'checked');
-    field('events[0].checked').should('have.attr', 'checked');
-    field('otherOffers[0].checked').should('have.attr', 'checked');
+    field('semesters[0].checked').should('be.checked');
+    field('events[0].checked').should('be.checked');
+    field('otherOffers[0].checked').should('be.checked');
 
     cy.contains('Oppdater bedriftsinteresse').click();
     cy.url().should('not.include', `edit`);

--- a/lego-webapp/pages/+config.ts
+++ b/lego-webapp/pages/+config.ts
@@ -15,6 +15,7 @@ export default {
     '/pages/organisasjon/46-fondstyret/edit':
       '/pages/organisasjon/46-fondet/edit', // backwards compat for renamed slug
     '/pages/organisasjon/46-fondstyret': '/pages/organisasjon/46-fondet', // backwards compat for renamed slug
+    '/register-interest': '/interesse?lang=en', // the English form is the same page in another language
   },
 
   passToClient: ['storeInitialState'],

--- a/lego-webapp/pages/bdb/company-interest/@companyInterestId/edit/+Page.tsx
+++ b/lego-webapp/pages/bdb/company-interest/@companyInterestId/edit/+Page.tsx
@@ -1,5 +1,5 @@
 import CompanyInterestForm from '../../CompanyInterestForm';
 
 export default function Page() {
-  return <CompanyInterestForm language="norwegian" />;
+  return <CompanyInterestForm />;
 }

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -439,7 +439,13 @@ const ReadmePromo = ({ language }: { language: Language }): ReactNode => {
       <div className={cx(styles.readmePromo, selected && styles.readmePromoOn)}>
         <div className={styles.readmeCovers}>
           {readmes.slice(0, 2).map(({ image, pdf, title }) => (
-            <a key={title} href={pdf} className={styles.readmeCover}>
+            <a
+              key={title}
+              href={pdf}
+              rel="noreferrer"
+              target="_blank"
+              className={styles.readmeCover}
+            >
               <Image src={image} alt={`Forsidebildet til ${title}`} />
             </a>
           ))}

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -78,8 +78,6 @@ import {
   PARTICIPANT_RANGE_TYPES,
   semesterToText,
   sortSemesterChronologically,
-  surveyOffersToString,
-  targetGradeToString,
 } from './utils';
 import type { MouseEvent, ReactNode } from 'react';
 import type { PillSwitchOption } from '~/components/PillSwitch';
@@ -231,39 +229,19 @@ const StepRail = ({ language }: { language: Language }): ReactNode => {
   });
 };
 
-const SemesterBox = ({
+const ChipOptions = ({
   fields,
-  language,
+  getLabel,
 }: {
   fields: any;
-  language: string;
+  getLabel: (value: any) => ReactNode;
 }): ReactNode => (
   <div className={styles.optionRow}>
     {fields.map((item, index) => (
       <Field
-        key={`semesters[${index}]`}
-        name={`semesters[${index}].checked`}
-        label={semesterToText({ ...fields.value[index], language })}
-        type="checkbox"
-        component={Chip.Field}
-      />
-    ))}
-  </div>
-);
-
-const SurveyOffersBox = ({
-  fields,
-  language,
-}: {
-  fields: any;
-  language: string;
-}): ReactNode => (
-  <div className={styles.optionRow}>
-    {fields.map((item, index) => (
-      <Field
-        key={`companyCourseThemes[${index}]`}
-        name={`companyCourseThemes[${index}].checked`}
-        label={SURVEY_OFFERS[surveyOffersToString(item)][language]}
+        key={item}
+        name={`${item}.checked`}
+        label={getLabel(fields.value[index])}
         type="checkbox"
         component={Chip.Field}
       />
@@ -371,32 +349,14 @@ const EventBox = ({
   </FormSpy>
 );
 
-const TargetGradeBox = ({
+const CardOptions = ({
   fields,
-  language,
+  getLabel,
+  getDescription,
 }: {
   fields: any;
-  language: string;
-}): ReactNode => (
-  <div className={styles.optionRow}>
-    {fields.map((key, index) => (
-      <Field
-        key={`targetGrades[${index}]`}
-        name={`targetGrades[${index}].checked`}
-        label={TARGET_GRADES[targetGradeToString(key)][language]}
-        type="checkbox"
-        component={Chip.Field}
-      />
-    ))}
-  </div>
-);
-
-const OtherBox = ({
-  fields,
-  language,
-}: {
-  fields: any;
-  language: string;
+  getLabel: (name: string) => ReactNode;
+  getDescription?: (name: string) => string | undefined;
 }): ReactNode => (
   <Flex column gap="var(--spacing-sm)" className={styles.cardList}>
     {fields.map((item, index) => {
@@ -404,10 +364,12 @@ const OtherBox = ({
       return (
         <div key={name} className={cx(styles.eventCard, styles.optionCard)}>
           <Field
-            name={`otherOffers[${index}].checked`}
-            label={readmeIfy(OTHER_OFFERS[name][language])}
+            name={`${item}.checked`}
+            label={getLabel(name)}
             type="checkbox"
             component={CheckBox.Field}
+            description={getDescription?.(name)}
+            descriptionPosition="inline"
             fieldClassName={styles.optionField}
             labelClassName={styles.optionLabel}
           />
@@ -507,44 +469,13 @@ const ReadmePromo = ({ language }: { language: Language }): ReactNode => {
   });
 };
 
-const CollaborationBox = ({
-  fields,
-  language,
-}: {
-  fields: any;
-  language: string;
-}): ReactNode => (
-  <Flex column gap="var(--spacing-sm)" className={styles.cardList}>
-    {fields.map((item, index) => {
-      const name = fields.value[index].name;
-      return (
-        <div key={name} className={cx(styles.eventCard, styles.optionCard)}>
-          <Field
-            name={`collaborations[${index}].checked`}
-            label={COLLABORATION_TYPES[name][language]}
-            type="checkbox"
-            component={CheckBox.Field}
-            description={COLLABORATION_DESCRIPTIONS[name]?.[language]}
-            descriptionPosition="inline"
-            fieldClassName={styles.optionField}
-            labelClassName={styles.optionLabel}
-          />
-        </div>
-      );
-    })}
-  </Flex>
-);
-
 const LANGUAGE_OPTIONS: PillSwitchOption<Language>[] = [
   { label: 'Norsk', value: 'norwegian' },
   { label: 'English', value: 'english' },
 ];
 
-/**
- * The language lives in the URL rather than in which URL, so switching only
- * rewrites the query string in place and the mounted form keeps every value.
- * The default stays out of the URL, leaving /interesse canonical.
- */
+/* Language lives in ?lang, so switching rewrites the URL in place and the
+   mounted form keeps every value. The default stays out of the URL. */
 const LANGUAGE_QUERY_DEFAULTS = { lang: 'no' };
 
 const useFormLanguage = (): Language => {
@@ -572,12 +503,8 @@ type CompanyObjectProps = {
   value?: string;
 };
 
-/**
- * The company the form starts on, or nothing at all when none is known.
- *
- * Returning an option with empty fields instead of nothing leaves the select
- * holding a value, and it only offers its placeholder while it holds none.
- */
+/* No company means no value: the select only shows its placeholder while
+   it holds nothing, and an empty option counts as something. */
 const companySelection = (
   companyInterest?: DetailedCompanyInterest,
 ): CompanyObjectProps | undefined => {
@@ -637,7 +564,6 @@ type CompanyInterestFormEntity = {
 };
 type EventTypeEntity = {
   name: string;
-  translated: string;
   description?: string;
   commentName?: string;
   commentPlaceholder?: string;
@@ -672,7 +598,7 @@ const validate = createValidator({
   semesters: [required()],
   breakfastTalkComment: [requiredIfEventType('breakfast_talk')],
   companyPresentationComment: [requiredIfEventType('company_presentation')],
-  lunchPresentationComment: [requiredIfEventType('lunsh_presentation')],
+  lunchPresentationComment: [requiredIfEventType('lunch_presentation')],
   courseComment: [requiredIfEventType('course')],
   bedexComment: [requiredIfEventType('bedex')],
   otherEventComment: [requiredIfEventType('other')],
@@ -841,64 +767,51 @@ const CompanyInterestForm = () => {
   const eventTypeEntities: EventTypeEntity[] = [
     {
       name: 'company_presentation',
-      translated: EVENTS.company_presentation[language],
       description: interestText.companyPresentationDescription[language],
       commentName: 'companyPresentationComment',
       commentPlaceholder: interestText.companyPresentationComment[language],
     },
     {
       name: 'lunch_presentation',
-      translated: EVENTS.lunch_presentation[language],
-      description: interestText.lunchPresentationDescriptiont[language],
+      description: interestText.lunchPresentationDescription[language],
       commentName: 'lunchPresentationComment',
       commentPlaceholder: interestText.lunchPresentationComment[language],
     },
     {
       name: 'course',
-      translated: EVENTS.course[language],
       description: interestText.courseDescription[language],
       commentName: 'courseComment',
       commentPlaceholder: interestText.courseComment[language],
     },
     {
       name: 'breakfast_talk',
-      translated: EVENTS.breakfast_talk[language],
       description: interestText.breakfastTalkDescription[language],
       commentName: 'breakfastTalkComment',
       commentPlaceholder: interestText.breakfastTalkComment[language],
     },
     {
       name: 'bedex',
-      translated: EVENTS.bedex[language],
       description: interestText.bedexDescription[language],
       commentName: 'bedexComment',
       commentPlaceholder: interestText.bedexComment[language],
     },
     {
       name: 'other',
-      translated: EVENTS.other[language],
       description: interestText.otherEventDescription[language],
       commentName: 'otherEventComment',
       commentPlaceholder: interestText.otherEventComment[language],
     },
     // {
     //   name: 'start_up',
-    //   translated: EVENTS.start_up[language],
     //   description: interestText.startUpDescription[language],
     //   commentName: 'startupComment',
     //   commentPlaceholder: interestText.startUpComment[language],
     // },
     {
       name: 'company_to_company',
-      translated: EVENTS.company_to_company[language],
       description: interestText.companyToCompanyDescription[language],
       commentName: 'companyToCompanyComment',
       commentPlaceholder: interestText.companyToCompanyComment[language],
-    },
-    {
-      name: 'collaboration_revue',
-      translated: COLLABORATION_TYPES.collaboration_revue[language],
-      description: interestText.revueCollaboration[language],
     },
   ];
 
@@ -1045,7 +958,10 @@ const CompanyInterestForm = () => {
                   >
                     <FieldArray name="companyCourseThemes">
                       {(props) => (
-                        <SurveyOffersBox {...props} language={language} />
+                        <ChipOptions
+                          {...props}
+                          getLabel={({ name }) => SURVEY_OFFERS[name][language]}
+                        />
                       )}
                     </FieldArray>
                   </MultiSelectGroup>
@@ -1074,7 +990,12 @@ const CompanyInterestForm = () => {
                       >
                         <FieldArray name="targetGrades">
                           {(props) => (
-                            <TargetGradeBox {...props} language={language} />
+                            <ChipOptions
+                              {...props}
+                              getLabel={({ name }) =>
+                                TARGET_GRADES[name][language]
+                              }
+                            />
                           )}
                         </FieldArray>
                       </MultiSelectGroup>
@@ -1087,7 +1008,12 @@ const CompanyInterestForm = () => {
                       >
                         <FieldArray name="semesters">
                           {(props) => (
-                            <SemesterBox {...props} language={language} />
+                            <ChipOptions
+                              {...props}
+                              getLabel={(value) =>
+                                semesterToText({ ...value, language })
+                              }
+                            />
                           )}
                         </FieldArray>
                       </MultiSelectGroup>
@@ -1133,7 +1059,15 @@ const CompanyInterestForm = () => {
                   >
                     <FieldArray name="collaborations">
                       {(props) => (
-                        <CollaborationBox {...props} language={language} />
+                        <CardOptions
+                          {...props}
+                          getLabel={(name) =>
+                            COLLABORATION_TYPES[name][language]
+                          }
+                          getDescription={(name) =>
+                            COLLABORATION_DESCRIPTIONS[name]?.[language]
+                          }
+                        />
                       )}
                     </FieldArray>
                   </MultiSelectGroup>
@@ -1144,7 +1078,14 @@ const CompanyInterestForm = () => {
                       legend={FORM_LABELS.otherOffers[language]}
                     >
                       <FieldArray name="otherOffers">
-                        {(props) => <OtherBox {...props} language={language} />}
+                        {(props) => (
+                          <CardOptions
+                            {...props}
+                            getLabel={(name) =>
+                              readmeIfy(OTHER_OFFERS[name][language])
+                            }
+                          />
+                        )}
                       </FieldArray>
                     </MultiSelectGroup>
                     <ReadmePromo language={language} />

--- a/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
+++ b/lego-webapp/pages/bdb/company-interest/CompanyInterestForm.tsx
@@ -52,6 +52,7 @@ import {
 } from '~/redux/slices/companySemesters';
 import { spyValues } from '~/utils/formSpyUtils';
 import { useParams } from '~/utils/useParams';
+import useQuery from '~/utils/useQuery';
 import {
   createValidator,
   isEmail,
@@ -539,19 +540,32 @@ const LANGUAGE_OPTIONS: PillSwitchOption<Language>[] = [
   { label: 'English', value: 'english' },
 ];
 
-const LANGUAGE_ROUTES: Record<Language, string> = {
-  norwegian: '/interesse',
-  english: '/register-interest',
+/**
+ * The language lives in the URL rather than in which URL, so switching only
+ * rewrites the query string in place and the mounted form keeps every value.
+ * The default stays out of the URL, leaving /interesse canonical.
+ */
+const LANGUAGE_QUERY_DEFAULTS = { lang: 'no' };
+
+const useFormLanguage = (): Language => {
+  const { query } = useQuery(LANGUAGE_QUERY_DEFAULTS);
+  return query.lang === 'en' ? 'english' : 'norwegian';
 };
 
-const LanguageSwitch = ({ language }: { language: Language }) => (
-  <PillSwitch
-    options={LANGUAGE_OPTIONS}
-    value={language}
-    onChange={(value) => navigate(LANGUAGE_ROUTES[value])}
-    ariaLabel={language === 'english' ? 'Language' : 'Språk'}
-  />
-);
+const LanguageSwitch = ({ language }: { language: Language }) => {
+  const { setQueryValue } = useQuery(LANGUAGE_QUERY_DEFAULTS);
+
+  return (
+    <PillSwitch
+      options={LANGUAGE_OPTIONS}
+      value={language}
+      onChange={(value) =>
+        setQueryValue('lang')(value === 'english' ? 'en' : 'no')
+      }
+      ariaLabel={language === 'english' ? 'Language' : 'Språk'}
+    />
+  );
+};
 type CompanyObjectProps = {
   label: string | undefined;
   title: string | undefined;
@@ -666,11 +680,8 @@ const validate = createValidator({
   companyToCompanyComment: [requiredIfEventType('company_to_company')],
 });
 
-type Props = {
-  language: Language;
-};
-
-const CompanyInterestForm = ({ language }: Props) => {
+const CompanyInterestForm = () => {
+  const language = useFormLanguage();
   const { companyInterestId } = useParams();
   const edit = companyInterestId !== undefined;
   const companyInterest = useAppSelector((state) =>

--- a/lego-webapp/pages/bdb/company-interest/new/+Page.tsx
+++ b/lego-webapp/pages/bdb/company-interest/new/+Page.tsx
@@ -1,5 +1,5 @@
 import CompanyInterestForm from '../CompanyInterestForm';
 
 export default function Page() {
-  return <CompanyInterestForm language="norwegian" />;
+  return <CompanyInterestForm />;
 }

--- a/lego-webapp/pages/bdb/company-interest/utils.tsx
+++ b/lego-webapp/pages/bdb/company-interest/utils.tsx
@@ -1,7 +1,6 @@
 import qs from 'qs';
 import { CompanyInterestEventType } from '~/redux/models/CompanyInterest';
 import { appConfig } from '~/utils/appConfig';
-import { EVENTS, SURVEY_OFFERS, TARGET_GRADES } from './Translations';
 import type CompanySemester from '~/redux/models/CompanySemester';
 
 export const sortSemesterChronologically = (
@@ -67,17 +66,6 @@ export const EVENT_TYPE_OPTIONS: CompanyInterestEventTypeOption[] = [
   },
 ];
 
-export const eventToString = (event) =>
-  Object.keys(EVENTS)[Number(event.charAt(event.length - 2))];
-
-export const surveyOffersToString = (offer) =>
-  Object.keys(SURVEY_OFFERS)[Number(offer.charAt(offer.length - 2))];
-
-export const targetGradeToString = (targetGrade) =>
-  Object.keys(TARGET_GRADES)[
-    Number(targetGrade.charAt(targetGrade.length - 2))
-  ];
-
 export const getCsvUrl = (
   year: number | string,
   semester: string,
@@ -89,7 +77,7 @@ export const getCsvUrl = (
     event,
   })}`;
 
-export const SEMESTER_TRANSLATION = {
+const SEMESTER_TRANSLATION = {
   spring: {
     norwegian: 'Vår',
     english: 'Spring',
@@ -151,23 +139,6 @@ export const interestText = {
     norwegian: 'Skriv litt om hva slags bedriftspresentasjon dere ønsker.',
     english: 'Write a litte about the company presentation event you wish for.',
   },
-  bedex: {
-    norwegian:
-      '«Husk å ranger datoer og gruppestørrelse dersom du har huket av for BedEx»',
-    english: '«Remember to rank dates and groupsize if you have checked BedEx»',
-  },
-  anniversaryCollaboration: {
-    norwegian:
-      '*Samarbeid med Jubileum vil si promoteringsmuligheter på Abakus sitt jubileum i vår, eller Revyen sitt Jubileum i november 2021. Dersom det er av interesse, vil dere informeres om hva et slikt samarbeid vil innebære.',
-    english:
-      '*A collaboration with the anniversary committees would mean great opportunities  for your company to promote oneself. Either while Abakus has its anniversary in the  spring, or while the revue´s anniversary is celebrated in November 2021. If this is of  interest, we will further inform you what exactly is offered your company.',
-  },
-  revueCollaboration: {
-    norwegian:
-      '**Samarbeid med Revyen innebærer at dere får holde bedriftspresentasjon på datoen for Revyen, samt gode promoteringsmuligheter (logo på revy-gensere, logo på revyplakater o.l.)',
-    english:
-      '**A collaboration with the Revue means being their main sponsor. The Revue is a “show”, made and starred by students, and is widely popular within Abakus. As part of the collaboration, we offer you to give a Company presentation the same date as the revue. The company proceeds to join the students at the show after the presentation, guaranteeing a popular event. We also offer promotion opportunities, including your logo on merch/posters associated with the revue, etc.',
-  },
   priorityReasoningTitle: {
     norwegian: 'Abakus sin begrunnelse for prioritering',
     english: 'How we in Abakus prioritize',
@@ -185,7 +156,7 @@ export const interestText = {
       'We would like for you to describe the type of company presentation you want. Do you have any thoughts about the content of the presentation that you want to focus on or the type of networking afterwards?',
   },
 
-  lunchPresentationDescriptiont: {
+  lunchPresentationDescription: {
     norwegian:
       'Skriv gjerne litt om hvordan presentasjon dere ønsker i forhold til innhold og mingling. I motsetning til bedriftspresentasjon legger denne opp til å starte ved lunsjtider og holder minglingen på Gløshaugen.',
     english:

--- a/lego-webapp/pages/interesse/+Page.tsx
+++ b/lego-webapp/pages/interesse/+Page.tsx
@@ -1,5 +1,5 @@
 import CompanyInterestForm from '~/pages/bdb/company-interest/CompanyInterestForm';
 
 export default function Page() {
-  return <CompanyInterestForm language="norwegian" />;
+  return <CompanyInterestForm />;
 }

--- a/lego-webapp/pages/register-interest/+Page.tsx
+++ b/lego-webapp/pages/register-interest/+Page.tsx
@@ -1,5 +1,0 @@
-import CompanyInterestForm from '~/pages/bdb/company-interest/CompanyInterestForm';
-
-export default function Page() {
-  return <CompanyInterestForm language="english" />;
-}

--- a/lego-webapp/redux/slices/companyInterest.ts
+++ b/lego-webapp/redux/slices/companyInterest.ts
@@ -53,6 +53,7 @@ const companyInterestSlice = createSlice({
   reducers: {},
   extraReducers: legoAdapter.buildReducers({
     fetchActions: [CompanyInterestForm.FETCH_ALL],
+    deleteActions: [CompanyInterestForm.DELETE],
   }),
 });
 


### PR DESCRIPTION
## Description

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->

Language moves into a `?lang` query parameter, so switching rewrites the URL
in place and the mounted form keeps every value already typed. The separate
`/register-interest` page becomes a redirect to `/interesse?lang=en`.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
  <thead>
    <tr>
      <th width="25%">Description</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Better UI/UX flow</td>
      <td>

<!-- paste image/video URL directly under this line -->
https://github.com/user-attachments/assets/01514b36-173d-4177-bd39-25a73f350f58

</td>
      <td>

<!-- paste image/video URL directly under this line -->
https://github.com/user-attachments/assets/7c958a79-c2ad-41ec-a4c7-daaa81f3765b

</td>
    </tr>
  </tbody>
</table>

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

Tested and visual changes in 4th PR


## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Dependent on <!-- ... backend PR link, delete if none --> 

Resolves #6025

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>