### PR TITLE
Add text animation public frontpage

### DIFF
--- a/lego-webapp/pages/index/_components/public/Hero.module.css
+++ b/lego-webapp/pages/index/_components/public/Hero.module.css
@@ -193,7 +193,13 @@
   color: var(--secondary-font-color);
 }
 
+/* --chars comes from the StudyChip component */
 .studyChip {
+  --chip-padding-x: 11px;
+  --type-delay: 0.6s;
+  --type-duration: calc(var(--chars) * 45ms);
+
+  position: relative;
   display: inline-block;
   font-family: var(--font-family-mono);
   font-size: var(--font-size-sm);
@@ -201,7 +207,7 @@
   background: var(--lego-card-color);
   border: 1px solid var(--color-gray-3);
   border-radius: 999px;
-  padding: 2px 11px;
+  padding: 2px var(--chip-padding-x);
   margin: 2px 0;
   vertical-align: 1px;
   transition: var(--easing-fast);
@@ -210,6 +216,64 @@
   &:hover {
     border-color: var(--lego-red-color);
     color: var(--lego-red-color);
+  }
+}
+
+.studyChip::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: var(--chip-padding-x);
+  width: 1.5px;
+  height: 1.05em;
+  background: var(--lego-red-color);
+  animation:
+    chip-caret var(--type-duration) steps(var(--chars)) var(--type-delay) both,
+    chip-caret-blink 1s step-end infinite,
+    chip-caret-out 250ms linear
+      calc(var(--type-delay) + var(--type-duration) + 1s) forwards;
+}
+
+/* Mono font, so one step of the clip reveals exactly one character */
+.typewriter {
+  display: inline-block;
+  animation: chip-type var(--type-duration) steps(var(--chars))
+    var(--type-delay) both;
+}
+
+@keyframes chip-type {
+  from {
+    clip-path: inset(-0.25em 100% -0.25em 0);
+  }
+
+  to {
+    clip-path: inset(-0.25em 0 -0.25em 0);
+  }
+}
+
+@keyframes chip-caret {
+  from {
+    transform: translate(0, -50%);
+  }
+
+  to {
+    transform: translate(calc(var(--chars) * 1ch), -50%);
+  }
+}
+
+@keyframes chip-caret-blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes chip-caret-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
   }
 }
 
@@ -283,5 +347,13 @@
 
   .titleDot {
     opacity: 1;
+  }
+
+  .typewriter {
+    animation: none;
+  }
+
+  .studyChip::after {
+    display: none;
   }
 }

--- a/lego-webapp/pages/index/_components/public/Hero.module.css
+++ b/lego-webapp/pages/index/_components/public/Hero.module.css
@@ -193,13 +193,9 @@
   color: var(--secondary-font-color);
 }
 
-/* --chars comes from the StudyChip component */
 .studyChip {
   --chip-padding-x: 11px;
-  --type-delay: 0.6s;
-  --type-duration: calc(var(--chars) * 45ms);
 
-  position: relative;
   display: inline-block;
   font-family: var(--font-family-mono);
   font-size: var(--font-size-sm);
@@ -219,7 +215,14 @@
   }
 }
 
-.studyChip::after {
+.typedChip {
+  --type-delay: 0.6s;
+  --type-duration: calc(var(--chars) * 45ms);
+
+  position: relative;
+}
+
+.typedChip::after {
   content: '';
   position: absolute;
   top: 50%;
@@ -235,7 +238,7 @@
 }
 
 /* Mono font, so one step of the clip reveals exactly one character */
-.typewriter {
+.typedText {
   display: inline-block;
   animation: chip-type var(--type-duration) steps(var(--chars))
     var(--type-delay) both;
@@ -243,11 +246,11 @@
 
 @keyframes chip-type {
   from {
-    clip-path: inset(-0.25em 100% -0.25em 0);
+    clip-path: inset(0 100% 0 0);
   }
 
   to {
-    clip-path: inset(-0.25em 0 -0.25em 0);
+    clip-path: inset(0);
   }
 }
 
@@ -275,6 +278,13 @@
   to {
     opacity: 0;
   }
+}
+
+/* Holds the pill open while the scrambled text grows into it */
+.scrambledText {
+  display: inline-block;
+  width: calc(var(--chars) * 1ch);
+  white-space: nowrap;
 }
 
 .actions {
@@ -349,11 +359,11 @@
     opacity: 1;
   }
 
-  .typewriter {
+  .typedText {
     animation: none;
   }
 
-  .studyChip::after {
+  .typedChip::after {
     display: none;
   }
 }

--- a/lego-webapp/pages/index/_components/public/Hero.tsx
+++ b/lego-webapp/pages/index/_components/public/Hero.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import Auth from '~/components/Auth';
 import styles from './Hero.module.css';
 import { beads, beadRight, beadRowCenter, beadTop } from './heroBeads';
+import useScrambleText from './useScrambleText';
 import useTitleBeadAnimation from './useTitleBeadAnimation';
 import type { CSSProperties } from 'react';
 
@@ -11,17 +12,36 @@ type StudyChipProps = {
   label: string;
 };
 
-const StudyChip = ({ href, label }: StudyChipProps) => (
+const TypedChip = ({ href, label }: StudyChipProps) => (
   <a
-    className={styles.studyChip}
+    className={cx(styles.studyChip, styles.typedChip)}
     href={href}
     rel="noreferrer"
     target="_blank"
     style={{ '--chars': label.length } as CSSProperties}
   >
-    <span className={styles.typewriter}>{label}</span>
+    <span className={styles.typedText}>{label}</span>
   </a>
 );
+
+const ScrambledChip = ({ href, label }: StudyChipProps) => {
+  const textRef = useScrambleText(label);
+
+  return (
+    <a
+      className={styles.studyChip}
+      href={href}
+      rel="noreferrer"
+      target="_blank"
+      aria-label={label}
+      style={{ '--chars': label.length } as CSSProperties}
+    >
+      <span className={styles.scrambledText} ref={textRef} aria-hidden="true">
+        {label}
+      </span>
+    </a>
+  );
+};
 
 const Hero = () => {
   const {
@@ -72,12 +92,12 @@ const Hero = () => {
             </h1>
             <p className={cx(styles.lead, styles.fadeUp, styles.fadeUpDelay1)}>
               Abakus er linjeforeningen for studentene ved{' '}
-              <StudyChip
+              <TypedChip
                 href="https://www.ntnu.no/studier/mtdt"
                 label="Datateknologi"
               />{' '}
               og{' '}
-              <StudyChip
+              <ScrambledChip
                 href="https://www.ntnu.no/studier/mtkom"
                 label="Cybersikkerhet og datakommunikasjon"
               />{' '}

--- a/lego-webapp/pages/index/_components/public/Hero.tsx
+++ b/lego-webapp/pages/index/_components/public/Hero.tsx
@@ -4,6 +4,24 @@ import Auth from '~/components/Auth';
 import styles from './Hero.module.css';
 import { beads, beadRight, beadRowCenter, beadTop } from './heroBeads';
 import useTitleBeadAnimation from './useTitleBeadAnimation';
+import type { CSSProperties } from 'react';
+
+type StudyChipProps = {
+  href: string;
+  label: string;
+};
+
+const StudyChip = ({ href, label }: StudyChipProps) => (
+  <a
+    className={styles.studyChip}
+    href={href}
+    rel="noreferrer"
+    target="_blank"
+    style={{ '--chars': label.length } as CSSProperties}
+  >
+    <span className={styles.typewriter}>{label}</span>
+  </a>
+);
 
 const Hero = () => {
   const {
@@ -54,23 +72,15 @@ const Hero = () => {
             </h1>
             <p className={cx(styles.lead, styles.fadeUp, styles.fadeUpDelay1)}>
               Abakus er linjeforeningen for studentene ved{' '}
-              <a
-                className={styles.studyChip}
+              <StudyChip
                 href="https://www.ntnu.no/studier/mtdt"
-                rel="noreferrer"
-                target="_blank"
-              >
-                Datateknologi
-              </a>{' '}
+                label="Datateknologi"
+              />{' '}
               og{' '}
-              <a
-                className={styles.studyChip}
+              <StudyChip
                 href="https://www.ntnu.no/studier/mtkom"
-                rel="noreferrer"
-                target="_blank"
-              >
-                Cybersikkerhet og datakommunikasjon
-              </a>{' '}
+                label="Cybersikkerhet og datakommunikasjon"
+              />{' '}
               på NTNU, og drives av studenter ved disse studiene.
             </p>
             <p

--- a/lego-webapp/pages/index/_components/public/UsefulLinks.module.css
+++ b/lego-webapp/pages/index/_components/public/UsefulLinks.module.css
@@ -21,11 +21,6 @@
     box-shadow var(--easing-medium),
     transform var(--easing-medium);
 
-  &:hover {
-    box-shadow: var(--shadow-md);
-    transform: translateY(-4px);
-  }
-
   &:hover .arrow {
     transform: translateX(4px);
   }

--- a/lego-webapp/pages/index/_components/public/useScrambleText.ts
+++ b/lego-webapp/pages/index/_components/public/useScrambleText.ts
@@ -1,0 +1,41 @@
+import { gsap } from 'gsap';
+import { ScrambleTextPlugin } from 'gsap/ScrambleTextPlugin';
+import { useLayoutEffect, useRef } from 'react';
+
+gsap.registerPlugin(ScrambleTextPlugin);
+
+const SCRAMBLE_CHARS = '0123456789abcdef!@#$%^*+=?/\\|~_';
+
+const TYPEWRITER_HANDOFF = 1.5;
+
+const SCRAMBLE_DURATION = 2;
+
+const useScrambleText = (text: string) => {
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  useLayoutEffect(() => {
+    const element = textRef.current;
+
+    if (!element) return;
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    element.textContent = '';
+
+    const tween = gsap.to(element, {
+      duration: SCRAMBLE_DURATION,
+      delay: TYPEWRITER_HANDOFF,
+      ease: 'none',
+      scrambleText: { text, chars: SCRAMBLE_CHARS, speed: 1 },
+    });
+
+    return () => {
+      tween.kill();
+      element.textContent = text;
+    };
+  }, [text]);
+
+  return textRef;
+};
+
+export default useScrambleText;


### PR DESCRIPTION
## Description

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->
Animates the two study pills in the public frontpage hero so they resolve in sequence instead of appearing statically.

`Datateknologi` types out character by character with a blinking caret, then `Cybersikkerhet og datakommunikasjon` scrambles in through hex and symbol noise before settling on the real text.

The typewriter is pure CSS: a `clip-path` animated with `steps(var(--chars))`, which reveals exactly one character per step since the pills use `--font-family-mono`.

Also removed the bump animation when hovering useful link cards. Was annoying...

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
  <thead>
    <tr>
      <th width="25%">Description</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Text animation</td>
      <td>

<!-- paste image/video URL directly under this line -->
https://github.com/user-attachments/assets/b546030e-bc4e-455b-a338-58648424cb97

</td>
      <td>

<!-- paste image/video URL directly under this line -->
https://github.com/user-attachments/assets/342eff66-794c-4f55-b300-9aab19123e16


</td>
    </tr>
  </tbody>
</table>

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6032 
