### PR TITLE
Fix theme toggle position on first load

### DIFF
--- a/lego-webapp/components/Header/ToggleTheme.tsx
+++ b/lego-webapp/components/Header/ToggleTheme.tsx
@@ -1,7 +1,6 @@
 import { Icon } from '@webkom/lego-bricks';
 import cx from 'classnames';
 import { MoonStar, Sun } from 'lucide-react';
-import { useEffect, useState } from 'react';
 import { useAppDispatch } from '~/redux/hooks';
 import { applySelectedTheme, useTheme } from '~/utils/themeUtils';
 import styles from './toggleTheme.module.css';
@@ -22,11 +21,6 @@ const ToggleTheme = ({
 }: Props) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   const handleThemeChange = (e: MouseEvent) => {
     e.preventDefault();
@@ -38,13 +32,11 @@ const ToggleTheme = ({
   return (
     <Component
       name="Endre tema"
-      className={cx(className, styles.toggleWrapper, styles[variant], {
-        [styles.noTransition]: !mounted,
-      })}
+      className={cx(className, styles.toggleWrapper, styles[variant])}
       onClick={handleThemeChange}
     >
       {children}
-      <div className={styles.iconTrack} data-theme={theme}>
+      <div className={styles.iconTrack}>
         <Icon iconNode={<Sun />} className={styles.icon} />
         <Icon iconNode={<MoonStar />} className={styles.icon} />
       </div>

--- a/lego-webapp/components/Header/toggleTheme.module.css
+++ b/lego-webapp/components/Header/toggleTheme.module.css
@@ -22,19 +22,19 @@
   padding-bottom: var(--spacing-sm);
 }
 
-.navbar .iconTrack[data-theme='dark'] {
+html[data-theme='dark'] .navbar .iconTrack {
   transform: translateY(8px);
 }
 
-.navbar .iconTrack[data-theme='light'] {
+html[data-theme='light'] .navbar .iconTrack {
   transform: translateY(-24px);
 }
 
-.header .iconTrack[data-theme='dark'] {
+html[data-theme='dark'] .header .iconTrack {
   transform: translateY(20px);
 }
 
-.header .iconTrack[data-theme='light'] {
+html[data-theme='light'] .header .iconTrack {
   transform: translateY(-12px);
 }
 
@@ -46,8 +46,4 @@
 .icon:last-child:hover {
   color: var(--color-blue-8);
   transition: color var(--linear-fast);
-}
-
-.noTransition .iconTrack {
-  transition: none !important;
 }

--- a/lego-webapp/pages/+onBeforeRenderClient.ts
+++ b/lego-webapp/pages/+onBeforeRenderClient.ts
@@ -3,6 +3,7 @@ import cookie from 'js-cookie';
 import moment from 'moment-timezone';
 import { PageContextClient } from 'vike/types';
 import { maybeRefreshToken } from '~/redux/actions/UserActions';
+import { setTheme } from '~/redux/slices/theme';
 import createStore from '../redux/createStore';
 import 'moment/dist/locale/nb';
 
@@ -42,6 +43,13 @@ export async function onBeforeRenderClient(pageContext: PageContextClient) {
       Sentry,
       getCookie: (key) => cookie.get(key),
     });
+    pageContext.store.dispatch(
+      setTheme(
+        document.documentElement.getAttribute('data-theme') === 'dark'
+          ? 'dark'
+          : 'light',
+      ),
+    );
     pageContext.store.dispatch(maybeRefreshToken());
     pageContext.store.dispatch({ type: 'REHYDRATED' });
   }


### PR DESCRIPTION
## Description

Theme selector was sometimes buggy. When first loading the page it would initially load a dark theme and switch to a light theme

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->
- toggleTheme.module.css: the icon track is now positioned by html[data-theme='...'] .navbar/.header .iconTrack selectors (same idiom as Footer.module.css), so it's correct from the very first paint via the bootstrap-set attribute, before any JS runs.
- ToggleTheme.tsx: dropped the track's redux-driven data-theme prop and the whole mounted/noTransition workaround, which existed only to mask the jump this fix removes.
- +onBeforeRenderClient.ts: the client store now seeds theme from document.documentElement's data-theme right after creation, so every redux theme consumer agrees with the DOM from before hydration.

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6035 
