### PR TITLE
Fix scrambled study chip flashing on first load

### DIFF
--- a/lego-webapp/pages/index/_components/public/Hero.module.css
+++ b/lego-webapp/pages/index/_components/public/Hero.module.css
@@ -280,11 +280,20 @@
   }
 }
 
-/* Holds the pill open while the scrambled text grows into it */
+/* Holds the pill open while the scrambled text grows into it; hidden until the
+   scramble runs, or revealed at 1.5s + 2s by CSS alone if JS never arrives */
 .scrambledText {
   display: inline-block;
   width: calc(var(--chars) * 1ch);
   white-space: nowrap;
+  visibility: hidden;
+  animation: scramble-reveal 1ms linear 3.5s forwards;
+}
+
+@keyframes scramble-reveal {
+  to {
+    visibility: visible;
+  }
 }
 
 .actions {
@@ -365,5 +374,10 @@
 
   .typedChip::after {
     display: none;
+  }
+
+  .scrambledText {
+    visibility: visible;
+    animation: none;
   }
 }

--- a/lego-webapp/pages/index/_components/public/useScrambleText.ts
+++ b/lego-webapp/pages/index/_components/public/useScrambleText.ts
@@ -25,13 +25,9 @@ const useScrambleText = (text: string) => {
     element.textContent = '';
     element.style.visibility = 'visible';
 
-    const paintTime =
-      performance.getEntriesByType('paint')[0]?.startTime ?? performance.now();
-    const elapsed = (performance.now() - paintTime) / 1000;
-
     const tween = gsap.to(element, {
       duration: SCRAMBLE_DURATION,
-      delay: Math.max(0, TYPEWRITER_HANDOFF - elapsed),
+      delay: TYPEWRITER_HANDOFF,
       ease: 'none',
       scrambleText: { text, chars: SCRAMBLE_CHARS, speed: 1 },
     });

--- a/lego-webapp/pages/index/_components/public/useScrambleText.ts
+++ b/lego-webapp/pages/index/_components/public/useScrambleText.ts
@@ -20,11 +20,18 @@ const useScrambleText = (text: string) => {
 
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
+    if (getComputedStyle(element).visibility === 'visible') return;
+
     element.textContent = '';
+    element.style.visibility = 'visible';
+
+    const paintTime =
+      performance.getEntriesByType('paint')[0]?.startTime ?? performance.now();
+    const elapsed = (performance.now() - paintTime) / 1000;
 
     const tween = gsap.to(element, {
       duration: SCRAMBLE_DURATION,
-      delay: TYPEWRITER_HANDOFF,
+      delay: Math.max(0, TYPEWRITER_HANDOFF - elapsed),
       ease: 'none',
       scrambleText: { text, chars: SCRAMBLE_CHARS, speed: 1 },
     });
@@ -32,6 +39,7 @@ const useScrambleText = (text: string) => {
     return () => {
       tween.kill();
       element.textContent = text;
+      element.style.visibility = '';
     };
   }, [text]);
 


### PR DESCRIPTION
## Description

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->

The "Cybersikkerhet og datakommunikasjon" chip ships its label in the SSR HTML, but hiding it and starting the scramble only happens in JS. On cold loads the text was visible from first paint until hydration, then abruptly wiped and re-scrambled.

- Hide .scrambledText with CSS from first paint, so the SSR text never flashes
- Pure-CSS fallback reveals the plain text at 3.5s (when the scramble would have finished) if JS hasn't run, e.g. slow connections or JS disabled; the hook skips scrambling in that case so visible text is never wiped
- Show the text immediately under prefers-reduced-motion

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6034 
