### PR TITLE
Fix double-fired OIDC validate request on student confirmation

### DIFF
--- a/lego-webapp/pages/+Layout.tsx
+++ b/lego-webapp/pages/+Layout.tsx
@@ -65,15 +65,18 @@ const useLocation: ComponentProps<typeof LegoBricksProvider>['useLocation'] = <
   };
 };
 
+const bricksNavigate: ComponentProps<typeof LegoBricksProvider>['navigate'] = (
+  href,
+  { navigationState, ...options } = {},
+) => navigate(href, { ...options, pageContext: { navigationState } });
+
 export default function Layout({ children }: { children: ReactNode }) {
   const theme = useTheme();
 
   return (
     <LegoBricksProvider
       theme={theme}
-      navigate={(href, { navigationState, ...options } = {}) =>
-        navigate(href, { ...options, pageContext: { navigationState } })
-      }
+      navigate={bricksNavigate}
       useLocation={useLocation}
     >
       <div className={styles.appRoute}>

--- a/lego-webapp/utils/__tests__/useClearSearchParams.spec.tsx
+++ b/lego-webapp/utils/__tests__/useClearSearchParams.spec.tsx
@@ -1,0 +1,50 @@
+import { act, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it } from 'vitest';
+import {
+  RouterContext,
+  useClearSearchParams,
+} from '../../../packages/lego-bricks/src/RouterContext';
+import type { RouterContextData } from '../../../packages/lego-bricks/src/RouterContext';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const routerValue: RouterContextData = {
+  navigate: () => {},
+  useLocation: () => ({ pathname: '/users/me/settings', search: '' }),
+};
+
+describe('useClearSearchParams', () => {
+  it('returns a referentially stable callback across re-renders', async () => {
+    const seen: (() => void)[] = [];
+    let forceRender = () => {};
+
+    const Probe = () => {
+      const [, setTick] = useState(0);
+      forceRender = () => setTick((tick) => tick + 1);
+      seen.push(useClearSearchParams());
+      return null;
+    };
+
+    const root = createRoot(document.createElement('div'));
+    await act(async () => {
+      root.render(
+        <RouterContext.Provider value={routerValue}>
+          <Probe />
+        </RouterContext.Provider>,
+      );
+    });
+    await act(async () => {
+      forceRender();
+    });
+
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    expect(seen.at(-1)).toBe(seen[0]);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/packages/lego-bricks/src/Provider.tsx
+++ b/packages/lego-bricks/src/Provider.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { RouterProvider } from 'react-aria-components';
 import { RouterContext } from './RouterContext';
 import { ThemeContext } from './ThemeContext';
@@ -11,10 +12,16 @@ type Props = {
   children: ReactNode;
 };
 
-export const Provider = ({ theme, navigate, useLocation, children }: Props) => (
-  <RouterProvider navigate={navigate}>
-    <RouterContext.Provider value={{ navigate, useLocation }}>
-      <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
-    </RouterContext.Provider>
-  </RouterProvider>
-);
+export const Provider = ({ theme, navigate, useLocation, children }: Props) => {
+  const routerContextValue = useMemo(
+    () => ({ navigate, useLocation }),
+    [navigate, useLocation],
+  );
+  return (
+    <RouterProvider navigate={navigate}>
+      <RouterContext.Provider value={routerContextValue}>
+        <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+      </RouterContext.Provider>
+    </RouterProvider>
+  );
+};

--- a/packages/lego-bricks/src/RouterContext.ts
+++ b/packages/lego-bricks/src/RouterContext.ts
@@ -1,4 +1,9 @@
-import { type ComponentProps, createContext, useContext } from 'react';
+import {
+  type ComponentProps,
+  createContext,
+  useCallback,
+  useContext,
+} from 'react';
 import type { RouterOptions } from '@react-types/shared';
 import type { RouterProvider } from 'react-aria-components';
 
@@ -43,12 +48,21 @@ export const useClearSearchParams = (options: RouterOptions = {}) => {
   const {
     overwriteLastHistoryEntry = true,
     keepScrollPosition = true,
-    ...rest
+    navigationState,
   } = options;
-  return () =>
-    navigate(pathname, {
+  return useCallback(
+    () =>
+      navigate(pathname, {
+        overwriteLastHistoryEntry,
+        keepScrollPosition,
+        navigationState,
+      }),
+    [
+      navigate,
+      pathname,
       overwriteLastHistoryEntry,
       keepScrollPosition,
-      ...rest,
-    });
+      navigationState,
+    ],
+  );
 };


### PR DESCRIPTION
## Description

The student confirmation page could fire `/oidc/validate/` twice for one Feide callback: `useClearSearchParams` returned a new function on every render while sitting in the effect's dependency array, and the router context value and navigate prop were also unstable, so the effect re-ran with stale `code`/`state`. The replayed request consumes the one-time OAuth state and surfaces as a validation error despite a successful verification (noise on [LEGO-10H](https://abakus.sentry.io/issues/LEGO-10H)).

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.


## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->
New spec pins the referential stability of `useClearSearchParams` across re-renders. It fails on master and passes here.

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

Resolves #6039 
