### PR TITLE
Fix events gap

### DIFF
--- a/lego-webapp/pages/users/@username/_components/UserProfile.module.css
+++ b/lego-webapp/pages/users/@username/_components/UserProfile.module.css
@@ -7,6 +7,7 @@
     'info header'
     'info events';
   grid-template-columns: 348.53px 1fr; /* The width of the info cards below */
+  grid-template-rows: auto auto 1fr; /* A tall info column must stretch the events row, not the header row */
   gap: var(--spacing-md) var(--spacing-lg);
 
   @media (--medium-viewport) {
@@ -16,6 +17,7 @@
       'info'
       'events';
     grid-template-columns: 1fr;
+    grid-template-rows: none;
   }
 }
 


### PR DESCRIPTION
## Description
<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->
This issue has annoyed me for so long, and it seems that I am the only effected (weird viewport ig). Huge vertical gap between trophies and my coming events.


## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
  <thead>
    <tr>
      <th width="25%">Description</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Vertical gap</td>
      <td>

<!-- paste image/video URL directly under this line -->
https://github.com/user-attachments/assets/453f2a5d-2490-4f90-b63d-9b9403518ff0


</td>
      <td>

<!-- paste image/video URL directly under this line -->
https://github.com/user-attachments/assets/4d046535-bb52-4e07-b8f1-03b26bb83e3c

</td>
    </tr>
  </tbody>
</table>

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6042 
