### PR TITLE
Fix: Admin unregister and notifications for it

### DIFF
--- a/lego-webapp/components/Feed/index.tsx
+++ b/lego-webapp/components/Feed/index.tsx
@@ -7,6 +7,7 @@ import { FeedActivityVerb } from '~/redux/models/FeedActivity';
 import { selectFeedActivitiesByFeedId } from '~/redux/slices/feeds';
 import Activity from './activity';
 import AdminRegistrationRenderer from './renders/adminRegistration';
+import AdminUnregistrationRenderer from './renders/adminUnregistration';
 import AnnouncementRenderer from './renders/announcement';
 import CommentRenderer from './renders/comment';
 import CommentReplyRenderer from './renders/comment_reply';
@@ -27,6 +28,7 @@ export const activityRenderers = {
   [FeedActivityVerb.RestrictedMailSent]: RestrictedMailSentRenderer,
   [FeedActivityVerb.RegistrationBump]: RegistrationBumpRenderer,
   [FeedActivityVerb.AdminRegistration]: AdminRegistrationRenderer,
+  [FeedActivityVerb.AdminUnregistration]: AdminUnregistrationRenderer,
   [FeedActivityVerb.Announcement]: AnnouncementRenderer,
   [FeedActivityVerb.GroupJoin]: GroupJoinRenderer,
   [FeedActivityVerb.EventRegister]: EventRegisterRenderer,

--- a/lego-webapp/components/Feed/renders/adminUnregistration.tsx
+++ b/lego-webapp/components/Feed/renders/adminUnregistration.tsx
@@ -1,0 +1,50 @@
+import { Icon } from '@webkom/lego-bricks';
+import AggregatedFeedActivity, {
+  FeedActivityVerb,
+} from '~/redux/models/FeedActivity';
+import { isNotNullish } from '~/utils';
+import { contextRender } from '../context';
+import { formatHeader } from './utils';
+import type ActivityRenderer from '~/components/Feed/ActivityRenderer';
+
+const AdminUnregistrationRenderer: ActivityRenderer<FeedActivityVerb.AdminUnregistration> =
+  {
+    Header: ({ aggregatedActivity, tag: Tag }) => {
+      const events = getEvents(aggregatedActivity);
+      if (events.length === 0) {
+        return null;
+      }
+      return (
+        <b>
+          {'Du har blitt fjernet fra '}
+          {formatHeader(
+            events.map((event) => (
+              <Tag
+                key={event.id}
+                {...contextRender[event.contentType](event)}
+              />
+            )),
+          )}
+          {' av en administrator'}
+        </b>
+      );
+    },
+    Content: () => null,
+    Icon: () => <Icon name="calendar" />,
+    getNotificationUrl: (aggregatedActivity) => {
+      const events = getEvents(aggregatedActivity);
+      if (!events || events.length !== 1) {
+        return '/events';
+      }
+      return `/events/${events[0].id}`;
+    },
+  };
+
+const getEvents = (
+  aggregatedActivity: AggregatedFeedActivity<FeedActivityVerb.AdminUnregistration>,
+) =>
+  aggregatedActivity.activities
+    .map((activity) => aggregatedActivity.context[activity.actor])
+    .filter(isNotNullish);
+
+export default AdminUnregistrationRenderer;

--- a/lego-webapp/pages/events/@eventId/administrate/attendees/AttendeeElements.tsx
+++ b/lego-webapp/pages/events/@eventId/administrate/attendees/AttendeeElements.tsx
@@ -14,9 +14,11 @@ import {
   Turtle,
   X,
 } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
 import { Button } from 'react-aria-components';
+import { TextInput } from '~/components/Form';
 import {
-  unregister,
+  adminUnregister,
   updatePayment,
   updatePresence,
 } from '~/redux/actions/EventActions';
@@ -26,7 +28,6 @@ import { useParams } from '~/utils/useParams';
 import styles from '../Administrate.module.css';
 import type { EntityId } from '@reduxjs/toolkit';
 import type { EventRegistrationPaymentStatus } from 'app/models';
-import type { ReactNode } from 'react';
 import type { PressEvent } from 'react-aria-components';
 import type { SelectedAdminRegistration } from '~/redux/slices/events';
 
@@ -205,6 +206,7 @@ export const Unregister = ({
 }: UnregisterProps) => {
   const dispatch = useAppDispatch();
   const { eventId } = useParams<{ eventId: string }>();
+  const [reason, setReason] = useState('');
 
   return (
     <>
@@ -213,15 +215,29 @@ export const Unregister = ({
       ) : (
         <ConfirmModal
           title="Bekreft avregistrering"
-          message={`Er du sikker på at du vil melde av "${registration.user.fullName}"?`}
+          message={
+            <Flex column gap="var(--spacing-sm)">
+              <p>
+                Er du sikker på at du vil melde av &quot;
+                {registration.user.fullName}
+                &quot;?
+              </p>
+              <TextInput
+                type="text"
+                placeholder="Begrunnelse"
+                onChange={(e) => setReason(e.target.value)}
+              />
+            </Flex>
+          }
           onConfirm={() => {
             if (!eventId) return;
             dispatch(
-              unregister({
+              adminUnregister(
                 eventId,
-                registrationId: registration.id,
-                admin: true,
-              }),
+                registration.user.id,
+                registration.id,
+                reason || 'Avregistrert av administrator',
+              ),
             );
           }}
           closeOnConfirm

--- a/lego-webapp/redux/actions/EventActions.ts
+++ b/lego-webapp/redux/actions/EventActions.ts
@@ -166,11 +166,9 @@ export function register({
 export function unregister({
   eventId,
   registrationId,
-  admin = false,
 }: {
   eventId: EntityId;
   registrationId: EntityId;
-  admin?: boolean;
 }) {
   return callAPI({
     types: Event.REQUEST_UNREGISTER,
@@ -179,7 +177,6 @@ export function unregister({
     body: {},
     meta: {
       errorMessage: 'Avregistrering fra arrangement feilet',
-      admin,
       id: Number(registrationId),
     },
   });
@@ -205,6 +202,29 @@ export function adminRegister(
     meta: {
       errorMessage: 'Admin registrering feilet',
       successMessage: 'Brukeren ble registrert',
+    },
+  });
+}
+
+export function adminUnregister(
+  eventId: EntityId,
+  userId: EntityId,
+  registrationId: EntityId,
+  adminUnregistrationReason: string,
+) {
+  return callAPI({
+    types: Event.REQUEST_UNREGISTER,
+    endpoint: `/events/${eventId}/registrations/admin_unregister/`,
+    method: 'POST',
+    body: {
+      user: userId,
+      adminUnregistrationReason,
+    },
+    meta: {
+      errorMessage: 'Admin avregistrering feilet',
+      successMessage: 'Brukeren ble avregistrert',
+      admin: true,
+      id: Number(registrationId),
     },
   });
 }

--- a/lego-webapp/redux/models/FeedActivity.ts
+++ b/lego-webapp/redux/models/FeedActivity.ts
@@ -18,6 +18,7 @@ export enum FeedActivityVerb {
   RestrictedMailSent = 'restricted_mail_sent',
   RegistrationBump = 'registration_bump',
   AdminRegistration = 'admin_registration',
+  AdminUnregistration = 'admin_unregistration',
   Announcement = 'announcement',
   GroupJoin = 'group_join',
   EventRegister = 'event_register',
@@ -31,6 +32,7 @@ export type FeedActivityVerbAttr = {
   [FeedActivityVerb.RestrictedMailSent]: FeedAttrRestrictedMail;
   [FeedActivityVerb.RegistrationBump]: FeedAttrRegistration;
   [FeedActivityVerb.AdminRegistration]: FeedAttrRegistration;
+  [FeedActivityVerb.AdminUnregistration]: FeedAttrRegistration;
   [FeedActivityVerb.Announcement]: FeedAttrAnnouncement;
   [FeedActivityVerb.GroupJoin]: FeedAttrGroup;
   [FeedActivityVerb.EventRegister]: FeedAttrEvent;

--- a/lego-webapp/redux/slices/feedActivities.ts
+++ b/lego-webapp/redux/slices/feedActivities.ts
@@ -1,9 +1,8 @@
-import { type AnyAction, createSlice } from '@reduxjs/toolkit';
+import { type AnyAction, createSlice, EntityId } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { Feed } from '~/redux/actionTypes';
 import createLegoAdapter from '~/redux/legoAdapter/createLegoAdapter';
 import { EntityType } from '~/redux/models/entities';
-import type { EntityId } from '@reduxjs/toolkit';
 import type { RootState } from '~/redux/rootReducer';
 
 const legoAdapter = createLegoAdapter(EntityType.FeedActivities);


### PR DESCRIPTION
## Description

When an admin unregisters an user from an event, the user does not get any notification that they were removed.
This is because the unregister happened at the standard unregister endpoint, not the admin_unregister endpoint.
In addition, the user did not get the notification on their feed when they were unregistered.
The pull request fixes both of these issues.


## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
  <thead>
    <tr>
      <th width="25%">Description</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Confirm Modal</td>
      <td>
<img width="737" height="302" alt="bilde" src="https://github.com/user-attachments/assets/a794df56-78f2-4eef-a166-16f1fb8a0528" />
</td>
      <td>
<img width="730" height="386" alt="Skjermbilde_20260807_111451" src="https://github.com/user-attachments/assets/f175456b-3c6f-4730-b0ec-7dc5cc4ac84c" />
</td>
    </tr>
<tr>
<td>Notification Feed</td>
<td>
</td>
<td>
<img width="625" height="305" alt="bilde" src="https://github.com/user-attachments/assets/959bad4b-3c3c-48fa-a63c-109ec66b6197" />
</td>
</tr>
  </tbody>
</table>

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6044 
