### PR TITLE
Fix pinned post flashing wrong content on frontpage

### DIFF
--- a/lego-webapp/redux/slices/__tests__/frontpage.spec.ts
+++ b/lego-webapp/redux/slices/__tests__/frontpage.spec.ts
@@ -1,0 +1,121 @@
+import moment from 'moment-timezone';
+import { describe, it, expect } from 'vitest';
+import { Frontpage } from '~/redux/actionTypes';
+import frontpage, { selectPinned } from '../frontpage';
+import type { RootState } from '~/redux/rootReducer';
+
+describe('reducers', () => {
+  describe('frontpage', () => {
+    it('stores returned article and event ids on Frontpage.FETCH.SUCCESS', () => {
+      const action = {
+        type: Frontpage.FETCH.SUCCESS,
+        payload: {
+          entities: {
+            frontpage: {
+              undefined: { articles: [6], events: [3, 32], poll: null },
+            },
+          },
+          result: undefined,
+        },
+      };
+      expect(frontpage(undefined, action)).toEqual({
+        fetching: false,
+        articleIds: [6],
+        eventIds: [3, 32],
+      });
+    });
+  });
+});
+
+describe('selectors', () => {
+  const entityStateBase = {
+    actionGrant: [],
+    fetching: false,
+    paginationNext: {},
+  };
+  const createState = ({
+    articleIds,
+    eventIds,
+    articles,
+    events,
+  }: {
+    articleIds: number[];
+    eventIds: number[];
+    articles: Record<number, object>;
+    events: Record<number, object>;
+  }) =>
+    ({
+      frontpage: { fetching: false, articleIds, eventIds },
+      articles: {
+        ...entityStateBase,
+        ids: Object.keys(articles).map(Number),
+        entities: articles,
+      },
+      events: {
+        ...entityStateBase,
+        ids: Object.keys(events).map(Number),
+        entities: events,
+      },
+    }) as unknown as RootState;
+
+  describe('selectPinned', () => {
+    it('ignores entities in the store that were not part of the frontpage response', () => {
+      const state = createState({
+        articleIds: [],
+        eventIds: [3],
+        articles: {},
+        events: {
+          3: {
+            id: 3,
+            pinned: false,
+            startTime: moment().add(1, 'day').toISOString(),
+          },
+          99: {
+            id: 99,
+            pinned: false,
+            startTime: moment().add(1, 'minute').toISOString(),
+          },
+        },
+      });
+      expect(selectPinned(state)?.id).toBe(3);
+    });
+
+    it('sorts pinned frontpage objects first', () => {
+      const state = createState({
+        articleIds: [6],
+        eventIds: [3],
+        articles: {
+          6: {
+            id: 6,
+            pinned: true,
+            createdAt: moment().subtract(1, 'month').toISOString(),
+          },
+        },
+        events: {
+          3: {
+            id: 3,
+            pinned: false,
+            startTime: moment().add(1, 'minute').toISOString(),
+          },
+        },
+      });
+      expect(selectPinned(state)?.id).toBe(6);
+    });
+
+    it('returns undefined before the frontpage has been fetched', () => {
+      const state = createState({
+        articleIds: [],
+        eventIds: [],
+        articles: {},
+        events: {
+          99: {
+            id: 99,
+            pinned: false,
+            startTime: moment().add(1, 'minute').toISOString(),
+          },
+        },
+      });
+      expect(selectPinned(state)).toBeUndefined();
+    });
+  });
+});

--- a/lego-webapp/redux/slices/frontpage.ts
+++ b/lego-webapp/redux/slices/frontpage.ts
@@ -8,16 +8,32 @@ import { EntityType } from '~/redux/models/entities';
 import { selectArticles } from './articles';
 import { selectAllEvents } from './events';
 
+import type { AnyAction, EntityId } from '@reduxjs/toolkit';
 import type { PublicArticle } from '~/redux/models/Article';
 import type { FrontpageEvent } from '~/redux/models/Event';
+import type { RootState } from '~/redux/rootReducer';
+
+type NormalizedFrontpage = {
+  articles?: EntityId[];
+  events?: EntityId[];
+};
 
 const frontpageSlice = createSlice({
   name: 'frontpage',
   initialState: {
     fetching: false,
+    articleIds: [] as EntityId[],
+    eventIds: [] as EntityId[],
   },
   reducers: {},
   extraReducers: (builder) => {
+    builder.addCase(Frontpage.FETCH.SUCCESS, (state, action: AnyAction) => {
+      const frontpage = Object.values<NormalizedFrontpage>(
+        action.payload.entities.frontpage ?? {},
+      )[0];
+      state.articleIds = frontpage?.articles ?? [];
+      state.eventIds = frontpage?.events ?? [];
+    });
     buildFetchingReducer(builder, [Frontpage.FETCH]);
   },
 });
@@ -55,9 +71,20 @@ export const frontpageObjectDate = (object: ArticleWithType | EventWithType) =>
 export const selectPinned = createSelector(
   selectArticles<PublicArticle>,
   selectAllEvents<FrontpageEvent>,
-  (articles, events) => {
+  (state: RootState) => state.frontpage.articleIds,
+  (state: RootState) => state.frontpage.eventIds,
+  (articles, events, articleIds, eventIds) => {
+    const frontpageArticleIds = new Set(articleIds);
+    const frontpageEventIds = new Set(eventIds);
     const pinnedObjects = sortBy(
-      [...articles.map(addArticleType), ...events.map(addEventType)],
+      [
+        ...articles
+          .filter((article) => frontpageArticleIds.has(article.id))
+          .map(addArticleType),
+        ...events
+          .filter((event) => frontpageEventIds.has(event.id))
+          .map(addEventType),
+      ],
       [
         (object) => (object.pinned ? 0 : 1), // Sort pinned objects first
         (object) => Math.abs(moment().diff(frontpageObjectDate(object))), // Sort by most recently published/starting soonest


### PR DESCRIPTION
## Description

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->
When navigating to the frontpage, the "Festet oppslag" card could briefly show the last viewed event/article (its cover, title and link) before switching to the actual pinned post. selectPinned picked from all events/articles in the redux store, so entities cached from previously visited pages won the sort while /frontpage/ was still loading.

The frontpage slice now records which article/event ids the /frontpage/ response actually returned, and selectPinned only considers those. Before the first frontpage fetch resolves the card shows its skeleton instead of a wrong item. Added unit tests for the reducer and selector.

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
  <thead>
    <tr>
      <th width="25%">Description</th>
      <th>Issue</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Old image</td>
      <td>

<!-- paste image/video URL directly under this line -->

https://github.com/user-attachments/assets/2f658196-5ab6-41a7-bd20-e5f88171c662

  </tbody>
</table>

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6047 
