### PR TITLE
fix hydration by adding redux store

### DIFF
--- a/lego-webapp/pages/+onBeforeRenderClient.ts
+++ b/lego-webapp/pages/+onBeforeRenderClient.ts
@@ -4,11 +4,17 @@ import moment from 'moment-timezone';
 import { PageContextClient } from 'vike/types';
 import { maybeRefreshToken } from '~/redux/actions/UserActions';
 import { setTheme } from '~/redux/slices/theme';
-import createStore from '../redux/createStore';
+import createStore, { Store } from '../redux/createStore';
 import 'moment/dist/locale/nb';
 
+// The store must be shared across every client-side pageContext. Vike renders
+// with isHydration=false both for its error page and after an aborted
+// hydration, so a store created only during hydration leaves those renders
+// without one.
+let store: Store | undefined;
+
 export async function onBeforeRenderClient(pageContext: PageContextClient) {
-  if (pageContext.isHydration) {
+  if (!store) {
     !import.meta.env.DEV &&
       console.error(`
                      \`smMMms\`
@@ -39,18 +45,20 @@ export async function onBeforeRenderClient(pageContext: PageContextClient) {
 `);
     moment.locale('nb-NO');
 
-    pageContext.store = createStore(pageContext.storeInitialState, {
+    store = createStore(pageContext.storeInitialState, {
       Sentry,
       getCookie: (key) => cookie.get(key),
     });
-    pageContext.store.dispatch(
+    store.dispatch(
       setTheme(
         document.documentElement.getAttribute('data-theme') === 'dark'
           ? 'dark'
           : 'light',
       ),
     );
-    pageContext.store.dispatch(maybeRefreshToken());
-    pageContext.store.dispatch({ type: 'REHYDRATED' });
+    store.dispatch(maybeRefreshToken());
+    store.dispatch({ type: 'REHYDRATED' });
   }
+
+  pageContext.store = store;
 }


### PR DESCRIPTION
## Description

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->
`+onBeforeRenderClient.ts` only created the Redux store when `pageContext.isHydration` was true. But vike's client runtime sets isHydration: isFirstRender && !isForErrorPage - so two real paths get a pageContext with no store:

- Error-page renders: any failure in the first-render pipeline (chunk load failures, hook errors - things Sentry shows happening regularly) makes vike render its error page with isHydration: false. The store was never created, so the shared +Wrapper.tsx crashed the error page itself with undefined is not an object (evaluating 'store.getState'), leaving users a blank page exactly when error UX matters most.
- Aborted hydration: vike-react ships hydrationCanBeAborted: true, so clicking a link before hydration finishes (slow mobile devices - matching the Mobile Safari-heavy event data) renders the target page as a non-first render, again store-less, and the freshly mounting Wrapper crashed.

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6046 
