### PR TITLE
Fix horisontal overflow

### DIFF
--- a/lego-webapp/pages/events/interest/InterestEvents.module.css
+++ b/lego-webapp/pages/events/interest/InterestEvents.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: clamp(24px, 4vw, 48px);
-  padding: clamp(24px, 4vw, 52px) 0 var(--footer-spacing-lg);
+  padding: 0 0 var(--footer-spacing-lg);
 }
 
 .hero {

--- a/lego-webapp/pages/events/interest/_components/GroupsSection.module.css
+++ b/lego-webapp/pages/events/interest/_components/GroupsSection.module.css
@@ -61,7 +61,7 @@
   min-height: calc(4 * var(--tile-height));
 
   @media (--medium-viewport) {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     min-height: 0;
   }
 }


### PR DESCRIPTION
## Description

<!-- What changed, and why? Include motivation and context. -->
<!-- Label the PR: bug-fix, new-feature, docs, etc. -->
Horisontal overflow on interest page because interest group section took more horisontal space than viewport. Underlying issue was the truncation messed with the grid.

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
  <thead>
    <tr>
      <th width="25%">Description</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Fix horisontal overflow</td>
      <td>

<!-- paste image/video URL directly under this line -->
https://github.com/user-attachments/assets/46c6fa8b-69a4-42a3-ad01-a0d7aed359c8

</td>
      <td>

<!-- paste image/video URL directly under this line -->
https://github.com/user-attachments/assets/93aad455-8cb9-4f48-a0f1-857dd523fc95


</td>
    </tr>
  </tbody>
</table>

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6055 
