### PR TITLE
Remove notion link

### DIFF
--- a/lego-webapp/components/HsSection/HsSection.tsx
+++ b/lego-webapp/components/HsSection/HsSection.tsx
@@ -1,25 +1,11 @@
 import { Icon, Flex } from '@webkom/lego-bricks';
-import { BookOpenText, FileText, MailWarning, PiggyBank } from 'lucide-react';
+import { FileText, MailWarning, PiggyBank } from 'lucide-react';
 import styles from './HsSection.module.css';
 
 const HsSectionContent = () => {
   return (
     <div className={styles.container}>
       <Flex column gap="var(--spacing-xs)">
-        <a
-          href="https://recondite-physician-fe4.notion.site/Hovedstyret-1c05ae4fac2580b2bb12f5c3ca1093be"
-          target="_blank"
-          rel="noreferrer"
-          className={`${styles.item} ${styles.accentNotion} ${styles.fullWidthButton}`}
-        >
-          <Icon iconNode={<BookOpenText size={18} />} />
-          <div className={styles.textWrapper}>
-            <h4 className={styles.title}>Notion</h4>
-            <span className={`secondaryFontColor ${styles.subtext}`}>
-              Dokumentasjon, rutiner og nyttig info
-            </span>
-          </div>
-        </a>
         <a
           href="https://drive.google.com/drive/folders/0B81c-8ZaKBCgUjFPS2Nab3VpVWM?resourcekey=0-xn6rSLIJmRJk78ZFzym5sQ&usp=drive_link"
           target="_blank"


### PR DESCRIPTION
## Description

Removes the notion link from the HS section as it is no longer used.

## Result

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

| Before | After |
| -- | -- |
|<img width="719" height="571" alt="Screenshot From 2026-08-19 23-27-23" src="https://github.com/user-attachments/assets/bb0121aa-af59-49a3-8d39-f062584f4b65" /> | <img width="719" height="571" alt="Screenshot From 2026-08-19 23-28-44" src="https://github.com/user-attachments/assets/53188c63-ec1d-4fbf-a36d-451f8117dfb6" /> |


## Testing

- [x] I have thoroughly tested my changes.

Resolves #6054 
