### PR TITLE
Add share button to event detail page (#6015)

### DIFF
--- a/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/+Page.tsx
@@ -35,6 +35,7 @@ import { AttendeeSection } from './AttendeeSection';
 import styles from './EventDetail.module.css';
 import { InterestedButton } from './InterestedButton';
 import JoinEventForm from './JoinEventForm';
+import { ShareButton } from './ShareButton';
 import { SidebarInfo } from './SidebarInfo';
 import { UnansweredSurveys } from './UnansweredSurveys';
 import { useDeadlineInfoList, useEventCreatorInfoList } from './infoLists';
@@ -169,6 +170,7 @@ const EventDetail = () => {
           <Flex alignItems="center" gap="var(--spacing-sm)">
             {loggedIn && <InterestedButton event={event} />}
             {event.title}
+            <ShareButton event={event} />
           </Flex>
         )
       }

--- a/lego-webapp/pages/events/@eventIdOrSlug/EventDetail.module.css
+++ b/lego-webapp/pages/events/@eventIdOrSlug/EventDetail.module.css
@@ -5,6 +5,10 @@
   color: var(--color-orange-6);
 }
 
+.shareButton {
+  margin-left: auto;
+}
+
 .eventType {
   height: 100%;
   display: flex;

--- a/lego-webapp/pages/events/@eventIdOrSlug/ShareButton.tsx
+++ b/lego-webapp/pages/events/@eventIdOrSlug/ShareButton.tsx
@@ -1,0 +1,48 @@
+import { Icon, Tooltip } from '@webkom/lego-bricks';
+import { Share2 } from 'lucide-react';
+import { addToast } from '~/components/Toast/ToastProvider';
+import { appConfig } from '~/utils/appConfig';
+import styles from './EventDetail.module.css';
+import type {
+  AuthUserDetailedEvent,
+  UserDetailedEvent,
+} from '~/redux/models/Event';
+
+export type ShareButtonProps = {
+  event: AuthUserDetailedEvent | UserDetailedEvent;
+};
+
+export const ShareButton = ({ event }: ShareButtonProps) => {
+  const shareUrl = `${appConfig?.webUrl}/events/${event.slug || event.id}`;
+
+  const onPress = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: event.title, url: shareUrl });
+      } catch {
+        // User cancelled the native share sheet - do nothing
+      }
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      addToast({
+        message: 'Lenke kopiert til utklippstavlen',
+        type: 'success',
+      });
+    } catch {
+      addToast({ message: 'Kunne ikke kopiere lenken', type: 'error' });
+    }
+  };
+
+  return (
+    <Tooltip content="Del arrangementet">
+      <Icon
+        iconNode={<Share2 />}
+        onPress={onPress}
+        className={styles.shareButton}
+      />
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
## Description
Adds a share button to the event detail page (issue #6015). Clicking the
button next to the event title opens the native share sheet on devices/
browsers that support the Web Share API, or falls back to copying the
event URL to the clipboard with a toast confirmation on browsers that
don't support it.

Label: new-feature

## Result
- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

<table>
  <thead>
    <tr>
      <th width="25%">Description</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Event title row</td>
      <td>
<!-- paste image/video URL directly under this line -->
</td>
      <td>
<!-- paste image/video URL directly under this line -->
</td>
    </tr>
  </tbody>
</table>

## Testing
- [x] I have thoroughly tested my changes.

Tested locally on desktop Chrome: clicking the share icon copies the
event URL to the clipboard and shows a success toast. Verified `pnpm
run types` and `eslint`/`prettier` pass on the changed files (repo-wide
`types`/`lint` failures are pre-existing and unrelated to this change).

To reproduce: open any event detail page, click the share icon next to
the title. On a browser/device with Web Share API support, the native
share sheet opens instead of the clipboard fallback.

---
Dependent on <!-- ... backend PR link, delete if none -->
Resolves #6015