### PR TITLE
Fix timeline bu removing incompatible linkify-react

### DIFF
--- a/lego-webapp/components/Feed/activity.tsx
+++ b/lego-webapp/components/Feed/activity.tsx
@@ -1,5 +1,4 @@
 import { BaseCard, CardContent, CardFooter, Flex } from '@webkom/lego-bricks';
-import Linkify from 'linkify-react';
 import { LinkTag } from '~/components/Feed/Tag';
 import { ProfilePicture } from '~/components/Image';
 import Time from '~/components/Time';
@@ -22,23 +21,7 @@ const AggregatedActivityItem = <Verb extends FeedActivityVerb>({
   return (
     <BaseCard>
       <CardContent>
-        <Linkify
-          options={{
-            rel: 'noopener noreferrer',
-            format: (value, type) => {
-              if (type === 'url' && value.length > 50) {
-                value = value.slice(0, 50) + '…';
-              }
-
-              return value;
-            },
-            attributes: {
-              target: '_blank',
-            },
-          }}
-        >
-          <Header aggregatedActivity={aggregatedActivity} tag={LinkTag} />
-        </Linkify>
+        <Header aggregatedActivity={aggregatedActivity} tag={LinkTag} />
       </CardContent>
       <CardFooter variant="border">
         {aggregatedActivity.activities.map((activity) => (
@@ -69,8 +52,9 @@ const ActivityFooter = ({
   aggregatedActivity,
   activity,
 }: ActivityHeaderProps) => {
-  const actor = aggregatedActivity.context[activity.actor];
-  if (actor.contentType !== 'users.user') return null;
+  const actor = aggregatedActivity.context?.[activity.actor];
+  if (!actor || actor.contentType !== 'users.user') return null;
+
   return (
     <Flex
       alignItems="center"

--- a/lego-webapp/components/Feed/renders/comment_reply.tsx
+++ b/lego-webapp/components/Feed/renders/comment_reply.tsx
@@ -14,12 +14,15 @@ const CommentReplyRenderer: ActivityRenderer<FeedActivityVerb.CommentReply> = {
   Header: ({ aggregatedActivity, tag: Tag }) => {
     const target =
       aggregatedActivity.context[aggregatedActivity.lastActivity.target];
+    const renderFn = target?.contentType
+      ? contextRender[target.contentType]
+      : null;
 
     return (
       <b>
         <UserActors aggregatedActivity={aggregatedActivity} Tag={Tag} /> svarte
         på din kommentar på{' '}
-        <Tag {...contextRender[target.contentType](target)} />
+        {renderFn ? <Tag {...renderFn(target)} /> : 'et element'}
       </b>
     );
   },

--- a/lego-webapp/pages/timeline/+Page.tsx
+++ b/lego-webapp/pages/timeline/+Page.tsx
@@ -10,7 +10,11 @@ import { guardLogin } from '~/utils/replaceUnlessLoggedIn';
 const TimelinePage = () => {
   const dispatch = useAppDispatch();
 
-  usePreparedEffect('fetchTimeline', () => dispatch(fetchPersonalFeed()), []);
+  usePreparedEffect(
+    'fetchTimeline',
+    () => (import.meta.env.SSR ? undefined : dispatch(fetchPersonalFeed())),
+    [],
+  );
 
   const feed = useAppSelector((state) => selectFeedById(state, 'personal'));
 

--- a/lego-webapp/redux/slices/__tests__/feeds.spec.ts
+++ b/lego-webapp/redux/slices/__tests__/feeds.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Feed } from '~/redux/actionTypes';
-import feeds from '../feeds';
+import { createRootReducer } from '~/redux/rootReducer';
+import feeds, { selectFeedActivitiesByFeedId } from '../feeds';
 import type { FeedType } from '~/redux/models/Feed';
 
 describe('reducers', () => {
@@ -36,6 +37,62 @@ describe('reducers', () => {
           },
         },
       });
+    });
+
+    it('skips feed activity IDs that have not been normalized', () => {
+      const initialState = createRootReducer()(undefined, {
+        type: '@@test/init',
+      });
+      const presentActivity = {
+        id: 'present',
+        orderingKey: 'present',
+        verb: 'comment',
+        createdAt: '',
+        updatedAt: '',
+        lastActivity: {
+          activityId: 'present',
+          verb: 0,
+          time: '',
+          extraContext: {},
+          actor: '',
+          object: '',
+          target: '',
+        },
+        activities: [],
+        activityCount: 0,
+        actorIds: [],
+        read: false,
+        seen: false,
+        context: {},
+      };
+      const state = {
+        ...initialState,
+        feeds: {
+          ...initialState.feeds,
+          entities: {
+            ...initialState.feeds.entities,
+            personal: {
+              id: 'personal',
+              type: 'personal',
+              activities: ['missing', 'present'],
+            },
+          },
+        },
+        feedActivities: {
+          ...initialState.feedActivities,
+          entities: {
+            ...initialState.feedActivities.entities,
+            present: presentActivity,
+          },
+        },
+      };
+
+      expect(selectFeedActivitiesByFeedId(state, 'personal')).toEqual([
+        expect.objectContaining({
+          id: 'present',
+          verb: 'comment',
+        }),
+      ]);
     });
   });
 });

--- a/lego-webapp/redux/slices/feeds.ts
+++ b/lego-webapp/redux/slices/feeds.ts
@@ -7,6 +7,7 @@ import createLegoAdapter from '~/redux/legoAdapter/createLegoAdapter';
 import { EntityType } from '~/redux/models/entities';
 import { selectFeedActivityEntities } from '~/redux/slices/feedActivities';
 import { asArray } from '~/redux/slices/utils';
+import { isNotNullish } from '~/utils';
 import type { AnyAction } from '@reduxjs/toolkit';
 import type { RootState } from '~/redux/rootReducer';
 
@@ -68,7 +69,9 @@ export const selectFeedActivitiesByFeedId = createSelector(
       return [];
     }
 
-    return feed.activities.map((id) => feedActivityEntities[id]);
+    return feed.activities
+      .map((id) => feedActivityEntities[id])
+      .filter(isNotNullish);
   },
 );
 


### PR DESCRIPTION
## Description

The timeline tool was broken due to incompatible linkify usage which is now removed. Also add guards to prevent incomplete notifications from breaking the page. 

## Result

<!-- For visual changes, fill in the table and tick the boxes. -->

- [x] Changes look good on both light and dark theme.
- [x] Changes look good with different viewports (mobile, tablet, etc.).
- [x] Changes look good with slower Internet connections.

> [!CAUTION]
> Make sure your images do not contain any real user information.

<table>
  <thead>
    <tr>
      <th width="25%">Description</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
Fix the timeline
</td>
      <td>

<!-- paste image/video URL directly under this line -->
<img width="1081" height="372" alt="image" src="https://github.com/user-attachments/assets/554ef7af-cc15-4c49-b676-43d56def6032" />


</td>
      <td>

<!-- paste image/video URL directly under this line -->
<img width="1248" height="527" alt="image" src="https://github.com/user-attachments/assets/bef7ceae-c17c-414c-97aa-31344cc7526b" />


</td>
    </tr>
  </tbody>
</table>

## Testing

<!-- What did you test, and how? Add steps to reproduce if it helps a reviewer. -->

- [x] I have thoroughly tested my changes.

Please describe what and how the changes have been tested, and provide instructions to reproduce if necessary.

---

Resolves #6063
